### PR TITLE
feat: Refactor project persistence and editor state management

### DIFF
--- a/docs/research/editor-state-and-persistence-boundary-pass.md
+++ b/docs/research/editor-state-and-persistence-boundary-pass.md
@@ -355,13 +355,13 @@ Checklist:
 
 ### Persistence Hierarchy
 
-| Layer | Role | Updated by |
-| --- | --- | --- |
-| Local draft | Crash-recovery working state for the current device/tab | Any committed track-data change once interaction/history sessions settle |
-| Named local project | Deliberate device-side continuity for reopening a project later | Track-data changes for designs with meaningful project content |
-| Restore point | Earlier snapshot of one local/account project state | Manual snapshot, periodic snapshot, or save-before-replace flows |
-| Account-backed project | Authenticated cross-device continuity and ownership | Explicit sync or autosync after committed track-data changes |
-| Published share | Read-only handoff snapshot | Explicit publish action only |
+| Layer                  | Role                                                            | Updated by                                                               |
+| ---------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Local draft            | Crash-recovery working state for the current device/tab         | Any committed track-data change once interaction/history sessions settle |
+| Named local project    | Deliberate device-side continuity for reopening a project later | Track-data changes for designs with meaningful project content           |
+| Restore point          | Earlier snapshot of one local/account project state             | Manual snapshot, periodic snapshot, or save-before-replace flows         |
+| Account-backed project | Authenticated cross-device continuity and ownership             | Explicit sync or autosync after committed track-data changes             |
+| Published share        | Read-only handoff snapshot                                      | Explicit publish action only                                             |
 
 Autosave trigger rules in the current implementation:
 

--- a/docs/research/editor-state-and-persistence-boundary-pass.md
+++ b/docs/research/editor-state-and-persistence-boundary-pass.md
@@ -1,0 +1,565 @@
+# Editor State And Persistence Boundary Pass
+
+This document outlines the editor and persistence improvements that would make TrackDraw cleaner today and reduce future cost for collaboration, review, and publishing features.
+
+Status: recommended foundation work. This is product improvement work, not a collaboration commitment.
+
+## Current Fit
+
+TrackDraw already works well as a local-first editor, but its core editing model mixes several concerns together:
+
+- persistent track data
+- temporary UI state
+- undo/redo history
+- local autosave
+- local projects and restore points
+- account-backed project persistence
+- published share snapshots
+
+Those concerns are individually sensible, but the lines between them can be clearer.
+
+Relevant current files:
+
+- [src/store/editor.ts](../../src/store/editor.ts)
+- [src/hooks/useEditorProjects.ts](../../src/hooks/useEditorProjects.ts)
+- [src/lib/projects.ts](../../src/lib/projects.ts)
+- [src/lib/track/design.ts](../../src/lib/track/design.ts)
+- [src/app/api/projects/route.ts](../../src/app/api/projects/route.ts)
+- [src/app/api/shares/route.ts](../../src/app/api/shares/route.ts)
+
+## Main Problems To Solve
+
+### 1. Track Data And UI State Are Too Close Together
+
+The editor store currently holds:
+
+- the actual `TrackDesign`
+- selection state
+- tool state
+- hover state
+- draft interaction state
+- drag previews
+
+That makes the editor powerful, but it also makes it harder to reason about what should:
+
+- persist
+- affect undo/redo
+- trigger autosave
+- remain purely local and temporary
+
+### 2. Meaningful Edits Are Not Formalized Enough
+
+Many editor changes happen through direct store mutations.
+
+That works, but it limits:
+
+- clear testability
+- change instrumentation
+- intentional undo grouping
+- future reuse for review or sync-related features
+
+### 3. Persistence Layers Need A Clearer User Model
+
+TrackDraw currently has several persistence concepts:
+
+- local autosave
+- local projects
+- restore points
+- account-backed projects
+- published shares
+
+All of these are useful, but the product model is easier to misunderstand when the boundaries are not explicit.
+
+### 4. Undo/Redo Is Functional But Not Yet Intent-Oriented
+
+`zundo` provides a strong base, but some interactions would benefit from cleaner “meaningful change” boundaries instead of relying mostly on raw temporal history.
+
+## Concrete Current-State Assessment
+
+The current editor is already closer to a useful split than it may first appear.
+
+TrackDraw effectively has three kinds of state today:
+
+### 1. Persistent Document State
+
+This should remain part of the saved project model:
+
+- `design`
+- `design.field`
+- `design.shapeOrder`
+- `design.shapeById`
+- design metadata such as title, description, tags, inventory, and author fields
+
+This is the actual saved track data.
+
+### 2. Local Editor Session State
+
+This is not part of the saved project, but it does affect editing flow:
+
+- `selection`
+- `historyPaused`
+- `historySessionDepth`
+- `interactionSessionDepth`
+
+This state belongs to the active editing session, not the project payload.
+
+### 3. Temporary UI State
+
+This is highly local UI state and should never be treated as saved track data:
+
+- active tool and preset
+- zoom and pan
+- hover state
+- segment and vertex selection
+- draft path state
+- marquee state
+- rotation preview state
+- group drag preview state
+- live shape patches
+
+Most of this already lives under a dedicated UI-state area in [src/lib/editor/store-types.ts](../../src/lib/editor/store-types.ts), which is a useful starting point in the current code. The main gap is that these boundaries are not explicit enough in the implementation and surrounding persistence behavior.
+
+## Desired End State
+
+This work does not need a new editor architecture from scratch.
+
+The desired end state should be:
+
+### 1. One Clear Track Data Area
+
+TrackDraw should have one clearly identified track data area that owns:
+
+- the full `TrackDesign`
+- track-data-changing editor actions
+- track data normalization and updated-at behavior
+
+### 2. One Clear Local UI Area
+
+TrackDraw should have one clearly identified local UI area that owns:
+
+- selection
+- active tool and preset
+- camera/canvas view state
+- hover state
+- previews and drafts
+- temporary interaction affordances
+
+### 3. Clear Persistence Rules
+
+TrackDraw should be able to answer these questions unambiguously:
+
+- what triggers autosave
+- what enters undo/redo history
+- what survives a reload
+- what belongs only to the current tab/session
+- what is publishable
+
+### 4. Clear Meaningful Edit Rules
+
+TrackDraw should be able to distinguish between:
+
+- track data edits
+- interaction previews
+- session-only changes
+- view-only changes
+
+That is the key to cleaner undo/redo and safer future changes.
+
+## Recommended Direction
+
+### 1. Split Store Responsibilities More Explicitly
+
+TrackDraw should move toward a clearer separation between:
+
+- persistent track data
+- local editor session state
+- temporary UI state
+
+That does not require a full rewrite. It can be done incrementally.
+
+### 2. Introduce Clearer Action Boundaries
+
+TrackDraw should gradually formalize meaningful edit actions such as:
+
+- add shape
+- move shape
+- rotate selection
+- edit route section
+- update project metadata
+
+This does not require a full event-sourcing system. It just means edits become easier to understand, test, group, and observe.
+
+### 3. Clarify Persistence Ownership
+
+TrackDraw should make it easier to distinguish:
+
+- what is a crash-recovery draft
+- what is a named local project
+- what is a restore point
+- what is an account-backed project
+- what is a published read-only snapshot
+
+This is one of the highest-value usability improvements because it improves project continuity even without any new headline feature.
+
+### 4. Improve Undo Grouping Around Intent
+
+TrackDraw should preserve the current fast editing feel, but make undo/redo cleaner around:
+
+- drag sessions
+- rotation sessions
+- path editing sessions
+- grouped inspector edits
+
+That would improve day-to-day editing quality directly.
+
+## Concrete Implementation Direction
+
+This should be handled as an incremental refactor with behavior-preserving checkpoints.
+
+### Phase 1. State Ownership
+
+Goal:
+
+- make current boundaries explicit without changing major behavior
+
+Phase starts when:
+
+- the current store still mixes track data, session state, and temporary UI state in one broad surface
+- there is not yet one agreed ownership table for editor state
+
+Concrete changes:
+
+- define and document which editor fields are `track data`, `session`, and `temporary UI state`
+- stop treating `selection` as if it lives on the same conceptual level as the saved track data
+- make the store API reflect those state boundaries more clearly
+
+Likely files:
+
+- [src/store/editor.ts](../../src/store/editor.ts)
+- [src/lib/editor/store-types.ts](../../src/lib/editor/store-types.ts)
+- [src/lib/editor/store-state.ts](../../src/lib/editor/store-state.ts)
+
+Phase is done when:
+
+- track-data-changing actions are easy to identify
+- non-track-data fields are easy to identify
+- no user-facing behavior regression
+
+Checklist:
+
+- [x] Document all current editor store fields as `track data`, `session`, or `temporary UI state`
+- [x] Confirm `selection` is treated as session state, not track data
+- [x] Confirm `historyPaused`, `historySessionDepth`, and `interactionSessionDepth` are treated as session state
+- [x] Confirm hover, draft, preview, and camera/canvas fields are treated as temporary UI state
+- [x] Update store types or naming where needed so the ownership split is obvious in code
+- [x] Verify no saved design payload depends on session or temporary UI state
+
+### Phase 2. Track Data Actions
+
+Goal:
+
+- make meaningful track data edits easier to reason about and test
+
+Phase starts when:
+
+- phase 1 ownership is clear enough to tell which store methods change track data
+- the store API still mixes track-data-changing actions and UI-only setters too closely
+
+Concrete changes:
+
+- group track-data-changing store methods under clearer structure
+- keep temporary-UI-only setters separate from track-data-changing setters
+- centralize updated-at changes for track data edits where practical
+
+Examples of track data actions:
+
+- add, duplicate, remove, reorder, rotate, or nudge shapes
+- edit route/polyline content
+- update field settings
+- update design metadata
+- replace or create a project track
+
+Examples of non-track-data actions:
+
+- set hover state
+- set zoom or pan
+- set marquee state
+- set draft path state
+- set live preview patches
+
+Likely files:
+
+- [src/store/editor.ts](../../src/store/editor.ts)
+- [src/lib/editor/shape-mutations.ts](../../src/lib/editor/shape-mutations.ts)
+
+Phase is done when:
+
+- the store API makes it obvious what changes the track data and what does not
+- tests can target track data mutations separately from temporary UI updates
+
+Checklist:
+
+- [x] Identify every store method that changes `design`
+- [x] Identify every store method that only changes session or temporary UI state
+- [x] Group or rename track-data-changing methods so they are easier to distinguish from UI-only setters
+- [x] Centralize `updatedAt` handling for track data edits where practical
+- [x] Ensure track-data-changing actions do not also mutate unrelated temporary UI state unless truly necessary
+- [x] Ensure temporary-UI-only setters do not affect saved project state or document history
+
+### Phase 3. Persistence Rules
+
+Goal:
+
+- make project continuity easier to understand for both implementation and user behavior
+
+Phase starts when:
+
+- phase 2 makes it clear which changes count as real track changes
+- autosave, local projects, restore points, account projects, and published shares still feel too loosely defined next to each other
+
+Concrete changes:
+
+- define a clear hierarchy for:
+  - crash-recovery draft
+  - named local project
+  - restore point
+  - account-backed project
+  - published share
+- ensure autosave is tied to track data changes rather than incidental UI state
+- document how switching projects, importing, restoring, and publishing interact
+
+Likely files:
+
+- [src/hooks/useEditorProjects.ts](../../src/hooks/useEditorProjects.ts)
+- [src/lib/projects.ts](../../src/lib/projects.ts)
+- [src/app/api/projects/route.ts](../../src/app/api/projects/route.ts)
+- [src/app/api/shares/route.ts](../../src/app/api/shares/route.ts)
+
+Phase is done when:
+
+- the persistence model can be explained in one short internal diagram or table
+- autosave behavior is intentionally tied to track data change boundaries
+- restore/share/project flows no longer feel like parallel concepts with fuzzy overlap
+
+Checklist:
+
+- [x] Write down the intended role of local autosave
+- [x] Write down the intended role of named local projects
+- [x] Write down the intended role of restore points
+- [x] Write down the intended role of account-backed projects
+- [x] Write down the intended role of published shares
+- [x] Confirm which actions should trigger local autosave
+- [x] Confirm which actions should create or update local projects
+- [x] Confirm switching/opening/restoring/importing behavior against the intended persistence hierarchy
+- [x] Ensure persistence code follows track-data change boundaries rather than incidental UI updates
+
+### Persistence Hierarchy
+
+| Layer | Role | Updated by |
+| --- | --- | --- |
+| Local draft | Crash-recovery working state for the current device/tab | Any committed track-data change once interaction/history sessions settle |
+| Named local project | Deliberate device-side continuity for reopening a project later | Track-data changes for designs with meaningful project content |
+| Restore point | Earlier snapshot of one local/account project state | Manual snapshot, periodic snapshot, or save-before-replace flows |
+| Account-backed project | Authenticated cross-device continuity and ownership | Explicit sync or autosync after committed track-data changes |
+| Published share | Read-only handoff snapshot | Explicit publish action only |
+
+Autosave trigger rules in the current implementation:
+
+- local draft writes after committed track-data revisions, not UI-only state changes
+- named local project writes after committed track-data revisions when the design has meaningful project content
+- restore points only write through explicit snapshot or periodic snapshot flows
+- account autosync only runs for account-backed projects after committed track-data revisions
+- published shares only change when the user republishes
+
+### Phase 4. Undo And Redo Behavior
+
+Goal:
+
+- keep the current fast editor feel while making undo/redo cleaner
+
+Phase starts when:
+
+- the ownership split and persistence rules are clear enough to define what should and should not enter history
+- current drag, rotate, or route-edit flows still feel noisier than they should in undo/redo
+
+Concrete changes:
+
+- identify which edit sessions should collapse into one history step
+- treat drag, rotate, and route edit sessions as meaningful grouped edits where possible
+- keep view/canvas changes out of track data history
+
+Likely files:
+
+- [src/store/editor.ts](../../src/store/editor.ts)
+- [src/hooks/useUndoRedo.ts](../../src/hooks/useUndoRedo.ts)
+- canvas interaction hooks that currently pause/resume history
+
+Phase is done when:
+
+- drag and rotate interactions do not create noisy history
+- undo/redo behavior feels more intentional without removing precision when needed
+
+Checklist:
+
+- [x] Identify the current interactions that pause and resume history
+- [x] Define which edit flows should collapse into one meaningful undo step
+- [x] Define which edit flows should remain granular
+- [x] Ensure zoom, pan, hover, and other view-only changes never pollute track data history
+- [x] Verify drag sessions create clean undo behavior
+- [x] Verify rotation sessions create clean undo behavior
+- [x] Verify route/polyline editing history feels deliberate rather than noisy
+
+Current grouped history sessions:
+
+- keyboard nudge and rotate batches collapse repeated key presses into one interaction session
+- inspector numeric drags collapse one pointer/edit session into one history step
+- 2D rotation guide interactions commit one final rotation at pointer-up
+- 3D elevation, rotation, tilt, and ladder-elevation drags commit one final track change at drag end
+- view-only updates such as hover, zoom, pan, marquee previews, live shape patches, and rotation previews stay out of temporal document history
+
+## Scope Limits
+
+To keep this implementation tractable, the first pass should explicitly avoid:
+
+- rewriting the whole store into multiple Zustand stores unless it proves necessary
+- introducing collaboration-specific transport or CRDT concerns
+- redesigning project/account UI at the same time
+- changing publish/share product behavior beyond clarifying persistence ownership
+
+This work should stay focused on editor clarity and persistence reliability.
+
+## Why This Is Worth Doing Even Without Collaboration
+
+This foundation work creates direct product value now:
+
+- clearer autosave and project continuity
+- less editor state confusion
+- cleaner undo and redo behavior
+- easier testing for fragile editing flows
+- better hooks for analysis, review, and publishing improvements
+
+It also lowers the cost of future work in:
+
+- collaboration
+- anchored review
+- published gallery
+- richer account-backed project behavior
+
+## Suggested First Step
+
+The best first step is not a full store rewrite.
+
+It is:
+
+1. define what belongs to persistent track data
+2. define what belongs to temporary UI state
+3. identify which actions should count as meaningful history entries
+4. document the persistence hierarchy across local draft, local project, restore point, account project, and published share
+
+That would already make future implementation work much safer.
+
+## Decision Table
+
+This is the practical baseline for implementation.
+
+### Persisted In The Saved Design
+
+- field settings
+- shape order
+- shape data
+- route/path geometry
+- title, description, tags, author, inventory
+
+### Persisted Across Reload Only For Local Recovery
+
+- current draft track
+- named local projects
+- restore points
+
+### Kept Only In The Current Editor Session
+
+- current selection
+- active tool
+- active preset
+- history session state
+
+### Purely Transient UI State
+
+- hover state
+- zoom and pan
+- marquee state
+- draft path state
+- rotation preview
+- group drag preview
+- live shape patches
+
+## Implementation Checklist
+
+Use this as the short version when turning the research into work.
+
+### Phase Order
+
+- [x] Phase 1 complete: State Ownership
+- [x] Phase 2 complete: Track Data Actions
+- [x] Phase 3 complete: Persistence Rules
+- [x] Phase 4 complete: Undo And Redo Behavior
+
+### State Ownership
+
+- [ ] Separate editor concerns into `track data`, `session`, and `temporary UI state`
+- [ ] Keep `TrackDesign` and field/meta changes in the track data boundary
+- [ ] Keep `selection` and history session fields out of the track data boundary
+- [ ] Keep hover, preview, zoom/pan, and draft interaction fields fully temporary UI state
+
+### Store API
+
+- [ ] Make track-data-changing actions clearly identifiable
+- [ ] Make temporary-UI-only setters clearly identifiable
+- [ ] Reduce mixed actions that touch both track data and temporary UI state
+
+### Persistence
+
+- [x] Tie autosave to track data changes
+- [x] Clarify the role of local draft, local project, restore point, account project, and published share
+- [x] Verify persistence flows against open, import, restore, and publish behavior
+
+### History
+
+- [x] Group meaningful edit sessions more deliberately
+- [x] Keep view-only changes out of undo/redo
+- [x] Validate drag, rotate, and route editing history behavior
+
+### Validation
+
+- [ ] Check that saved design payloads only contain track data
+- [ ] Check that reload/recovery behavior still works
+- [ ] Check that project open/restore/import behavior still works
+- [ ] Check that share/publish behavior is unaffected
+- [ ] Run `npm run lint`
+- [ ] Run `npm run type`
+
+## Ready-For-Implementation Outcome
+
+After this research pass, the implementation brief should be:
+
+1. formalize the current store into explicit track data, session, and temporary UI state groups
+2. separate track-data-changing actions from temporary-UI-only setters
+3. tie autosave and persistence behavior more explicitly to track data changes
+4. clean up undo/redo grouping around meaningful edit sessions
+
+That is concrete enough to move from research into implementation.
+
+## Recommendation
+
+This should be treated as worthwhile foundation work, not as hidden collaboration work.
+
+It improves TrackDraw on its own merits and makes multiple future roadmap items easier, including collaboration if that ever becomes strategically important.
+
+## References
+
+- Editor store: [src/store/editor.ts](../../src/store/editor.ts)
+- Local project persistence: [src/lib/projects.ts](../../src/lib/projects.ts)
+- Autosave and restore workflow: [src/hooks/useEditorProjects.ts](../../src/hooks/useEditorProjects.ts)
+- Design serialization: [src/lib/track/design.ts](../../src/lib/track/design.ts)
+- Account project API: [src/app/api/projects/route.ts](../../src/app/api/projects/route.ts)
+- Published share API: [src/app/api/shares/route.ts](../../src/app/api/shares/route.ts)

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -142,9 +142,12 @@ Important boundary:
 
 Improve the core editor model so TrackDraw stays easier to reason about, project continuity is clearer, and future review or collaboration work does not require a full editor reset.
 
+Completed.
+The editor store now separates track, session, and local UI state more explicitly, action ownership is clearer in code, local draft versus project versus restore-point persistence is more deliberate, and grouped history sessions now better match drag, rotate, and inspector editing intent.
+
 Suggested first slices:
 
-- Split persistent document state from transient local UI state such as active tools, hover state, marquee state, and drag previews
+- Split persistent document state from local UI state such as active tools, hover state, marquee state, and drag previews
 - Introduce clearer action boundaries for meaningful editor changes so testing, analysis hooks, and future sync-related work have better integration points
 - Clarify the boundaries between local autosave, restore points, saved projects, account-backed projects, and published shares
 - Make undo and redo more intention-aware so drag, rotate, and route editing sessions produce cleaner history

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -39,15 +39,15 @@ Labels used below:
 
 ## Engineering Foundation
 
-- [ ] Editor state and persistence boundary pass (`No account required`)
+- [x] Editor state and persistence boundary pass (`No account required`)
       Improve core editor boundaries so TrackDraw stays easier to reason about, autosave and project continuity become clearer, and future collaboration or review work does not require a full reset of the editor model.
-  - [ ] Separate document state from transient UI state
+  - [x] Separate document state from local UI state
         Split persistent track data more clearly from local interaction state such as tool mode, hover state, drag previews, and temporary selections.
-  - [ ] Introduce clearer editor action boundaries
+  - [x] Introduce clearer editor action boundaries
         Move toward more explicit editor actions for meaningful changes so undo, testing, analysis hooks, and future sync-related work all have cleaner integration points.
-  - [ ] Clarify persistence layers
+  - [x] Clarify persistence layers
         Tighten the boundaries between local autosave, restore points, saved projects, account-backed projects, and published shares so the user model stays easier to understand.
-  - [ ] Make undo and redo more intention-aware
+  - [x] Make undo and redo more intention-aware
         Group meaningful edit sessions more deliberately so history feels cleaner during drag, rotate, and route editing work.
 
 - [ ] Test infrastructure
@@ -68,7 +68,7 @@ Labels used below:
   - [x] Remaining large-file splits
         Break up any remaining oversized files identified in the audit, especially where editor composition and mobile/desktop orchestration still live together.
   - [x] Reduce cross-module coupling in editor state
-        Moved shared editor-store state shapes into dedicated types, centralized transient/session reset profiles, and reduced duplicated store wiring so state changes stay more local to the editor boundary.
+        Moved shared editor-store state shapes into dedicated types, centralized UI/session reset profiles, and reduced duplicated store wiring so state changes stay more local to the editor boundary.
 
 ## Follow-up
 
@@ -434,7 +434,3 @@ Labels used below:
         Continue tightening folder ownership and splitting broad components and modules where internal navigation and safe iteration are still harder than they should be.
 
 </details>
-
----
-
-_Last updated: 11 April 2026_

--- a/src/components/canvas/TrackCanvas.tsx
+++ b/src/components/canvas/TrackCanvas.tsx
@@ -159,7 +159,9 @@ const TrackCanvas = memo(
     const vertexSel = useEditor((state) => state.ui.vertexSelection);
     const draftPath = useEditor((state) => state.ui.draftPath);
     const draftForceClosed = useEditor((state) => state.ui.draftForceClosed);
-    const draftSourceShapeId = useEditor((state) => state.ui.draftSourceShapeId);
+    const draftSourceShapeId = useEditor(
+      (state) => state.ui.draftSourceShapeId
+    );
     const marqueeRect = useEditor((state) => state.ui.marqueeRect);
     const rotationSession = useEditor((state) => state.ui.rotationSession);
     const groupDragPreview = useEditor((state) => state.ui.groupDragPreview);

--- a/src/components/canvas/TrackCanvas.tsx
+++ b/src/components/canvas/TrackCanvas.tsx
@@ -31,7 +31,13 @@ import {
 } from "@/components/canvas/renderers";
 import { useTrackCanvasShortcuts } from "@/components/canvas/useTrackCanvasShortcuts";
 import { useTrackCanvasViewport } from "@/components/canvas/useTrackCanvasViewport";
+import { useHistorySession } from "@/hooks/useHistorySession";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
+import {
+  useSessionActions,
+  useTrackActions,
+  useUiActions,
+} from "@/store/actions";
 import { useEditor } from "@/store/editor";
 import {
   selectDesignShapes,
@@ -113,70 +119,64 @@ const TrackCanvas = memo(
     ref
   ) {
     usePerfMetric("render:TrackCanvas");
-    const design = useEditor((state) => state.design);
+    const design = useEditor((state) => state.track.design);
     const designShapes = useEditor(selectDesignShapes);
     const [zmin, zmax] = useEditor(selectDesignPolylineZRange);
     const shapeById = useEditor(selectShapeRecordMap);
     const primaryPolylineId = useEditor(
       (state) => selectPrimaryPolyline(state)?.id ?? null
     );
-    const selection = useEditor((state) => state.selection);
-    const setSelection = useEditor((state) => state.setSelection);
-    const updateShape = useEditor((state) => state.updateShape);
-    const setShapesLocked = useEditor((state) => state.setShapesLocked);
-    const insertPolylinePoint = useEditor((state) => state.insertPolylinePoint);
-    const setPolylinePoints = useEditor((state) => state.setPolylinePoints);
-    const removePolylinePoint = useEditor((state) => state.removePolylinePoint);
-    const addShape = useEditor((state) => state.addShape);
-    const addShapes = useEditor((state) => state.addShapes);
-    const activeTool = useEditor((state) => state.transient.activeTool);
-    const activePresetId = useEditor((state) => state.transient.activePresetId);
-    const segmentSel = useEditor((state) => state.transient.segmentSelection);
-    const vertexSel = useEditor((state) => state.transient.vertexSelection);
-    const draftPath = useEditor((state) => state.transient.draftPath);
-    const draftForceClosed = useEditor(
-      (state) => state.transient.draftForceClosed
-    );
-    const draftSourceShapeId = useEditor(
-      (state) => state.transient.draftSourceShapeId
-    );
-    const marqueeRect = useEditor((state) => state.transient.marqueeRect);
-    const rotationSession = useEditor(
-      (state) => state.transient.rotationSession
-    );
-    const groupDragPreview = useEditor(
-      (state) => state.transient.groupDragPreview
-    );
-    const setActiveTool = useEditor((state) => state.setActiveTool);
-    const setSegmentSel = useEditor((state) => state.setSegmentSelection);
-    const setVertexSel = useEditor((state) => state.setVertexSelection);
-    const setDraftPath = useEditor((state) => state.setDraftPath);
-    const setDraftForceClosed = useEditor((state) => state.setDraftForceClosed);
-    const setDraftSourceShapeId = useEditor(
-      (state) => state.setDraftSourceShapeId
-    );
-    const setMarqueeRect = useEditor((state) => state.setMarqueeRect);
-    const setRotationSession = useEditor((state) => state.setRotationSession);
-    const setGroupDragPreview = useEditor((state) => state.setGroupDragPreview);
-    const rotateShapes = useEditor((state) => state.rotateShapes);
-    const removeShapes = useEditor((state) => state.removeShapes);
-    const duplicateShapes = useEditor((state) => state.duplicateShapes);
-    const groupSelection = useEditor((state) => state.groupSelection);
-    const joinPolylines = useEditor((state) => state.joinPolylines);
-    const closePolyline = useEditor((state) => state.closePolyline);
-    const nudgeShapes = useEditor((state) => state.nudgeShapes);
-    const ungroupSelection = useEditor((state) => state.ungroupSelection);
-    const pauseHistory = useEditor((state) => state.pauseHistory);
-    const resumeHistory = useEditor((state) => state.resumeHistory);
-    const beginInteraction = useEditor((state) => state.beginInteraction);
-    const endInteraction = useEditor((state) => state.endInteraction);
-    const setZoom = useEditor((state) => state.setZoom);
-    const hoveredShapeId = useEditor((state) => state.transient.hoveredShapeId);
-    const hoveredWaypoint = useEditor(
-      (state) => state.transient.hoveredWaypoint
-    );
-    const bringForward = useEditor((state) => state.bringForward);
-    const sendBackward = useEditor((state) => state.sendBackward);
+    const selection = useEditor((state) => state.session.selection);
+    const {
+      setSelection,
+      pauseHistory,
+      resumeHistory,
+      beginInteraction,
+      endInteraction,
+    } = useSessionActions();
+    const {
+      updateShape,
+      setShapesLocked,
+      insertPolylinePoint,
+      setPolylinePoints,
+      removePolylinePoint,
+      addShape,
+      addShapes,
+      rotateShapes,
+      removeShapes,
+      duplicateShapes,
+      groupSelection,
+      joinPolylines,
+      closePolyline,
+      nudgeShapes,
+      ungroupSelection,
+      bringForward,
+      sendBackward,
+    } = useTrackActions();
+    const activeTool = useEditor((state) => state.ui.activeTool);
+    const activePresetId = useEditor((state) => state.ui.activePresetId);
+    const segmentSel = useEditor((state) => state.ui.segmentSelection);
+    const vertexSel = useEditor((state) => state.ui.vertexSelection);
+    const draftPath = useEditor((state) => state.ui.draftPath);
+    const draftForceClosed = useEditor((state) => state.ui.draftForceClosed);
+    const draftSourceShapeId = useEditor((state) => state.ui.draftSourceShapeId);
+    const marqueeRect = useEditor((state) => state.ui.marqueeRect);
+    const rotationSession = useEditor((state) => state.ui.rotationSession);
+    const groupDragPreview = useEditor((state) => state.ui.groupDragPreview);
+    const {
+      setActiveTool,
+      setSegmentSelection: setSegmentSel,
+      setVertexSelection: setVertexSel,
+      setDraftPath,
+      setDraftForceClosed,
+      setDraftSourceShapeId,
+      setMarqueeRect,
+      setRotationSession,
+      setGroupDragPreview,
+      setZoom,
+    } = useUiActions();
+    const hoveredShapeId = useEditor((state) => state.ui.hoveredShapeId);
+    const hoveredWaypoint = useEditor((state) => state.ui.hoveredWaypoint);
 
     const estimateRotationGuideRadiusPx = useCallback(
       (shape: Shape) => {
@@ -208,11 +208,19 @@ const TrackCanvas = memo(
     >("none");
     const syncFrameRef = useRef<number | null>(null);
     const rotationSessionRef = useRef(rotationSession);
-    const resumeHistoryRef = useRef(resumeHistory);
     const updateShapeRef = useRef(updateShape);
     const rotationEffectSessionKeyRef = useRef<string | null>(null);
     const rotationEffectCleanupRef = useRef<(() => void) | null>(null);
-    const rotationEffectResumedRef = useRef(false);
+    const {
+      startSession: startRotationHistorySession,
+      finishSession: finishRotationHistorySession,
+      cancelSession: cancelRotationHistorySession,
+    } = useHistorySession({
+      beginInteraction,
+      endInteraction,
+      pauseHistory,
+      resumeHistory,
+    });
 
     const [cursor, setCursor] = useState<CursorState | null>(null);
     const [snapTarget, setSnapTarget] = useState<{
@@ -311,10 +319,6 @@ const TrackCanvas = memo(
     useEffect(() => {
       rotationSessionRef.current = rotationSession;
     }, [rotationSession]);
-
-    useEffect(() => {
-      resumeHistoryRef.current = resumeHistory;
-    }, [resumeHistory]);
 
     useEffect(() => {
       updateShapeRef.current = updateShape;
@@ -1247,7 +1251,6 @@ const TrackCanvas = memo(
       rotationEffectCleanupRef.current?.();
       rotationEffectCleanupRef.current = null;
       rotationEffectSessionKeyRef.current = sessionKey;
-      rotationEffectResumedRef.current = false;
 
       if (!session) return;
 
@@ -1306,16 +1309,12 @@ const TrackCanvas = memo(
 
       const handlePointerUp = () => {
         const activeSession = rotationSessionRef.current;
-        if (!rotationEffectResumedRef.current) {
-          resumeHistoryRef.current();
-          rotationEffectResumedRef.current = true;
-        }
-        if (activeSession) {
+        finishRotationHistorySession(() => {
+          if (!activeSession) return;
           updateShapeRef.current(activeSession.shapeId, {
             rotation: activeSession.previewRotation,
           });
-        }
-        endInteraction();
+        });
         setRotationSession(null);
       };
 
@@ -1326,11 +1325,7 @@ const TrackCanvas = memo(
         window.removeEventListener("touchmove", handleTouchMove);
         window.removeEventListener("touchend", handlePointerUp);
         window.removeEventListener("touchcancel", handlePointerUp);
-        if (!rotationEffectResumedRef.current) {
-          resumeHistoryRef.current();
-          rotationEffectResumedRef.current = true;
-        }
-        endInteraction();
+        cancelRotationHistorySession();
       };
 
       window.addEventListener("mousemove", handleMouseMove);
@@ -1342,7 +1337,11 @@ const TrackCanvas = memo(
       window.addEventListener("touchcancel", handlePointerUp);
 
       rotationEffectCleanupRef.current = cleanup;
-    });
+    }, [
+      cancelRotationHistorySession,
+      finishRotationHistorySession,
+      setRotationSession,
+    ]);
 
     useEffect(
       () => () => {
@@ -1778,8 +1777,7 @@ const TrackCanvas = memo(
                     const stage = stageRef.current;
                     const pointer = stage?.getRelativePointerPosition();
                     if (!pointer) return;
-                    beginInteraction();
-                    pauseHistory();
+                    startRotationHistorySession();
 
                     const startAngle =
                       (Math.atan2(

--- a/src/components/canvas/TrackPreview3D.tsx
+++ b/src/components/canvas/TrackPreview3D.tsx
@@ -101,8 +101,13 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
     usePerfMetric("render:TrackPreview3D");
     const field = useEditor((state) => state.track.design.field);
     const selection = useEditor((state) => state.session.selection);
-    const { setSelection, pauseHistory, resumeHistory, beginInteraction, endInteraction } =
-      useSessionActions();
+    const {
+      setSelection,
+      pauseHistory,
+      resumeHistory,
+      beginInteraction,
+      endInteraction,
+    } = useSessionActions();
     const { setPolylinePoints, updateShape } = useTrackActions();
     const { setLiveShapePatch, clearLiveShapePatch } = useUiActions();
     const shapes = useEditor(selectDesignShapes);

--- a/src/components/canvas/TrackPreview3D.tsx
+++ b/src/components/canvas/TrackPreview3D.tsx
@@ -31,6 +31,11 @@ import {
 } from "@/store/selectors";
 import { useEditor } from "@/store/editor";
 import {
+  useSessionActions,
+  useTrackActions,
+  useUiActions,
+} from "@/store/actions";
+import {
   CameraAxisTracker,
   CameraCapture,
   DiveGateTiltHandle3D,
@@ -94,17 +99,12 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
     ref
   ) {
     usePerfMetric("render:TrackPreview3D");
-    const field = useEditor((state) => state.design.field);
-    const selection = useEditor((state) => state.selection);
-    const setSelection = useEditor((state) => state.setSelection);
-    const pauseHistory = useEditor((state) => state.pauseHistory);
-    const resumeHistory = useEditor((state) => state.resumeHistory);
-    const beginInteraction = useEditor((state) => state.beginInteraction);
-    const endInteraction = useEditor((state) => state.endInteraction);
-    const setPolylinePoints = useEditor((state) => state.setPolylinePoints);
-    const updateShape = useEditor((state) => state.updateShape);
-    const setLiveShapePatch = useEditor((state) => state.setLiveShapePatch);
-    const clearLiveShapePatch = useEditor((state) => state.clearLiveShapePatch);
+    const field = useEditor((state) => state.track.design.field);
+    const selection = useEditor((state) => state.session.selection);
+    const { setSelection, pauseHistory, resumeHistory, beginInteraction, endInteraction } =
+      useSessionActions();
+    const { setPolylinePoints, updateShape } = useTrackActions();
+    const { setLiveShapePatch, clearLiveShapePatch } = useUiActions();
     const shapes = useEditor(selectDesignShapes);
     const hasPath = useEditor(selectHasPath);
     const primaryPolyline = useEditor(selectPrimaryPolyline);

--- a/src/components/canvas/useTrackCanvasShortcuts.ts
+++ b/src/components/canvas/useTrackCanvasShortcuts.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { type RefObject, useEffect, useRef } from "react";
+import { useHistorySession } from "@/hooks/useHistorySession";
 import { isPolylineShape } from "@/lib/track/shape-utils";
 import type { EditorTool } from "@/lib/editor-tools";
 import type { Shape, ShapeDraft } from "@/lib/types";
@@ -79,15 +80,46 @@ export function useTrackCanvasShortcuts({
   endInteraction,
 }: TrackCanvasShortcutsParams) {
   const keyboardBatchTimeoutRef = useRef<number | null>(null);
-  const keyboardBatchActiveRef = useRef(false);
+  const activeToolRef = useRef(activeTool);
+  const designFieldGridStepRef = useRef(designFieldGridStep);
+  const shapeByIdRef = useRef(shapeById);
+  const draftPathRef = useRef(draftPath);
+  const selectionRef = useRef(selection);
+  const effectiveVertexSelRef = useRef(effectiveVertexSel);
+  const { startSession, finishSession, cancelSession } = useHistorySession({
+    beginInteraction,
+    endInteraction,
+    pauseHistory,
+    resumeHistory,
+  });
+
+  useEffect(() => {
+    activeToolRef.current = activeTool;
+  }, [activeTool]);
+
+  useEffect(() => {
+    designFieldGridStepRef.current = designFieldGridStep;
+  }, [designFieldGridStep]);
+
+  useEffect(() => {
+    shapeByIdRef.current = shapeById;
+  }, [shapeById]);
+
+  useEffect(() => {
+    draftPathRef.current = draftPath;
+  }, [draftPath]);
+
+  useEffect(() => {
+    selectionRef.current = selection;
+  }, [selection]);
+
+  useEffect(() => {
+    effectiveVertexSelRef.current = effectiveVertexSel;
+  }, [effectiveVertexSel]);
 
   useEffect(() => {
     const beginKeyboardBatch = () => {
-      if (!keyboardBatchActiveRef.current) {
-        keyboardBatchActiveRef.current = true;
-        beginInteraction();
-        pauseHistory();
-      }
+      startSession();
 
       if (keyboardBatchTimeoutRef.current !== null) {
         window.clearTimeout(keyboardBatchTimeoutRef.current);
@@ -95,17 +127,14 @@ export function useTrackCanvasShortcuts({
 
       keyboardBatchTimeoutRef.current = window.setTimeout(() => {
         keyboardBatchTimeoutRef.current = null;
-        if (!keyboardBatchActiveRef.current) return;
-        keyboardBatchActiveRef.current = false;
-        resumeHistory();
-        endInteraction();
+        finishSession();
       }, 220);
     };
 
     const rotateSelection = (delta: number) => {
       beginKeyboardBatch();
-      const rotatableIds = selection.filter((id) => {
-        const shape = shapeById[id];
+      const rotatableIds = selectionRef.current.filter((id) => {
+        const shape = shapeByIdRef.current[id];
         return Boolean(shape && canRotateShape(shape));
       });
       if (rotatableIds.length) {
@@ -128,7 +157,7 @@ export function useTrackCanvasShortcuts({
 
       if (meta && event.key === "d") {
         event.preventDefault();
-        if (selection.length) duplicateShapes(selection);
+        if (selectionRef.current.length) duplicateShapes(selectionRef.current);
         return;
       }
 
@@ -140,8 +169,8 @@ export function useTrackCanvasShortcuts({
         clipboard.splice(
           0,
           clipboard.length,
-          ...selection
-            .map((id) => shapeById[id])
+          ...selectionRef.current
+            .map((id) => shapeByIdRef.current[id])
             .filter((shape): shape is Shape => Boolean(shape))
         );
         return;
@@ -176,12 +205,12 @@ export function useTrackCanvasShortcuts({
         ["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(
           event.key
         ) &&
-        selection.length > 0 &&
-        activeTool === "select"
+        selectionRef.current.length > 0 &&
+        activeToolRef.current === "select"
       ) {
         event.preventDefault();
         beginKeyboardBatch();
-        const step = event.altKey ? 0.1 : designFieldGridStep;
+        const step = event.altKey ? 0.1 : designFieldGridStepRef.current;
         const dx =
           event.key === "ArrowLeft"
             ? -step
@@ -194,14 +223,14 @@ export function useTrackCanvasShortcuts({
             : event.key === "ArrowDown"
               ? step
               : 0;
-        nudgeShapes(selection, dx, dy);
+        nudgeShapes(selectionRef.current, dx, dy);
         return;
       }
 
       if (
         ["[", "]", "q", "e", "Q", "E"].includes(event.key) &&
-        selection.length > 0 &&
-        activeTool === "select"
+        selectionRef.current.length > 0 &&
+        activeToolRef.current === "select"
       ) {
         event.preventDefault();
         const step = event.altKey ? 1 : event.shiftKey ? 5 : 15;
@@ -219,7 +248,7 @@ export function useTrackCanvasShortcuts({
 
       const key = event.key;
       if (key === "Escape") {
-        if (draftPath.length) cancelDraftPath();
+        if (draftPathRef.current.length) cancelDraftPath();
         else {
           setSelection([]);
           setVertexSel(null);
@@ -227,26 +256,26 @@ export function useTrackCanvasShortcuts({
         }
       }
 
-      if (key === "Enter" && draftPath.length >= 2) finalizePath();
+      if (key === "Enter" && draftPathRef.current.length >= 2) finalizePath();
 
       if (key === "Backspace" || key === "Delete") {
-        if (draftPath.length && activeTool === "polyline") {
+        if (draftPathRef.current.length && activeToolRef.current === "polyline") {
           setDraftPath((previous) =>
             previous.slice(0, Math.max(0, previous.length - 1))
           );
           return;
         }
 
-        if (effectiveVertexSel) {
-          const shape = shapeById[effectiveVertexSel.shapeId];
+        if (effectiveVertexSelRef.current) {
+          const shape = shapeByIdRef.current[effectiveVertexSelRef.current.shapeId];
           if (shape && isPolylineShape(shape)) {
-            removePolylinePoint(shape.id, effectiveVertexSel.idx);
+            removePolylinePoint(shape.id, effectiveVertexSelRef.current.idx);
           }
           setVertexSel(null);
           return;
         }
 
-        if (selection.length) removeShapes(selection);
+        if (selectionRef.current.length) removeShapes(selectionRef.current);
       }
 
       switch (key.toLowerCase()) {
@@ -290,37 +319,26 @@ export function useTrackCanvasShortcuts({
         window.clearTimeout(keyboardBatchTimeoutRef.current);
         keyboardBatchTimeoutRef.current = null;
       }
-      if (keyboardBatchActiveRef.current) {
-        keyboardBatchActiveRef.current = false;
-        resumeHistory();
-        endInteraction();
-      }
+      cancelSession();
     };
   }, [
-    activeTool,
     addShapes,
-    beginInteraction,
     cancelDraftPath,
+    cancelSession,
     containerRef,
-    designFieldGridStep,
-    shapeById,
-    draftPath,
     duplicateShapes,
-    endInteraction,
-    effectiveVertexSel,
     finalizePath,
+    finishSession,
     fitFieldToViewport,
     nudgeShapes,
-    pauseHistory,
     removeShapes,
     removePolylinePoint,
-    resumeHistory,
     rotateShapes,
-    selection,
     setActiveTool,
     setDraftPath,
     setManualView,
     setSelection,
     setVertexSel,
+    startSession,
   ]);
 }

--- a/src/components/canvas/useTrackCanvasShortcuts.ts
+++ b/src/components/canvas/useTrackCanvasShortcuts.ts
@@ -259,7 +259,10 @@ export function useTrackCanvasShortcuts({
       if (key === "Enter" && draftPathRef.current.length >= 2) finalizePath();
 
       if (key === "Backspace" || key === "Delete") {
-        if (draftPathRef.current.length && activeToolRef.current === "polyline") {
+        if (
+          draftPathRef.current.length &&
+          activeToolRef.current === "polyline"
+        ) {
           setDraftPath((previous) =>
             previous.slice(0, Math.max(0, previous.length - 1))
           );
@@ -267,7 +270,8 @@ export function useTrackCanvasShortcuts({
         }
 
         if (effectiveVertexSelRef.current) {
-          const shape = shapeByIdRef.current[effectiveVertexSelRef.current.shapeId];
+          const shape =
+            shapeByIdRef.current[effectiveVertexSelRef.current.shapeId];
           if (shape && isPolylineShape(shape)) {
             removePolylinePoint(shape.id, effectiveVertexSelRef.current.idx);
           }

--- a/src/components/canvas/useTrackPreview3DInteractions.ts
+++ b/src/components/canvas/useTrackPreview3DInteractions.ts
@@ -9,6 +9,7 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from "react";
 import type { ThreeEvent } from "@react-three/fiber";
+import { useHistorySession } from "@/hooks/useHistorySession";
 import * as THREE from "three";
 import type {
   DiveGateShape,
@@ -74,6 +75,12 @@ export function useTrackPreview3DInteractions({
     startElevation: number;
   } | null>(null);
   const [isMiddleMousePanning, setIsMiddleMousePanning] = useState(false);
+  const { startSession, finishSession, cancelSession } = useHistorySession({
+    beginInteraction,
+    endInteraction,
+    pauseHistory,
+    resumeHistory,
+  });
 
   const elevationDragRef = useRef(elevationDrag);
   const elevationPreviewPointsRef = useRef<PolylinePoint[] | null>(
@@ -162,8 +169,7 @@ export function useTrackPreview3DInteractions({
       event.stopPropagation();
       const point = selectedPolyline?.points[index];
       if (!selectedPolyline || !point) return;
-      beginInteraction();
-      pauseHistory();
+      startSession();
       setSelection([selectedPolyline.id]);
       setElevationPreviewPoints(selectedPolyline.points);
       setElevationDrag({
@@ -173,7 +179,7 @@ export function useTrackPreview3DInteractions({
         startZ: point.z ?? 0,
       });
     },
-    [beginInteraction, pauseHistory, selectedPolyline, setSelection]
+    [selectedPolyline, setSelection, startSession]
   );
 
   const applyElevationDrag = useCallback(
@@ -219,11 +225,10 @@ export function useTrackPreview3DInteractions({
       const drag = elevationDragRef.current;
       const finalPoints = drag ? elevationPreviewPointsRef.current : null;
       cleanupListeners();
-      resumeHistory();
-      if (drag && finalPoints) {
+      finishSession(() => {
+        if (!drag || !finalPoints) return;
         setPolylinePoints(drag.shapeId, finalPoints);
-      }
-      endInteraction();
+      });
       setElevationPreviewPoints(null);
       setElevationDrag(null);
     };
@@ -263,13 +268,19 @@ export function useTrackPreview3DInteractions({
     window.addEventListener("touchcancel", stopDrag);
 
     return () => {
-      finishDrag();
+      if (finished) return;
+      finished = true;
+      cleanupListeners();
+      cancelSession(() => {
+        setElevationPreviewPoints(null);
+        setElevationDrag(null);
+      });
     };
   }, [
     applyElevationDrag,
+    cancelSession,
     elevationDrag,
-    endInteraction,
-    resumeHistory,
+    finishSession,
     setPolylinePoints,
   ]);
 
@@ -328,11 +339,10 @@ export function useTrackPreview3DInteractions({
         );
         if (angle !== null) startAngle = angle;
       }
-      beginInteraction();
-      pauseHistory();
+      startSession();
       setRotationDrag({ shapeId, startAngle, startRotation: currentRotation });
     },
-    [beginInteraction, pauseHistory, shapeById]
+    [shapeById, startSession]
   );
 
   useEffect(() => {
@@ -357,14 +367,13 @@ export function useTrackPreview3DInteractions({
       const drag = rotationDragRef.current;
       const finalRotation = rotationDragValueRef.current;
       cleanupListeners();
-      resumeHistory();
-      if (drag && finalRotation !== null) {
+      finishSession(() => {
+        if (!drag || finalRotation === null) return;
         updateShape(drag.shapeId, {
           rotation: snapRotationDegrees(finalRotation),
         });
-      }
+      });
       rotationDragValueRef.current = null;
-      endInteraction();
       setRotationDrag(null);
     };
 
@@ -408,12 +417,18 @@ export function useTrackPreview3DInteractions({
     window.addEventListener("touchcancel", stopDrag);
 
     return () => {
-      finishDrag();
+      if (finished) return;
+      finished = true;
+      cleanupListeners();
+      rotationDragValueRef.current = null;
+      cancelSession(() => {
+        setRotationDrag(null);
+      });
     };
   }, [
     applyRotationDrag,
-    endInteraction,
-    resumeHistory,
+    cancelSession,
+    finishSession,
     rotationDrag,
     updateShape,
   ]);
@@ -469,11 +484,10 @@ export function useTrackPreview3DInteractions({
       event.stopPropagation();
       const shape = shapeById[shapeId];
       if (!shape || shape.kind !== "divegate" || shape.locked) return;
-      beginInteraction();
-      pauseHistory();
+      startSession();
       setTiltDrag({ shapeId, startTilt: currentTilt });
     },
-    [beginInteraction, pauseHistory, shapeById]
+    [shapeById, startSession]
   );
 
   const applyLadderElevationDrag = useCallback(
@@ -509,8 +523,7 @@ export function useTrackPreview3DInteractions({
       event.stopPropagation();
       const shape = shapeById[shapeId];
       if (!shape || shape.kind !== "ladder" || shape.locked) return;
-      beginInteraction();
-      pauseHistory();
+      startSession();
       ladderElevationDragValueRef.current = currentElevation;
       setLadderElevationDrag({
         shapeId,
@@ -518,7 +531,7 @@ export function useTrackPreview3DInteractions({
         startElevation: currentElevation,
       });
     },
-    [beginInteraction, pauseHistory, shapeById]
+    [shapeById, startSession]
   );
 
   useEffect(() => {
@@ -543,12 +556,11 @@ export function useTrackPreview3DInteractions({
       const drag = tiltDragRef.current;
       const finalTilt = tiltDragValueRef.current;
       cleanupListeners();
-      resumeHistory();
-      if (drag && finalTilt !== null) {
+      finishSession(() => {
+        if (!drag || finalTilt === null) return;
         updateShape(drag.shapeId, { tilt: Math.round(finalTilt) });
-      }
+      });
       tiltDragValueRef.current = null;
-      endInteraction();
       setTiltDrag(null);
     };
 
@@ -587,9 +599,15 @@ export function useTrackPreview3DInteractions({
     window.addEventListener("touchcancel", stopDrag);
 
     return () => {
-      finishDrag();
+      if (finished) return;
+      finished = true;
+      cleanupListeners();
+      tiltDragValueRef.current = null;
+      cancelSession(() => {
+        setTiltDrag(null);
+      });
     };
-  }, [applyTiltDrag, endInteraction, resumeHistory, tiltDrag, updateShape]);
+  }, [applyTiltDrag, cancelSession, finishSession, tiltDrag, updateShape]);
 
   useEffect(() => {
     if (!ladderElevationDrag) return;
@@ -615,15 +633,15 @@ export function useTrackPreview3DInteractions({
       const drag = ladderElevationDragRef.current;
       const finalElevation = ladderElevationDragValueRef.current;
       cleanupListeners();
-      resumeHistory();
-      if (drag && finalElevation !== null) {
-        updateShape(drag.shapeId, { elevation: finalElevation });
-      }
-      if (drag) {
-        clearLiveShapePatch(drag.shapeId);
-      }
+      finishSession(() => {
+        if (drag && finalElevation !== null) {
+          updateShape(drag.shapeId, { elevation: finalElevation });
+        }
+        if (drag) {
+          clearLiveShapePatch(drag.shapeId);
+        }
+      });
       ladderElevationDragValueRef.current = null;
-      endInteraction();
       setLadderElevationDrag(null);
     };
 
@@ -664,14 +682,24 @@ export function useTrackPreview3DInteractions({
     window.addEventListener("touchcancel", stopDrag);
 
     return () => {
-      finishDrag();
+      if (finished) return;
+      finished = true;
+      cleanupListeners();
+      ladderElevationDragValueRef.current = null;
+      cancelSession(() => {
+        const drag = ladderElevationDragRef.current;
+        if (drag) {
+          clearLiveShapePatch(drag.shapeId);
+        }
+        setLadderElevationDrag(null);
+      });
     };
   }, [
     applyLadderElevationDrag,
+    cancelSession,
     clearLiveShapePatch,
-    endInteraction,
+    finishSession,
     ladderElevationDrag,
-    resumeHistory,
     updateShape,
   ]);
 

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -214,7 +214,7 @@ export default function ExportDialog({
   activeTab,
   onRequest3DView,
 }: ExportDialogProps) {
-  const design = useEditor((s) => s.design);
+  const design = useEditor((s) => s.track.design);
   const currentTheme = useTheme();
   const isMobile = useIsMobile();
   const [busy, setBusy] = useState<string | null>(null);

--- a/src/components/dialogs/ImportDialog.tsx
+++ b/src/components/dialogs/ImportDialog.tsx
@@ -4,7 +4,7 @@ import { useRef, useState, useCallback } from "react";
 import { MobileDrawer } from "@/components/MobileDrawer";
 import { DesktopModal } from "@/components/DesktopModal";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { useEditor } from "@/store/editor";
+import { useTrackActions } from "@/store/actions";
 import { cn } from "@/lib/utils";
 import { Upload, FileJson, AlertCircle, CheckCircle2 } from "lucide-react";
 import type { TrackDesign } from "@/lib/types";
@@ -24,7 +24,7 @@ export default function ImportDialog({
   onBackupCurrent,
   onBeforeConfirm,
 }: ImportDialogProps) {
-  const replaceDesign = useEditor((state) => state.replaceDesign);
+  const { replaceDesign } = useTrackActions();
   const isMobile = useIsMobile();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);

--- a/src/components/dialogs/ShareDialog.tsx
+++ b/src/components/dialogs/ShareDialog.tsx
@@ -79,7 +79,7 @@ function ShareContent({
   onSharePublished?: () => void;
   mobile?: boolean;
 }) {
-  const design = useEditor((s) => s.design);
+  const design = useEditor((s) => s.track.design);
   const shapeCount = useEditor(selectDesignShapeCount);
   const searchParams = useSearchParams();
   const { data: session } = authClient.useSession();

--- a/src/components/editor/AGENTS.md
+++ b/src/components/editor/AGENTS.md
@@ -32,7 +32,7 @@ Follow the repository-level guidance in the root `AGENTS.md` and keep contributo
 ## Component Design
 
 - Prefer deriving button disabled state from existing props rather than duplicating eligibility logic locally.
-- Keep transient UI state local only when it is purely presentational, such as temporary panel expansion.
+- Keep local UI state local only when it is purely presentational, such as temporary panel expansion.
 - If a component grows more complex, extract small focused subcomponents instead of adding deeply nested conditionals.
 - Never solve editor layout by nesting one card-like surface inside another card-like surface. Prefer spacing, dividers, typography, or grouping within a single surface before adding extra bordered containers.
 - The reason is product clarity: card-in-card layouts make hierarchy feel muddy, add unnecessary density, and can make action groups look bolted on instead of intentionally integrated.

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -136,8 +136,12 @@ export default function EditorShell({
     setShapesLocked,
     ungroupSelection,
   } = useTrackActions();
-  const { setActiveTool, setActivePresetId, setSegmentSelection, setVertexSelection } =
-    useUiActions();
+  const {
+    setActiveTool,
+    setActivePresetId,
+    setSegmentSelection,
+    setVertexSelection,
+  } = useUiActions();
   const { setSelection } = useSessionActions();
   const historyPaused = useEditor((state) => state.session.historyPaused);
   const interactionSessionDepth = useEditor(
@@ -147,9 +151,7 @@ export default function EditorShell({
   const hasPath = useEditor(selectHasPath);
   const shapeById = useEditor(selectShapeRecordMap);
   const selectionLocked = useEditor(selectSelectionLocked);
-  const segmentSelection = useEditor(
-    (state) => state.ui.segmentSelection
-  );
+  const segmentSelection = useEditor((state) => state.ui.segmentSelection);
   const vertexSelection = useEditor((state) => state.ui.vertexSelection);
   const activePreset = getLayoutPresetById(activePresetId);
   const {

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -50,6 +50,11 @@ import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { useEditorProjects } from "@/hooks/useEditorProjects";
 import { StarterSteps, StarterActions } from "@/components/editor/StarterFlow";
 import type { EditorView } from "@/lib/view";
+import {
+  useSessionActions,
+  useTrackActions,
+  useUiActions,
+} from "@/store/actions";
 import { useEditor } from "@/store/editor";
 import {
   selectDesignShapes,
@@ -114,38 +119,38 @@ export default function EditorShell({
   const { undo, redo, canUndo, canRedo } = useUndoRedo();
   const { enabled: developerModeEnabled, toggle: toggleDeveloperMode } =
     useDeveloperMode();
-  const selection = useEditor((state) => state.selection);
-  const design = useEditor((state) => state.design);
-  const activeTool = useEditor((state) => state.transient.activeTool);
-  const activePresetId = useEditor((state) => state.transient.activePresetId);
-  const duplicateShapes = useEditor((state) => state.duplicateShapes);
-  const groupSelection = useEditor((state) => state.groupSelection);
-  const insertPolylinePoint = useEditor((state) => state.insertPolylinePoint);
-  const nudgeShapes = useEditor((state) => state.nudgeShapes);
-  const removeShapes = useEditor((state) => state.removeShapes);
-  const removePolylinePoint = useEditor((state) => state.removePolylinePoint);
-  const replaceDesign = useEditor((state) => state.replaceDesign);
-  const rotateShapes = useEditor((state) => state.rotateShapes);
-  const setGroupName = useEditor((state) => state.setGroupName);
-  const setActiveTool = useEditor((state) => state.setActiveTool);
-  const setActivePresetId = useEditor((state) => state.setActivePresetId);
-  const setSegmentSelection = useEditor((state) => state.setSegmentSelection);
-  const setSelection = useEditor((state) => state.setSelection);
-  const setShapesLocked = useEditor((state) => state.setShapesLocked);
-  const setVertexSelection = useEditor((state) => state.setVertexSelection);
-  const ungroupSelection = useEditor((state) => state.ungroupSelection);
-  const historyPaused = useEditor((state) => state.historyPaused);
+  const selection = useEditor((state) => state.session.selection);
+  const design = useEditor((state) => state.track.design);
+  const activeTool = useEditor((state) => state.ui.activeTool);
+  const activePresetId = useEditor((state) => state.ui.activePresetId);
+  const {
+    duplicateShapes,
+    groupSelection,
+    insertPolylinePoint,
+    nudgeShapes,
+    removeShapes,
+    removePolylinePoint,
+    replaceDesign,
+    rotateShapes,
+    setGroupName,
+    setShapesLocked,
+    ungroupSelection,
+  } = useTrackActions();
+  const { setActiveTool, setActivePresetId, setSegmentSelection, setVertexSelection } =
+    useUiActions();
+  const { setSelection } = useSessionActions();
+  const historyPaused = useEditor((state) => state.session.historyPaused);
   const interactionSessionDepth = useEditor(
-    (state) => state.interactionSessionDepth
+    (state) => state.session.interactionSessionDepth
   );
   const designShapes = useEditor(selectDesignShapes);
   const hasPath = useEditor(selectHasPath);
   const shapeById = useEditor(selectShapeRecordMap);
   const selectionLocked = useEditor(selectSelectionLocked);
   const segmentSelection = useEditor(
-    (state) => state.transient.segmentSelection
+    (state) => state.ui.segmentSelection
   );
-  const vertexSelection = useEditor((state) => state.transient.vertexSelection);
+  const vertexSelection = useEditor((state) => state.ui.vertexSelection);
   const activePreset = getLayoutPresetById(activePresetId);
   const {
     activePresetLabel,
@@ -248,7 +253,6 @@ export default function EditorShell({
     readOnly,
     seedToken,
     design,
-    designShapesLength: designShapes.length,
     historyPaused,
     interactionSessionDepth,
     replaceDesign,

--- a/src/components/editor/PerformanceHud.tsx
+++ b/src/components/editor/PerformanceHud.tsx
@@ -31,7 +31,7 @@ export default function PerformanceHud() {
   const prefersReducedMotion = useReducedMotion();
   const theme = useTheme();
   const activeTool = useEditor(selectActiveTool);
-  const selectionCount = useEditor((state) => state.selection.length);
+  const selectionCount = useEditor((state) => state.session.selection.length);
   const metrics = useSyncExternalStore(
     subscribePerf,
     getPerfSnapshot,

--- a/src/components/editor/StatusBar.tsx
+++ b/src/components/editor/StatusBar.tsx
@@ -28,13 +28,13 @@ interface StatusBarProps {
 
 export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
   const { enabled, toggle } = useDeveloperMode();
-  const activeTool = useEditor((state) => state.transient.activeTool);
-  const activePresetId = useEditor((state) => state.transient.activePresetId);
-  const field = useEditor((state) => state.design.field);
-  const selection = useEditor((state) => state.selection);
+  const activeTool = useEditor((state) => state.ui.activeTool);
+  const activePresetId = useEditor((state) => state.ui.activePresetId);
+  const field = useEditor((state) => state.track.design.field);
+  const selection = useEditor((state) => state.session.selection);
   const selectionCount = selection.length;
   const shapeById = useEditor(selectShapeRecordMap);
-  const zoom = useEditor((state) => state.transient.zoom);
+  const zoom = useEditor((state) => state.ui.zoom);
   const activePreset = getLayoutPresetById(activePresetId);
   const selectedShapes = selection.map((id) => shapeById[id]).filter(Boolean);
   const selectedGroupIds = Array.from(

--- a/src/components/editor/Toolbar.tsx
+++ b/src/components/editor/Toolbar.tsx
@@ -27,6 +27,7 @@ import {
 import { Kbd } from "@/components/ui/kbd";
 import { cn } from "@/lib/utils";
 import { useEditor } from "@/store/editor";
+import { useSessionActions, useUiActions } from "@/store/actions";
 import { Download, FolderOpen, Import } from "lucide-react";
 
 function TrackDrawIcon({ className }: { className?: string }) {
@@ -74,9 +75,9 @@ export default function Toolbar({
   onOpenPresets,
   collapsed,
 }: ToolbarProps) {
-  const activeTool = useEditor((state) => state.transient.activeTool);
-  const setActiveTool = useEditor((state) => state.setActiveTool);
-  const setSelection = useEditor((state) => state.setSelection);
+  const activeTool = useEditor((state) => state.ui.activeTool);
+  const { setActiveTool } = useUiActions();
+  const { setSelection } = useSessionActions();
   const theme = useTheme();
 
   function handleToolSelect(

--- a/src/components/inspector/Inspector.tsx
+++ b/src/components/inspector/Inspector.tsx
@@ -9,6 +9,11 @@ import {
 } from "@/components/inspector/views";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { cn } from "@/lib/utils";
+import {
+  useSessionActions,
+  useTrackActions,
+  useUiActions,
+} from "@/store/actions";
 import { useEditor } from "@/store/editor";
 import { selectDesignShapes, selectSelectedShapes } from "@/store/selectors";
 
@@ -20,34 +25,33 @@ function Inspector({
   mobileInline?: boolean;
 }) {
   usePerfMetric("render:Inspector");
-  const design = useEditor((state) => state.design);
-  const selection = useEditor((state) => state.selection);
-  const updateShape = useEditor((state) => state.updateShape);
-  const setShapesLocked = useEditor((state) => state.setShapesLocked);
-  const updatePolylinePoint = useEditor((state) => state.updatePolylinePoint);
-  const insertPolylinePoint = useEditor((state) => state.insertPolylinePoint);
-  const removePolylinePoint = useEditor((state) => state.removePolylinePoint);
-  const appendPolylinePoint = useEditor((state) => state.appendPolylinePoint);
-  const reversePolylinePoints = useEditor(
-    (state) => state.reversePolylinePoints
-  );
-  const removeShapes = useEditor((state) => state.removeShapes);
-  const duplicateShapes = useEditor((state) => state.duplicateShapes);
-  const groupSelection = useEditor((state) => state.groupSelection);
-  const joinPolylines = useEditor((state) => state.joinPolylines);
-  const closePolyline = useEditor((state) => state.closePolyline);
-  const setGroupName = useEditor((state) => state.setGroupName);
-  const setSelection = useEditor((state) => state.setSelection);
-  const ungroupSelection = useEditor((state) => state.ungroupSelection);
-  const updateField = useEditor((state) => state.updateField);
-  const updateDesignMeta = useEditor((state) => state.updateDesignMeta);
-  const setHoveredShapeId = useEditor((state) => state.setHoveredShapeId);
-  const setHoveredWaypoint = useEditor((state) => state.setHoveredWaypoint);
+  const design = useEditor((state) => state.track.design);
+  const selection = useEditor((state) => state.session.selection);
+  const {
+    updateShape,
+    setShapesLocked,
+    updatePolylinePoint,
+    insertPolylinePoint,
+    removePolylinePoint,
+    appendPolylinePoint,
+    reversePolylinePoints,
+    removeShapes,
+    duplicateShapes,
+    groupSelection,
+    joinPolylines,
+    closePolyline,
+    setGroupName,
+    ungroupSelection,
+    updateField,
+    updateDesignMeta,
+  } = useTrackActions();
+  const { setSelection } = useSessionActions();
+  const { setHoveredShapeId, setHoveredWaypoint } = useUiActions();
   const designShapes = useEditor(selectDesignShapes);
   const selectedShapes = useEditor(selectSelectedShapes);
   const liveSelectedShapePatch = useEditor((state) =>
-    state.selection.length === 1
-      ? (state.transient.liveShapePatches[state.selection[0]] ?? null)
+    state.session.selection.length === 1
+      ? (state.ui.liveShapePatches[state.session.selection[0]] ?? null)
       : null
   );
   const count = selectedShapes.length;

--- a/src/components/inspector/shared.tsx
+++ b/src/components/inspector/shared.tsx
@@ -1,42 +1,37 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import type { ReactNode } from "react";
+import { useHistorySession } from "@/hooks/useHistorySession";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
-import { useEditor } from "@/store/editor";
+import { useSessionActions } from "@/store/actions";
 
 export const fmt = (value: number) => Number(value.toFixed(2));
 
 export function useInspectorInputBatch() {
-  const beginInteraction = useEditor((state) => state.beginInteraction);
-  const endInteraction = useEditor((state) => state.endInteraction);
-  const pauseHistory = useEditor((state) => state.pauseHistory);
-  const resumeHistory = useEditor((state) => state.resumeHistory);
-  const batchActiveRef = useRef(false);
+  const { beginInteraction, endInteraction, pauseHistory, resumeHistory } =
+    useSessionActions();
+  const { startSession, finishSession, cancelSession } = useHistorySession({
+    beginInteraction,
+    endInteraction,
+    pauseHistory,
+    resumeHistory,
+  });
 
   const startBatch = () => {
-    if (batchActiveRef.current) return;
-    batchActiveRef.current = true;
-    beginInteraction();
-    pauseHistory();
+    startSession();
   };
 
   const finishBatch = () => {
-    if (!batchActiveRef.current) return;
-    batchActiveRef.current = false;
-    resumeHistory();
-    endInteraction();
+    finishSession();
   };
 
   useEffect(
     () => () => {
-      if (!batchActiveRef.current) return;
-      batchActiveRef.current = false;
-      resumeHistory();
-      endInteraction();
+      cancelSession();
     },
-    [endInteraction, resumeHistory]
+    [cancelSession]
   );
 
   return {

--- a/src/hooks/useEditorProjects.ts
+++ b/src/hooks/useEditorProjects.ts
@@ -120,12 +120,7 @@ export function useEditorProjects({
     }, 350);
 
     return () => window.clearTimeout(timeoutId);
-  }, [
-    design,
-    historyPaused,
-    interactionSessionDepth,
-    readOnly,
-  ]);
+  }, [design, historyPaused, interactionSessionDepth, readOnly]);
 
   // Periodic restore points — every 5 min if the design changed
   useEffect(() => {

--- a/src/hooks/useEditorProjects.ts
+++ b/src/hooks/useEditorProjects.ts
@@ -6,16 +6,18 @@ import {
   deleteProject,
   deleteProjects,
   deleteRestorePoint,
+  hasMeaningfulProjectContent,
   listProjects,
   listRestorePointsForProject,
+  loadLocalDraft,
   loadProject,
   loadRestorePoint,
   renameProject,
+  saveLocalDraft,
   saveProject,
   type ProjectMeta,
   type RestorePointMeta,
 } from "@/lib/projects";
-import { parseDesign } from "@/lib/track/design";
 import { decodeDesign } from "@/lib/share";
 import { recordPerfSample } from "@/lib/perf";
 import { useEditor } from "@/store/editor";
@@ -26,7 +28,6 @@ export function useEditorProjects({
   readOnly,
   seedToken,
   design,
-  designShapesLength,
   historyPaused,
   interactionSessionDepth,
   replaceDesign,
@@ -34,7 +35,6 @@ export function useEditorProjects({
   readOnly: boolean;
   seedToken?: string;
   design: TrackDesign;
-  designShapesLength: number;
   historyPaused: boolean;
   interactionSessionDepth: number;
   replaceDesign: (design: TrackDesign) => void;
@@ -68,17 +68,14 @@ export function useEditorProjects({
     }
 
     try {
-      const saved = localStorage.getItem("trackdraw-design");
-      if (saved) {
-        const parsed = parseDesign(JSON.parse(saved));
-        if (parsed) {
-          replaceDesign(parsed);
-          setSaveStatusLabel("Restored from local autosave");
-          setProjects(listProjects());
-          setRestorePoints(listRestorePointsForProject(parsed.id));
-          setInitialized(true);
-          return;
-        }
+      const draft = loadLocalDraft();
+      if (draft) {
+        replaceDesign(draft);
+        setSaveStatusLabel("Restored from local draft");
+        setProjects(listProjects());
+        setRestorePoints(listRestorePointsForProject(draft.id));
+        setInitialized(true);
+        return;
       }
       setSaveStatusLabel("Fresh local project");
     } catch {
@@ -102,8 +99,8 @@ export function useEditorProjects({
     const timeoutId = window.setTimeout(() => {
       try {
         const startedAt = performance.now();
-        localStorage.setItem("trackdraw-design", JSON.stringify(design));
-        if (designShapesLength > 0 || design.title.trim()) {
+        saveLocalDraft(design);
+        if (hasMeaningfulProjectContent(design)) {
           saveProject(design);
           setProjects(listProjects());
         }
@@ -125,7 +122,6 @@ export function useEditorProjects({
     return () => window.clearTimeout(timeoutId);
   }, [
     design,
-    designShapesLength,
     historyPaused,
     interactionSessionDepth,
     readOnly,
@@ -134,10 +130,10 @@ export function useEditorProjects({
   // Periodic restore points — every 5 min if the design changed
   useEffect(() => {
     if (readOnly) return;
-    let lastUpdatedAt = useEditor.getState().design.updatedAt;
+    let lastUpdatedAt = useEditor.getState().track.design.updatedAt;
     const intervalId = window.setInterval(
       () => {
-        const current = useEditor.getState().design;
+        const current = useEditor.getState().track.design;
         if (current.updatedAt === lastUpdatedAt) return;
         createRestorePoint(current);
         setRestorePoints(listRestorePointsForProject(current.id));
@@ -186,9 +182,10 @@ export function useEditorProjects({
       const loaded = loadProject(id);
       if (!loaded) return;
       // Save current work and snapshot before switching
-      if (designShapesLength > 0 || design.title.trim()) {
+      if (hasMeaningfulProjectContent(design)) {
         saveProject(design);
         createRestorePoint(design);
+        saveLocalDraft(design);
       }
       replaceDesign(loaded);
       setProjects(listProjects());
@@ -196,7 +193,7 @@ export function useEditorProjects({
       setActiveRestorePointId(null);
       setSaveStatusLabel("Project opened");
     },
-    [design, designShapesLength, replaceDesign]
+    [design, replaceDesign]
   );
 
   const handleDeleteProject = useCallback(
@@ -259,13 +256,13 @@ export function useEditorProjects({
   }, []);
 
   const snapshotCurrentDesign = useCallback(() => {
-    if (designShapesLength > 0 || design.title.trim()) {
+    if (hasMeaningfulProjectContent(design)) {
       saveProject(design);
       createRestorePoint(design);
       setProjects(listProjects());
       setRestorePoints(listRestorePointsForProject(design.id));
     }
-  }, [design, designShapesLength]);
+  }, [design]);
 
   return {
     projects,

--- a/src/hooks/useHistorySession.ts
+++ b/src/hooks/useHistorySession.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+interface UseHistorySessionOptions {
+  beginInteraction: () => void;
+  endInteraction: () => void;
+  pauseHistory: () => void;
+  resumeHistory: () => void;
+}
+
+export function useHistorySession({
+  beginInteraction,
+  endInteraction,
+  pauseHistory,
+  resumeHistory,
+}: UseHistorySessionOptions) {
+  const activeRef = useRef(false);
+
+  const startSession = useCallback(() => {
+    if (activeRef.current) return false;
+    activeRef.current = true;
+    beginInteraction();
+    pauseHistory();
+    return true;
+  }, [beginInteraction, pauseHistory]);
+
+  const finishSession = useCallback(
+    (commit?: () => void) => {
+      if (!activeRef.current) return false;
+      activeRef.current = false;
+      resumeHistory();
+      commit?.();
+      endInteraction();
+      return true;
+    },
+    [endInteraction, resumeHistory]
+  );
+
+  const cancelSession = useCallback(
+    (cleanup?: () => void) => {
+      if (!activeRef.current) return false;
+      activeRef.current = false;
+      resumeHistory();
+      cleanup?.();
+      endInteraction();
+      return true;
+    },
+    [endInteraction, resumeHistory]
+  );
+
+  useEffect(
+    () => () => {
+      if (!activeRef.current) return;
+      activeRef.current = false;
+      resumeHistory();
+      endInteraction();
+    },
+    [endInteraction, resumeHistory]
+  );
+
+  return {
+    activeRef,
+    startSession,
+    finishSession,
+    cancelSession,
+  };
+}

--- a/src/hooks/useUndoRedo.ts
+++ b/src/hooks/useUndoRedo.ts
@@ -1,12 +1,13 @@
 "use client";
 
 import { useCallback, useEffect } from "react";
+import { useSessionActions } from "@/store/actions";
 import { useEditor } from "@/store/editor";
 import { useStore } from "zustand";
 
 export function useUndoRedo() {
   const { undo, redo, pastStates, futureStates } = useStore(useEditor.temporal);
-  const sanitizeHistoryState = useEditor((state) => state.sanitizeHistoryState);
+  const { sanitizeHistoryState } = useSessionActions();
 
   const runHistoryStep = useCallback(
     (step: () => void) => {

--- a/src/lib/editor/store-state.ts
+++ b/src/lib/editor/store-state.ts
@@ -1,18 +1,26 @@
 import { DEFAULT_LAYOUT_PRESET_ID } from "@/lib/planning/layout-presets";
+import { createDefaultDesign } from "@/lib/track/design";
 import type {
   EditorSessionState,
-  EditorTransientState,
+  EditorTrackState,
+  EditorUiState,
 } from "@/lib/editor/store-types";
 
-interface EditorTransientResetOptions {
+interface EditorUiResetOptions {
   activePresetId?: string | null;
   zoom?: number;
   panOffset?: { x: number; y: number };
 }
 
-export function createDefaultEditorTransientState(
-  options: EditorTransientResetOptions = {}
-): EditorTransientState {
+export function createDefaultEditorTrackState(): EditorTrackState {
+  return {
+    design: createDefaultDesign(),
+  };
+}
+
+export function createDefaultEditorUiState(
+  options: EditorUiResetOptions = {}
+): EditorUiState {
   return {
     activeTool: "select",
     activePresetId: options.activePresetId ?? DEFAULT_LAYOUT_PRESET_ID,
@@ -32,20 +40,18 @@ export function createDefaultEditorTransientState(
   };
 }
 
-export function resetEditorTransientState(
-  current: EditorTransientState,
-  options: EditorTransientResetOptions = {}
-): EditorTransientState {
-  return createDefaultEditorTransientState({
+export function resetEditorUiState(
+  current: EditorUiState,
+  options: EditorUiResetOptions = {}
+): EditorUiState {
+  return createDefaultEditorUiState({
     activePresetId: options.activePresetId ?? current.activePresetId,
     zoom: options.zoom ?? current.zoom,
     panOffset: options.panOffset ?? current.panOffset,
   });
 }
 
-export function sanitizeEditorTransientState(
-  current: EditorTransientState
-): EditorTransientState {
+export function sanitizeEditorUiState(current: EditorUiState): EditorUiState {
   return {
     ...current,
     hoveredShapeId: null,
@@ -59,6 +65,7 @@ export function sanitizeEditorTransientState(
 
 export function createDefaultEditorSessionState(): EditorSessionState {
   return {
+    selection: [],
     historyPaused: false,
     historySessionDepth: 0,
     interactionSessionDepth: 0,

--- a/src/lib/editor/store-types.ts
+++ b/src/lib/editor/store-types.ts
@@ -113,7 +113,9 @@ export interface EditorUiActions {
   setZoom: (zoom: number) => void;
   setPanOffset: (offset: { x: number; y: number }) => void;
   setHoveredShapeId: (shapeId: string | null) => void;
-  setHoveredWaypoint: (waypoint: { shapeId: string; idx: number } | null) => void;
+  setHoveredWaypoint: (
+    waypoint: { shapeId: string; idx: number } | null
+  ) => void;
   setSegmentSelection: (
     value:
       | {

--- a/src/lib/editor/store-types.ts
+++ b/src/lib/editor/store-types.ts
@@ -1,8 +1,19 @@
-import type { Shape } from "@/lib/types";
+import type {
+  FieldSpec,
+  PolylinePoint,
+  SerializedTrackDesign,
+  Shape,
+  ShapeDraft,
+  TrackDesign,
+} from "@/lib/types";
 import type { EditorTool } from "@/lib/editor-tools";
 import type { DraftPoint, RectLike } from "@/lib/canvas/shared";
 
-export interface EditorTransientState {
+export interface EditorTrackState {
+  design: TrackDesign;
+}
+
+export interface EditorUiState {
   activeTool: EditorTool;
   activePresetId: string | null;
   zoom: number;
@@ -36,7 +47,253 @@ export interface EditorTransientState {
 }
 
 export interface EditorSessionState {
+  selection: string[];
   historyPaused: boolean;
   historySessionDepth: number;
   interactionSessionDepth: number;
 }
+
+export interface EditorTrackActions {
+  addShape: (shape: ShapeDraft) => string;
+  addShapes: (shapes: ShapeDraft[]) => string[];
+  updateShape: (id: string, patch: Partial<Shape>) => void;
+  updateShapes: (ids: string[], patch: Partial<Shape>) => void;
+  setShapesLocked: (ids: string[], locked: boolean) => void;
+  setPolylinePoints: (id: string, points: PolylinePoint[]) => void;
+  updatePolylinePoint: (
+    id: string,
+    index: number,
+    patch: Partial<PolylinePoint>
+  ) => void;
+  insertPolylinePoint: (
+    id: string,
+    index: number,
+    point: PolylinePoint
+  ) => void;
+  removePolylinePoint: (id: string, index: number) => void;
+  appendPolylinePoint: (id: string, point: PolylinePoint) => void;
+  reversePolylinePoints: (id: string) => void;
+  rotateShapes: (ids: string[], delta: number) => void;
+  removeShapes: (ids: string[]) => void;
+  duplicateShapes: (ids: string[]) => void;
+  groupSelection: (ids: string[]) => string | null;
+  setGroupName: (ids: string[], name: string) => void;
+  ungroupSelection: (ids: string[]) => void;
+  joinPolylines: (ids: string[]) => string | null;
+  closePolyline: (id: string) => boolean;
+  nudgeShapes: (ids: string[], dx: number, dy: number) => void;
+  updateField: (patch: Partial<FieldSpec>) => void;
+  updateDesignMeta: (
+    patch: Partial<
+      Pick<
+        TrackDesign,
+        "title" | "description" | "authorName" | "tags" | "inventory"
+      >
+    >
+  ) => void;
+  replaceDesign: (design: TrackDesign | SerializedTrackDesign) => void;
+  newProject: () => void;
+  bringForward: (id: string) => void;
+  sendBackward: (id: string) => void;
+}
+
+export interface EditorSessionActions {
+  setSelection: (ids: string[]) => void;
+  pauseHistory: () => void;
+  resumeHistory: () => void;
+  clearHistory: () => void;
+  beginInteraction: () => void;
+  endInteraction: () => void;
+  sanitizeHistoryState: () => void;
+}
+
+export interface EditorUiActions {
+  setActiveTool: (tool: EditorTool) => void;
+  setActivePresetId: (presetId: string | null) => void;
+  setZoom: (zoom: number) => void;
+  setPanOffset: (offset: { x: number; y: number }) => void;
+  setHoveredShapeId: (shapeId: string | null) => void;
+  setHoveredWaypoint: (waypoint: { shapeId: string; idx: number } | null) => void;
+  setSegmentSelection: (
+    value:
+      | {
+          shapeId: string;
+          segmentIndex: number;
+          point: { x: number; y: number };
+        }
+      | null
+      | ((
+          previous: {
+            shapeId: string;
+            segmentIndex: number;
+            point: { x: number; y: number };
+          } | null
+        ) => {
+          shapeId: string;
+          segmentIndex: number;
+          point: { x: number; y: number };
+        } | null)
+  ) => void;
+  setVertexSelection: (
+    value:
+      | { shapeId: string; idx: number }
+      | null
+      | ((
+          previous: { shapeId: string; idx: number } | null
+        ) => { shapeId: string; idx: number } | null)
+  ) => void;
+  setDraftPath: (
+    value: DraftPoint[] | ((previous: DraftPoint[]) => DraftPoint[])
+  ) => void;
+  setDraftForceClosed: (
+    value: boolean | ((previous: boolean) => boolean)
+  ) => void;
+  setDraftSourceShapeId: (
+    value: string | null | ((previous: string | null) => string | null)
+  ) => void;
+  setMarqueeRect: (
+    value: RectLike | null | ((previous: RectLike | null) => RectLike | null)
+  ) => void;
+  setRotationSession: (
+    value:
+      | {
+          center: { x: number; y: number };
+          shapeId: string;
+          startAngle: number;
+          startRotation: number;
+          previewRotation: number;
+        }
+      | null
+      | ((
+          previous: {
+            center: { x: number; y: number };
+            shapeId: string;
+            startAngle: number;
+            startRotation: number;
+            previewRotation: number;
+          } | null
+        ) => {
+          center: { x: number; y: number };
+          shapeId: string;
+          startAngle: number;
+          startRotation: number;
+          previewRotation: number;
+        } | null)
+  ) => void;
+  setGroupDragPreview: (
+    value:
+      | {
+          ids: string[];
+          origin: { x: number; y: number };
+          dx: number;
+          dy: number;
+        }
+      | null
+      | ((
+          previous: {
+            ids: string[];
+            origin: { x: number; y: number };
+            dx: number;
+            dy: number;
+          } | null
+        ) => {
+          ids: string[];
+          origin: { x: number; y: number };
+          dx: number;
+          dy: number;
+        } | null)
+  ) => void;
+  setLiveShapePatch: (id: string, patch: Partial<Shape>) => void;
+  clearLiveShapePatch: (id: string) => void;
+}
+
+export interface EditorActionGroups {
+  track: EditorTrackActions;
+  session: EditorSessionActions;
+  ui: EditorUiActions;
+}
+
+export const editorStateOwnership = {
+  track: ["design"],
+  session: [
+    "selection",
+    "historyPaused",
+    "historySessionDepth",
+    "interactionSessionDepth",
+  ],
+  ui: [
+    "activeTool",
+    "activePresetId",
+    "zoom",
+    "panOffset",
+    "hoveredShapeId",
+    "hoveredWaypoint",
+    "segmentSelection",
+    "vertexSelection",
+    "draftPath",
+    "draftForceClosed",
+    "draftSourceShapeId",
+    "marqueeRect",
+    "rotationSession",
+    "groupDragPreview",
+    "liveShapePatches",
+  ],
+} as const;
+
+export const editorActionOwnership = {
+  track: [
+    "addShape",
+    "addShapes",
+    "updateShape",
+    "updateShapes",
+    "setShapesLocked",
+    "setPolylinePoints",
+    "updatePolylinePoint",
+    "insertPolylinePoint",
+    "removePolylinePoint",
+    "appendPolylinePoint",
+    "reversePolylinePoints",
+    "rotateShapes",
+    "removeShapes",
+    "duplicateShapes",
+    "groupSelection",
+    "setGroupName",
+    "ungroupSelection",
+    "joinPolylines",
+    "closePolyline",
+    "nudgeShapes",
+    "updateField",
+    "updateDesignMeta",
+    "replaceDesign",
+    "newProject",
+    "bringForward",
+    "sendBackward",
+  ],
+  session: [
+    "setSelection",
+    "pauseHistory",
+    "resumeHistory",
+    "clearHistory",
+    "beginInteraction",
+    "endInteraction",
+    "sanitizeHistoryState",
+  ],
+  ui: [
+    "setActiveTool",
+    "setActivePresetId",
+    "setZoom",
+    "setPanOffset",
+    "setHoveredShapeId",
+    "setHoveredWaypoint",
+    "setSegmentSelection",
+    "setVertexSelection",
+    "setDraftPath",
+    "setDraftForceClosed",
+    "setDraftSourceShapeId",
+    "setMarqueeRect",
+    "setRotationSession",
+    "setGroupDragPreview",
+    "setLiveShapePatch",
+    "clearLiveShapePatch",
+  ],
+} as const;

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -110,10 +110,10 @@ function removeKey(key: string): void {
 export function hasMeaningfulProjectContent(design: TrackDesign): boolean {
   return Boolean(
     design.shapeOrder.length > 0 ||
-      design.title.trim() ||
-      (design.description ?? "").trim() ||
-      (design.tags ?? []).length > 0 ||
-      (design.authorName ?? "").trim()
+    design.title.trim() ||
+    (design.description ?? "").trim() ||
+    (design.tags ?? []).length > 0 ||
+    (design.authorName ?? "").trim()
   );
 }
 

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -2,15 +2,29 @@
  * Local-first project persistence and restore point management.
  *
  * Storage keys:
- *   trackdraw-project-list   — JSON: ProjectMeta[]
+ *   trackdraw-design         — JSON: SerializedTrackDesign (crash-recovery draft)
+ *   trackdraw-project-list   — JSON: ProjectMeta[] (named local projects)
  *   trackdraw-project-{id}   — JSON: SerializedTrackDesign
- *   trackdraw-restore-list   — JSON: RestorePointMeta[]
+ *   trackdraw-restore-list   — JSON: RestorePointMeta[] (manual/periodic snapshots)
  *   trackdraw-restore-{id}   — JSON: SerializedTrackDesign
  */
 
 import { parseDesign, serializeDesign } from "@/lib/track/design";
 import type { TrackDesign } from "@/lib/types";
 import { nanoid } from "nanoid";
+
+export type PersistenceLayerId =
+  | "local-draft"
+  | "local-project"
+  | "restore-point"
+  | "account-project"
+  | "published-share";
+
+export interface PersistenceLayerDefinition {
+  id: PersistenceLayerId;
+  label: string;
+  role: string;
+}
 
 export interface ProjectMeta {
   id: string;
@@ -29,9 +43,39 @@ export interface RestorePointMeta {
   shapeCount: number;
 }
 
+export const LOCAL_DRAFT_KEY = "trackdraw-design";
 const PROJECT_LIST_KEY = "trackdraw-project-list";
 const RESTORE_LIST_KEY = "trackdraw-restore-list";
 const MAX_RESTORE_POINTS = 7;
+
+export const persistenceLayerDefinitions: readonly PersistenceLayerDefinition[] =
+  [
+    {
+      id: "local-draft",
+      label: "Local draft",
+      role: "Crash-recovery working state for the current tab/device.",
+    },
+    {
+      id: "local-project",
+      label: "Local project",
+      role: "Named project state stored on this device and reopened later.",
+    },
+    {
+      id: "restore-point",
+      label: "Restore point",
+      role: "Deliberate or periodic snapshot of a project's earlier state.",
+    },
+    {
+      id: "account-project",
+      label: "Account project",
+      role: "Authenticated project continuity and sync across devices.",
+    },
+    {
+      id: "published-share",
+      label: "Published share",
+      role: "Read-only snapshot published for sharing, not the working state.",
+    },
+  ] as const;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -61,6 +105,30 @@ function removeKey(key: string): void {
   } catch {
     /* ignore */
   }
+}
+
+export function hasMeaningfulProjectContent(design: TrackDesign): boolean {
+  return Boolean(
+    design.shapeOrder.length > 0 ||
+      design.title.trim() ||
+      (design.description ?? "").trim() ||
+      (design.tags ?? []).length > 0 ||
+      (design.authorName ?? "").trim()
+  );
+}
+
+export function saveLocalDraft(design: TrackDesign): void {
+  writeJson(LOCAL_DRAFT_KEY, serializeDesign(design));
+}
+
+export function loadLocalDraft(): TrackDesign | null {
+  const raw = readJson<unknown>(LOCAL_DRAFT_KEY);
+  if (!raw) return null;
+  return parseDesign(raw);
+}
+
+export function clearLocalDraft(): void {
+  removeKey(LOCAL_DRAFT_KEY);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -11,7 +11,9 @@ export function useTrackActions() {
   const insertPolylinePoint = useEditor((state) => state.insertPolylinePoint);
   const removePolylinePoint = useEditor((state) => state.removePolylinePoint);
   const appendPolylinePoint = useEditor((state) => state.appendPolylinePoint);
-  const reversePolylinePoints = useEditor((state) => state.reversePolylinePoints);
+  const reversePolylinePoints = useEditor(
+    (state) => state.reversePolylinePoints
+  );
   const rotateShapes = useEditor((state) => state.rotateShapes);
   const removeShapes = useEditor((state) => state.removeShapes);
   const duplicateShapes = useEditor((state) => state.duplicateShapes);
@@ -89,7 +91,9 @@ export function useUiActions() {
   const setVertexSelection = useEditor((state) => state.setVertexSelection);
   const setDraftPath = useEditor((state) => state.setDraftPath);
   const setDraftForceClosed = useEditor((state) => state.setDraftForceClosed);
-  const setDraftSourceShapeId = useEditor((state) => state.setDraftSourceShapeId);
+  const setDraftSourceShapeId = useEditor(
+    (state) => state.setDraftSourceShapeId
+  );
   const setMarqueeRect = useEditor((state) => state.setMarqueeRect);
   const setRotationSession = useEditor((state) => state.setRotationSession);
   const setGroupDragPreview = useEditor((state) => state.setGroupDragPreview);

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,0 +1,117 @@
+import { useEditor } from "@/store/editor";
+
+export function useTrackActions() {
+  const addShape = useEditor((state) => state.addShape);
+  const addShapes = useEditor((state) => state.addShapes);
+  const updateShape = useEditor((state) => state.updateShape);
+  const updateShapes = useEditor((state) => state.updateShapes);
+  const setShapesLocked = useEditor((state) => state.setShapesLocked);
+  const setPolylinePoints = useEditor((state) => state.setPolylinePoints);
+  const updatePolylinePoint = useEditor((state) => state.updatePolylinePoint);
+  const insertPolylinePoint = useEditor((state) => state.insertPolylinePoint);
+  const removePolylinePoint = useEditor((state) => state.removePolylinePoint);
+  const appendPolylinePoint = useEditor((state) => state.appendPolylinePoint);
+  const reversePolylinePoints = useEditor((state) => state.reversePolylinePoints);
+  const rotateShapes = useEditor((state) => state.rotateShapes);
+  const removeShapes = useEditor((state) => state.removeShapes);
+  const duplicateShapes = useEditor((state) => state.duplicateShapes);
+  const groupSelection = useEditor((state) => state.groupSelection);
+  const setGroupName = useEditor((state) => state.setGroupName);
+  const ungroupSelection = useEditor((state) => state.ungroupSelection);
+  const joinPolylines = useEditor((state) => state.joinPolylines);
+  const closePolyline = useEditor((state) => state.closePolyline);
+  const nudgeShapes = useEditor((state) => state.nudgeShapes);
+  const updateField = useEditor((state) => state.updateField);
+  const updateDesignMeta = useEditor((state) => state.updateDesignMeta);
+  const replaceDesign = useEditor((state) => state.replaceDesign);
+  const newProject = useEditor((state) => state.newProject);
+  const bringForward = useEditor((state) => state.bringForward);
+  const sendBackward = useEditor((state) => state.sendBackward);
+
+  return {
+    addShape,
+    addShapes,
+    updateShape,
+    updateShapes,
+    setShapesLocked,
+    setPolylinePoints,
+    updatePolylinePoint,
+    insertPolylinePoint,
+    removePolylinePoint,
+    appendPolylinePoint,
+    reversePolylinePoints,
+    rotateShapes,
+    removeShapes,
+    duplicateShapes,
+    groupSelection,
+    setGroupName,
+    ungroupSelection,
+    joinPolylines,
+    closePolyline,
+    nudgeShapes,
+    updateField,
+    updateDesignMeta,
+    replaceDesign,
+    newProject,
+    bringForward,
+    sendBackward,
+  };
+}
+
+export function useSessionActions() {
+  const setSelection = useEditor((state) => state.setSelection);
+  const pauseHistory = useEditor((state) => state.pauseHistory);
+  const resumeHistory = useEditor((state) => state.resumeHistory);
+  const clearHistory = useEditor((state) => state.clearHistory);
+  const beginInteraction = useEditor((state) => state.beginInteraction);
+  const endInteraction = useEditor((state) => state.endInteraction);
+  const sanitizeHistoryState = useEditor((state) => state.sanitizeHistoryState);
+
+  return {
+    setSelection,
+    pauseHistory,
+    resumeHistory,
+    clearHistory,
+    beginInteraction,
+    endInteraction,
+    sanitizeHistoryState,
+  };
+}
+
+export function useUiActions() {
+  const setActiveTool = useEditor((state) => state.setActiveTool);
+  const setActivePresetId = useEditor((state) => state.setActivePresetId);
+  const setZoom = useEditor((state) => state.setZoom);
+  const setPanOffset = useEditor((state) => state.setPanOffset);
+  const setHoveredShapeId = useEditor((state) => state.setHoveredShapeId);
+  const setHoveredWaypoint = useEditor((state) => state.setHoveredWaypoint);
+  const setSegmentSelection = useEditor((state) => state.setSegmentSelection);
+  const setVertexSelection = useEditor((state) => state.setVertexSelection);
+  const setDraftPath = useEditor((state) => state.setDraftPath);
+  const setDraftForceClosed = useEditor((state) => state.setDraftForceClosed);
+  const setDraftSourceShapeId = useEditor((state) => state.setDraftSourceShapeId);
+  const setMarqueeRect = useEditor((state) => state.setMarqueeRect);
+  const setRotationSession = useEditor((state) => state.setRotationSession);
+  const setGroupDragPreview = useEditor((state) => state.setGroupDragPreview);
+  const setLiveShapePatch = useEditor((state) => state.setLiveShapePatch);
+  const clearLiveShapePatch = useEditor((state) => state.clearLiveShapePatch);
+
+  return {
+    setActiveTool,
+    setActivePresetId,
+    setZoom,
+    setPanOffset,
+    setHoveredShapeId,
+    setHoveredWaypoint,
+    setSegmentSelection,
+    setVertexSelection,
+    setDraftPath,
+    setDraftForceClosed,
+    setDraftSourceShapeId,
+    setMarqueeRect,
+    setRotationSession,
+    setGroupDragPreview,
+    setLiveShapePatch,
+    clearLiveShapePatch,
+  };
+}

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -4,17 +4,8 @@ import { create } from "zustand";
 import { temporal } from "zundo";
 import { immer } from "zustand/middleware/immer";
 import { nanoid } from "nanoid";
-import type {
-  FieldSpec,
-  PolylinePoint,
-  PolylineShape,
-  SerializedTrackDesign,
-  Shape,
-  ShapeDraft,
-  TrackDesign,
-} from "@/lib/types";
+import type { PolylineShape, Shape, TrackDesign } from "@/lib/types";
 import {
-  createDefaultDesign,
   getDesignShapeById,
   normalizeDesign,
   nowIso,
@@ -36,173 +27,80 @@ import {
 } from "@/lib/editor/shape-mutations";
 import {
   createDefaultEditorSessionState,
-  createDefaultEditorTransientState,
-  resetEditorTransientState,
-  sanitizeEditorTransientState,
+  createDefaultEditorTrackState,
+  createDefaultEditorUiState,
+  resetEditorUiState,
+  sanitizeEditorUiState,
 } from "@/lib/editor/store-state";
 import type {
   EditorSessionState,
-  EditorTransientState,
+  EditorSessionActions,
+  EditorTrackActions,
+  EditorTrackState,
+  EditorUiActions,
+  EditorUiState,
 } from "@/lib/editor/store-types";
-import type { EditorTool } from "@/lib/editor-tools";
 import {
   expandGroupedSelection,
   getShapeGroupId,
 } from "@/lib/track/shape-groups";
-import type { DraftPoint, RectLike } from "@/lib/canvas/shared";
 
 export type { EditorTool } from "@/lib/editor-tools";
 
-interface EditorState extends EditorSessionState {
-  design: TrackDesign;
-  selection: string[];
-  transient: EditorTransientState;
+interface EditorState {
+  track: EditorTrackState;
+  session: EditorSessionState;
+  ui: EditorUiState;
 
-  addShape: (s: ShapeDraft) => string;
-  addShapes: (shapes: ShapeDraft[]) => string[];
-  updateShape: (id: string, patch: Partial<Shape>) => void;
-  updateShapes: (ids: string[], patch: Partial<Shape>) => void;
-  setShapesLocked: (ids: string[], locked: boolean) => void;
-  setPolylinePoints: (id: string, points: PolylinePoint[]) => void;
-  updatePolylinePoint: (
-    id: string,
-    index: number,
-    patch: Partial<PolylinePoint>
-  ) => void;
-  insertPolylinePoint: (
-    id: string,
-    index: number,
-    point: PolylinePoint
-  ) => void;
-  removePolylinePoint: (id: string, index: number) => void;
-  appendPolylinePoint: (id: string, point: PolylinePoint) => void;
-  reversePolylinePoints: (id: string) => void;
-  rotateShapes: (ids: string[], delta: number) => void;
-  removeShapes: (ids: string[]) => void;
-  duplicateShapes: (ids: string[]) => void;
-  groupSelection: (ids: string[]) => string | null;
-  setGroupName: (ids: string[], name: string) => void;
-  ungroupSelection: (ids: string[]) => void;
-  joinPolylines: (ids: string[]) => string | null;
-  closePolyline: (id: string) => boolean;
-  nudgeShapes: (ids: string[], dx: number, dy: number) => void;
-  setSelection: (ids: string[]) => void;
-  setActiveTool: (tool: EditorTool) => void;
-  setActivePresetId: (presetId: string | null) => void;
-  setZoom: (zoom: number) => void;
-  setPanOffset: (offset: { x: number; y: number }) => void;
-  setHoveredShapeId: (shapeId: string | null) => void;
-  setHoveredWaypoint: (w: { shapeId: string; idx: number } | null) => void;
-  setSegmentSelection: (
-    value:
-      | {
-          shapeId: string;
-          segmentIndex: number;
-          point: { x: number; y: number };
-        }
-      | null
-      | ((
-          previous: {
-            shapeId: string;
-            segmentIndex: number;
-            point: { x: number; y: number };
-          } | null
-        ) => {
-          shapeId: string;
-          segmentIndex: number;
-          point: { x: number; y: number };
-        } | null)
-  ) => void;
-  setVertexSelection: (
-    value:
-      | { shapeId: string; idx: number }
-      | null
-      | ((
-          previous: { shapeId: string; idx: number } | null
-        ) => { shapeId: string; idx: number } | null)
-  ) => void;
-  setDraftPath: (
-    value: DraftPoint[] | ((previous: DraftPoint[]) => DraftPoint[])
-  ) => void;
-  setDraftForceClosed: (
-    value: boolean | ((previous: boolean) => boolean)
-  ) => void;
-  setDraftSourceShapeId: (
-    value: string | null | ((previous: string | null) => string | null)
-  ) => void;
-  setMarqueeRect: (
-    value: RectLike | null | ((previous: RectLike | null) => RectLike | null)
-  ) => void;
-  setRotationSession: (
-    value:
-      | {
-          center: { x: number; y: number };
-          shapeId: string;
-          startAngle: number;
-          startRotation: number;
-          previewRotation: number;
-        }
-      | null
-      | ((
-          previous: {
-            center: { x: number; y: number };
-            shapeId: string;
-            startAngle: number;
-            startRotation: number;
-            previewRotation: number;
-          } | null
-        ) => {
-          center: { x: number; y: number };
-          shapeId: string;
-          startAngle: number;
-          startRotation: number;
-          previewRotation: number;
-        } | null)
-  ) => void;
-  setGroupDragPreview: (
-    value:
-      | {
-          ids: string[];
-          origin: { x: number; y: number };
-          dx: number;
-          dy: number;
-        }
-      | null
-      | ((
-          previous: {
-            ids: string[];
-            origin: { x: number; y: number };
-            dx: number;
-            dy: number;
-          } | null
-        ) => {
-          ids: string[];
-          origin: { x: number; y: number };
-          dx: number;
-          dy: number;
-        } | null)
-  ) => void;
-  setLiveShapePatch: (id: string, patch: Partial<Shape>) => void;
-  clearLiveShapePatch: (id: string) => void;
-  updateField: (patch: Partial<FieldSpec>) => void;
-  updateDesignMeta: (
-    patch: Partial<
-      Pick<
-        TrackDesign,
-        "title" | "description" | "authorName" | "tags" | "inventory"
-      >
-    >
-  ) => void;
-  replaceDesign: (design: TrackDesign | SerializedTrackDesign) => void;
-  newProject: () => void;
-  bringForward: (id: string) => void;
-  sendBackward: (id: string) => void;
-  pauseHistory: () => void;
-  resumeHistory: () => void;
-  clearHistory: () => void;
-  beginInteraction: () => void;
-  endInteraction: () => void;
-  sanitizeHistoryState: () => void;
+  addShape: EditorTrackActions["addShape"];
+  addShapes: EditorTrackActions["addShapes"];
+  updateShape: EditorTrackActions["updateShape"];
+  updateShapes: EditorTrackActions["updateShapes"];
+  setShapesLocked: EditorTrackActions["setShapesLocked"];
+  setPolylinePoints: EditorTrackActions["setPolylinePoints"];
+  updatePolylinePoint: EditorTrackActions["updatePolylinePoint"];
+  insertPolylinePoint: EditorTrackActions["insertPolylinePoint"];
+  removePolylinePoint: EditorTrackActions["removePolylinePoint"];
+  appendPolylinePoint: EditorTrackActions["appendPolylinePoint"];
+  reversePolylinePoints: EditorTrackActions["reversePolylinePoints"];
+  rotateShapes: EditorTrackActions["rotateShapes"];
+  removeShapes: EditorTrackActions["removeShapes"];
+  duplicateShapes: EditorTrackActions["duplicateShapes"];
+  groupSelection: EditorTrackActions["groupSelection"];
+  setGroupName: EditorTrackActions["setGroupName"];
+  ungroupSelection: EditorTrackActions["ungroupSelection"];
+  joinPolylines: EditorTrackActions["joinPolylines"];
+  closePolyline: EditorTrackActions["closePolyline"];
+  nudgeShapes: EditorTrackActions["nudgeShapes"];
+  updateField: EditorTrackActions["updateField"];
+  updateDesignMeta: EditorTrackActions["updateDesignMeta"];
+  replaceDesign: EditorTrackActions["replaceDesign"];
+  newProject: EditorTrackActions["newProject"];
+  bringForward: EditorTrackActions["bringForward"];
+  sendBackward: EditorTrackActions["sendBackward"];
+  setSelection: EditorSessionActions["setSelection"];
+  pauseHistory: EditorSessionActions["pauseHistory"];
+  resumeHistory: EditorSessionActions["resumeHistory"];
+  clearHistory: EditorSessionActions["clearHistory"];
+  beginInteraction: EditorSessionActions["beginInteraction"];
+  endInteraction: EditorSessionActions["endInteraction"];
+  sanitizeHistoryState: EditorSessionActions["sanitizeHistoryState"];
+  setActiveTool: EditorUiActions["setActiveTool"];
+  setActivePresetId: EditorUiActions["setActivePresetId"];
+  setZoom: EditorUiActions["setZoom"];
+  setPanOffset: EditorUiActions["setPanOffset"];
+  setHoveredShapeId: EditorUiActions["setHoveredShapeId"];
+  setHoveredWaypoint: EditorUiActions["setHoveredWaypoint"];
+  setSegmentSelection: EditorUiActions["setSegmentSelection"];
+  setVertexSelection: EditorUiActions["setVertexSelection"];
+  setDraftPath: EditorUiActions["setDraftPath"];
+  setDraftForceClosed: EditorUiActions["setDraftForceClosed"];
+  setDraftSourceShapeId: EditorUiActions["setDraftSourceShapeId"];
+  setMarqueeRect: EditorUiActions["setMarqueeRect"];
+  setRotationSession: EditorUiActions["setRotationSession"];
+  setGroupDragPreview: EditorUiActions["setGroupDragPreview"];
+  setLiveShapePatch: EditorUiActions["setLiveShapePatch"];
+  clearLiveShapePatch: EditorUiActions["clearLiveShapePatch"];
 }
 
 function addShapeRecord(design: TrackDesign, shape: Shape) {
@@ -231,20 +129,23 @@ function clearTemporalHistory() {
   useEditor.temporal.getState().clear();
 }
 
+function touchTrackDesign(state: EditorState) {
+  state.track.design.updatedAt = nowIso();
+}
+
 export const useEditor = create<EditorState>()(
   temporal(
     immer<EditorState>((set) => ({
-      design: createDefaultDesign(),
-      selection: [],
-      transient: createDefaultEditorTransientState(),
-      ...createDefaultEditorSessionState(),
+      track: createDefaultEditorTrackState(),
+      session: createDefaultEditorSessionState(),
+      ui: createDefaultEditorUiState(),
 
       addShape: (s) => {
         const id = nanoid();
         set((draft) => {
           const nextShape: Shape = { ...s, id };
-          addShapeRecord(draft.design, nextShape);
-          draft.design.updatedAt = nowIso();
+          addShapeRecord(draft.track.design, nextShape);
+          touchTrackDesign(draft);
         });
         return id;
       },
@@ -256,18 +157,18 @@ export const useEditor = create<EditorState>()(
             ...shape,
             id: ids[index],
           }));
-          nextShapes.forEach((shape) => addShapeRecord(draft.design, shape));
-          draft.design.updatedAt = nowIso();
+          nextShapes.forEach((shape) => addShapeRecord(draft.track.design, shape));
+          touchTrackDesign(draft);
         });
         return ids;
       },
 
       updateShape: (id, patch) =>
         set((draft) => {
-          const shape = draft.design.shapeById[id];
+          const shape = draft.track.design.shapeById[id];
           if (!shape) return;
           applyShapePatch(shape, patch);
-          draft.design.updatedAt = nowIso();
+          touchTrackDesign(draft);
         }),
 
       updateShapes: (ids, patch) =>
@@ -275,14 +176,14 @@ export const useEditor = create<EditorState>()(
           let changed = false;
 
           for (const id of ids) {
-            const shape = draft.design.shapeById[id];
+            const shape = draft.track.design.shapeById[id];
             if (!shape) continue;
             applyShapePatch(shape, patch);
             changed = true;
           }
 
           if (changed) {
-            draft.design.updatedAt = nowIso();
+            touchTrackDesign(draft);
           }
         }),
 
@@ -291,85 +192,97 @@ export const useEditor = create<EditorState>()(
           let changed = false;
 
           for (const id of ids) {
-            const shape = draft.design.shapeById[id];
+            const shape = draft.track.design.shapeById[id];
             if (!shape || shape.locked === locked) continue;
             shape.locked = locked;
             changed = true;
           }
 
           if (changed) {
-            draft.design.updatedAt = nowIso();
+            touchTrackDesign(draft);
           }
         }),
 
       setPolylinePoints: (id, points) =>
         set((draft) => {
-          if (!setPolylinePoints(draft.design.shapeById[id], points)) return;
-          draft.design.updatedAt = nowIso();
+          if (!setPolylinePoints(draft.track.design.shapeById[id], points)) {
+            return;
+          }
+          touchTrackDesign(draft);
         }),
 
       updatePolylinePoint: (id, index, patch) =>
         set((draft) => {
-          if (!updatePolylinePoint(draft.design.shapeById[id], index, patch))
+          if (
+            !updatePolylinePoint(draft.track.design.shapeById[id], index, patch)
+          ) {
             return;
-          draft.design.updatedAt = nowIso();
+          }
+          touchTrackDesign(draft);
         }),
 
       insertPolylinePoint: (id, index, point) =>
         set((draft) => {
-          if (!insertPolylinePoint(draft.design.shapeById[id], index, point))
+          if (!insertPolylinePoint(draft.track.design.shapeById[id], index, point)) {
             return;
-          draft.transient.segmentSelection = null;
-          draft.design.updatedAt = nowIso();
+          }
+          draft.ui.segmentSelection = null;
+          touchTrackDesign(draft);
         }),
 
       removePolylinePoint: (id, index) =>
         set((draft) => {
-          if (!removePolylinePoint(draft.design.shapeById[id], index)) return;
-          draft.transient.segmentSelection = null;
-          draft.design.updatedAt = nowIso();
+          if (!removePolylinePoint(draft.track.design.shapeById[id], index)) {
+            return;
+          }
+          draft.ui.segmentSelection = null;
+          touchTrackDesign(draft);
         }),
 
       appendPolylinePoint: (id, point) =>
         set((draft) => {
-          if (!appendPolylinePoint(draft.design.shapeById[id], point)) return;
-          draft.design.updatedAt = nowIso();
+          if (!appendPolylinePoint(draft.track.design.shapeById[id], point)) {
+            return;
+          }
+          touchTrackDesign(draft);
         }),
 
       reversePolylinePoints: (id) =>
         set((draft) => {
-          if (!reversePolylinePoints(draft.design.shapeById[id])) return;
-          draft.design.updatedAt = nowIso();
+          if (!reversePolylinePoints(draft.track.design.shapeById[id])) return;
+          touchTrackDesign(draft);
         }),
 
       rotateShapes: (ids, delta) =>
         set((draft) => {
-          const changed = rotateShapes(draft.design.shapeById, ids, delta);
+          const changed = rotateShapes(draft.track.design.shapeById, ids, delta);
           if (changed) {
-            draft.design.updatedAt = nowIso();
+            touchTrackDesign(draft);
           }
         }),
 
       removeShapes: (ids) =>
         set((draft) => {
           const idSet = new Set(ids);
-          ids.forEach((id) => removeShapeRecord(draft.design, id));
-          draft.selection = draft.selection.filter((id) => !idSet.has(id));
-          draft.design.updatedAt = nowIso();
+          ids.forEach((id) => removeShapeRecord(draft.track.design, id));
+          draft.session.selection = draft.session.selection.filter(
+            (id) => !idSet.has(id)
+          );
+          touchTrackDesign(draft);
         }),
 
       nudgeShapes: (ids, dx, dy) =>
         set((draft) => {
-          if (!nudgeShapes(draft.design.shapeById, ids, dx, dy)) return;
-          draft.design.updatedAt = nowIso();
+          if (!nudgeShapes(draft.track.design.shapeById, ids, dx, dy)) return;
+          touchTrackDesign(draft);
         }),
 
       duplicateShapes: (ids) =>
         set((draft) => {
-          const newShapes = duplicateShapes(draft.design, ids);
-          newShapes.forEach((shape) => addShapeRecord(draft.design, shape));
-          draft.selection = newShapes.map((s) => s.id);
-          draft.design.updatedAt = nowIso();
+          const newShapes = duplicateShapes(draft.track.design, ids);
+          newShapes.forEach((shape) => addShapeRecord(draft.track.design, shape));
+          draft.session.selection = newShapes.map((s) => s.id);
+          touchTrackDesign(draft);
         }),
 
       groupSelection: (ids) => {
@@ -377,11 +290,11 @@ export const useEditor = create<EditorState>()(
         let grouped = false;
 
         set((draft) => {
-          const expandedIds = expandGroupedSelection(draft.design, ids);
+          const expandedIds = expandGroupedSelection(draft.track.design, ids);
           if (expandedIds.length < 2) return;
 
           for (const id of expandedIds) {
-            const shape = draft.design.shapeById[id];
+            const shape = draft.track.design.shapeById[id];
             if (!shape) continue;
             shape.meta = {
               ...shape.meta,
@@ -389,8 +302,8 @@ export const useEditor = create<EditorState>()(
             };
           }
 
-          draft.selection = expandedIds;
-          draft.design.updatedAt = nowIso();
+          draft.session.selection = expandedIds;
+          touchTrackDesign(draft);
           grouped = true;
         });
 
@@ -399,12 +312,12 @@ export const useEditor = create<EditorState>()(
 
       setGroupName: (ids, name) =>
         set((draft) => {
-          const expandedIds = expandGroupedSelection(draft.design, ids);
+          const expandedIds = expandGroupedSelection(draft.track.design, ids);
           const selectedGroupIds = new Set<string>();
           let changed = false;
 
           for (const id of expandedIds) {
-            const shape = draft.design.shapeById[id];
+            const shape = draft.track.design.shapeById[id];
             if (!shape) continue;
 
             const groupId = getShapeGroupId(shape);
@@ -415,8 +328,8 @@ export const useEditor = create<EditorState>()(
 
           if (selectedGroupIds.size === 0) return;
 
-          for (const id of draft.design.shapeOrder) {
-            const shape = draft.design.shapeById[id];
+          for (const id of draft.track.design.shapeOrder) {
+            const shape = draft.track.design.shapeById[id];
             if (!shape) continue;
 
             const groupId = getShapeGroupId(shape);
@@ -435,17 +348,17 @@ export const useEditor = create<EditorState>()(
           }
 
           if (changed) {
-            draft.design.updatedAt = nowIso();
+            touchTrackDesign(draft);
           }
         }),
 
       ungroupSelection: (ids) =>
         set((draft) => {
-          const expandedIds = expandGroupedSelection(draft.design, ids);
+          const expandedIds = expandGroupedSelection(draft.track.design, ids);
           let changed = false;
 
           for (const id of expandedIds) {
-            const shape = draft.design.shapeById[id];
+            const shape = draft.track.design.shapeById[id];
             if (!shape || !shape.meta || !("groupId" in shape.meta)) continue;
 
             const {
@@ -459,8 +372,8 @@ export const useEditor = create<EditorState>()(
           }
 
           if (changed) {
-            draft.selection = expandedIds;
-            draft.design.updatedAt = nowIso();
+            draft.session.selection = expandedIds;
+            touchTrackDesign(draft);
           }
         }),
 
@@ -470,9 +383,9 @@ export const useEditor = create<EditorState>()(
 
         set((draft) => {
           const idSet = new Set(ids);
-          const polylineShapes = draft.design.shapeOrder
+          const polylineShapes = draft.track.design.shapeOrder
             .filter((id) => idSet.has(id))
-            .map((id) => draft.design.shapeById[id])
+            .map((id) => draft.track.design.shapeById[id])
             .filter(
               (shape): shape is PolylineShape =>
                 Boolean(shape) && shape.kind === "polyline"
@@ -480,8 +393,8 @@ export const useEditor = create<EditorState>()(
           const merged = joinPolylineShapes(polylineShapes);
           if (!merged) return;
 
-          ids.forEach((id) => removeShapeRecord(draft.design, id));
-          addShapeRecord(draft.design, {
+          ids.forEach((id) => removeShapeRecord(draft.track.design, id));
+          addShapeRecord(draft.track.design, {
             ...merged,
             id: nextId,
             name:
@@ -489,8 +402,8 @@ export const useEditor = create<EditorState>()(
                 ? "Joined path"
                 : `Joined ${polylineShapes.length} paths`,
           });
-          draft.selection = [nextId];
-          draft.design.updatedAt = nowIso();
+          draft.session.selection = [nextId];
+          touchTrackDesign(draft);
           created = true;
         });
 
@@ -501,10 +414,10 @@ export const useEditor = create<EditorState>()(
         let closed = false;
 
         set((draft) => {
-          const shape = getDesignShapeById(draft.design, id);
+          const shape = getDesignShapeById(draft.track.design, id);
           if (!closePolyline(shape ?? undefined)) return;
-          draft.selection = [id];
-          draft.design.updatedAt = nowIso();
+          draft.session.selection = [id];
+          touchTrackDesign(draft);
           closed = true;
         });
 
@@ -513,197 +426,194 @@ export const useEditor = create<EditorState>()(
 
       setSelection: (ids) =>
         set((draft) => {
-          draft.selection = expandGroupedSelection(draft.design, ids);
-          draft.transient.segmentSelection = null;
-          if (draft.selection.length !== 1) {
-            draft.transient.vertexSelection = null;
+          draft.session.selection = expandGroupedSelection(
+            draft.track.design,
+            ids
+          );
+          draft.ui.segmentSelection = null;
+          if (draft.session.selection.length !== 1) {
+            draft.ui.vertexSelection = null;
           }
         }),
 
       setActiveTool: (tool) =>
         set((draft) => {
-          draft.transient.activeTool = tool;
+          draft.ui.activeTool = tool;
         }),
 
       setActivePresetId: (presetId) =>
         set((draft) => {
-          draft.transient.activePresetId = presetId;
+          draft.ui.activePresetId = presetId;
         }),
 
       setZoom: (zoom) =>
         set((draft) => {
-          draft.transient.zoom = Math.max(0.1, Math.min(5, zoom));
+          draft.ui.zoom = Math.max(0.1, Math.min(5, zoom));
         }),
 
       setPanOffset: (offset) =>
         set((draft) => {
-          draft.transient.panOffset = offset;
+          draft.ui.panOffset = offset;
         }),
 
       updateField: (patch) =>
         set((draft) => {
-          Object.assign(draft.design.field, patch);
-          draft.design.updatedAt = nowIso();
+          Object.assign(draft.track.design.field, patch);
+          touchTrackDesign(draft);
         }),
 
       updateDesignMeta: (patch) =>
         set((draft) => {
-          Object.assign(draft.design, patch);
-          draft.design.updatedAt = nowIso();
+          Object.assign(draft.track.design, patch);
+          touchTrackDesign(draft);
         }),
 
       replaceDesign: (design) => {
         set((draft) => {
-          draft.design = normalizeDesign(design);
-          draft.selection = [];
-          draft.transient = resetEditorTransientState(draft.transient);
-          Object.assign(draft, createDefaultEditorSessionState());
+          draft.track.design = normalizeDesign(design);
+          draft.session = createDefaultEditorSessionState();
+          draft.ui = resetEditorUiState(draft.ui);
         });
         clearTemporalHistory();
       },
 
       setHoveredShapeId: (shapeId) =>
         set((draft) => {
-          draft.transient.hoveredShapeId = shapeId;
+          draft.ui.hoveredShapeId = shapeId;
         }),
 
       setHoveredWaypoint: (w) =>
         set((draft) => {
-          draft.transient.hoveredWaypoint = w;
+          draft.ui.hoveredWaypoint = w;
         }),
 
       setSegmentSelection: (value) =>
         set((draft) => {
-          draft.transient.segmentSelection =
+          draft.ui.segmentSelection =
             typeof value === "function"
-              ? value(draft.transient.segmentSelection)
+              ? value(draft.ui.segmentSelection)
               : value;
-          if (draft.transient.segmentSelection) {
-            draft.transient.vertexSelection = null;
+          if (draft.ui.segmentSelection) {
+            draft.ui.vertexSelection = null;
           }
         }),
 
       setVertexSelection: (value) =>
         set((draft) => {
-          draft.transient.vertexSelection =
+          draft.ui.vertexSelection =
             typeof value === "function"
-              ? value(draft.transient.vertexSelection)
+              ? value(draft.ui.vertexSelection)
               : value;
-          if (draft.transient.vertexSelection) {
-            draft.transient.segmentSelection = null;
+          if (draft.ui.vertexSelection) {
+            draft.ui.segmentSelection = null;
           }
         }),
 
       setDraftPath: (value) =>
         set((draft) => {
-          draft.transient.draftPath =
-            typeof value === "function"
-              ? value(draft.transient.draftPath)
-              : value;
+          draft.ui.draftPath =
+            typeof value === "function" ? value(draft.ui.draftPath) : value;
         }),
 
       setDraftForceClosed: (value) =>
         set((draft) => {
-          draft.transient.draftForceClosed =
+          draft.ui.draftForceClosed =
             typeof value === "function"
-              ? value(draft.transient.draftForceClosed)
+              ? value(draft.ui.draftForceClosed)
               : value;
         }),
 
       setDraftSourceShapeId: (value) =>
         set((draft) => {
-          draft.transient.draftSourceShapeId =
+          draft.ui.draftSourceShapeId =
             typeof value === "function"
-              ? value(draft.transient.draftSourceShapeId)
+              ? value(draft.ui.draftSourceShapeId)
               : value;
         }),
 
       setMarqueeRect: (value) =>
         set((draft) => {
-          draft.transient.marqueeRect =
-            typeof value === "function"
-              ? value(draft.transient.marqueeRect)
-              : value;
+          draft.ui.marqueeRect =
+            typeof value === "function" ? value(draft.ui.marqueeRect) : value;
         }),
 
       setRotationSession: (value) =>
         set((draft) => {
-          draft.transient.rotationSession =
+          draft.ui.rotationSession =
             typeof value === "function"
-              ? value(draft.transient.rotationSession)
+              ? value(draft.ui.rotationSession)
               : value;
         }),
 
       setGroupDragPreview: (value) =>
         set((draft) => {
-          draft.transient.groupDragPreview =
+          draft.ui.groupDragPreview =
             typeof value === "function"
-              ? value(draft.transient.groupDragPreview)
+              ? value(draft.ui.groupDragPreview)
               : value;
         }),
 
       setLiveShapePatch: (id, patch) =>
         set((draft) => {
-          draft.transient.liveShapePatches[id] = patch;
+          draft.ui.liveShapePatches[id] = patch;
         }),
 
       clearLiveShapePatch: (id) =>
         set((draft) => {
-          delete draft.transient.liveShapePatches[id];
+          delete draft.ui.liveShapePatches[id];
         }),
 
       newProject: () => {
         set((draft) => {
-          draft.design = createDefaultDesign();
-          draft.selection = [];
-          draft.transient = resetEditorTransientState(draft.transient, {
+          draft.track = createDefaultEditorTrackState();
+          draft.session = createDefaultEditorSessionState();
+          draft.ui = resetEditorUiState(draft.ui, {
             zoom: 1,
             panOffset: { x: 0, y: 0 },
           });
-          Object.assign(draft, createDefaultEditorSessionState());
         });
         clearTemporalHistory();
       },
 
       bringForward: (id) =>
         set((draft) => {
-          const idx = findShapeOrderIndex(draft.design, id);
-          if (idx < draft.design.shapeOrder.length - 1) {
-            const [shapeId] = draft.design.shapeOrder.splice(idx, 1);
-            draft.design.shapeOrder.splice(idx + 1, 0, shapeId);
-            draft.design.updatedAt = nowIso();
+          const idx = findShapeOrderIndex(draft.track.design, id);
+          if (idx < draft.track.design.shapeOrder.length - 1) {
+            const [shapeId] = draft.track.design.shapeOrder.splice(idx, 1);
+            draft.track.design.shapeOrder.splice(idx + 1, 0, shapeId);
+            touchTrackDesign(draft);
           }
         }),
 
       sendBackward: (id) =>
         set((draft) => {
-          const idx = findShapeOrderIndex(draft.design, id);
+          const idx = findShapeOrderIndex(draft.track.design, id);
           if (idx > 0) {
-            const [shapeId] = draft.design.shapeOrder.splice(idx, 1);
-            draft.design.shapeOrder.splice(idx - 1, 0, shapeId);
-            draft.design.updatedAt = nowIso();
+            const [shapeId] = draft.track.design.shapeOrder.splice(idx, 1);
+            draft.track.design.shapeOrder.splice(idx - 1, 0, shapeId);
+            touchTrackDesign(draft);
           }
         }),
 
       pauseHistory: () => {
         set((draft) => {
-          draft.historySessionDepth += 1;
-          if (draft.historySessionDepth === 1) {
+          draft.session.historySessionDepth += 1;
+          if (draft.session.historySessionDepth === 1) {
             pauseTemporalHistory();
-            draft.historyPaused = true;
+            draft.session.historyPaused = true;
           }
         });
       },
 
       resumeHistory: () => {
         set((draft) => {
-          draft.historySessionDepth = Math.max(
+          draft.session.historySessionDepth = Math.max(
             0,
-            draft.historySessionDepth - 1
+            draft.session.historySessionDepth - 1
           );
-          if (draft.historySessionDepth === 0) {
+          if (draft.session.historySessionDepth === 0) {
             resumeTemporalHistory();
-            draft.historyPaused = false;
+            draft.session.historyPaused = false;
           }
         });
       },
@@ -711,41 +621,44 @@ export const useEditor = create<EditorState>()(
       clearHistory: () => {
         clearTemporalHistory();
         set((draft) => {
-          draft.historyPaused = false;
-          draft.historySessionDepth = 0;
+          draft.session.historyPaused = false;
+          draft.session.historySessionDepth = 0;
         });
       },
 
       beginInteraction: () => {
         set((draft) => {
-          draft.interactionSessionDepth += 1;
+          draft.session.interactionSessionDepth += 1;
         });
       },
 
       endInteraction: () => {
         set((draft) => {
-          draft.interactionSessionDepth = Math.max(
+          draft.session.interactionSessionDepth = Math.max(
             0,
-            draft.interactionSessionDepth - 1
+            draft.session.interactionSessionDepth - 1
           );
         });
       },
 
       sanitizeHistoryState: () => {
         set((draft) => {
-          draft.design = normalizeDesign(draft.design);
-          draft.transient = sanitizeEditorTransientState(draft.transient);
-          Object.assign(draft, createDefaultEditorSessionState());
+          draft.track.design = normalizeDesign(draft.track.design);
+          draft.session = createDefaultEditorSessionState();
+          draft.ui = sanitizeEditorUiState(draft.ui);
         });
       },
+
     })),
     {
       partialize: (state) => ({
-        design: normalizeDesign(serializeDesign(state.design)),
+        track: {
+          design: normalizeDesign(serializeDesign(state.track.design)),
+        },
       }),
       equality: (past, current) =>
-        past.design.id === current.design.id &&
-        past.design.updatedAt === current.design.updatedAt,
+        past.track.design.id === current.track.design.id &&
+        past.track.design.updatedAt === current.track.design.updatedAt,
       limit: 100,
     }
   )

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -157,7 +157,9 @@ export const useEditor = create<EditorState>()(
             ...shape,
             id: ids[index],
           }));
-          nextShapes.forEach((shape) => addShapeRecord(draft.track.design, shape));
+          nextShapes.forEach((shape) =>
+            addShapeRecord(draft.track.design, shape)
+          );
           touchTrackDesign(draft);
         });
         return ids;
@@ -223,7 +225,9 @@ export const useEditor = create<EditorState>()(
 
       insertPolylinePoint: (id, index, point) =>
         set((draft) => {
-          if (!insertPolylinePoint(draft.track.design.shapeById[id], index, point)) {
+          if (
+            !insertPolylinePoint(draft.track.design.shapeById[id], index, point)
+          ) {
             return;
           }
           draft.ui.segmentSelection = null;
@@ -255,7 +259,11 @@ export const useEditor = create<EditorState>()(
 
       rotateShapes: (ids, delta) =>
         set((draft) => {
-          const changed = rotateShapes(draft.track.design.shapeById, ids, delta);
+          const changed = rotateShapes(
+            draft.track.design.shapeById,
+            ids,
+            delta
+          );
           if (changed) {
             touchTrackDesign(draft);
           }
@@ -280,7 +288,9 @@ export const useEditor = create<EditorState>()(
       duplicateShapes: (ids) =>
         set((draft) => {
           const newShapes = duplicateShapes(draft.track.design, ids);
-          newShapes.forEach((shape) => addShapeRecord(draft.track.design, shape));
+          newShapes.forEach((shape) =>
+            addShapeRecord(draft.track.design, shape)
+          );
           draft.session.selection = newShapes.map((s) => s.id);
           touchTrackDesign(draft);
         }),
@@ -648,7 +658,6 @@ export const useEditor = create<EditorState>()(
           draft.ui = sanitizeEditorUiState(draft.ui);
         });
       },
-
     })),
     {
       partialize: (state) => ({

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -41,22 +41,22 @@ function getCachedShapeRecordMap(design: TrackDesign): Record<string, Shape> {
 }
 
 export function selectDesignShapes(state: EditorSnapshot): Shape[] {
-  return getCachedDesignShapes(state.design);
+  return getCachedDesignShapes(state.track.design);
 }
 
 export function selectShapeRecordMap(state: EditorSnapshot) {
-  return getCachedShapeRecordMap(state.design);
+  return getCachedShapeRecordMap(state.track.design);
 }
 
 export function selectDesignShapeCount(state: EditorSnapshot) {
-  return getCachedDesignShapes(state.design).length;
+  return getCachedDesignShapes(state.track.design).length;
 }
 
 export function selectShapeById(
   state: EditorSnapshot,
   id: string
 ): Shape | null {
-  return getDesignShapeById(state.design, id);
+  return getDesignShapeById(state.track.design, id);
 }
 
 export function selectShapesByIds(
@@ -64,30 +64,33 @@ export function selectShapesByIds(
   ids: string[]
 ): Shape[] {
   return ids
-    .map((id) => getDesignShapeById(state.design, id))
+    .map((id) => getDesignShapeById(state.track.design, id))
     .filter((shape): shape is Shape => Boolean(shape));
 }
 
 export function selectSelectedShapes(state: EditorSnapshot): Shape[] {
-  let designCache = selectedShapesCache.get(state.design);
+  let designCache = selectedShapesCache.get(state.track.design);
   if (!designCache) {
     designCache = new WeakMap<string[], Shape[]>();
-    selectedShapesCache.set(state.design, designCache);
+    selectedShapesCache.set(state.track.design, designCache);
   }
 
-  const cached = designCache.get(state.selection);
+  const cached = designCache.get(state.session.selection);
   if (cached) return cached;
 
-  const next = selectShapesByIds(state, state.selection);
-  designCache.set(state.selection, next);
+  const next = selectShapesByIds(state, state.session.selection);
+  designCache.set(state.session.selection, next);
   return next;
 }
 
 export function selectSelectedPolyline(
   state: EditorSnapshot
 ): PolylineShape | null {
-  if (state.selection.length !== 1) return null;
-  const shape = getDesignShapeById(state.design, state.selection[0]);
+  if (state.session.selection.length !== 1) return null;
+  const shape = getDesignShapeById(
+    state.track.design,
+    state.session.selection[0]
+  );
   return shape?.kind === "polyline" ? shape : null;
 }
 
@@ -97,25 +100,27 @@ export function selectPrimaryPolyline(
   const selected = selectSelectedPolyline(state);
   if (selected) return selected;
   return (
-    getCachedDesignShapes(state.design).find(
+    getCachedDesignShapes(state.track.design).find(
       (shape): shape is PolylineShape => shape.kind === "polyline"
     ) ?? null
   );
 }
 
 export function selectDesignPolylineZRange(state: EditorSnapshot) {
-  return getCachedDesignPolylineZRange(state.design);
+  return getCachedDesignPolylineZRange(state.track.design);
 }
 
 export function selectSelectionLocked(state: EditorSnapshot) {
   return (
-    state.selection.length > 0 &&
-    state.selection.every((id) => Boolean(selectShapeById(state, id)?.locked))
+    state.session.selection.length > 0 &&
+    state.session.selection.every((id) =>
+      Boolean(selectShapeById(state, id)?.locked)
+    )
   );
 }
 
 export function selectHasPath(state: EditorSnapshot) {
-  return getCachedDesignShapes(state.design).some(
+  return getCachedDesignShapes(state.track.design).some(
     (shape): shape is PolylineShape =>
       shape.kind === "polyline" && shape.points.length >= 2
   );
@@ -126,49 +131,49 @@ export function selectHasSelectedPolyline(state: EditorSnapshot) {
 }
 
 export function selectActiveTool(state: EditorSnapshot) {
-  return state.transient.activeTool;
+  return state.ui.activeTool;
 }
 
 export function selectZoom(state: EditorSnapshot) {
-  return state.transient.zoom;
+  return state.ui.zoom;
 }
 
 export function selectPanOffset(state: EditorSnapshot) {
-  return state.transient.panOffset;
+  return state.ui.panOffset;
 }
 
 export function selectHoveredShapeId(state: EditorSnapshot) {
-  return state.transient.hoveredShapeId;
+  return state.ui.hoveredShapeId;
 }
 
 export function selectHoveredWaypoint(state: EditorSnapshot) {
-  return state.transient.hoveredWaypoint;
+  return state.ui.hoveredWaypoint;
 }
 
 export function selectVertexSelection(state: EditorSnapshot) {
-  return state.transient.vertexSelection;
+  return state.ui.vertexSelection;
 }
 
 export function selectDraftPath(state: EditorSnapshot) {
-  return state.transient.draftPath;
+  return state.ui.draftPath;
 }
 
 export function selectDraftForceClosed(state: EditorSnapshot) {
-  return state.transient.draftForceClosed;
+  return state.ui.draftForceClosed;
 }
 
 export function selectDraftSourceShapeId(state: EditorSnapshot) {
-  return state.transient.draftSourceShapeId;
+  return state.ui.draftSourceShapeId;
 }
 
 export function selectMarqueeRect(state: EditorSnapshot) {
-  return state.transient.marqueeRect;
+  return state.ui.marqueeRect;
 }
 
 export function selectRotationSession(state: EditorSnapshot) {
-  return state.transient.rotationSession;
+  return state.ui.rotationSession;
 }
 
 export function selectGroupDragPreview(state: EditorSnapshot) {
-  return state.transient.groupDragPreview;
+  return state.ui.groupDragPreview;
 }


### PR DESCRIPTION
- Introduced new persistence layer definitions for local drafts, projects, and restore points in `projects.ts`.
- Added functions to save, load, and clear local drafts in the persistence layer.
- Created a new `actions.ts` file to encapsulate track, session, and UI actions for better organization.
- Refactored the editor state in `editor.ts` to separate track, session, and UI states, improving clarity and maintainability.
- Updated selectors in `selectors.ts` to reflect changes in the editor state structure, ensuring correct data retrieval.
- Enhanced type definitions for better clarity and maintainability across the codebase.