### PR TITLE
feat: Account-only durable embeds and share lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ See the [public roadmap discussion](https://github.com/dutchdronesquad/trackdraw
 ### With an account
 
 - 🖼️ **Publish gallery tracks** - opt published shares into the public gallery so visitors can discover them and open the canonical read-only share view
+- 🌐 **Embed published tracks** - copy iframe embed code for account-published tracks so clubs and event sites can show a live read-only layout
 - 💾 **Sync projects across devices** - keep account-backed work accessible from another browser or device while local-first editing stays available without signing in
 - 🔐 **Manage your account and shares** - use a passkey or email magic link, update your profile, change your account email safely, and manage or revoke published shares from the Projects dialog
 
-## Experimental
+### Experimental
 
 - 🧪 **Velocidrone draft export** - generate an experimental `.trk` export as a starting point for simulator testing
 
@@ -77,7 +78,7 @@ See the [public roadmap discussion](https://github.com/dutchdronesquad/trackdraw
 3. **Review how the layout will ride** with the live 3D preview, elevation tools, floating ladder placement, and route-flow checks before race day.
 4. **Turn the design into a handoff** by saving it locally, syncing it to your account, publishing a read-only share link, listing it in the gallery, or exporting the assets you need, including race-day documents and cinematic FPV video.
 
-TrackDraw works without an account. You can create, manage, share, recover, import, and export projects in the browser, while signing in adds continuity across devices.
+TrackDraw works without an account. You can create, manage, temporarily share, recover, import, and export projects in the browser, while signing in adds continuity across devices, durable published links, gallery publishing, and embeds.
 
 ## Sponsors
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -10,12 +10,12 @@ TrackDraw is now strong in these areas:
 - Track path authoring with elevation-aware planning and a live 3D preview
 - Share-first collaboration through read-only links
 - Public gallery discovery through opt-in published shares
+- Account-published embeds through a dedicated read-only `/embed/[token]` route
 - Practical mobile editing for quick venue-side changes
 - Portable outputs through PNG, SVG, PDF, 3D render capture, and JSON project files
 
 The most useful next product moves are:
 
-- A stronger embeddable share surface that extends published read-only viewing beyond TrackDraw itself
 - A sharper decision on how far account-backed project continuity should go after the shipped account and authorization foundation
 - A clearer separation between local-first workflows and account-backed follow-up
 - Versioned publish history for account-backed shares
@@ -44,29 +44,20 @@ Labels used below:
 - `Account-backed`: depends on ownership, sync, identity, or shared persistence
 - `Research`: still primarily exploratory
 
-### 1. Embeddable Shared Views (`No account required`)
+### 1. Embeddable Shared Views (`Account-backed`) ✓
 
-Published shares should be able to travel beyond TrackDraw links when a club, organizer, or venue wants to place a read-only layout directly on another site.
+Account-backed published shares can now travel beyond TrackDraw links when a club, organizer, or venue wants to place a read-only layout directly on another site.
 
-Why now:
+Shipped:
 
-- Published sharing is already a core product surface
-- The gallery now gives TrackDraw a stronger public discovery surface, but external club and event sites still need a way to show a specific track directly
-- An embed flow increases reuse and visibility without requiring collaborative editing, social features, or a separate gallery detail model
-- The safest implementation path can build on the existing read-only share model instead of introducing a second viewer stack
-
-Focus:
-
-- Add an embed option to the share flow with copyable iframe code and a clear preview
-- Keep embeds read-only, lightweight, and compatible with the canonical published share route
-- Preserve pan, zoom, and basic route review interaction without exposing editing controls
-- Treat sandboxing, performance, and invalid-share failure states as product requirements, not implementation details
-
-Suggested first slices:
-
-- Lightweight embed page that reuses the current share resolution and read-only viewer foundations
-- Share dialog follow-up that exposes iframe code generation alongside the existing share link actions
-- Validation of mobile and desktop behavior for embeds on third-party pages with constrained container sizes
+- Added `/embed/[token]`, a lightweight read-only embed route that reuses stored share resolution and the shared viewer foundation
+- Made embeds account-only: only active `published` shares render track data in embed context
+- Kept anonymous shares temporary and non-embeddable, including when someone manually constructs an `/embed/[token]` URL
+- Added clear unavailable states for temporary, expired, revoked, and missing embeds
+- Added a dedicated Embed section in ShareDialog with copyable iframe code, 2D layout / 3D preview initial view selection, and a larger default iframe height
+- Kept gallery discovery separate from share lifecycle, so listing, unlisting, featuring, and hiding do not change share expiry
+- Added automated coverage for share lifecycle, embed authorization, gallery expiry independence, and cleanup targeting
+- Validated the current embed container behavior for mobile and desktop, including iframe sizing and compact mobile controls
 
 ### 2. Accounts And Ownership Model (`Research`)
 
@@ -145,11 +136,16 @@ Shipped:
 - Shares published by signed-in users are always linked to the active account project via `project_id`
 - Shares tab added to the Projects dialog: lists active shares with copy-link, open-in-tab, and revoke actions
 - Revoke button in ShareDialog hidden for unauthenticated sessions
+- Share lifecycle is explicit: anonymous shares are temporary and always expire; account-backed shares are published and stay live until revoked
+- Account project publishing reuses the active published share token instead of creating unbounded duplicate shares
+- Gallery visibility is decoupled from share expiry; list, unlist, feature, and hide only change gallery state
+- Account-published shares are automatically embeddable through `/embed/[token]`; anonymous, expired, revoked, and missing embeds never render track data
+- ShareDialog has a dedicated Embed section with 2D layout / 3D preview initial view selection and copyable iframe code
 
 Focus:
 
 - Keep local-first publish flows simple for unauthenticated use
-- Revisit any replace/regenerate flow only once account ownership is properly defined
+- Improve operator visibility for temporary, published, revoked, gallery-linked, and embedded share states before adding deeper share administration
 
 #### Share Version History
 
@@ -409,12 +405,13 @@ Keep these usable without an account where possible:
 
 - Core editing, preview, import/export, and local project work
 - Local inventory, venue setup, and lightweight notes in their initial versions
-- One-off share publishing and local revoke from the current Studio session
+- One-off temporary share publishing with explicit expiry
 
 Likely account-backed follow-up:
 
 - Cross-device project sync and cloud-backed project libraries
 - Durable ownership and administration of published shares
+- Durable published embeds
 - Version history for account-backed published shares
 - Operator-controlled gallery visibility through feature, hide, restore, and delete actions
 - Curated gallery collections

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -22,15 +22,6 @@ Labels used below:
 
 ## Current Priority
 
-- [ ] Embeddable shared views (`No account required`)
-      Let published layouts be embedded on external sites through a lightweight read-only viewer that reuses the current share model instead of introducing a separate viewing stack.
-  - [ ] Embed code in share flow
-        Add a share-dialog path for iframe embed code with copy-to-clipboard and preview.
-  - [ ] Lightweight embed viewer
-        Reuse the existing share resolution and read-only viewer foundations so embeds keep pan, zoom, and basic route review without exposing editing controls.
-  - [ ] Constrained-container validation
-        Validate desktop and mobile behavior for embeds inside real third-party page containers, including sandboxing and failure states.
-
 - [ ] Velocidrone experimental export stabilization (`No account required`)
       The first experimental `.trk` export is already shipped. The remaining work here is narrowing the gap between "importable" and "dependable" by validating more real layouts and tightening the remaining prefab mapping and orientation edge cases before this can be treated as a more supported workflow.
   - [ ] Validate the current `.trk` export on more layouts
@@ -55,6 +46,19 @@ Labels used below:
 
 - [x] Published gallery (`Account-backed`)
       TrackDraw now has an opt-in public gallery at `/gallery` built on published shares. Signed-in owners can list and remove gallery entries, visitors can browse community tracks, and moderators/admins can manage gallery visibility from the dashboard.
+
+- [x] Embeddable shared views (`Account-backed`)
+      Account-backed published layouts can now be embedded on external sites through a lightweight read-only viewer that reuses the current share model.
+  - [x] Account-only durable share lifecycle
+        Account-backed shares are durable published links that stay live until revoked, while anonymous shares remain temporary with explicit expiry.
+  - [x] Embed code in share flow
+        The Share dialog has a dedicated Embed section with iframe code, copy-to-clipboard, and 2D layout / 3D preview initial view selection.
+  - [x] Lightweight embed viewer
+        `/embed/[token]` reuses stored share resolution and only renders active published shares; temporary, expired, revoked, and missing embeds show unavailable states.
+  - [x] Gallery lifecycle independence
+        Gallery visibility is decoupled from share expiry, so listing, unlisting, featuring, and hiding do not change whether the share or embed stays live.
+  - [x] Embed container validation
+        Desktop and mobile embed behavior is validated for the current iframe sizing, compact mobile controls, and unavailable states.
 
 ## Follow-up
 

--- a/migrations/0008_share_lifecycle.sql
+++ b/migrations/0008_share_lifecycle.sql
@@ -1,0 +1,14 @@
+ALTER TABLE shares
+  ADD COLUMN share_type TEXT NOT NULL DEFAULT 'temporary';
+
+UPDATE shares
+SET
+  share_type = 'published',
+  expires_at = NULL,
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE owner_user_id IS NOT NULL
+  AND revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS shares_share_type_idx ON shares(share_type);
+CREATE INDEX IF NOT EXISTS shares_owner_project_type_idx
+  ON shares(owner_user_id, project_id, share_type);

--- a/src/app/api/shares/[token]/route.ts
+++ b/src/app/api/shares/[token]/route.ts
@@ -11,7 +11,6 @@ import {
   updateGalleryEntryMetadata,
 } from "@/lib/server/gallery";
 import {
-  getShareExpiresAtByToken,
   getOrCreateGalleryEntryForShare,
   resolveStoredShare,
   revokeShare,
@@ -216,14 +215,14 @@ export async function PATCH(request: Request, context: ShareTokenRouteContext) {
       await deleteGalleryEntry(authorized.token);
     }
 
-    const expiresAt = await getShareExpiresAtByToken(authorized.token);
     const updatedEntry = await getGalleryEntryByShareToken(authorized.token);
 
     return NextResponse.json({
       ok: true,
       share: {
         token: authorized.token,
-        expiresAt,
+        expiresAt: authorized.share.expiresAt,
+        shareType: authorized.share.shareType,
         galleryState: updatedEntry?.galleryState ?? null,
         galleryTitle: updatedEntry?.galleryTitle ?? null,
         galleryDescription: updatedEntry?.galleryDescription ?? null,

--- a/src/app/api/shares/route.ts
+++ b/src/app/api/shares/route.ts
@@ -85,7 +85,7 @@ export async function POST(request: Request) {
     }
 
     const share = await createShare(design, {
-      expiresInDays: body.expiresInDays ?? 90,
+      expiresInDays: user ? undefined : (body.expiresInDays ?? 90),
       ownerUserId: user?.id ?? null,
       projectId: body.projectId ?? null,
     });
@@ -102,6 +102,7 @@ export async function POST(request: Request) {
         expiresAt: share.expiresAt,
         ownerUserId: share.ownerUserId,
         projectId: share.projectId,
+        shareType: share.shareType,
       },
     });
   } catch (error) {

--- a/src/app/embed/EmbedUnavailable.tsx
+++ b/src/app/embed/EmbedUnavailable.tsx
@@ -1,0 +1,103 @@
+import Image from "next/image";
+import Link from "next/link";
+import { LockKeyhole, Unlink } from "lucide-react";
+
+type EmbedUnavailableReason = "temporary" | "expired" | "revoked" | "missing";
+
+const copyByReason: Record<
+  EmbedUnavailableReason,
+  { title: string; description: string }
+> = {
+  temporary: {
+    title: "Embed unavailable",
+    description:
+      "Embeds are available for published account shares. Open the share link or sign in to publish a durable embed.",
+  },
+  expired: {
+    title: "This embed has expired",
+    description:
+      "This temporary TrackDraw share is no longer active. Ask the owner to publish a durable account share.",
+  },
+  revoked: {
+    title: "This embed was revoked",
+    description:
+      "The owner has revoked this TrackDraw share, so the embedded track is no longer available.",
+  },
+  missing: {
+    title: "Track not found",
+    description:
+      "This TrackDraw embed does not match an active published account share.",
+  },
+};
+
+export default function EmbedUnavailable({
+  reason,
+  shareHref,
+}: {
+  reason: EmbedUnavailableReason;
+  shareHref?: string;
+}) {
+  const copy = copyByReason[reason];
+  const Icon = reason === "temporary" ? LockKeyhole : Unlink;
+
+  return (
+    <main className="bg-background text-foreground flex min-h-dvh items-center justify-center px-4 py-6">
+      <div className="border-border/60 bg-card/80 w-full max-w-md rounded-2xl border px-5 py-5 shadow-[0_18px_40px_rgba(15,23,42,0.10)]">
+        <div className="flex items-start gap-3">
+          <div className="bg-muted text-muted-foreground flex size-10 shrink-0 items-center justify-center rounded-xl">
+            <Icon className="size-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="relative h-6 w-28">
+              <Image
+                src="/assets/brand/trackdraw-logo-color-lightbg.svg"
+                alt="TrackDraw"
+                fill
+                priority
+                unoptimized
+                className="object-contain dark:hidden"
+              />
+              <Image
+                src="/assets/brand/trackdraw-logo-color-darkbg.svg"
+                alt="TrackDraw"
+                fill
+                priority
+                unoptimized
+                className="hidden object-contain dark:block"
+              />
+            </div>
+            <h1 className="mt-4 text-base font-semibold">{copy.title}</h1>
+            <p className="text-muted-foreground mt-2 text-sm leading-6">
+              {copy.description}
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {shareHref ? (
+                <Link
+                  href={shareHref}
+                  target="_blank"
+                  className="border-border text-foreground hover:bg-muted inline-flex h-9 items-center rounded-lg border px-3 text-xs font-medium transition-colors"
+                >
+                  Open share link
+                </Link>
+              ) : null}
+              <Link
+                href="/login"
+                target="_blank"
+                className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-9 items-center rounded-lg px-3 text-xs font-medium transition-colors"
+              >
+                Sign in
+              </Link>
+              <Link
+                href="/"
+                target="_blank"
+                className="border-border text-foreground hover:bg-muted inline-flex h-9 items-center rounded-lg border px-3 text-xs font-medium transition-colors"
+              >
+                TrackDraw
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/embed/EmbedViewer.tsx
+++ b/src/app/embed/EmbedViewer.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect } from "react";
+import { useEditor } from "@/store/editor";
+import type { TrackDesign } from "@/lib/types";
+import type { EditorView } from "@/lib/view";
+
+const EditorShell = dynamic(
+  () => import("@/components/editor/shared/EditorShell"),
+  {
+    ssr: false,
+    loading: () => <div className="bg-background h-dvh" />,
+  }
+);
+
+export default function EmbedViewer({
+  design,
+  initialTab = "2d",
+}: {
+  design: TrackDesign;
+  initialTab?: EditorView;
+}) {
+  const replaceDesign = useEditor((s) => s.replaceDesign);
+
+  useEffect(() => {
+    replaceDesign(design);
+  }, [design, replaceDesign]);
+
+  return (
+    <div className="relative h-dvh">
+      <EditorShell initialTab={initialTab} embedMode existingShareMode />
+    </div>
+  );
+}

--- a/src/app/embed/[token]/page.tsx
+++ b/src/app/embed/[token]/page.tsx
@@ -1,0 +1,46 @@
+import { resolveStoredShare } from "@/lib/server/shares";
+import { parseEditorView } from "@/lib/view";
+import EmbedUnavailable from "../EmbedUnavailable";
+import EmbedViewer from "../EmbedViewer";
+
+type EmbedTokenPageProps = {
+  params: Promise<{
+    token: string;
+  }>;
+  searchParams?: Promise<{
+    view?: string;
+  }>;
+};
+
+export default async function EmbedTokenPage({
+  params,
+  searchParams,
+}: EmbedTokenPageProps) {
+  const { token } = await params;
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const resolvedShare = await resolveStoredShare(token);
+  const shareHref = `/share/${encodeURIComponent(token)}`;
+
+  if (resolvedShare.status === "available") {
+    if (resolvedShare.share.shareType !== "published") {
+      return <EmbedUnavailable reason="temporary" shareHref={shareHref} />;
+    }
+
+    return (
+      <EmbedViewer
+        design={resolvedShare.share.design}
+        initialTab={parseEditorView(resolvedSearchParams?.view) ?? "2d"}
+      />
+    );
+  }
+
+  if (resolvedShare.status === "expired") {
+    return <EmbedUnavailable reason="expired" />;
+  }
+
+  if (resolvedShare.status === "revoked") {
+    return <EmbedUnavailable reason="revoked" />;
+  }
+
+  return <EmbedUnavailable reason="missing" />;
+}

--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Track Embed",
+  description: "Embedded TrackDraw read-only track view.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function EmbedLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,7 +56,6 @@ import {
   Check,
   CheckCircle2,
   ClipboardCheck,
-  Minus,
   Orbit,
   Route,
   Share2,
@@ -65,6 +64,7 @@ import {
 } from "lucide-react";
 import { Screenshot } from "@/components/landing/Screenshot";
 import { FaqAccordion } from "@/components/landing/FaqAccordion";
+import { PricingSection } from "@/components/landing/PricingSection";
 import {
   Reveal,
   RevealStagger,
@@ -131,7 +131,7 @@ const features = [
     surface: "from-violet-500/[0.13] via-violet-500/[0.035] to-transparent",
     glow: "#a855f7",
     title: "Shared review links",
-    text: "Share one current layout with pilots and crew in read-only mode, no install or login required.",
+    text: "Share a read-only layout with pilots and crew. Guest links are temporary; account-published links can stay live until revoked.",
   },
   {
     icon: ClipboardCheck,
@@ -155,18 +155,6 @@ const features = [
   },
 ];
 
-const compareRows = [
-  { label: "Full track designer", guest: true, account: true },
-  { label: "2D & 3D preview", guest: true, account: true },
-  { label: "PDF, SVG, PNG & JSON export", guest: true, account: true },
-  { label: "Read-only share links", guest: true, account: true },
-  { label: "Durable published links", guest: false, account: true },
-  { label: "Embeddable track views", guest: false, account: true },
-  { label: "Publish tracks in the gallery", guest: false, account: true },
-  { label: "Cloud-synced projects", guest: false, account: true },
-  { label: "Open projects on any device", guest: false, account: true },
-];
-
 const faq = [
   {
     q: "What is the best way to plan an FPV race track?",
@@ -174,7 +162,7 @@ const faq = [
   },
   {
     q: "Can pilots review the layout without an account?",
-    a: "Yes. Share links open in read-only mode on any device, no account or app needed. Send it to pilots, judges, or crew and everyone sees the same current version.",
+    a: "Yes. Share links open in read-only mode on any device, no account or app needed. Send it to pilots, judges, or crew and everyone sees the same published version.",
   },
   {
     q: "Does it work on a tablet at the venue?",
@@ -186,7 +174,7 @@ const faq = [
   },
   {
     q: "Do I need an account to get started?",
-    a: "No. Open the studio and start designing right away. Creating an account adds cloud storage so your projects are accessible from any device.",
+    a: "No. Open the studio and start designing right away. Creating an account adds cloud storage, durable published links, gallery publishing, and embeds.",
   },
   {
     q: "Can I reuse a layout for a future event?",
@@ -597,113 +585,7 @@ export default function Home() {
           </div>
         </section>
 
-        {/* ── Compare ──────────────────────────────────────── */}
-        <section id="plans" className="border-border/40 border-t">
-          <div className="mx-auto w-full max-w-6xl px-6 py-14 sm:py-20">
-            <Reveal className="mb-12">
-              <Eyebrow>Pricing</Eyebrow>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">
-                Start now, sign up when you need more.
-              </h2>
-              <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-7">
-                Open TrackDraw and start designing right away. Create an account
-                to sync projects across devices, keep published links live, and
-                embed layouts on club or event sites.
-              </p>
-            </Reveal>
-
-            <div className="-mx-6 scroll-px-6 overflow-x-auto px-6 pb-2 sm:mx-auto sm:max-w-2xl sm:scroll-px-0 sm:overflow-visible sm:px-0 sm:pb-0">
-              <div className="flex w-max min-w-full snap-x snap-mandatory gap-4 sm:grid sm:w-auto sm:min-w-0 sm:grid-cols-2">
-                {/* Guest */}
-                <Reveal>
-                  <div className="border-border/50 bg-card/20 flex h-full max-w-78 min-w-74 snap-start flex-col rounded-2xl border p-6 sm:max-w-none sm:min-w-0">
-                    <p className="text-muted-foreground text-[11px] font-semibold tracking-[0.2em] uppercase">
-                      No sign-up
-                    </p>
-                    <p className="mt-2 text-xl font-semibold">Guest</p>
-                    <p className="text-muted-foreground mt-1 text-sm">
-                      Open the studio, share temporary links, and export your
-                      work.
-                    </p>
-                    <Link
-                      href="/studio"
-                      className="border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground mt-5 inline-flex h-9 items-center justify-center gap-2 rounded-full border px-5 text-sm transition"
-                    >
-                      Open Studio <ArrowRight className="size-3.5" />
-                    </Link>
-                    <ul className="mt-6 space-y-2.5">
-                      {compareRows.map((row) => (
-                        <li
-                          key={row.label}
-                          className="flex items-center gap-2.5 text-sm"
-                        >
-                          {row.guest ? (
-                            <Check className="text-brand-primary size-3.5 shrink-0" />
-                          ) : (
-                            <Minus className="text-muted-foreground/40 size-3.5 shrink-0" />
-                          )}
-                          <span
-                            className={
-                              row.guest
-                                ? "text-foreground"
-                                : "text-muted-foreground/40"
-                            }
-                          >
-                            {row.label}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                </Reveal>
-
-                {/* Account */}
-                <Reveal delay={0.07}>
-                  <div className="border-brand-primary/25 bg-brand-primary/5 from-brand-primary/8 relative mr-6 flex h-full max-w-78 min-w-74 snap-start flex-col overflow-hidden rounded-2xl border bg-linear-to-br to-transparent p-6 sm:mr-0 sm:max-w-none sm:min-w-0">
-                    <div className="pointer-events-none absolute -top-10 -right-10 size-36 rounded-full bg-[#1E93DB] opacity-[0.12] blur-2xl" />
-                    <p className="text-brand-primary text-[11px] font-semibold tracking-[0.2em] uppercase">
-                      With account
-                    </p>
-                    <p className="mt-2 text-xl font-semibold">Free</p>
-                    <p className="text-muted-foreground mt-1 text-sm">
-                      Cloud sync, durable published links, embeds, and gallery
-                      publishing.
-                    </p>
-                    <Link
-                      href="/login"
-                      className="mt-5 inline-flex h-9 items-center justify-center gap-2 rounded-full bg-[#1E93DB] px-5 text-sm font-medium text-white shadow-md shadow-[#1E93DB]/25 transition hover:brightness-110"
-                    >
-                      Create account <ArrowRight className="size-3.5" />
-                    </Link>
-                    <ul className="mt-6 space-y-2.5">
-                      {compareRows.map((row) => (
-                        <li
-                          key={row.label}
-                          className="flex items-center gap-2.5 text-sm"
-                        >
-                          {row.account ? (
-                            <Check className="text-brand-primary size-3.5 shrink-0" />
-                          ) : (
-                            <Minus className="text-muted-foreground/40 size-3.5 shrink-0" />
-                          )}
-                          <span
-                            className={
-                              row.account
-                                ? "text-foreground"
-                                : "text-muted-foreground/40"
-                            }
-                          >
-                            {row.label}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                </Reveal>
-              </div>
-            </div>
-          </div>
-        </section>
+        <PricingSection />
 
         {/* ── FAQ ──────────────────────────────────────────── */}
         <section id="faq" className="border-border/40 border-t">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -160,6 +160,8 @@ const compareRows = [
   { label: "2D & 3D preview", guest: true, account: true },
   { label: "PDF, SVG, PNG & JSON export", guest: true, account: true },
   { label: "Read-only share links", guest: true, account: true },
+  { label: "Durable published links", guest: false, account: true },
+  { label: "Embeddable track views", guest: false, account: true },
   { label: "Publish tracks in the gallery", guest: false, account: true },
   { label: "Cloud-synced projects", guest: false, account: true },
   { label: "Open projects on any device", guest: false, account: true },
@@ -605,8 +607,8 @@ export default function Home() {
               </h2>
               <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-7">
                 Open TrackDraw and start designing right away. Create an account
-                to sync projects across devices and publish layouts to the
-                gallery.
+                to sync projects across devices, keep published links live, and
+                embed layouts on club or event sites.
               </p>
             </Reveal>
 
@@ -620,7 +622,8 @@ export default function Home() {
                     </p>
                     <p className="mt-2 text-xl font-semibold">Guest</p>
                     <p className="text-muted-foreground mt-1 text-sm">
-                      Open the studio and start designing right away.
+                      Open the studio, share temporary links, and export your
+                      work.
                     </p>
                     <Link
                       href="/studio"
@@ -663,7 +666,8 @@ export default function Home() {
                     </p>
                     <p className="mt-2 text-xl font-semibold">Free</p>
                     <p className="text-muted-foreground mt-1 text-sm">
-                      Cloud sync, multi-device access, and publishing.
+                      Cloud sync, durable published links, embeds, and gallery
+                      publishing.
                     </p>
                     <Link
                       href="/login"

--- a/src/components/dialogs/ProjectManager/SharesTab.tsx
+++ b/src/components/dialogs/ProjectManager/SharesTab.tsx
@@ -12,7 +12,7 @@ import {
 } from "./shared";
 
 function formatExpiresIn(iso: string | null): string {
-  if (!iso) return "no expiry";
+  if (!iso) return "published";
   const days = Math.ceil(
     (new Date(iso).getTime() - Date.now()) / (1000 * 60 * 60 * 24)
   );
@@ -81,7 +81,9 @@ export function ProjectManagerSharesTab({
               </p>
               <p className="text-muted-foreground mt-0.5 text-[11px]">
                 {itemLabel(share.shapeCount)} ·{" "}
-                {formatExpiresIn(share.expiresAt)}
+                {share.shareType === "published"
+                  ? "published until revoked"
+                  : formatExpiresIn(share.expiresAt)}
               </p>
             </div>
             <div

--- a/src/components/dialogs/ShareDialog.tsx
+++ b/src/components/dialogs/ShareDialog.tsx
@@ -10,7 +10,11 @@ import {
 } from "@/components/SidebarDialog";
 import { Button } from "@/components/ui/button";
 import { useEditor } from "@/store/editor";
-import { buildStoredSharePath, encodeDesign } from "@/lib/share";
+import {
+  buildStoredEmbedPath,
+  buildStoredSharePath,
+  encodeDesign,
+} from "@/lib/share";
 import { parseEditorView } from "@/lib/view";
 import { authClient } from "@/lib/auth-client";
 import {
@@ -35,6 +39,9 @@ import {
   EyeOff,
   Sparkles,
   Trash2,
+  Code2,
+  Route,
+  Orbit,
 } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -52,13 +59,14 @@ type GalleryState = "unlisted" | "listed" | "featured" | "hidden";
 type ActiveShare = {
   url: string;
   shareToken: string;
+  shareType: "temporary" | "published";
   expiresInDays: 7 | 30 | 90 | null;
   galleryState: GalleryState;
   galleryTitle: string;
   galleryDescription: string;
 };
 
-type Tab = "share" | "gallery" | "actions";
+type Tab = "share" | "embed" | "gallery" | "actions";
 
 const SHARE_EXPIRY_OPTIONS = [
   { value: 7 as const, label: "7 days" },
@@ -129,8 +137,12 @@ function clearAnonShare() {
 
 function getLifetimeCopy(hostname: string, expiresInDays: 7 | 30 | 90 | null) {
   return expiresInDays === null
-    ? `Read-only snapshot on ${hostname} with no expiry`
+    ? `Published link on ${hostname}, stays live until revoked`
     : `Read-only snapshot on ${hostname}, expires in ${expiresInDays} days`;
+}
+
+function buildIframeCode(embedUrl: string) {
+  return `<iframe src="${embedUrl}" title="TrackDraw track embed" loading="lazy" style="width:100%;height:600px;border:0;" allowfullscreen></iframe>`;
 }
 
 const PREVIEW_MAX_W = 960;
@@ -210,6 +222,8 @@ export default function ShareDialog({
   const [revoking, setRevoking] = useState(false);
   const [galleryUpdating, setGalleryUpdating] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [copiedEmbed, setCopiedEmbed] = useState(false);
+  const [embedView, setEmbedView] = useState<"2d" | "3d">(currentView);
   const [showGalleryForm, setShowGalleryForm] = useState(false);
   const [confirmRemoveFromGallery, setConfirmRemoveFromGallery] =
     useState(false);
@@ -223,13 +237,30 @@ export default function ShareDialog({
 
   const shareNeedsRefresh =
     share !== null &&
-    ((publishedDesignToken !== null &&
-      publishedDesignToken !== currentDesignToken) ||
-      (share.expiresInDays !== null && expiresInDays !== share.expiresInDays));
+    publishedDesignToken !== null &&
+    publishedDesignToken !== currentDesignToken;
+  const expiryNeedsRefresh =
+    share !== null &&
+    share.shareType === "temporary" &&
+    share.expiresInDays !== null &&
+    expiresInDays !== share.expiresInDays;
+  const linkNeedsRefresh = shareNeedsRefresh || expiryNeedsRefresh;
+  const showExpirySelector = !isAuthenticated;
+  const embedUrl =
+    share?.shareType === "published"
+      ? new URL(
+          buildStoredEmbedPath(share.shareToken, embedView),
+          typeof window !== "undefined"
+            ? window.location.origin
+            : "https://trackdraw.app"
+        ).toString()
+      : null;
+  const iframeCode = embedUrl ? buildIframeCode(embedUrl) : null;
 
   const isGalleryVisible =
     share?.galleryState === "listed" || share?.galleryState === "featured";
   const blockedByModeration = share?.galleryState === "hidden";
+  const showEmbedSection = isAuthenticated && !existingShareMode;
   const showGallerySection = isAuthenticated && !!projectId;
 
   const galleryTitleValid = isGalleryTitleValid(galleryTitleInput);
@@ -290,6 +321,7 @@ export default function ShareDialog({
             share?: {
               token: string;
               expiresAt: string | null;
+              shareType: "temporary" | "published";
               galleryState: string | null;
               galleryTitle: string | null;
               galleryDescription: string | null;
@@ -307,6 +339,7 @@ export default function ShareDialog({
                 window.location.origin
               ).toString(),
               shareToken: s.token,
+              shareType: s.shareType,
               expiresInDays: expiry,
               galleryState: parseGalleryState(s.galleryState),
               galleryTitle: s.galleryTitle ?? "",
@@ -322,6 +355,7 @@ export default function ShareDialog({
             setShare({
               url: stored.url,
               shareToken: stored.shareToken,
+              shareType: "temporary",
               expiresInDays: stored.expiresInDays,
               galleryState: "unlisted",
               galleryTitle: "",
@@ -371,14 +405,19 @@ export default function ShareDialog({
         body: JSON.stringify({
           design,
           view: currentView,
-          expiresInDays,
+          ...(!isAuthenticated ? { expiresInDays } : {}),
           ...(projectId ? { projectId } : {}),
         }),
       });
       const data = (await res.json()) as
         | {
             ok: true;
-            share: { token: string; path: string; expiresAt: string | null };
+            share: {
+              token: string;
+              path: string;
+              expiresAt: string | null;
+              shareType: "temporary" | "published";
+            };
           }
         | { ok: false; error?: string };
 
@@ -386,9 +425,12 @@ export default function ShareDialog({
         throw new Error(data.error ?? "Failed to create share link");
 
       const url = new URL(data.share.path, window.location.origin).toString();
-      const expiry = inferExpiryDays(data.share.expiresAt) ?? expiresInDays;
+      const expiry =
+        data.share.shareType === "published"
+          ? null
+          : (inferExpiryDays(data.share.expiresAt) ?? expiresInDays);
 
-      if (force && share) {
+      if (force && share && share.shareToken !== data.share.token) {
         fetch(`/api/shares/${encodeURIComponent(share.shareToken)}`, {
           method: "DELETE",
         }).catch(() => {
@@ -399,6 +441,7 @@ export default function ShareDialog({
       const newShare: ActiveShare = {
         url,
         shareToken: data.share.token,
+        shareType: data.share.shareType,
         expiresInDays: expiry,
         galleryState: "unlisted",
         galleryTitle: design.title.trim(),
@@ -437,9 +480,9 @@ export default function ShareDialog({
   const handleCopy = async () => {
     try {
       const url =
-        share && !shareNeedsRefresh
+        share && !linkNeedsRefresh
           ? share.url
-          : await doPublish(shareNeedsRefresh);
+          : await doPublish(linkNeedsRefresh);
       await navigator.clipboard.writeText(url);
       setCopied(true);
       toast.success("Link copied");
@@ -452,9 +495,9 @@ export default function ShareDialog({
   const handleNativeShare = async () => {
     try {
       const url =
-        share && !shareNeedsRefresh
+        share && !linkNeedsRefresh
           ? share.url
-          : await doPublish(shareNeedsRefresh);
+          : await doPublish(linkNeedsRefresh);
       await navigator.share({
         title: design.title || "TrackDraw",
         text: `Check out this FPV track: ${design.title || "Untitled"}`,
@@ -470,9 +513,9 @@ export default function ShareDialog({
   const handleOpenInTab = async () => {
     try {
       const url =
-        share && !shareNeedsRefresh
+        share && !linkNeedsRefresh
           ? share.url
-          : await doPublish(shareNeedsRefresh);
+          : await doPublish(linkNeedsRefresh);
       window.open(url, "_blank", "noopener,noreferrer");
     } catch (err) {
       toast.error(
@@ -500,6 +543,18 @@ export default function ShareDialog({
       toast.error(err instanceof Error ? err.message : "Failed to revoke link");
     } finally {
       setRevoking(false);
+    }
+  };
+
+  const handleCopyEmbed = async () => {
+    if (!iframeCode) return;
+    try {
+      await navigator.clipboard.writeText(iframeCode);
+      setCopiedEmbed(true);
+      toast.success("Embed code copied");
+      setTimeout(() => setCopiedEmbed(false), 2000);
+    } catch {
+      toast.error("Failed to copy embed code");
     }
   };
 
@@ -677,19 +732,19 @@ export default function ShareDialog({
   };
 
   const primaryActionLabel = share
-    ? shareNeedsRefresh
+    ? linkNeedsRefresh
       ? "Update link"
       : "Copy link"
     : "Create link";
   const PrimaryIcon = share
-    ? shareNeedsRefresh
+    ? linkNeedsRefresh
       ? Link2
       : copied
         ? Check
         : Copy
     : Link2;
   const primaryAction = share
-    ? shareNeedsRefresh
+    ? linkNeedsRefresh
       ? () => handlePublish(true)
       : handleCopy
     : () => handlePublish();
@@ -713,7 +768,7 @@ export default function ShareDialog({
       : share?.galleryState === "listed"
         ? "Visible in the public gallery."
         : share?.galleryState === "hidden"
-          ? "Hidden by moderation. The direct link still works until expiry or revoke."
+          ? "Hidden by moderation. The direct link still works until it is revoked."
           : share
             ? "Direct link only. Not visible in the public gallery."
             : "Create a share link first.";
@@ -731,9 +786,11 @@ export default function ShareDialog({
             : "No link";
   const galleryShareLinkValue = !share
     ? "No link"
-    : share.expiresInDays === null
-      ? "No expiry"
-      : `Expires in ${share.expiresInDays} days`;
+    : share.shareType === "published"
+      ? "Published"
+      : share.expiresInDays === null
+        ? "No expiry"
+        : `Expires in ${share.expiresInDays} days`;
   const GalleryStatusIcon = !loadDone
     ? Loader2
     : share?.galleryState === "featured"
@@ -768,6 +825,15 @@ export default function ShareDialog({
       ]
     : [
         { id: "share", label: "Share", icon: <Link2 className="size-4" /> },
+        ...(showEmbedSection
+          ? [
+              {
+                id: "embed",
+                label: "Embed",
+                icon: <Code2 className="size-4" />,
+              },
+            ]
+          : []),
         ...(showGallerySection
           ? [
               {
@@ -794,12 +860,19 @@ export default function ShareDialog({
       title: "Share link",
       description: existingShareMode
         ? "Copy or resend this published read-only link, or open Studio to make your own editable copy."
-        : "Create a read-only snapshot link and control how long it stays active.",
+        : isAuthenticated
+          ? "Publish a durable read-only link that stays live until revoked."
+          : "Create a temporary read-only snapshot link and control how long it stays active.",
     },
     gallery: {
       title: "Gallery visibility",
       description:
         "Manage how this published link appears in the public gallery.",
+    },
+    embed: {
+      title: "Embed",
+      description:
+        "Copy iframe code for an account-published track that stays live until revoked.",
     },
     actions: {
       title: "Actions",
@@ -863,32 +936,44 @@ export default function ShareDialog({
               </div>
             ) : (
               <>
-                <div className="space-y-3">
-                  <div>
+                {showExpirySelector ? (
+                  <div className="space-y-3">
+                    <div>
+                      <p className="text-foreground text-sm font-medium">
+                        Link expires after
+                      </p>
+                      <p className="text-muted-foreground mt-1 text-[11px]">
+                        Temporary snapshots stay available until they expire.
+                      </p>
+                    </div>
+                    <div className="grid grid-cols-3 gap-2">
+                      {SHARE_EXPIRY_OPTIONS.map((option) => (
+                        <button
+                          key={option.value}
+                          type="button"
+                          onClick={() => setExpiresInDays(option.value)}
+                          className={cn(
+                            "border-border/60 bg-background/65 text-foreground hover:bg-muted/40 cursor-pointer rounded-lg border px-3 py-2 text-xs transition-colors",
+                            expiresInDays === option.value &&
+                              "border-primary bg-primary/10 text-primary"
+                          )}
+                        >
+                          {option.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="border-border/60 bg-muted/18 rounded-xl border px-3 py-3">
                     <p className="text-foreground text-sm font-medium">
-                      Link expires after
+                      Published account link
                     </p>
-                    <p className="text-muted-foreground mt-1 text-[11px]">
-                      Published snapshots stay available until they expire.
+                    <p className="text-muted-foreground mt-1 text-[12px] leading-relaxed">
+                      Account shares stay live until you revoke them. The same
+                      published track can also be embedded.
                     </p>
                   </div>
-                  <div className="grid grid-cols-3 gap-2">
-                    {SHARE_EXPIRY_OPTIONS.map((option) => (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() => setExpiresInDays(option.value)}
-                        className={cn(
-                          "border-border/60 bg-background/65 text-foreground hover:bg-muted/40 cursor-pointer rounded-lg border px-3 py-2 text-xs transition-colors",
-                          expiresInDays === option.value &&
-                            "border-primary bg-primary/10 text-primary"
-                        )}
-                      >
-                        {option.label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
+                )}
 
                 <div className="border-border/60 space-y-3 border-t pt-4">
                   <div className="flex items-center gap-2">
@@ -897,12 +982,20 @@ export default function ShareDialog({
                     </div>
                     <div className="min-w-0">
                       <p className="text-foreground text-sm font-medium">
-                        {share ? "Published link" : "No published link yet"}
+                        {share
+                          ? share.shareType === "published"
+                            ? "Published link"
+                            : "Temporary link"
+                          : isAuthenticated
+                            ? "No published link yet"
+                            : "No temporary link yet"}
                       </p>
                       <p className="text-muted-foreground text-[11px]">
                         {share
                           ? getLifetimeCopy(hostname, share.expiresInDays)
-                          : "Choose when it expires and create a read-only snapshot."}
+                          : isAuthenticated
+                            ? "Create a durable read-only track that can be shared or embedded."
+                            : "Choose when it expires and create a read-only snapshot."}
                       </p>
                     </div>
                   </div>
@@ -915,12 +1008,13 @@ export default function ShareDialog({
                       className="border-border bg-background/70 text-foreground focus:ring-primary/50 w-full min-w-0 truncate rounded-lg border px-3 py-2 font-mono text-xs outline-hidden focus:ring-1"
                     />
                   ) : null}
-                  {shareNeedsRefresh ? (
+                  {linkNeedsRefresh ? (
                     <div className="flex items-start gap-2 rounded-lg border border-amber-500/25 bg-amber-500/8 px-3 py-2.5 text-xs text-amber-400">
                       <Share2 className="mt-0.5 size-3.5 shrink-0" />
                       <span className="leading-relaxed">
-                        This link no longer reflects the latest design or expiry
-                        selection.
+                        {shareNeedsRefresh
+                          ? "This link no longer reflects the latest design."
+                          : "This link no longer reflects the latest expiry selection."}
                       </span>
                     </div>
                   ) : null}
@@ -929,7 +1023,7 @@ export default function ShareDialog({
                       "grid grid-cols-1 gap-2",
                       share &&
                         isAuthenticated &&
-                        (shareNeedsRefresh
+                        (linkNeedsRefresh
                           ? "min-[520px]:grid-cols-2"
                           : "min-[520px]:grid-cols-3")
                     )}
@@ -944,7 +1038,7 @@ export default function ShareDialog({
                     </Button>
                     {share && isAuthenticated ? (
                       <>
-                        {!shareNeedsRefresh ? (
+                        {!linkNeedsRefresh ? (
                           <Button
                             variant="outline"
                             onClick={() => handlePublish(true)}
@@ -952,7 +1046,7 @@ export default function ShareDialog({
                             className="w-full"
                           >
                             <RefreshCw className="size-4" />
-                            Regenerate link
+                            Update link
                           </Button>
                         ) : null}
                         <Button
@@ -970,6 +1064,189 @@ export default function ShareDialog({
                 </div>
               </>
             )}
+          </div>
+        )}
+
+        {resolvedTab === "embed" && (
+          <div className="space-y-4">
+            {!loadDone ? (
+              <div className="flex items-center gap-2">
+                <Loader2 className="text-muted-foreground size-4 animate-spin" />
+                <p className="text-muted-foreground text-sm">
+                  Loading embed state…
+                </p>
+              </div>
+            ) : !share ? (
+              <div className="space-y-3">
+                <div className="flex items-start gap-3">
+                  <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-lg">
+                    <Code2 className="text-muted-foreground size-4" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-foreground text-sm font-medium">
+                      Publish before embedding
+                    </p>
+                    <p className="text-muted-foreground mt-1 text-[12px] leading-relaxed">
+                      Embeds use the durable account-published link, so create
+                      the published link before copying iframe code.
+                    </p>
+                  </div>
+                </div>
+                <Button
+                  onClick={() => handlePublish()}
+                  disabled={busy}
+                  className="w-full"
+                >
+                  {publishing ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Link2 className="size-4" />
+                  )}
+                  Create published link
+                </Button>
+              </div>
+            ) : share.shareType !== "published" ? (
+              <div className="space-y-2">
+                <p className="text-foreground text-sm font-medium">
+                  Temporary links cannot be embedded
+                </p>
+                <p className="text-muted-foreground text-[12px] leading-relaxed">
+                  Sign in and publish this track from your account to create a
+                  durable embed.
+                </p>
+              </div>
+            ) : linkNeedsRefresh ? (
+              <div className="space-y-3">
+                <div className="flex items-start gap-2 rounded-lg border border-amber-500/25 bg-amber-500/8 px-3 py-2.5 text-xs text-amber-400">
+                  <Share2 className="mt-0.5 size-3.5 shrink-0" />
+                  <span className="leading-relaxed">
+                    Update the published link first so the embed uses the latest
+                    design.
+                  </span>
+                </div>
+                <Button
+                  onClick={() => handlePublish(true)}
+                  disabled={busy}
+                  className="w-full"
+                >
+                  {publishing ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <RefreshCw className="size-4" />
+                  )}
+                  Update link
+                </Button>
+              </div>
+            ) : iframeCode ? (
+              <div className="space-y-4">
+                <div className="flex items-center gap-2">
+                  <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-lg">
+                    <Code2 className="text-muted-foreground size-4" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="text-foreground text-sm font-medium">
+                      Embed code
+                    </p>
+                    <p className="text-muted-foreground text-[11px]">
+                      Account-published tracks can be embedded on club or event
+                      sites.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-muted-foreground text-[11px] font-medium">
+                    Initial view
+                  </p>
+                  <div className="grid grid-cols-1 gap-2 min-[420px]:grid-cols-2">
+                    {(
+                      [
+                        {
+                          view: "2d",
+                          label: "2D layout",
+                          description: "Open as the flat field plan",
+                          icon: Route,
+                        },
+                        {
+                          view: "3d",
+                          label: "3D preview",
+                          description: "Open in the orbit review",
+                          icon: Orbit,
+                        },
+                      ] as const
+                    ).map((option) => {
+                      const Icon = option.icon;
+                      return (
+                        <button
+                          key={option.view}
+                          type="button"
+                          onClick={() => {
+                            setEmbedView(option.view);
+                            setCopiedEmbed(false);
+                          }}
+                          className={cn(
+                            "border-border/60 bg-background/65 flex cursor-pointer items-start gap-2 rounded-lg border px-3 py-2 text-left transition-colors",
+                            embedView === option.view
+                              ? "border-primary/50 bg-primary/10 text-primary"
+                              : "text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+                          )}
+                        >
+                          <Icon className="mt-0.5 size-3.5 shrink-0" />
+                          <span className="min-w-0">
+                            <span className="block text-xs font-medium">
+                              {option.label}
+                            </span>
+                            <span
+                              className={cn(
+                                "mt-0.5 block text-[10px] leading-snug",
+                                embedView === option.view
+                                  ? "text-primary/75"
+                                  : "text-muted-foreground"
+                              )}
+                            >
+                              {option.description}
+                            </span>
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex flex-col gap-2 min-[520px]:flex-row min-[520px]:items-center min-[520px]:justify-between">
+                    <div>
+                      <p className="text-muted-foreground text-[11px] font-medium">
+                        Iframe code
+                      </p>
+                      <p className="text-muted-foreground/75 mt-0.5 text-[10px]">
+                        Includes the selected initial view.
+                      </p>
+                    </div>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleCopyEmbed}
+                      className="w-full min-[520px]:w-auto"
+                    >
+                      {copiedEmbed ? (
+                        <Check className="size-4" />
+                      ) : (
+                        <Copy className="size-4" />
+                      )}
+                      Copy code
+                    </Button>
+                  </div>
+                  <textarea
+                    readOnly
+                    value={iframeCode}
+                    rows={3}
+                    onFocus={(e) => e.target.select()}
+                    className="border-border bg-background/70 text-foreground focus:ring-primary/50 w-full min-w-0 resize-none rounded-lg border px-3 py-2 font-mono text-xs outline-hidden focus:ring-1"
+                  />
+                </div>
+              </div>
+            ) : null}
           </div>
         )}
 
@@ -1043,8 +1320,7 @@ export default function ShareDialog({
                 </p>
                 <p className="text-destructive text-[11px] leading-relaxed">
                   This track is hidden from the gallery by moderation. The
-                  direct share link can still work until it expires or is
-                  revoked.
+                  direct share link can still work until it is revoked.
                 </p>
               </div>
             ) : showGalleryForm ? (
@@ -1221,8 +1497,7 @@ export default function ShareDialog({
                         <div className="border-border/60 flex flex-col gap-2 border-t pt-3">
                           <p className="text-muted-foreground text-[11px] leading-relaxed">
                             Remove from the public gallery? The share link
-                            itself will continue to work until it expires or is
-                            revoked.
+                            itself will continue to work until it is revoked.
                           </p>
                           <div className="flex flex-col-reverse gap-2 min-[380px]:flex-row min-[380px]:justify-end">
                             <Button
@@ -1272,22 +1547,24 @@ export default function ShareDialog({
                           its own title, description and preview.
                         </p>
                       </div>
-                      <Button
-                        onClick={() => {
-                          setConfirmRemoveFromGallery(false);
-                          setShowGalleryForm(true);
-                        }}
-                        disabled={busy || shareNeedsRefresh}
-                        className="w-full"
-                      >
-                        Add to gallery
-                      </Button>
                       {shareNeedsRefresh ? (
                         <p className="text-muted-foreground text-[11px] leading-relaxed">
                           Update the share link first so the gallery uses the
                           latest snapshot.
                         </p>
                       ) : null}
+                      <div className="border-border/60 flex border-t pt-3 min-[520px]:justify-end">
+                        <Button
+                          onClick={() => {
+                            setConfirmRemoveFromGallery(false);
+                            setShowGalleryForm(true);
+                          }}
+                          disabled={busy || shareNeedsRefresh}
+                          className="w-full min-[520px]:w-auto"
+                        >
+                          Add to gallery
+                        </Button>
+                      </div>
                     </>
                   )}
                 </div>

--- a/src/components/editor/mobile/ViewControls.tsx
+++ b/src/components/editor/mobile/ViewControls.tsx
@@ -19,6 +19,7 @@ interface EditorMobileViewControlsProps {
   onStartFlyThrough: () => void;
   onTabChange: (tab: EditorViewportTab) => void;
   saveStatusLabel: string;
+  showShareActions?: boolean;
   studioHref?: string;
   tab: EditorViewportTab;
   closePanel?: () => void;
@@ -82,6 +83,7 @@ export function ViewControls({
   onTabChange,
   readOnly = false,
   saveStatusLabel,
+  showShareActions = true,
   studioHref = "/studio",
   tab,
 }: EditorMobileViewControlsProps) {
@@ -99,7 +101,7 @@ export function ViewControls({
     <>
       <div>
         <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-          {readOnly ? "Shared review" : "Current mode"}
+          {readOnly ? saveStatusLabel : "Current mode"}
         </p>
         <div className="border-border/50 bg-muted/18 rounded-2xl border px-3 py-3">
           <p className="text-foreground text-sm font-medium">
@@ -198,7 +200,7 @@ export function ViewControls({
           </>
         )}
       </div>
-      {readOnly ? (
+      {readOnly && showShareActions ? (
         <div>
           <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
             Share

--- a/src/components/editor/shared/EditorShell.tsx
+++ b/src/components/editor/shared/EditorShell.tsx
@@ -57,10 +57,12 @@ const MobilePanels = dynamic(() => import("./MobilePanels"), { ssr: false });
 
 export default function EditorShell({
   initialTab = "2d",
+  embedMode = false,
   studioHref,
   existingShareMode = false,
 }: {
   initialTab?: EditorView;
+  embedMode?: boolean;
   studioHref?: string;
   existingShareMode?: boolean;
 }) {
@@ -130,6 +132,7 @@ export default function EditorShell({
           <Header
             tab={tab}
             onTabChange={handleTabChange}
+            embedMode={embedMode}
             studioHref={studioHref}
             showObstacleNumbers={showObstacleNumbers}
             onToggleObstacleNumbers={() =>
@@ -178,6 +181,7 @@ export default function EditorShell({
             mobileGizmoEnabled={mobileGizmoEnabled}
             mobileObstacleNumbersEnabled={showObstacleNumbers}
             mobileRulersEnabled={mobileRulersEnabled}
+            embedMode={embedMode}
             onFitView={() => canvasRef.current?.fitToWindow()}
             onSetMobileGizmoEnabled={setMobileGizmoEnabled}
             onSetMobileObstacleNumbersEnabled={setShowObstacleNumbers}
@@ -193,14 +197,14 @@ export default function EditorShell({
             onTabChange={handleTabChange}
             onSetReadOnlyMenuOpen={setReadOnlyMenuOpen}
             readOnlyMenuOpen={readOnlyMenuOpen}
-            saveStatusLabel="Shared review"
+            saveStatusLabel={embedMode ? "Embedded track" : "Shared review"}
             studioHref={studioHref}
             tab={tab}
           />
         ) : null}
       </div>
 
-      {shareOpen ? (
+      {shareOpen && !embedMode ? (
         <ShareDialog
           open={shareOpen}
           onOpenChange={setShareOpen}

--- a/src/components/editor/shared/Header.tsx
+++ b/src/components/editor/shared/Header.tsx
@@ -10,6 +10,7 @@ import { useTheme } from "@/hooks/useTheme";
 interface HeaderProps {
   tab: "2d" | "3d";
   onTabChange: (tab: "2d" | "3d") => void;
+  embedMode?: boolean;
   studioHref?: string;
   showObstacleNumbers?: boolean;
   onToggleObstacleNumbers?: () => void;
@@ -18,6 +19,7 @@ interface HeaderProps {
 export default function Header({
   tab,
   onTabChange,
+  embedMode = false,
   studioHref = "/studio",
   showObstacleNumbers = false,
   onToggleObstacleNumbers,
@@ -127,18 +129,22 @@ export default function Header({
         <div className="bg-border/80 mx-1 hidden h-4 w-px sm:block" />
         <span className="hidden shrink-0 items-center gap-1 rounded-md border border-sky-500/30 bg-sky-500/10 px-1.5 py-0.5 text-[11px] font-medium text-sky-400 sm:flex">
           <Eye className="size-3" />
-          Shared review
+          {embedMode ? "Embed" : "Shared review"}
         </span>
-        <div className="bg-border/80 mx-1 hidden h-4 w-px sm:block" />
-        <Link
-          href={studioHref}
-          className={cn(
-            buttonVariants({ variant: "outline", size: "sm" }),
-            "hidden h-8 gap-1.5 px-2 text-xs sm:inline-flex sm:h-7 sm:px-2.5"
-          )}
-        >
-          Make editable copy
-        </Link>
+        {!embedMode ? (
+          <>
+            <div className="bg-border/80 mx-1 hidden h-4 w-px sm:block" />
+            <Link
+              href={studioHref}
+              className={cn(
+                buttonVariants({ variant: "outline", size: "sm" }),
+                "hidden h-8 gap-1.5 px-2 text-xs sm:inline-flex sm:h-7 sm:px-2.5"
+              )}
+            >
+              Make editable copy
+            </Link>
+          </>
+        ) : null}
       </div>
     </header>
   );

--- a/src/components/editor/shared/MobilePanels.tsx
+++ b/src/components/editor/shared/MobilePanels.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ArrowRight, Scan, Share2 } from "lucide-react";
 import { MobileDrawer } from "@/components/MobileDrawer";
 import { ViewControls } from "@/components/editor/mobile/ViewControls";
+import { cn } from "@/lib/utils";
 
 export interface MobilePanelsProps {
   hasPath: boolean;
@@ -11,6 +12,7 @@ export interface MobilePanelsProps {
   mobileGizmoEnabled: boolean;
   mobileObstacleNumbersEnabled: boolean;
   mobileRulersEnabled: boolean;
+  embedMode?: boolean;
   onFitView: () => void;
   onSetMobileGizmoEnabled: (enabled: boolean) => void;
   onSetMobileObstacleNumbersEnabled: (enabled: boolean) => void;
@@ -26,6 +28,7 @@ export interface MobilePanelsProps {
 }
 
 export default function MobilePanels({
+  embedMode = false,
   hasPath,
   mobileFlyModeActive,
   mobileGizmoEnabled,
@@ -54,28 +57,44 @@ export default function MobilePanels({
         className="pointer-events-none fixed inset-x-0 z-30 flex justify-center px-3 lg:hidden"
         style={{ bottom: "calc(0.55rem + env(safe-area-inset-bottom))" }}
       >
-        <div className="pointer-events-auto flex w-full max-w-sm items-center gap-1 rounded-[1.35rem] border border-white/10 bg-slate-950/86 p-1.5 text-white shadow-[0_18px_36px_rgba(15,23,42,0.32)] backdrop-blur">
+        <div
+          className={cn(
+            "pointer-events-auto flex items-center gap-1 border border-white/10 bg-slate-950/86 text-white shadow-[0_18px_36px_rgba(15,23,42,0.32)] backdrop-blur",
+            embedMode
+              ? "rounded-full p-1"
+              : "w-full max-w-sm rounded-[1.35rem] p-1.5"
+          )}
+        >
           <button
             onClick={() => onSetReadOnlyMenuOpen(true)}
-            className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
+            className={cn(
+              "flex min-w-0 items-center font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white",
+              embedMode
+                ? "gap-1.5 rounded-full px-3 py-2 text-xs"
+                : "flex-1 flex-col gap-1 rounded-2xl px-2 py-2 text-[11px]"
+            )}
           >
             <Scan className="size-3.5" />
-            <span>Review</span>
+            <span>{embedMode ? "View" : "Review"}</span>
           </button>
-          <button
-            onClick={onShare}
-            className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
-          >
-            <Share2 className="size-3.5" />
-            <span>Share</span>
-          </button>
-          <Link
-            href={studioHref}
-            className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
-          >
-            <ArrowRight className="size-3.5" />
-            <span>Edit copy</span>
-          </Link>
+          {!embedMode ? (
+            <button
+              onClick={onShare}
+              className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
+            >
+              <Share2 className="size-3.5" />
+              <span>Share</span>
+            </button>
+          ) : null}
+          {!embedMode ? (
+            <Link
+              href={studioHref}
+              className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
+            >
+              <ArrowRight className="size-3.5" />
+              <span>Edit copy</span>
+            </Link>
+          ) : null}
         </div>
       </div>
 
@@ -103,6 +122,7 @@ export default function MobilePanels({
           studioHref={studioHref}
           closePanel={() => onSetReadOnlyMenuOpen(false)}
           readOnly
+          showShareActions={!embedMode}
           tab={tab}
         />
       </MobileDrawer>

--- a/src/components/editor/useAccountProjectSync.ts
+++ b/src/components/editor/useAccountProjectSync.ts
@@ -31,6 +31,7 @@ export type AccountShareItem = {
   createdAt: string;
   expiresAt: string | null;
   projectId: string | null;
+  shareType: "temporary" | "published";
   galleryState: "unlisted" | "listed" | "featured" | "hidden" | null;
   galleryTitle: string | null;
   galleryDescription: string | null;

--- a/src/components/landing/PricingSection.tsx
+++ b/src/components/landing/PricingSection.tsx
@@ -1,0 +1,243 @@
+import Link from "next/link";
+import { ArrowRight, Check, Info, Minus } from "lucide-react";
+import { Reveal } from "@/components/landing/Motion";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+type PlanKey = "guest" | "account";
+
+type PlanCard = {
+  key: PlanKey;
+  eyebrow: string;
+  title: string;
+  priceLabel: string;
+  description: string;
+  href: string;
+  ctaLabel: string;
+  highlighted?: boolean;
+  delay?: number;
+};
+
+type CompareRow = {
+  label: string;
+  guest: boolean;
+  account: boolean;
+  guestDetail?: string;
+  accountDetail?: string;
+  info?: string;
+};
+
+const compareSections: Array<{ title: string; rows: CompareRow[] }> = [
+  {
+    title: "Design",
+    rows: [
+      { label: "Full track designer", guest: true, account: true },
+      { label: "2D & 3D preview", guest: true, account: true },
+      { label: "PDF, SVG, PNG & JSON export", guest: true, account: true },
+    ],
+  },
+  {
+    title: "Sharing",
+    rows: [
+      {
+        label: "Share links",
+        guest: true,
+        account: true,
+        guestDetail: "Temporary links",
+        accountDetail: "Published until revoked",
+        info: "Guest share links are temporary. Account-published links stay live until revoked and can also be embedded.",
+      },
+      {
+        label: "Embeds",
+        guest: false,
+        account: true,
+      },
+      {
+        label: "Gallery publishing",
+        guest: false,
+        account: true,
+      },
+    ],
+  },
+  {
+    title: "Projects",
+    rows: [
+      { label: "Cloud-synced projects", guest: false, account: true },
+      { label: "Open projects on any device", guest: false, account: true },
+    ],
+  },
+];
+
+const planCards: PlanCard[] = [
+  {
+    key: "guest",
+    eyebrow: "No sign-up",
+    title: "Guest",
+    priceLabel: "Free",
+    description:
+      "Best for quick drafts, one-off temporary review links, and local export without creating an account.",
+    href: "/studio",
+    ctaLabel: "Open Studio",
+  },
+  {
+    key: "account",
+    eyebrow: "With account",
+    title: "Account",
+    priceLabel: "Free",
+    description:
+      "Best for durable published links, embeds, gallery publishing, and reopening projects on another device.",
+    href: "/login",
+    ctaLabel: "Create account",
+    highlighted: true,
+    delay: 0.07,
+  },
+];
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="text-muted-foreground flex items-center gap-2 text-[11px] font-semibold tracking-[0.2em] uppercase">
+      <span className="bg-muted-foreground/50 size-1 rounded-full" />
+      {children}
+    </p>
+  );
+}
+
+function PlanFeatureList({ plan }: { plan: PlanKey }) {
+  return (
+    <div className="mt-6 space-y-4">
+      {compareSections.map((section) => (
+        <div key={section.title}>
+          <p className="text-muted-foreground/70 text-[10px] font-semibold tracking-[0.16em] uppercase">
+            {section.title}
+          </p>
+          <ul className="mt-2 space-y-2.5">
+            {section.rows.map((row) => {
+              const enabled = row[plan];
+              const detail =
+                plan === "guest" ? row.guestDetail : row.accountDetail;
+
+              return (
+                <li
+                  key={row.label}
+                  className="flex items-start gap-2.5 text-sm"
+                >
+                  {enabled ? (
+                    <Check className="text-brand-primary mt-0.5 size-3.5 shrink-0" />
+                  ) : (
+                    <Minus className="text-muted-foreground/40 mt-0.5 size-3.5 shrink-0" />
+                  )}
+                  <span className="min-w-0 flex-1">
+                    <span
+                      className={
+                        enabled ? "text-foreground" : "text-muted-foreground/40"
+                      }
+                    >
+                      {row.label}
+                    </span>
+                    {row.info ? (
+                      <Tooltip>
+                        <TooltipTrigger
+                          type="button"
+                          aria-label={`${row.label} details`}
+                          className="text-muted-foreground hover:text-foreground ml-1 inline-flex align-[-2px] transition-colors"
+                        >
+                          <Info className="size-3" />
+                        </TooltipTrigger>
+                        <TooltipContent side="top" sideOffset={6}>
+                          {row.info}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : null}
+                    {detail ? (
+                      <span
+                        className={
+                          enabled
+                            ? "text-muted-foreground mt-0.5 block text-[11px] leading-snug"
+                            : "text-muted-foreground/35 mt-0.5 block text-[11px] leading-snug"
+                        }
+                      >
+                        {detail}
+                      </span>
+                    ) : null}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function PricingSection() {
+  return (
+    <section id="plans" className="border-border/40 border-t">
+      <div className="mx-auto w-full max-w-6xl px-6 py-14 sm:py-20">
+        <Reveal className="mb-12">
+          <Eyebrow>Plans</Eyebrow>
+          <h2 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">
+            Start now, sign up when you need more.
+          </h2>
+          <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-7">
+            Both current options are free. Guest mode keeps the core editor open
+            without setup; accounts add durable publishing, embeds, gallery
+            listing, and project continuity across devices.
+          </p>
+        </Reveal>
+
+        <div className="-mx-6 scroll-px-6 overflow-x-auto px-6 pb-2 sm:mx-auto sm:max-w-2xl sm:scroll-px-0 sm:overflow-visible sm:px-0 sm:pb-0">
+          <div className="flex w-max min-w-full snap-x snap-mandatory gap-4 sm:grid sm:w-auto sm:min-w-0 sm:grid-cols-2">
+            {planCards.map((plan) => (
+              <Reveal key={plan.key} delay={plan.delay}>
+                <div
+                  className={
+                    plan.highlighted
+                      ? "border-brand-primary/25 bg-brand-primary/5 from-brand-primary/8 relative mr-6 flex h-full max-w-78 min-w-74 snap-start flex-col overflow-hidden rounded-2xl border bg-linear-to-br to-transparent p-6 sm:mr-0 sm:max-w-none sm:min-w-0"
+                      : "border-border/50 bg-card/20 flex h-full max-w-78 min-w-74 snap-start flex-col rounded-2xl border p-6 sm:max-w-none sm:min-w-0"
+                  }
+                >
+                  {plan.highlighted ? (
+                    <div className="pointer-events-none absolute -top-10 -right-10 size-36 rounded-full bg-[#1E93DB] opacity-[0.12] blur-2xl" />
+                  ) : null}
+                  <p
+                    className={
+                      plan.highlighted
+                        ? "text-brand-primary text-[11px] font-semibold tracking-[0.2em] uppercase"
+                        : "text-muted-foreground text-[11px] font-semibold tracking-[0.2em] uppercase"
+                    }
+                  >
+                    {plan.eyebrow}
+                  </p>
+                  <div className="mt-2 flex items-end gap-2">
+                    <p className="text-xl font-semibold">{plan.title}</p>
+                    <p className="text-muted-foreground pb-0.5 text-sm">
+                      {plan.priceLabel}
+                    </p>
+                  </div>
+                  <p className="text-muted-foreground mt-2 text-sm leading-6">
+                    {plan.description}
+                  </p>
+                  <Link
+                    href={plan.href}
+                    className={
+                      plan.highlighted
+                        ? "mt-5 inline-flex h-9 items-center justify-center gap-2 rounded-full bg-[#1E93DB] px-5 text-sm font-medium text-white shadow-md shadow-[#1E93DB]/25 transition hover:brightness-110"
+                        : "border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground mt-5 inline-flex h-9 items-center justify-center gap-2 rounded-full border px-5 text-sm transition"
+                    }
+                  >
+                    {plan.ctaLabel} <ArrowRight className="size-3.5" />
+                  </Link>
+                  <PlanFeatureList plan={plan.key} />
+                </div>
+              </Reveal>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/server/gallery.ts
+++ b/src/lib/server/gallery.ts
@@ -108,16 +108,6 @@ export type GalleryOverviewStats = {
   unlisted: number;
 };
 
-type TransitionOptions = {
-  retentionDays?: number;
-};
-
-const DEFAULT_SHARE_RETENTION_DAYS = 90;
-
-function toIsoDateAfterDays(days: number) {
-  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
-}
-
 export function parseGalleryState(value: string | null): GalleryState {
   if (!value) return "unlisted";
   if (value === "link_only") return "unlisted";
@@ -174,25 +164,6 @@ function mapPublicGalleryEntryRow(
         : Number.parseFloat(String(row.field_height)),
     shapeCount: row.shape_count ?? 0,
   };
-}
-
-async function setShareExpiryState(params: {
-  shareToken: string;
-  expiresAt: string | null;
-}) {
-  const db = await getDatabase();
-  const now = new Date().toISOString();
-
-  await db
-    .prepare(
-      `
-        update shares
-        set expires_at = ?, updated_at = ?
-        where token = ? and revoked_at is null
-      `
-    )
-    .bind(params.expiresAt, now, params.shareToken)
-    .run();
 }
 
 export async function getGalleryEntryByShareToken(shareToken: string) {
@@ -392,10 +363,7 @@ export async function createUnlistedGalleryEntry(params: {
   return getGalleryEntryByShareToken(params.shareToken);
 }
 
-export async function moveGalleryEntryToUnlisted(
-  shareToken: string,
-  options: TransitionOptions & { restoreShareExpiry?: boolean } = {}
-) {
+export async function moveGalleryEntryToUnlisted(shareToken: string) {
   const db = await getDatabase();
   const now = new Date().toISOString();
 
@@ -412,21 +380,9 @@ export async function moveGalleryEntryToUnlisted(
     )
     .bind(now, shareToken)
     .run();
-
-  if (options.restoreShareExpiry !== false) {
-    await setShareExpiryState({
-      shareToken,
-      expiresAt: toIsoDateAfterDays(
-        options.retentionDays ?? DEFAULT_SHARE_RETENTION_DAYS
-      ),
-    });
-  }
 }
 
-export async function deleteGalleryEntry(
-  shareToken: string,
-  options: TransitionOptions & { restoreShareExpiry?: boolean } = {}
-) {
+export async function deleteGalleryEntry(shareToken: string) {
   const db = await getDatabase();
   const existing = await getGalleryEntryByShareToken(shareToken);
 
@@ -443,15 +399,6 @@ export async function deleteGalleryEntry(
     )
     .bind(shareToken)
     .run();
-
-  if (options.restoreShareExpiry !== false) {
-    await setShareExpiryState({
-      shareToken,
-      expiresAt: toIsoDateAfterDays(
-        options.retentionDays ?? DEFAULT_SHARE_RETENTION_DAYS
-      ),
-    });
-  }
 }
 
 export async function moveGalleryEntryToListed(shareToken: string) {
@@ -472,11 +419,6 @@ export async function moveGalleryEntryToListed(shareToken: string) {
     )
     .bind(now, now, shareToken)
     .run();
-
-  await setShareExpiryState({
-    shareToken,
-    expiresAt: null,
-  });
 }
 
 export async function updateGalleryEntryMetadata(params: {
@@ -541,17 +483,9 @@ export async function moveGalleryEntryToFeatured(shareToken: string) {
     )
     .bind(now, now, shareToken)
     .run();
-
-  await setShareExpiryState({
-    shareToken,
-    expiresAt: null,
-  });
 }
 
-export async function moveGalleryEntryToHidden(
-  shareToken: string,
-  options: TransitionOptions = {}
-) {
+export async function moveGalleryEntryToHidden(shareToken: string) {
   const db = await getDatabase();
   const now = new Date().toISOString();
 
@@ -568,11 +502,4 @@ export async function moveGalleryEntryToHidden(
     )
     .bind(now, now, shareToken)
     .run();
-
-  await setShareExpiryState({
-    shareToken,
-    expiresAt: toIsoDateAfterDays(
-      options.retentionDays ?? DEFAULT_SHARE_RETENTION_DAYS
-    ),
-  });
 }

--- a/src/lib/server/share-retention.ts
+++ b/src/lib/server/share-retention.ts
@@ -11,8 +11,13 @@ export async function cleanupExpiredShares(db: D1Database) {
     .prepare(
       `
       delete from shares
-      where revoked_at is not null
+      where (
+           revoked_at is not null
+           and datetime(revoked_at) < datetime('now', '-30 days')
+         )
          or (
+           share_type = 'temporary'
+           and
            expires_at is not null
            and datetime(expires_at) < datetime('now', '-30 days')
          )

--- a/src/lib/server/shares.ts
+++ b/src/lib/server/shares.ts
@@ -23,6 +23,9 @@ const createShareToken = customAlphabet(
 
 export const DEFAULT_SHARE_EXPIRY_DAYS = 90;
 
+export const shareTypes = ["temporary", "published"] as const;
+export type ShareType = (typeof shareTypes)[number];
+
 type ShareRow = {
   id: string;
   token: string;
@@ -39,6 +42,7 @@ type ShareRow = {
   revoked_at: string | null;
   owner_user_id: string | null;
   project_id: string | null;
+  share_type: string | null;
 };
 
 export type StoredShare = {
@@ -57,6 +61,7 @@ export type StoredShare = {
   revokedAt: string | null;
   ownerUserId: string | null;
   projectId: string | null;
+  shareType: ShareType;
 };
 
 export type StoredShareResolution =
@@ -80,7 +85,8 @@ const SHARE_SELECT = `
   expires_at,
   revoked_at,
   owner_user_id,
-  project_id
+  project_id,
+  share_type
 `;
 
 const USER_SHARE_SELECT = `
@@ -90,6 +96,7 @@ const USER_SHARE_SELECT = `
   s.created_at,
   s.expires_at,
   s.project_id,
+  s.share_type,
   g.gallery_state,
   g.gallery_title,
   g.gallery_description
@@ -110,6 +117,10 @@ function toIsoDateAfterDays(days: number) {
 
 function parseNullableNumber(value: number | null) {
   return value === null ? null : Number.parseFloat(String(value));
+}
+
+function parseShareType(value: string | null): ShareType {
+  return value === "published" ? "published" : "temporary";
 }
 
 function mapShareRow(row: ShareRow): StoredShare {
@@ -135,6 +146,7 @@ function mapShareRow(row: ShareRow): StoredShare {
     revokedAt: row.revoked_at,
     ownerUserId: row.owner_user_id,
     projectId: row.project_id,
+    shareType: parseShareType(row.share_type),
   };
 }
 
@@ -146,6 +158,7 @@ function mapUserShareRow(row: UserShareRow): UserShare {
     createdAt: row.created_at,
     expiresAt: row.expires_at,
     projectId: row.project_id,
+    shareType: parseShareType(row.share_type),
     galleryState: parseGalleryState(row.gallery_state),
     galleryTitle: row.gallery_title,
     galleryDescription: row.gallery_description,
@@ -188,27 +201,6 @@ export async function getShareByToken(token: string) {
   return resolved.status === "available" ? resolved.share : null;
 }
 
-type ShareExpiresAtRow = {
-  expires_at: string | null;
-};
-
-export async function getShareExpiresAtByToken(token: string) {
-  const db = await getDatabase();
-  const row = await db
-    .prepare(
-      `
-        select expires_at
-        from shares
-        where token = ?
-        limit 1
-      `
-    )
-    .bind(token)
-    .first<ShareExpiresAtRow>();
-
-  return row?.expires_at ?? null;
-}
-
 type UserShareRow = {
   token: string;
   title: string | null;
@@ -216,6 +208,7 @@ type UserShareRow = {
   created_at: string;
   expires_at: string | null;
   project_id: string | null;
+  share_type: string | null;
   gallery_state: string | null;
   gallery_title: string | null;
   gallery_description: string | null;
@@ -228,6 +221,7 @@ export type UserShare = {
   createdAt: string;
   expiresAt: string | null;
   projectId: string | null;
+  shareType: ShareType;
   galleryState: "unlisted" | "listed" | "featured" | "hidden" | null;
   galleryTitle: string | null;
   galleryDescription: string | null;
@@ -275,6 +269,7 @@ export async function getShareByProjectIdForUser(
         left join gallery_entries g on g.share_token = s.token
         where s.owner_user_id = ?
           and s.project_id = ?
+          and s.share_type = 'published'
           and ${ACTIVE_USER_SHARE_WHERE}
         order by
           case g.gallery_state
@@ -313,9 +308,7 @@ export async function revokeShare(token: string) {
     .bind(now, now, token)
     .run();
 
-  await deleteGalleryEntry(token, {
-    restoreShareExpiry: false,
-  });
+  await deleteGalleryEntry(token);
 }
 
 type CreateShareOptions = {
@@ -341,16 +334,85 @@ export async function createShare(
   const title = getShareTitle(normalized);
   const description = getShareDescription(normalized);
   const shapeCount = getDesignShapes(normalized).length;
-  const expiresInDays = options.expiresInDays ?? DEFAULT_SHARE_EXPIRY_DAYS;
   const ownerUserId = options.ownerUserId ?? null;
   const projectId = options.projectId ?? null;
+  const shareType: ShareType = ownerUserId ? "published" : "temporary";
+  const expiresInDays = options.expiresInDays ?? DEFAULT_SHARE_EXPIRY_DAYS;
+  const expiresAt =
+    shareType === "published" ? null : toIsoDateAfterDays(expiresInDays);
   const db = await getDatabase();
+
+  if (shareType === "published" && projectId) {
+    const existing = await db
+      .prepare(
+        `
+          select
+            ${SHARE_SELECT}
+          from shares
+          where owner_user_id = ?
+            and project_id = ?
+            and share_type = 'published'
+            and revoked_at is null
+          order by updated_at desc
+          limit 1
+        `
+      )
+      .bind(ownerUserId, projectId)
+      .first<ShareRow>();
+
+    if (existing) {
+      const now = nowIso();
+
+      await db
+        .prepare(
+          `
+            update shares
+            set
+              design_json = ?,
+              title = ?,
+              description = ?,
+              field_width = ?,
+              field_height = ?,
+              shape_count = ?,
+              updated_at = ?,
+              expires_at = null
+            where id = ?
+          `
+        )
+        .bind(
+          serializedJson,
+          title,
+          description,
+          normalized.field.width,
+          normalized.field.height,
+          shapeCount,
+          now,
+          existing.id
+        )
+        .run();
+
+      const share: StoredShare = {
+        ...mapShareRow(existing),
+        design: normalized,
+        title,
+        description,
+        shapeCount,
+        fieldWidth: normalized.field.width,
+        fieldHeight: normalized.field.height,
+        updatedAt: now,
+        expiresAt: null,
+        shareType: "published",
+      };
+
+      await getOrCreateGalleryEntryForShare(share);
+      return share;
+    }
+  }
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const id = crypto.randomUUID();
     const token = createShareToken();
     const now = nowIso();
-    const expiresAt = toIsoDateAfterDays(expiresInDays);
 
     try {
       await db
@@ -371,9 +433,10 @@ export async function createShare(
               expires_at,
               revoked_at,
               owner_user_id,
-              project_id
+              project_id,
+              share_type
             )
-            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           `
         )
         .bind(
@@ -391,11 +454,12 @@ export async function createShare(
           expiresAt,
           null,
           ownerUserId,
-          projectId
+          projectId,
+          shareType
         )
         .run();
 
-      const share = {
+      const share: StoredShare = {
         id,
         token,
         design: normalized,
@@ -411,6 +475,7 @@ export async function createShare(
         revokedAt: null,
         ownerUserId,
         projectId,
+        shareType,
       };
 
       if (ownerUserId) {

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -53,6 +53,12 @@ export function buildStoredSharePath(token: string, view?: EditorView) {
   return `${path}?view=${view}`;
 }
 
+export function buildStoredEmbedPath(token: string, view?: EditorView) {
+  const path = `/embed/${encodeURIComponent(token)}`;
+  if (!view) return path;
+  return `${path}?view=${view}`;
+}
+
 export function isShareSafe(design: TrackDesign): boolean {
   return encodeDesign(design).length <= MAX_SAFE_TOKEN_LENGTH;
 }

--- a/tests/app/api/dashboard/gallery.route.test.ts
+++ b/tests/app/api/dashboard/gallery.route.test.ts
@@ -81,6 +81,7 @@ const storedShare = {
   revokedAt: null,
   ownerUserId: "owner-1",
   projectId: "project-1",
+  shareType: "published",
 } as unknown as StoredShare;
 
 function patchRequest(action: string) {

--- a/tests/app/api/shares.gallery.route.test.ts
+++ b/tests/app/api/shares.gallery.route.test.ts
@@ -22,7 +22,6 @@ vi.mock("@/lib/server/gallery", () => ({
 
 vi.mock("@/lib/server/shares", () => ({
   getOrCreateGalleryEntryForShare: vi.fn(),
-  getShareExpiresAtByToken: vi.fn(),
   resolveStoredShare: vi.fn(),
   revokeShare: vi.fn(),
 }));
@@ -40,7 +39,6 @@ import {
 } from "@/lib/server/gallery";
 import {
   getOrCreateGalleryEntryForShare,
-  getShareExpiresAtByToken,
   resolveStoredShare,
 } from "@/lib/server/shares";
 import type { StoredShare } from "@/lib/server/shares";
@@ -74,6 +72,7 @@ const share = {
   revokedAt: null,
   ownerUserId: owner.id,
   projectId: "project-1",
+  shareType: "published",
 } as unknown as StoredShare;
 
 const entry = {
@@ -112,7 +111,6 @@ describe("owner share gallery API route", () => {
     vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(owner);
     vi.mocked(isResourceOwner).mockReturnValue(true);
     vi.mocked(getOrCreateGalleryEntryForShare).mockResolvedValue(entry);
-    vi.mocked(getShareExpiresAtByToken).mockResolvedValue(null);
     vi.mocked(getGalleryEntryByShareToken).mockResolvedValue({
       ...entry,
       galleryState: "listed",
@@ -141,7 +139,8 @@ describe("owner share gallery API route", () => {
       ok: true,
       share: {
         token: share.token,
-        expiresAt: null,
+        expiresAt: share.expiresAt,
+        shareType: "published",
         galleryState: "listed",
         galleryTitle: "Public title",
         galleryDescription: "Public description",

--- a/tests/app/api/shares.route.test.ts
+++ b/tests/app/api/shares.route.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultDesign } from "@/lib/track/design";
+import type { StoredShare, UserShare } from "@/lib/server/shares";
+
+vi.mock("@/lib/server/auth-session", () => ({
+  getCurrentUserFromHeaders: vi.fn(),
+}));
+
+vi.mock("@/lib/server/projects", () => ({
+  getProjectForUser: vi.fn(),
+}));
+
+vi.mock("@/lib/server/shares", () => ({
+  createShare: vi.fn(),
+  getShareByProjectIdForUser: vi.fn(),
+  getSharesByUserId: vi.fn(),
+}));
+
+import { GET, POST } from "@/app/api/shares/route";
+import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
+import { getProjectForUser } from "@/lib/server/projects";
+import {
+  createShare,
+  getShareByProjectIdForUser,
+  getSharesByUserId,
+} from "@/lib/server/shares";
+
+const user = {
+  id: "user-1",
+  email: "pilot@trackdraw.local",
+  name: "Pilot",
+  image: null,
+  role: "user" as const,
+};
+
+function createStoredShare(overrides: Partial<StoredShare> = {}): StoredShare {
+  const design = createDefaultDesign();
+  return {
+    id: "share-id",
+    token: "share-token",
+    design,
+    title: design.title,
+    description: "Read-only TrackDraw plan.",
+    shapeCount: 0,
+    fieldWidth: design.field.width,
+    fieldHeight: design.field.height,
+    createdAt: "2026-04-20T10:00:00.000Z",
+    updatedAt: "2026-04-20T10:00:00.000Z",
+    publishedAt: "2026-04-20T10:00:00.000Z",
+    expiresAt: "2026-05-20T10:00:00.000Z",
+    revokedAt: null,
+    ownerUserId: null,
+    projectId: null,
+    shareType: "temporary",
+    ...overrides,
+  };
+}
+
+function postRequest(body: unknown) {
+  return new Request("http://localhost/api/shares", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("shares API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("creates anonymous temporary shares with requested expiry", async () => {
+    const design = createDefaultDesign();
+    const share = createStoredShare({ expiresAt: "2026-05-02T12:00:00.000Z" });
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
+    vi.mocked(createShare).mockResolvedValue(share);
+
+    const response = await POST(
+      postRequest({ design, view: "3d", expiresInDays: 7 })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      share: {
+        token: "share-token",
+        path: "/share/share-token?view=3d",
+        expiresAt: "2026-05-02T12:00:00.000Z",
+        ownerUserId: null,
+        projectId: null,
+        shareType: "temporary",
+      },
+    });
+    expect(createShare).toHaveBeenCalledWith(
+      expect.objectContaining({ id: design.id }),
+      {
+        expiresInDays: 7,
+        ownerUserId: null,
+        projectId: null,
+      }
+    );
+  });
+
+  it("creates authenticated project shares as published links and ignores expiry input", async () => {
+    const design = createDefaultDesign();
+    const share = createStoredShare({
+      expiresAt: null,
+      ownerUserId: user.id,
+      projectId: "project-1",
+      shareType: "published",
+    });
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(user);
+    vi.mocked(getProjectForUser).mockResolvedValue({
+      id: "project-1",
+      ownerUserId: user.id,
+      title: "Project",
+      description: "",
+      design,
+      designUpdatedAt: design.updatedAt,
+      fieldWidth: design.field.width,
+      fieldHeight: design.field.height,
+      shapeCount: 0,
+      createdAt: "2026-04-20T10:00:00.000Z",
+      updatedAt: "2026-04-20T10:00:00.000Z",
+      archivedAt: null,
+    });
+    vi.mocked(createShare).mockResolvedValue(share);
+
+    const response = await POST(
+      postRequest({
+        design,
+        view: "2d",
+        projectId: "project-1",
+        expiresInDays: 7,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      share: {
+        token: "share-token",
+        path: "/share/share-token?view=2d",
+        expiresAt: null,
+        ownerUserId: user.id,
+        projectId: "project-1",
+        shareType: "published",
+      },
+    });
+    expect(createShare).toHaveBeenCalledWith(
+      expect.objectContaining({ id: design.id }),
+      {
+        expiresInDays: undefined,
+        ownerUserId: user.id,
+        projectId: "project-1",
+      }
+    );
+  });
+
+  it("rejects project-linked publish for anonymous users", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
+
+    const response = await POST(
+      postRequest({
+        design: createDefaultDesign(),
+        projectId: "project-1",
+      })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Project-linked publish requires an authenticated user",
+    });
+    expect(createShare).not.toHaveBeenCalled();
+  });
+
+  it("returns a user's active project share", async () => {
+    const share: UserShare = {
+      token: "share-token",
+      title: "Project share",
+      shapeCount: 3,
+      createdAt: "2026-04-20T10:00:00.000Z",
+      expiresAt: null,
+      projectId: "project-1",
+      shareType: "published",
+      galleryState: "unlisted",
+      galleryTitle: null,
+      galleryDescription: null,
+    };
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(user);
+    vi.mocked(getShareByProjectIdForUser).mockResolvedValue(share);
+
+    const response = await GET(
+      new Request("http://localhost/api/shares?projectId=project-1")
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, share });
+    expect(getShareByProjectIdForUser).toHaveBeenCalledWith(
+      user.id,
+      "project-1"
+    );
+    expect(getSharesByUserId).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app/embed/page.test.tsx
+++ b/tests/app/embed/page.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TrackDesign } from "@/lib/types";
+
+vi.mock("@/lib/server/shares", () => ({
+  resolveStoredShare: vi.fn(),
+}));
+
+vi.mock("@/app/embed/EmbedViewer", () => ({
+  default: ({
+    design,
+    initialTab,
+  }: {
+    design: TrackDesign;
+    initialTab: "2d" | "3d";
+  }) => (
+    <div data-testid="embed-viewer" data-initial-tab={initialTab}>
+      {design.title}
+    </div>
+  ),
+}));
+
+vi.mock("@/app/embed/EmbedUnavailable", () => ({
+  default: ({ reason, shareHref }: { reason: string; shareHref?: string }) => (
+    <div data-testid="embed-unavailable" data-reason={reason}>
+      {shareHref ? <a href={shareHref}>Open share link</a> : null}
+    </div>
+  ),
+}));
+
+import EmbedTokenPage from "@/app/embed/[token]/page";
+import { resolveStoredShare } from "@/lib/server/shares";
+import { createDefaultDesign } from "@/lib/track/design";
+import type { StoredShare } from "@/lib/server/shares";
+
+function createShare(overrides: Partial<StoredShare> = {}): StoredShare {
+  const design = createDefaultDesign();
+  design.title = "Embed Test Track";
+
+  return {
+    id: "share-id",
+    token: "share-token",
+    design,
+    title: design.title,
+    description: "Read-only TrackDraw plan.",
+    shapeCount: 0,
+    fieldWidth: design.field.width,
+    fieldHeight: design.field.height,
+    createdAt: "2026-04-20T10:00:00.000Z",
+    updatedAt: "2026-04-20T10:00:00.000Z",
+    publishedAt: "2026-04-20T10:00:00.000Z",
+    expiresAt: null,
+    revokedAt: null,
+    ownerUserId: "user-1",
+    projectId: "project-1",
+    shareType: "published",
+    ...overrides,
+  };
+}
+
+function pageProps(view?: string) {
+  return {
+    params: Promise.resolve({ token: "share-token" }),
+    searchParams: Promise.resolve(view ? { view } : {}),
+  };
+}
+
+describe("embed token page", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("renders a published share for anonymous viewers with the requested initial view", async () => {
+    vi.mocked(resolveStoredShare).mockResolvedValue({
+      status: "available",
+      share: createShare(),
+    });
+
+    render(await EmbedTokenPage(pageProps("3d")));
+
+    expect(
+      screen.getByTestId("embed-viewer").getAttribute("data-initial-tab")
+    ).toBe("3d");
+    expect(screen.queryByTestId("embed-unavailable")).toBeNull();
+  });
+
+  it("blocks temporary shares from rendering track data in embed context", async () => {
+    vi.mocked(resolveStoredShare).mockResolvedValue({
+      status: "available",
+      share: createShare({
+        ownerUserId: null,
+        projectId: null,
+        shareType: "temporary",
+        expiresAt: "2026-05-20T10:00:00.000Z",
+      }),
+    });
+
+    render(await EmbedTokenPage(pageProps("2d")));
+
+    expect(screen.queryByTestId("embed-viewer")).toBeNull();
+    expect(
+      screen.getByTestId("embed-unavailable").getAttribute("data-reason")
+    ).toBe("temporary");
+    expect(
+      screen.getByRole("link", { name: "Open share link" }).getAttribute("href")
+    ).toBe("/share/share-token");
+  });
+
+  it.each([
+    ["expired", "expired"],
+    ["revoked", "revoked"],
+    ["missing", "missing"],
+  ] as const)("renders %s embeds as unavailable", async (status, reason) => {
+    vi.mocked(resolveStoredShare).mockResolvedValue(
+      status === "missing" ? { status } : { status, share: createShare() }
+    );
+
+    render(await EmbedTokenPage(pageProps()));
+
+    expect(screen.queryByTestId("embed-viewer")).toBeNull();
+    expect(
+      screen.getByTestId("embed-unavailable").getAttribute("data-reason")
+    ).toBe(reason);
+  });
+});

--- a/tests/components/editor/SharedMobilePanels.test.tsx
+++ b/tests/components/editor/SharedMobilePanels.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import MobilePanels from "@/components/editor/shared/MobilePanels";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/components/MobileDrawer", () => ({
+  MobileDrawer: ({
+    children,
+    open,
+    title,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    title: string;
+  }) =>
+    open ? (
+      <section aria-label={title} data-testid="mobile-drawer">
+        {children}
+      </section>
+    ) : null,
+}));
+
+function renderMobilePanels(
+  overrides: Partial<React.ComponentProps<typeof MobilePanels>> = {}
+) {
+  const props: React.ComponentProps<typeof MobilePanels> = {
+    hasPath: true,
+    mobileFlyModeActive: false,
+    mobileGizmoEnabled: false,
+    mobileObstacleNumbersEnabled: true,
+    mobileRulersEnabled: false,
+    onFitView: vi.fn(),
+    onSetMobileGizmoEnabled: vi.fn(),
+    onSetMobileObstacleNumbersEnabled: vi.fn(),
+    onSetMobileRulersEnabled: vi.fn(),
+    onShare: vi.fn(),
+    onStartFlyThrough: vi.fn(),
+    onTabChange: vi.fn(),
+    onSetReadOnlyMenuOpen: vi.fn(),
+    readOnlyMenuOpen: false,
+    saveStatusLabel: "Embedded track",
+    tab: "2d",
+    ...overrides,
+  };
+
+  render(<MobilePanels {...props} />);
+  return props;
+}
+
+describe("shared MobilePanels", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses a compact embed-only view action on mobile embeds", async () => {
+    const user = userEvent.setup();
+    const onSetReadOnlyMenuOpen = vi.fn();
+
+    renderMobilePanels({
+      embedMode: true,
+      onSetReadOnlyMenuOpen,
+    });
+
+    expect(screen.getByRole("button", { name: "View" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Review" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Share" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Edit copy" })).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "View" }));
+
+    expect(onSetReadOnlyMenuOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps the full shared-review toolbar outside embed mode", () => {
+    renderMobilePanels({
+      embedMode: false,
+      studioHref: "/studio?fromShare=1",
+    });
+
+    expect(screen.getByRole("button", { name: "Review" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Share" })).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Edit copy" }).getAttribute("href")
+    ).toBe("/studio?fromShare=1");
+    expect(screen.queryByRole("button", { name: "View" })).toBeNull();
+  });
+
+  it("hides share actions inside the embed view drawer", () => {
+    renderMobilePanels({
+      embedMode: true,
+      readOnlyMenuOpen: true,
+    });
+
+    expect(screen.getByTestId("mobile-drawer")).toBeTruthy();
+    expect(screen.getByText("Embedded track")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Share" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Open in Studio" })).toBeNull();
+  });
+});

--- a/tests/lib/server/gallery.test.ts
+++ b/tests/lib/server/gallery.test.ts
@@ -120,19 +120,12 @@ describe("gallery server helpers", () => {
     ]);
   });
 
-  it("pins shares when entries become listed or featured", async () => {
+  it("updates only gallery state when entries become listed or featured", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
     const listStatement = createStatement();
-    const listShareStatement = createStatement();
     const featureStatement = createStatement();
-    const featureShareStatement = createStatement();
-    installStatements([
-      listStatement,
-      listShareStatement,
-      featureStatement,
-      featureShareStatement,
-    ]);
+    installStatements([listStatement, featureStatement]);
 
     await moveGalleryEntryToListed("share-1");
     await moveGalleryEntryToFeatured("share-2");
@@ -142,47 +135,29 @@ describe("gallery server helpers", () => {
       "2026-04-25T12:00:00.000Z",
       "share-1"
     );
-    expect(listShareStatement.bind).toHaveBeenCalledWith(
-      null,
+    expect(featureStatement.bind).toHaveBeenCalledWith(
       "2026-04-25T12:00:00.000Z",
-      "share-1"
-    );
-    expect(featureShareStatement.bind).toHaveBeenCalledWith(
-      null,
       "2026-04-25T12:00:00.000Z",
       "share-2"
     );
   });
 
-  it("restores finite share expiry when entries are hidden or unlisted", async () => {
+  it("updates only gallery state when entries are hidden or unlisted", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
     const hiddenStatement = createStatement();
-    const hiddenShareStatement = createStatement();
     const unlistedStatement = createStatement();
-    const unlistedShareStatement = createStatement();
-    installStatements([
-      hiddenStatement,
-      hiddenShareStatement,
-      unlistedStatement,
-      unlistedShareStatement,
-    ]);
+    installStatements([hiddenStatement, unlistedStatement]);
 
-    await moveGalleryEntryToHidden("share-1", { retentionDays: 7 });
-    await moveGalleryEntryToUnlisted("share-2", { retentionDays: 30 });
+    await moveGalleryEntryToHidden("share-1");
+    await moveGalleryEntryToUnlisted("share-2");
 
     expect(hiddenStatement.bind).toHaveBeenCalledWith(
       "2026-04-25T12:00:00.000Z",
       "2026-04-25T12:00:00.000Z",
       "share-1"
     );
-    expect(hiddenShareStatement.bind).toHaveBeenCalledWith(
-      "2026-05-02T12:00:00.000Z",
-      "2026-04-25T12:00:00.000Z",
-      "share-1"
-    );
-    expect(unlistedShareStatement.bind).toHaveBeenCalledWith(
-      "2026-05-25T12:00:00.000Z",
+    expect(unlistedStatement.bind).toHaveBeenCalledWith(
       "2026-04-25T12:00:00.000Z",
       "share-2"
     );
@@ -207,21 +182,15 @@ describe("gallery server helpers", () => {
       },
     });
     const deleteStatement = createStatement();
-    const shareStatement = createStatement();
-    installStatements([entryStatement, deleteStatement, shareStatement]);
+    installStatements([entryStatement, deleteStatement]);
 
-    await deleteGalleryEntry("share-1", { retentionDays: 7 });
+    await deleteGalleryEntry("share-1");
 
     expect(mocks.deleteGalleryPreviewImage).toHaveBeenCalledWith(
       "gallery/previews/entry-1.webp"
     );
     expect(deleteStatement.sql).toContain("delete from gallery_entries");
     expect(deleteStatement.bind).toHaveBeenCalledWith("share-1");
-    expect(shareStatement.bind).toHaveBeenCalledWith(
-      "2026-05-02T12:00:00.000Z",
-      "2026-04-25T12:00:00.000Z",
-      "share-1"
-    );
   });
 
   it("aggregates gallery overview stats by state", async () => {

--- a/tests/lib/server/share-retention.test.ts
+++ b/tests/lib/server/share-retention.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { cleanupExpiredShares } from "@/lib/server/share-retention";
+
+describe("share retention", () => {
+  it("only expires temporary shares while keeping active published shares", async () => {
+    const run = vi.fn(async () => ({}));
+    const prepare = vi.fn((query: string) => ({ query, run }));
+
+    await cleanupExpiredShares({ prepare } as Parameters<
+      typeof cleanupExpiredShares
+    >[0]);
+
+    const sql = prepare.mock.calls[0][0];
+    expect(sql).toContain("share_type = 'temporary'");
+    expect(sql).toContain("datetime(revoked_at) < datetime('now', '-30 days')");
+    expect(run).toHaveBeenCalled();
+  });
+});

--- a/tests/lib/server/shares.test.ts
+++ b/tests/lib/server/shares.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultDesign, serializeDesign } from "@/lib/track/design";
+import type { SerializedTrackDesign } from "@/lib/types";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  prepare: vi.fn(),
+  createUnlistedGalleryEntry: vi.fn(),
+  deleteGalleryEntry: vi.fn(),
+  getGalleryEntryByShareToken: vi.fn(),
+}));
+
+vi.mock("@/lib/server/db", () => ({
+  getDatabase: vi.fn(async () => ({
+    prepare: mocks.prepare,
+  })),
+}));
+
+vi.mock("@/lib/server/gallery", () => ({
+  createUnlistedGalleryEntry: mocks.createUnlistedGalleryEntry,
+  deleteGalleryEntry: mocks.deleteGalleryEntry,
+  getGalleryEntryByShareToken: mocks.getGalleryEntryByShareToken,
+  parseGalleryState: (value: string | null | undefined) => {
+    if (
+      value === "listed" ||
+      value === "featured" ||
+      value === "hidden" ||
+      value === "unlisted"
+    ) {
+      return value;
+    }
+    return "unlisted";
+  },
+}));
+
+import { createShare } from "@/lib/server/shares";
+
+type Statement = {
+  sql: string;
+  bind: ReturnType<typeof vi.fn>;
+  first: ReturnType<typeof vi.fn>;
+  run: ReturnType<typeof vi.fn>;
+};
+
+function createStatement(result?: {
+  first?: unknown;
+  run?: unknown;
+}): Statement {
+  const statement = {
+    sql: "",
+    bind: vi.fn(() => statement),
+    first: vi.fn(async () => result?.first ?? null),
+    run: vi.fn(async () => result?.run ?? {}),
+  };
+
+  return statement;
+}
+
+function installStatements(statements: Statement[]) {
+  mocks.prepare.mockImplementation((sql: string) => {
+    const statement = statements.shift();
+    if (!statement) {
+      throw new Error(`Unexpected SQL: ${sql}`);
+    }
+
+    statement.sql = sql;
+    return statement;
+  });
+}
+
+function existingShareRow(serialized: SerializedTrackDesign) {
+  return {
+    id: "share-id-1",
+    token: "existing-token",
+    design_json: JSON.stringify(serialized),
+    title: "Old title",
+    description: "Old description",
+    field_width: 30,
+    field_height: 20,
+    shape_count: 0,
+    created_at: "2026-04-20T10:00:00.000Z",
+    updated_at: "2026-04-20T10:00:00.000Z",
+    published_at: "2026-04-20T10:00:00.000Z",
+    expires_at: null,
+    revoked_at: null,
+    owner_user_id: "user-1",
+    project_id: "project-1",
+    share_type: "published",
+  };
+}
+
+describe("share server helpers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
+    mocks.prepare.mockReset();
+    mocks.createUnlistedGalleryEntry.mockReset();
+    mocks.deleteGalleryEntry.mockReset();
+    mocks.getGalleryEntryByShareToken.mockReset();
+  });
+
+  it("creates anonymous shares as temporary links with an expiry", async () => {
+    const insertStatement = createStatement();
+    installStatements([insertStatement]);
+
+    const share = await createShare(createDefaultDesign(), {
+      expiresInDays: 7,
+    });
+
+    const bindArgs = insertStatement.bind.mock.calls[0];
+
+    expect(share.shareType).toBe("temporary");
+    expect(share.ownerUserId).toBeNull();
+    expect(share.projectId).toBeNull();
+    expect(share.expiresAt).toBe("2026-05-02T12:00:00.000Z");
+    expect(insertStatement.sql).toContain("share_type");
+    expect(bindArgs.at(-3)).toBeNull();
+    expect(bindArgs.at(-2)).toBeNull();
+    expect(bindArgs.at(-1)).toBe("temporary");
+    expect(mocks.createUnlistedGalleryEntry).not.toHaveBeenCalled();
+  });
+
+  it("creates account shares as published links without expiry", async () => {
+    const insertStatement = createStatement();
+    installStatements([insertStatement]);
+
+    const share = await createShare(createDefaultDesign(), {
+      ownerUserId: "user-1",
+    });
+
+    const bindArgs = insertStatement.bind.mock.calls[0];
+
+    expect(share.shareType).toBe("published");
+    expect(share.ownerUserId).toBe("user-1");
+    expect(share.expiresAt).toBeNull();
+    expect(bindArgs.at(-3)).toBe("user-1");
+    expect(bindArgs.at(-2)).toBeNull();
+    expect(bindArgs.at(-1)).toBe("published");
+    expect(mocks.createUnlistedGalleryEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shareToken: share.token,
+        ownerUserId: "user-1",
+      })
+    );
+  });
+
+  it("updates and reuses the active published share for an account project", async () => {
+    const design = createDefaultDesign();
+    design.title = "Updated project track";
+    const selectStatement = createStatement({
+      first: existingShareRow(serializeDesign(createDefaultDesign())),
+    });
+    const updateStatement = createStatement();
+    installStatements([selectStatement, updateStatement]);
+    mocks.getGalleryEntryByShareToken.mockResolvedValue({
+      id: "entry-1",
+      shareToken: "existing-token",
+      ownerUserId: "user-1",
+      galleryState: "unlisted",
+    });
+
+    const share = await createShare(design, {
+      ownerUserId: "user-1",
+      projectId: "project-1",
+    });
+
+    expect(selectStatement.sql).toContain("share_type = 'published'");
+    expect(selectStatement.sql).toContain("revoked_at is null");
+    expect(updateStatement.sql).toContain("update shares");
+    expect(updateStatement.sql).toContain("expires_at = null");
+    expect(updateStatement.bind).toHaveBeenCalledWith(
+      expect.any(String),
+      "Updated project track",
+      expect.any(String),
+      design.field.width,
+      design.field.height,
+      0,
+      "2026-04-25T12:00:00.000Z",
+      "share-id-1"
+    );
+    expect(share.token).toBe("existing-token");
+    expect(share.shareType).toBe("published");
+    expect(share.expiresAt).toBeNull();
+    expect(mocks.createUnlistedGalleryEntry).not.toHaveBeenCalled();
+  });
+});

--- a/tests/lib/share.test.ts
+++ b/tests/lib/share.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildShareUrl,
+  buildStoredEmbedPath,
   buildStoredSharePath,
   decodeDesign,
   decodeDesignWithReason,
@@ -38,6 +39,7 @@ describe("share helpers", () => {
     });
 
     expect(buildStoredSharePath("abc", "3d")).toBe("/share/abc?view=3d");
+    expect(buildStoredEmbedPath("abc", "2d")).toBe("/embed/abc?view=2d");
     expect(buildShareUrl(design, "2d")).toContain("/share/");
     expect(buildShareUrl(design, "2d")).toContain("view=2d");
   });


### PR DESCRIPTION
This PR makes embeds a first-class account-backed publishing feature. Anonymous shares stay temporary and non-embeddable, while signed-in published shares become durable links that stay live until revoked and can be embedded through a new `/embed/[token]` route.

### What changed

- Added explicit share lifecycle via `share_type`: `temporary` for anonymous shares and `published` for account-backed shares.
- Account project publishing now reuses the active published share token instead of creating duplicate active shares.
- Anonymous shares always keep an expiry; account-published shares use `expires_at = null`.
- Added `/embed/[token]` with account-only authorization based on share lifecycle, not viewer session.
- Temporary, expired, revoked, and missing embeds render unavailable states and never expose track data.
- Added a dedicated Embed section in the Share dialog with iframe copy, 2D layout / 3D preview initial view, and `600px` default iframe height.
- Updated shared mobile embed controls so embeds use a compact `View` pill instead of the full shared review toolbar.
- Decoupled gallery visibility from share expiry: list, unlist, feature, and hide no longer mutate `expires_at`.
