### PR TITLE
feat: Add map reference functionality and related geometry calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ See the [public roadmap discussion](https://github.com/dutchdronesquad/trackdraw
 ## What you can do
 
 - 🏁 **Design layouts to scale** - place obstacles on a real-scale canvas with field dimensions that map cleanly to the real world
+- 🗺️ **Line up with real venues** - add an editor-only satellite map reference, search or choose the field center, and align it with rotation and opacity controls
 - ⚡ **Start and iterate faster** - use obstacle presets, selection grouping, and starter layouts to get from blank canvas to a workable draft quickly
 - 💾 **Manage projects safely** - keep multiple local projects, reopen older layouts, rename or export them, and roll back through restore points and snapshots
 - 🎥 **Review route flow in 3D** - use the live 3D preview, elevation tools, floating ladder placement controls, and cinematic FPV fly-through review to check how the layout reads before race day

--- a/docs/pva/map-field-overlay-pva.md
+++ b/docs/pva/map-field-overlay-pva.md
@@ -1,367 +1,263 @@
-# Map And Field Overlay PVA
+# Map Field Reference PVA
 
 Date: April 14, 2026
 
-Status: proposed
+Status: v1 implemented as editor-only map reference
 
 ## Decision Summary
 
-Recommended decision:
+Recommended direction:
 
-- approve `Map and field overlay` for implementation planning
-- choose hybrid storage for v1: device-local for logged-out, synced asset storage for signed-in
-- keep overlay out of share/export in v1
-- treat this as an editor-first feature with signed-in cross-device continuity
+- build `Map reference` before any arbitrary image-upload reference
+- use a dedicated popup/dialog with Esri World Imagery satellite tiles
+- let the user choose the field center
+- use `field.width` and `field.height` to size the reference footprint
+- make rotation the main user adjustment
+- render the confirmed reference in the editor with a dedicated Konva tile layer, not a second DOM map under the canvas
+- store map metadata, not raw image payloads
+- keep export and share unaware of map references in v1
+
+This avoids the main UX problem with uploaded images: a loose image has no reliable scale unless the user calibrates it.
 
 For the full product evaluation and UX rationale, see [docs/research/map-field-overlay-evaluation.md](../research/map-field-overlay-evaluation.md).
 
 ## Approval Recommendation
 
-TrackDraw should approve this feature for build preparation if the team is comfortable with the following scope:
+Approve a narrow prototype if TrackDraw accepts:
 
-- one overlay per project
-- move, scale, opacity, visibility, lock
-- logged-out local storage
-- signed-in synced overlay asset storage
-- no export/share inclusion
+- Esri World Imagery satellite tiles as the primary v1 path
+- one map reference per project
+- center-point placement
+- project field dimensions as the sizing source
+- rotation, opacity, visibility, and remove controls
+- no arbitrary image upload in v1
+- no export/share inclusion in v1
 
-TrackDraw should not approve this feature yet if the team expects any of these to be part of v1:
-
-- multiple overlays
-- export inclusion
-- share inclusion
-- perspective correction
-- venue library behavior
+Do not approve this as image-upload work. Uploads belong in a later `Image reference` fallback with separate calibration rules.
 
 ## Delivery Checklist
 
-- [ ] Phase 0: lock the product model
-- [ ] Phase 1: ship a single image overlay first pass
-- [ ] Phase 2: add practical editor controls
-- [ ] Phase 3: define export and share behavior
-- [ ] Phase 4: revisit richer transforms later
+- [x] Phase 0: verify Esri World Imagery attribution requirements
+      The picker displays Esri/data-provider attribution while imagery is visible. Provider terms and traffic assumptions should still be reviewed before relying on heavy production usage.
+- [x] Phase 1: prototype map picker dialog with center-point selection
+      The picker supports search/typeahead, current-location jump, pointer/touch panning, center click/tap, desktop dialog, and mobile drawer.
+- [x] Phase 2: draw project field footprint over the map picker
+      The footprint is derived from the current project field dimensions and stays centered while the map moves underneath it.
+- [x] Phase 3: add rotation adjustment and confirm flow
+      Rotation can be adjusted in the picker and from the Project inspector.
+- [x] Phase 4: render the confirmed map reference behind the 2D layout with a Konva tile renderer
+      The editor renders non-interactive Esri imagery behind the field and normal layout objects.
+- [x] Phase 5: persist reference metadata in project JSON
+      Project serialization keeps map metadata, while share serialization strips it.
+- [x] Phase 6: add Project inspector controls for visibility, opacity, edit, and remove
+      Project inspector exposes compact controls for add/edit, show/hide, opacity, rotation, and remove.
+- [ ] Phase 7: decide whether 3D ground reference should follow
+      Deferred. V1 is intentionally limited to the 2D editor reference.
 
 ## Go / No-Go Criteria
 
 Go for implementation if:
 
-- the team accepts the hybrid storage model
-- the team accepts editor-only overlay behavior in v1
-- the existing media/storage path is considered good enough for signed-in project assets
-- mobile can ship with a simpler interaction model than desktop if needed
+- the user can set up a reference by choosing a location and rotation
+- the user does not need to enter scale or dimensions
+- the field footprint is derived from existing project field dimensions
+- the 2D editor remains readable with the map visible
+- Esri World Imagery attribution and usage terms are acceptable
 
 No-go or delay if:
 
-- the team wants export/share inclusion immediately
-- the team wants multiple overlays immediately
-- the media/storage path cannot support project-owned image assets cleanly
-- the product does not want logged-out and signed-in behavior to differ
+- Esri World Imagery usage terms do not fit TrackDraw's editor use case
+- map rendering makes the editor slow or visually noisy
+- editor rendering requires synchronizing a live DOM map under the Konva stage
+- the flow starts requiring manual scale calibration
+- export/share inclusion becomes mandatory for v1
+- the feature drifts into branding, custom logos, or decorative backgrounds
 
-## Required Preconditions Before Build
+## Product Flow
 
-Before implementation starts, TrackDraw should lock:
+### Add Map
 
-- accepted image formats
-- maximum upload size
-- signed-in upload ownership rules
-- overlay missing/failure UX
-- whether project duplication reuses or clones the overlay asset reference
+Entry points:
 
-## Technical Direction
+- Project inspector section: `Map reference`
 
-The v1 implementation should follow these technical rules:
+Flow:
 
-- keep overlay metadata in `TrackDesign`
-- keep raw image payloads out of the core project JSON
-- use browser-local blob storage for logged-out assets
-- use the existing media/storage path for signed-in synced assets
-- keep share and export flows unaware of overlays in v1
+1. Open a desktop dialog or mobile drawer with satellite imagery.
+2. User searches, uses current location, pans, or zooms to the venue.
+3. User clicks the center of the intended field.
+4. TrackDraw draws a rectangle using current `field.width` and `field.height`.
+5. User adjusts rotation to align with the venue.
+6. User confirms.
 
-## Current Codebase Fit
+The field dimensions remain editable through the existing Project field controls. The map flow should not introduce separate width/height controls.
 
-Relevant current boundaries:
+### Edit Map
 
-- project document types: [src/lib/types.ts](../../src/lib/types.ts)
-- design normalization and serialization: [src/lib/track/design.ts](../../src/lib/track/design.ts)
-- local project persistence: [src/lib/projects.ts](../../src/lib/projects.ts)
-- cloud project save/load: [src/app/api/projects/route.ts](../../src/app/api/projects/route.ts) and [src/lib/server/projects.ts](../../src/lib/server/projects.ts)
-- account sync orchestration: [src/components/editor/useAccountProjectSync.ts](../../src/components/editor/useAccountProjectSync.ts)
-- editor store and track mutations: [src/store/editor.ts](../../src/store/editor.ts)
+Flow:
 
-Important current behavior:
+1. User clicks `Edit map`.
+2. Dialog opens at the saved center and rotation.
+3. User moves the center or adjusts rotation.
+4. User confirms.
 
-- projects are saved as serialized design JSON
-- local and cloud persistence both treat the design as a single object
-- there is no current project-scoped asset model
+### Normal Editing
 
-So the first implementation should add a narrow overlay asset model rather than a broad reusable media system.
+After setup:
 
-## Technical Model
+- map reference is visible at low opacity by default
+- map reference is locked by default
+- normal object selection, snapping, route editing, and drag behavior are unchanged
+- Project inspector exposes visibility, opacity, edit, and remove controls
 
-### Overlay Metadata In `TrackDesign`
+## Data Model
 
-Add one optional `overlay` field to `TrackDesign`.
+Add one optional `mapReference` field to `TrackDesign` after the prototype validates the interaction.
 
-Recommended v1 fields:
+Recommended shape:
 
-- `assetId: string | null`
-- `x: number`
-- `y: number`
-- `scale: number`
+- `type: "map"`
+- `provider: "esri-world-imagery"`
+- `mapStyle: "satellite"`
+- `centerLat: number`
+- `centerLng: number`
+- `rotationDeg: number`
 - `opacity: number`
 - `visible: boolean`
 - `locked: boolean`
-- `width?: number`
-- `height?: number`
-- `source: "local" | "account"`
 
-This keeps the project document responsible for:
-
-- transform state
-- visibility
-- lock state
-- asset reference
-
-But not for:
+Do not store:
 
 - raw image bytes
-- large embedded payloads
+- tile data
+- screenshots
+- uploaded files
+- separate width/height values
 
-### Narrow Overlay Asset Model
+The footprint size comes from `design.field.width` and `design.field.height`.
 
-Do not store image payloads inside `TrackDesign`.
+## Technical Direction
 
-Instead:
-
-- logged-out mode stores the image in browser-local storage keyed by `assetId`
-- signed-in mode uploads the image through the existing media/storage path and stores a returned asset reference
-
-Expected first asset record shape:
-
-- `id`
-- `projectId`
-- `ownerUserId | null`
-- `storageKind: "local" | "account"`
-- `mimeType`
-- `byteSize`
-- `width`
-- `height`
-- `createdAt`
-- `updatedAt`
-- `localObjectKey | remoteKey`
-
-## Data Model Changes
-
-Update these boundaries first:
+Likely existing files to update after the prototype:
 
 - [src/lib/types.ts](../../src/lib/types.ts)
-- [src/lib/schema.d.ts](../../src/lib/schema.d.ts)
-- [src/lib/track/design.ts](../../src/lib/track/design.ts)
-
-Important normalization defaults:
-
-- `scale: 1`
-- `opacity: 0.5` or similar
-- `visible: true`
-- `locked: false`
-
-For signed-in sync, add a small overlay asset record or table keyed to:
-
-- `asset_id`
-- `project_id`
-- `owner_user_id`
-
-That record only needs to support:
-
-- create asset
-- resolve asset by project and owner
-- replace asset
-- delete asset
-
-## API Direction
-
-### Project Save API Stays Narrow
-
-Keep [src/app/api/projects/route.ts](../../src/app/api/projects/route.ts) focused on saving project JSON.
-
-Do not send raw image payloads through the normal project save route.
-
-The project payload should carry only overlay metadata and asset reference.
-
-### Overlay Asset Upload API
-
-Add a narrow authenticated route for signed-in uploads.
-
-Recommended first route:
-
-- `POST /api/project-assets/overlay`
-
-Responsibilities:
-
-- validate signed-in user
-- validate project ownership where needed
-- validate file type and size
-- store object in media/R2 path
-- create or update overlay asset record
-- return asset reference metadata
-
-Recommended matching delete path:
-
-- `DELETE /api/project-assets/overlay?projectId=...`
-
-### Share Flow Unchanged In V1
-
-Do not teach share routes or share storage about overlays in v1.
-
-The share payload can ignore overlay assets safely.
-
-## Editor Integration
-
-### Store Actions
-
-Extend the editor track actions in [src/store/editor.ts](../../src/store/editor.ts) with narrow overlay actions such as:
-
-- `setOverlayMeta`
-- `clearOverlay`
-- `setOverlayVisibility`
-- `setOverlayLocked`
-- `setOverlayTransform`
-
-These should mutate `track.design.overlay` and call `touchTrackDesign`.
-
-### Canvas Rendering
-
-Render the overlay behind normal shapes and route content.
-
-Most likely target:
-
-- [src/components/canvas/editor/TrackCanvas.tsx](../../src/components/canvas/editor/TrackCanvas.tsx)
-
-Recommended behavior:
-
-- if no overlay metadata or resolved asset URL, render nothing
-- if visible, render below shapes
-- if unlocked, allow transform interactions
-- if locked, do not intercept normal editing
-
-### Keep Overlay Interaction Isolated
-
-Avoid folding overlay manipulation into ordinary obstacle selection.
-
-Preferred interaction model:
-
-- explicit overlay-adjust mode or focused overlay controls
-- only when overlay is unlocked
-
-That reduces risk to existing selection and transform behavior.
-
-## Local And Signed-In Storage Behavior
-
-### Logged-Out
-
-For logged-out or local-only projects:
-
-- keep using current local project save path for project JSON
-- persist overlay blob separately in IndexedDB
-
-Recommended local helper boundary:
-
-- `src/lib/overlay-assets/local.ts`
-
-Responsibilities:
-
-- save local overlay blob
-- load local overlay blob by id
-- delete local overlay blob
-- return object URL for rendering
-
-Recommended local keying:
-
-- `overlay:${assetId}`
-
-### Signed-In
-
-For signed-in projects:
-
-1. upload overlay asset if it changed
-2. update `design.overlay.assetId`
-3. save project JSON through the normal project route
-
-When opening a signed-in project:
-
-1. load project JSON
-2. inspect `design.overlay`
-3. if `assetId` exists and source is `account`, resolve asset URL
-4. render overlay if it resolves
-5. if it fails, open the project normally and show a lightweight warning
-
-The likely coordination point is [src/components/editor/useAccountProjectSync.ts](../../src/components/editor/useAccountProjectSync.ts).
-
-## Failure Behavior
-
-The implementation should explicitly support these failure modes:
-
-### Upload Failure
-
-- show error
-- keep project open
-- do not block normal editing
-- preserve unsaved local overlay state where possible
-
-### Missing Asset On Load
-
-- open project normally
-- do not render overlay
-- show a lightweight non-blocking warning
-
-### Oversized File
-
-- reject before upload
-- explain size limit clearly
-
-### Unsupported Format
-
-- reject clearly
-- do not mutate project overlay metadata
-
-## File And Module Impact
-
-Likely first-pass additions:
-
-- `src/lib/overlay-assets/types.ts`
-- `src/lib/overlay-assets/local.ts`
-- `src/lib/server/overlay-assets.ts`
-- `src/app/api/project-assets/overlay/route.ts`
-- `src/components/editor/useOverlayAssetSync.ts`
-
-Likely existing files to update:
-
-- [src/lib/types.ts](../../src/lib/types.ts)
-- [src/lib/schema.d.ts](../../src/lib/schema.d.ts)
 - [src/lib/track/design.ts](../../src/lib/track/design.ts)
 - [src/store/editor.ts](../../src/store/editor.ts)
 - [src/components/canvas/editor/TrackCanvas.tsx](../../src/components/canvas/editor/TrackCanvas.tsx)
-- [src/components/editor/useAccountProjectSync.ts](../../src/components/editor/useAccountProjectSync.ts)
-- [src/lib/projects.ts](../../src/lib/projects.ts)
+- Project inspector view files under [src/components/inspector/views](../../src/components/inspector/views)
 
-## First Build Order
+Likely additions:
 
-The first engineering order should be:
+- `src/lib/map-reference/types.ts`
+- `src/lib/map-reference/geometry.ts`
+- `src/lib/map-reference/tiles.ts`
+- `src/components/map-reference/MapReferenceDialog.tsx`
+- `src/components/canvas/renderers/map-reference-layer.tsx`
 
-1. add `design.overlay` to `TrackDesign` and update types
-2. add local overlay blob helpers (`src/lib/overlay-assets/local.ts`)
-3. render one overlay in the editor behind existing shapes
-4. support local add/replace/remove/move/scale/opacity/lock
-5. keep export/share unaware of overlays
-6. wire signed-in asset upload and restore
+Store actions:
 
-## Open Implementation Questions
+- `setMapReference`
+- `clearMapReference`
+- `setMapReferenceVisibility`
+- `setMapReferenceOpacity`
+- `setMapReferenceRotation`
 
-These still need explicit answers before build:
+Geometry responsibilities:
 
-- accepted image formats
-- maximum upload size
-- whether asset URLs are public, signed, or proxied
-- whether project duplication reuses or clones the overlay asset reference
-- how orphaned remote overlay assets are cleaned up
-- whether sign-out should leave cached synced overlay blobs on-device
+- convert field dimensions to a map footprint around `centerLat`/`centerLng`
+- apply `rotationDeg`
+- produce canvas coordinates for rendering behind the design
+- avoid affecting the existing field coordinate system
+
+### Picker Vs Editor Renderer
+
+Use two deliberately separate pieces:
+
+- `MapReferenceDialog` uses the same Esri tile/provider helpers for panning, zooming, center selection, and field-heading adjustment.
+- Picker zoom is treated as a navigation aid only. The saved editor reference renders from the project field scale and latitude so the background dimensions do not depend on the zoom level used while choosing the center.
+- `map-reference-layer.tsx` renders the saved reference inside Konva as non-interactive imagery behind the design.
+
+Do not place a live DOM map behind the Konva stage in the editor.
+
+Reasoning:
+
+- the editor already has its own pan/zoom/stage transform
+- a DOM map layer would need fragile camera synchronization
+- mobile gestures would be split across the map and Konva
+- z-order, clipping, opacity, and export boundaries are cleaner inside Konva
+- `listening={false}` keeps the reference from intercepting normal editing
+
+The Konva renderer should load the minimum required provider tiles for the current field footprint, draw them clipped to the field area, and let the existing stage transform handle editor pan/zoom.
+
+## Provider Direction
+
+V1 should use Esri World Imagery as the single satellite provider.
+
+Use one central code config first:
+
+```ts
+export const mapReferenceProvider = {
+  id: "esri-world-imagery",
+  name: "Esri World Imagery",
+  defaultStyle: "satellite",
+  styles: {
+    satellite: {
+      tileUrl:
+        "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      attribution:
+        "Sources: Esri, Maxar, Earthstar Geographics, and the GIS User Community",
+    },
+  },
+} as const;
+```
+
+Recommended file:
+
+- `src/lib/map-reference/provider.ts`
+
+Both the picker and Konva tile renderer should use this same config.
+
+Do not add a `Map | Satellite` toggle in v1. Satellite is the default for this feature. Do not add provider env vars until TrackDraw actually needs provider switching, API-key-backed tiles, or deployment-specific map sources.
+
+Still verify before production release:
+
+- attribution requirements
+- tile caching rules
+- privacy implications of location searches
+
+Implementation should prefer provider APIs with clear browser usage and attribution terms.
+
+## Share And Export
+
+V1 behavior:
+
+- map reference is editor-only
+- share payloads do not include map imagery
+- exported PDFs/images do not include map imagery
+- project JSON may include map metadata so the editor can restore it
+
+Future export inclusion should be opt-in and provider-term-aware.
+
+## Future Image Reference Fallback
+
+Arbitrary image upload is out of scope for v1.
+
+If added later, it should be a separate flow:
+
+- `Image reference`
+- clear approximate/calibrated state
+- known-distance calibration
+- local or account-backed asset storage
+- explicit export/share behavior
+
+Do not mix uploaded images into the map-center flow, because a custom image cannot be correctly sized from a center point alone.
+
+## Test Plan
+
+- map reference metadata normalizes with valid defaults
+- invalid lat/lng/rotation values are rejected or clamped
+- field footprint uses `field.width` and `field.height`
+- toggling visibility does not affect field dimensions or shapes
+- changing field dimensions updates the footprint size
+- share/export serialization behavior stays unchanged for map imagery
+- editor interactions still select and drag shapes normally with the map reference visible

--- a/docs/research/map-field-overlay-evaluation.md
+++ b/docs/research/map-field-overlay-evaluation.md
@@ -1,366 +1,279 @@
-# Map And Field Overlay Evaluation
+# Map Field Reference Evaluation
 
-This document evaluates the product shape and UX approach for a map and field overlay feature in TrackDraw.
+This document evaluates the product shape and UX approach for adding real venue context behind a TrackDraw layout.
 
-Status: proposed. See `docs/pva/map-field-overlay-pva.md` for the implementation plan once approved.
+Status: v1 map-first implementation shipped. Arbitrary image upload remains out of scope.
 
-## Purpose
+## Decision
 
-TrackDraw already lets users build layouts on a clean field with precise scale, snapping, and route editing. The missing layer is real venue context. Users sometimes want to draft on top of:
+The first meaningful version should use a map or satellite picker instead of arbitrary image upload.
 
-- a field map
-- a satellite or drone image
-- a floor plan
-- a club venue sketch
+Users should not need to understand calibration, pixel scale, image dimensions, or georeferencing. The preferred UX is:
 
-The goal is to add that context without turning TrackDraw into a GIS tool, image editor, or calibration-heavy mapping product.
+1. Open `Add map reference`.
+2. Search, pan, or zoom the map.
+3. Click the center point of the field.
+4. TrackDraw draws the project field rectangle using `field.width` and `field.height`.
+5. The user adjusts rotation if needed.
+6. Confirm, then continue editing normally.
+
+This is a better first product shape because map tiles already have real-world scale. TrackDraw can use the project field dimensions to determine the correct size, so the user only needs to choose the location and direction.
 
 ## Product Goal
 
-Map and field overlay should make it easier to position a layout against real venue context.
+Map field reference should make it easy to line a TrackDraw project up with a real venue without making the editor feel like a mapping tool.
 
 That means:
 
-- users can place one background image behind the editor canvas
-- the image can be positioned and scaled until it roughly matches the TrackDraw field
-- the overlay helps placement decisions without becoming the source of truth for measurement accuracy
-- the feature remains practical on desktop and mobile
+- the user chooses a location, not an image scale
+- TrackDraw derives the field footprint from the existing project dimensions
+- the reference stays secondary to the track design
+- normal editing remains clean, readable, and fast
+- no account is required for the core flow
 
-## Core Boundary
+This is not a branding/customization feature. Replacing the TrackDraw logo with a club or event logo is a separate publishing concern.
 
-The first meaningful version should remain:
+## Why Not Image Upload In V1
 
-- usable without an account
-- local-first
-- project-bound rather than library-bound
+Loose image upload creates product and UX problems:
 
-Keep it in scope for the first release:
+- a photo, screenshot, floor plan, or sketch has no reliable scale on its own
+- asking users to calibrate every image adds setup friction
+- quick-fit can look plausible while being wrong
+- arbitrary images increase storage, sync, copyright, and privacy concerns immediately
+- the 2D editor can become visually noisy without actually improving measurement confidence
 
-- one overlay image per project
-- image import from the current device
-- position, scale, opacity, visibility, and lock state
-- editor-only overlay support first
+Image upload can remain a later fallback for floor plans or indoor venues, but it should not define the first version.
 
-Keep it out of scope for now:
+## Recommended V1 Model
 
-- multiple layered overlays
-- perspective correction
-- image warping
-- georeferencing
-- account-backed venue libraries
-- collaborative overlay annotation
+### 1. Map Reference, Not Overlay Image
 
-## Problem Framing
+Each project can optionally store one map reference.
 
-TrackDraw currently asks users to translate real venue context mentally.
+Recommended concept:
 
-That causes friction in a few common cases:
+- `centerLat`
+- `centerLng`
+- `rotationDeg`
+- `zoom` or tile resolution metadata
+- `mapStyle: "satellite" | "map"`
+- `opacity`
+- `visible`
+- `locked`
 
-1. Outdoor field planning against a real grass area or park boundary
-2. Indoor layout work against a hall floor plan
-3. Club reuse of a familiar venue where obstacle placement depends on known landmarks
+The TrackDraw field dimensions remain the source of truth for width and height.
 
-The first version should solve those cases through a simple visual underlay, not through advanced mapping tools.
+### 2. Center-First Setup
 
-## Recommended Product Model
+The user should only need to answer one main question:
 
-### 1. One Project-Level Overlay
+- Where is the center of the field?
 
-Each project can optionally carry one overlay image.
+TrackDraw handles:
 
-That keeps the model simple:
+- converting project field dimensions into a map footprint
+- drawing the field rectangle
+- fitting the map reference behind the layout
+- keeping scale tied to the map source instead of user-entered image dimensions
 
-- no overlay gallery
-- no overlay stack
-- no ambiguity about which image is active
+The only likely manual adjustment is rotation, because fields are rarely aligned exactly north/south.
 
-If TrackDraw needs richer overlay behavior later, that should be a follow-up.
+### 3. Rotation As The Main Adjustment
 
-### 2. Overlay Is Context, Not Measurement Truth
-
-The TrackDraw field dimensions remain the measurement model.
-
-The overlay helps align the design visually, but the product should not imply:
-
-- survey-grade accuracy
-- automatic real-world calibration
-- rules validation from the image alone
-
-This needs to stay explicit in the UX.
-
-### 3. Overlay Asset Handling Needs A Chosen Direction
-
-Map and field overlay is straightforward as an editor feature, but less straightforward as a storage feature.
-
-The main product question is:
-
-- should overlay images remain device-local only
-- or should signed-in account-backed projects sync overlay assets across devices
-
-This document recommends choosing the second path for v1. See Storage Options below.
-
-## UX Direction
-
-The feature should feel like a practical editor aid:
-
-- add overlay
-- align it roughly
-- lower opacity if needed
-- lock it
-- keep building normally
-
-The overlay should not compete with obstacle editing for attention.
+After choosing the center, the user should see the field rectangle over the map and adjust orientation.
 
 Recommended controls:
 
-- add or replace overlay
-- show or hide overlay
-- opacity slider
-- lock or unlock overlay interaction
-- reset transform
-- remove overlay
-
-Recommended interaction behavior:
-
-- overlay sits behind normal shapes and route content
-- when unlocked, it can be moved and scaled
-- when locked, it cannot intercept normal editor actions
-
-## Recommended Entry Points
-
-The first version should expose overlay controls inside the normal editor workflow rather than as a separate project-management feature.
-
-Recommended entry points:
-
-- editor toolbar or contextual canvas controls: `Add overlay`
-- inspector or canvas settings panel: overlay controls when an overlay exists
-- replacement action from the same overlay control area
-
-Recommended persistent controls once an overlay exists:
-
-- show or hide
-- lock or unlock
+- rotate left/right or drag a heading handle
+- snap rotation to common angles if useful
+- reset north-up
 - opacity
-- replace image
-- remove overlay
+- confirm
 
-Do not start with:
+Avoid exposing width/height scaling controls in the primary map flow. If the field size is wrong, the user should edit project field dimensions instead.
 
-- a dedicated venue-management screen
-- account-level overlay libraries
-- multi-step setup wizards before the first image can even be placed
+### 4. Editor Visibility
 
-## Screen-Level V1 Flow
+The reference should be available without permanently making the 2D editor busy.
 
-### 1. Add Overlay
+Recommended behavior:
 
-The user chooses `Add overlay` from the editor.
+- visible after setup, at low opacity
+- locked by default
+- quick show/hide toggle
+- `Edit map reference` opens the picker/adjustment view again
+- reference does not intercept object selection, route editing, snapping, or drag behavior
 
-The first version should support:
+The map reference should sit behind the field chrome and shapes, not inside a nested card or floating preview.
 
-- choosing an image from the current device
+## UX Flow
 
-After import:
+### Add Map Reference
 
-- the overlay appears behind the field
-- it starts visible and unlocked
-- TrackDraw surfaces the main transform controls immediately
+Entry point:
 
-### 2. Align Overlay
+- Project inspector: `Map reference`
+- Canvas or toolbar action: `Add map`
 
-The user should then be able to:
+Flow:
 
-- move the overlay
-- scale the overlay
-- reduce opacity
-- lock it once it is roughly aligned
+1. Desktop dialog or mobile drawer opens with map/satellite view.
+2. User searches, uses current location, or pans to venue.
+3. User clicks the center of the field.
+4. TrackDraw overlays the project field rectangle.
+5. User adjusts rotation if needed.
+6. User confirms.
 
-This step should feel lightweight. The product should support rough alignment, not force precision calibration.
+### Edit Map Reference
 
-### 3. Edit With Overlay
+Flow:
 
-Once locked:
+1. User opens `Edit map`.
+2. Dialog reopens at the current reference location.
+3. User moves center or adjusts rotation.
+4. Confirm updates the reference.
 
-- normal obstacle and route editing stays primary
-- the overlay remains visible as context
-- the overlay should not intercept selection or drag actions
+### Normal Editing
 
-### 4. Replace Or Remove Overlay
+Once confirmed:
 
-The user should be able to:
+- map reference renders beneath the layout when visible
+- field dimensions continue to come from TrackDraw
+- route and obstacle editing behave normally
+- opacity and visibility are available from the Project inspector
 
-- replace the image without deleting the rest of the project
-- remove the overlay entirely
-- restore a cleaner editor state without side effects on the design
+## Suggested UI Copy
 
-## Suggested V1 UI Copy Direction
+Use simple placement language:
 
-The feature should use practical, non-technical language:
-
-- `Add overlay`
-- `Replace overlay`
-- `Hide overlay`
-- `Lock overlay`
+- `Add map`
+- `Map reference`
+- `Choose field center`
+- `Align field`
+- `Show map`
+- `Hide map`
+- `Edit map`
+- `Remove map`
 - `Opacity`
-- `Reset overlay`
-- `Remove overlay`
 
-Avoid copy that implies advanced mapping behavior, such as:
+Avoid technical language in the main flow:
 
+- `Georeference`
 - `Calibrate map`
-- `Georeference image`
-- `Anchor to world`
+- `Set projection`
+- `Tile resolution`
 
-That would overpromise what the first version actually does.
+## 2D And 3D Behavior
 
-## Editor Behavior Recommendation
+### 2D
 
-### First Pass Controls
+V1 should start with 2D because the map reference is primarily a placement aid.
 
-The first version should support:
+Rules:
 
-- move
-- uniform scale
-- opacity
-- lock
-- visibility toggle
+- draw the map behind shapes and route content
+- keep opacity conservative by default
+- keep a fast visibility toggle
+- do not let the map participate in selection
 
-Do not require rotation in the first pass unless implementation turns out to be very cheap. Most real value comes from rough position and scale.
+### 3D
 
-### Mobile Recommendation
+3D can use the same reference later as a ground texture once the 2D placement model works.
 
-Mobile should support overlay visibility and lock state cleanly from ordinary controls.
+Do not block the first version on 3D. Validate 3D separately because ground textures add rendering and readability questions.
 
-Direct transform manipulation on mobile is acceptable only if it remains reliable and does not conflict with canvas pan/zoom. If needed, the first mobile pass can bias toward:
+## Technical Direction
 
-- visibility toggle
-- opacity
-- lock
-- simpler slider-based scale adjustment
+The first prototype should not accept arbitrary image uploads.
 
-That is better than forcing desktop-style transform handles into a cramped mobile interaction model.
+Recommended implementation direction:
 
-## Suggested Desktop Interaction Model
+- use a map provider that supports browser rendering and a suitable usage policy
+- store only reference metadata in the project
+- keep tile/image cache out of `TrackDesign`
+- use a dedicated tile picker dialog for field center selection
+- render confirmed editor imagery with a dedicated non-interactive Konva tile layer
+- keep share/export unaware of map references in v1
 
-The first desktop pass should support direct manipulation.
+Potential metadata:
 
-Recommended controls:
+- `type: "map"`
+- `centerLat: number`
+- `centerLng: number`
+- `rotationDeg: number`
+- `mapStyle: "satellite" | "map"`
+- `opacity: number`
+- `visible: boolean`
+- `locked: boolean`
+- `provider: string`
 
-- drag to move
-- handles or a simple focused control to scale uniformly
-- opacity slider in a side panel or compact control strip
-- lock toggle to exit overlay-adjustment mode cleanly
+Open provider questions:
 
-Desktop can carry the richer interaction model first because it has more room and lower gesture conflict.
+- provider licensing and attribution
+- allowed tile caching or snapshot behavior
+- API key handling
+- offline behavior
+- local development fallback
 
-## Suggested Mobile Interaction Model
+## Editor Renderer Decision
 
-The first mobile pass should favor safety and clarity over gesture richness.
+Use the tile picker for setup, not for the editor background.
 
-Recommended first direction:
+The editor should render the confirmed map reference inside Konva. A live DOM map underneath the Konva stage is tempting for a prototype, but it creates a second camera and gesture system that must stay in sync with TrackDraw's stage transform.
 
-- visibility toggle
-- opacity slider
-- lock toggle
-- simple scale control
-- optional reposition mode only if it remains reliable
+Konva rendering is the better production path because:
 
-If mobile direct manipulation feels fragile, it is acceptable for v1 mobile to be more limited than desktop as long as the overlay remains usable.
+- it follows existing canvas pan and zoom automatically
+- it can be `listening={false}` so normal editing remains safe
+- clipping, opacity, z-order, and dark/light field chrome stay predictable
+- mobile gestures stay owned by the editor
+- export and share boundaries remain explicit
 
-## Storage Options
+The renderer should calculate the required provider tiles from `centerLat`, `centerLng`, `rotationDeg`, field dimensions, and provider style, then draw those tiles as images behind the layout. The editor render should derive its tile detail from project scale and latitude; the picker zoom is only a navigation aid and must not change the saved field scale.
 
-The first overlay implementation needs a concrete storage answer before the rest of the feature is locked.
+## Storage And Sync
 
-TrackDraw already has existing media-oriented infrastructure and available bucket capacity through the current media path. That makes account-backed overlay sync a realistic option, but it still should not be treated as free.
+Because map references can be represented by metadata, v1 can avoid project asset storage.
 
-### Option A: Device-Local Only
+Recommended v1 behavior:
 
-Model:
+- project stores center, rotation, style, opacity, and provider metadata
+- logged-out users can save the reference with local project JSON
+- signed-in users can sync the same metadata with account-backed projects
+- no uploaded image blobs are needed
 
-- overlay image stays on the current device
-- project stores overlay metadata plus a local asset reference
-- opening the same project on another device may not restore the image
-
-Pros:
-
-- smallest implementation slice
-- no backend dependency
-- easier to ship quickly
-
-Cons:
-
-- weak cross-device continuity
-- signed-in users may reasonably expect the overlay to follow the project
-- the feature may feel incomplete for home-planning to race-day-mobile workflows
-
-### Option B: Hybrid Model With Signed-In Asset Sync
-
-Model:
-
-- logged-out projects keep overlay assets on-device
-- signed-in account-backed projects store overlay assets through the existing media/storage path
-- project metadata stores transform state plus an asset reference
-- opening the same signed-in project on another device restores the overlay if sync succeeded
-
-Pros:
-
-- matches the value proposition of account-backed projects better
-- supports real cross-device venue workflows
-- avoids treating overlay as a throwaway local-only aid for signed-in users
-
-Cons:
-
-- adds upload, replace, cleanup, and sync-state complexity immediately
-- requires payload limits, accepted format rules, and failure-state UX from day one
-- increases the implementation scope from editor feature to editor-plus-asset-sync feature
-
-### Chosen V1 Direction
-
-V1 should use the hybrid model.
-
-That means:
-
-- logged-out projects keep overlay assets on-device
-- signed-in account-backed projects sync overlay assets through the existing media/storage path
-- project metadata stores transform state plus an asset reference
-- export/share inclusion stays out of scope for v1
-
-This is the strongest product direction because the feature is meant to support:
-
-- desktop planning at home
-- mobile reopening on site
-- continuity across devices for signed-in projects
+This is simpler than image upload and aligns better with cross-device project continuity.
 
 ## Export And Share Behavior
 
-Even if the first version keeps overlays out of export and share by default, the editor should explain that cleanly.
+V1 should keep map references out of export and share output unless explicitly revisited.
 
-Recommended first behavior:
+Reasons:
 
-- overlay is visible in the editor
-- standard exports and shares continue to represent the TrackDraw design itself
-- TrackDraw does not silently include venue imagery in published output
+- venue imagery may have licensing or privacy implications
+- published shares should remain focused on the authored TrackDraw layout
+- map provider terms may restrict exported imagery
 
-This avoids:
+Future export inclusion should be a deliberate per-export option, not a silent side effect of editor visibility.
 
-- surprising users with accidental third-party imagery in exports
-- copyright and privacy questions from published venue images
-- turning a practical editor aid into a publishing commitment immediately
+## Future Image Upload Fallback
 
-If the product later revisits export inclusion, that should be a separate user decision per export path.
+Image upload may still be useful later for:
 
-## Risks
+- indoor floor plans
+- venue sketches
+- drone orthophotos
+- custom field diagrams
 
-- Users may over-trust visual alignment and assume real-world accuracy that the app does not guarantee
-- Image payload handling may create local-storage pressure if the implementation stores large overlays directly in project state
-- Mobile transform behavior may become frustrating if overlay gestures fight canvas gestures
-- Export/share expectations may become confused if the overlay appears in the editor but disappears elsewhere without clear messaging
+If added later, it should be a separate `Image reference` path with explicit limitations and optional known-distance calibration. It should not share the simple map-center UX because it cannot derive scale from a location alone.
 
 ## Success Criteria
 
 The first version is successful if:
 
-- a user can align an overlay quickly without fighting the editor
-- a signed-in user can reopen the same project on another device and still see the overlay
-- overlay failures do not block project open
-- the feature helps placement decisions without confusing users about measurement accuracy
+- a user can add a useful map reference by choosing a field center and rotation
+- TrackDraw sizes the reference from project field dimensions without user scale controls
+- normal 2D editing remains readable and responsive
+- the same project reference can reopen from saved metadata
+- users do not confuse map reference visibility with authoritative survey-grade measurement

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -36,8 +36,14 @@ Labels used below:
   - [x] Advanced snapping follow-up
         Added route-line snapping, x/y object-alignment snapping, and kept the existing angle/grid behavior on the same lightweight snap resolver.
 
-- [ ] Map and field overlay (`No account required`)
-      Support venue plans, field maps, or imagery behind the editor canvas.
+- [x] Map field reference (`No account required`)
+      Shipped an editor-only satellite map reference for lining a project up with a real venue. Users can search for a location, choose the field center, align rotation, adjust opacity, and render the saved reference behind the 2D layout through a non-interactive Konva tile layer. Project JSON keeps map metadata, while share/export payloads stay free of map imagery and location data.
+  - [x] Map picker and field footprint
+        Added a desktop dialog and mobile drawer with Esri World Imagery tiles, typeahead location search, current-location jump, center selection, touch/pointer panning, pinch/wheel zoom, and a field footprint derived from project dimensions.
+  - [x] Editor rendering and inspector controls
+        Added a locked, non-interactive Konva tile renderer plus Project inspector controls for add/edit, show/hide, opacity, rotation, and remove.
+  - [x] Persistence and share/export boundary
+        Persisted map reference metadata in project JSON and stripped it from share/export serialization so public outputs do not expose map references in v1.
 
 ## Shipped Foundation
 

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/lib/canvas/shared";
 import { useTrackCanvasInteractions } from "@/components/canvas/useTrackCanvasInteractions";
 import { StableFieldContent } from "@/components/canvas/renderers/field-layer";
+import { MapReferenceLayer } from "@/components/canvas/renderers/map-reference-layer";
 import { getShapeLocalBounds } from "@/components/canvas/renderers/shape-bounds";
 import { TrackShapeNode } from "@/components/canvas/renderers/shape-node";
 import { useTrackCanvasViewport } from "@/components/canvas/useTrackCanvasViewport";
@@ -1674,6 +1675,12 @@ const TrackCanvas = memo(
           >
             {/* Stable field layer: grid + borders — only redraws on design/theme change */}
             <Layer listening={false}>
+              <MapReferenceLayer
+                field={design.field}
+                heightPx={heightPx}
+                mapReference={design.mapReference ?? null}
+                widthPx={widthPx}
+              />
               <StableFieldContent
                 designField={design.field}
                 grid={grid}

--- a/src/components/canvas/renderers/map-reference-layer.tsx
+++ b/src/components/canvas/renderers/map-reference-layer.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Group, Image as KonvaImage } from "react-konva";
+import {
+  getFieldMapTileCoverage,
+  type MapReferenceTile,
+} from "@/lib/map-reference/geometry";
+import { getMapReferenceTileUrl } from "@/lib/map-reference/tiles";
+import type { FieldSpec, MapReference } from "@/lib/types";
+
+export function MapReferenceLayer({
+  field,
+  heightPx,
+  mapReference,
+  widthPx,
+}: {
+  field: Pick<FieldSpec, "width" | "height" | "ppm">;
+  heightPx: number;
+  mapReference?: MapReference | null;
+  widthPx: number;
+}) {
+  const tiles = useMemo(() => {
+    if (!mapReference?.visible) return [];
+    return getFieldMapTileCoverage({ field, mapReference });
+  }, [field, mapReference]);
+  const [images, setImages] = useState<Record<string, HTMLImageElement>>({});
+
+  useEffect(() => {
+    if (!mapReference?.visible) return;
+
+    const tileUrls = new Set(tiles.map(getMapReferenceTileUrl));
+    let mounted = true;
+    const missingTiles = tiles.filter(
+      (tile) => !images[getMapReferenceTileUrl(tile)]
+    );
+
+    for (const tile of missingTiles) {
+      const url = getMapReferenceTileUrl(tile);
+      const image = new window.Image();
+      image.crossOrigin = "anonymous";
+      image.onload = () => {
+        if (!mounted) return;
+        setImages((current) => {
+          const next: Record<string, HTMLImageElement> = {};
+          for (const [k, v] of Object.entries(current)) {
+            if (tileUrls.has(k)) next[k] = v;
+          }
+          if (!next[url]) next[url] = image;
+          return next;
+        });
+      };
+      image.src = url;
+    }
+
+    return () => {
+      mounted = false;
+    };
+  }, [images, mapReference?.visible, tiles]);
+
+  if (!mapReference?.visible || tiles.length === 0) return null;
+
+  return (
+    <Group
+      clipX={0}
+      clipY={0}
+      clipWidth={widthPx}
+      clipHeight={heightPx}
+      opacity={mapReference.opacity}
+      listening={false}
+    >
+      <Group
+        x={widthPx / 2}
+        y={heightPx / 2}
+        rotation={-mapReference.rotationDeg}
+        listening={false}
+      >
+        {tiles.map((tile) => (
+          <MapTileImage
+            key={`${tile.z}-${tile.x}-${tile.y}-${Math.round(tile.canvasX)}-${Math.round(tile.canvasY)}`}
+            image={images[getMapReferenceTileUrl(tile)]}
+            tile={tile}
+          />
+        ))}
+      </Group>
+    </Group>
+  );
+}
+
+function MapTileImage({
+  image,
+  tile,
+}: {
+  image?: HTMLImageElement;
+  tile: MapReferenceTile;
+}) {
+  if (!image) return null;
+
+  return (
+    <KonvaImage
+      image={image}
+      x={tile.canvasX}
+      y={tile.canvasY}
+      width={tile.canvasSize}
+      height={tile.canvasSize}
+      listening={false}
+    />
+  );
+}

--- a/src/components/inspector/Inspector.tsx
+++ b/src/components/inspector/Inspector.tsx
@@ -44,6 +44,11 @@ function Inspector({
     ungroupSelection,
     updateField,
     updateDesignMeta,
+    setMapReference,
+    clearMapReference,
+    setMapReferenceVisibility,
+    setMapReferenceOpacity,
+    setMapReferenceRotation,
   } = useTrackActions();
   const { setSelection } = useSessionActions();
   const { setHoveredShapeId, setHoveredWaypoint } = useUiActions();
@@ -195,6 +200,11 @@ function Inspector({
             setSelection={setSelection}
             updateField={updateField}
             updateDesignMeta={updateDesignMeta}
+            setMapReference={setMapReference}
+            clearMapReference={clearMapReference}
+            setMapReferenceVisibility={setMapReferenceVisibility}
+            setMapReferenceOpacity={setMapReferenceOpacity}
+            setMapReferenceRotation={setMapReferenceRotation}
             removeShapes={removeShapes}
             setHoveredShapeId={setHoveredShapeId}
           />

--- a/src/components/inspector/views/list-panel.tsx
+++ b/src/components/inspector/views/list-panel.tsx
@@ -17,7 +17,12 @@ import { MetaPill } from "./layout";
 export type DesignMetaPatch = Partial<
   Pick<
     TrackDesign,
-    "title" | "description" | "authorName" | "tags" | "inventory"
+    | "title"
+    | "description"
+    | "authorName"
+    | "tags"
+    | "inventory"
+    | "mapReference"
   >
 >;
 

--- a/src/components/inspector/views/project-layout.tsx
+++ b/src/components/inspector/views/project-layout.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { Eye, EyeOff, MapPinned, Trash2 } from "lucide-react";
 import ElevationChart from "@/components/inspector/ElevationChart";
+import { MapReferenceDialog } from "@/components/map-reference/MapReferenceDialog";
 import { Input } from "@/components/ui/input";
 import { shapeKindLabels } from "@/lib/editor-tools";
 import {
@@ -13,6 +15,7 @@ import { getObstacleNumberingReport } from "@/lib/track/obstacleNumbering";
 import type {
   FieldSpec,
   InventoryShapeKind,
+  MapReference,
   Shape,
   TrackDesign,
 } from "@/lib/types";
@@ -33,6 +36,128 @@ import { type DesignMetaPatch, ItemOverviewList } from "./list-panel";
 
 function getShapeDisplayName(shape: Shape, index: number) {
   return shape.name?.trim() || `${shapeKindLabels[shape.kind]} ${index + 1}`;
+}
+
+function MapReferenceSection({
+  design,
+  setMapReference,
+  clearMapReference,
+  setMapReferenceVisibility,
+  setMapReferenceOpacity,
+  setMapReferenceRotation,
+}: {
+  design: TrackDesign;
+  setMapReference: (reference: MapReference) => void;
+  clearMapReference: () => void;
+  setMapReferenceVisibility: (visible: boolean) => void;
+  setMapReferenceOpacity: (opacity: number) => void;
+  setMapReferenceRotation: (rotationDeg: number) => void;
+}) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const reference = design.mapReference ?? null;
+  const actionBtnClass =
+    "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-border/45 bg-background/80 px-2.5 text-[11px] font-medium text-foreground/82 transition-colors hover:bg-muted/35 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8";
+  const actionBtnPrimaryClass =
+    "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-primary/25 bg-primary/8 px-2.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/12 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8";
+
+  return (
+    <Section title="Map reference">
+      <div className="space-y-3">
+        {reference ? (
+          <>
+            <Row label="Opacity">
+              <div className="flex min-w-0 items-center gap-2">
+                <input
+                  type="range"
+                  min={0.05}
+                  max={1}
+                  step={0.05}
+                  value={reference.opacity}
+                  onChange={(event) =>
+                    setMapReferenceOpacity(Number(event.target.value))
+                  }
+                  className="accent-primary h-2 min-w-0 flex-1"
+                />
+                <span className="text-muted-foreground/70 w-9 text-right text-[10px] font-medium tabular-nums">
+                  {Math.round(reference.opacity * 100)}%
+                </span>
+              </div>
+            </Row>
+            <Row label="Rotation">
+              <Num
+                value={reference.rotationDeg}
+                onChange={setMapReferenceRotation}
+                step={1}
+                min={0}
+              />
+            </Row>
+          </>
+        ) : null}
+
+        <div
+          className={reference ? "grid grid-cols-3 gap-1.5" : "grid gap-1.5"}
+        >
+          <button
+            type="button"
+            title={reference ? "Edit map reference" : "Add map reference"}
+            aria-label={reference ? "Edit map reference" : "Add map reference"}
+            className={actionBtnPrimaryClass}
+            onClick={() => setDialogOpen(true)}
+          >
+            <MapPinned className="size-3" />
+            <span>{reference ? "Edit" : "Add map"}</span>
+          </button>
+          {reference ? (
+            <>
+              <button
+                type="button"
+                title={
+                  reference.visible === false
+                    ? "Show map reference"
+                    : "Hide map reference"
+                }
+                aria-label={
+                  reference.visible === false
+                    ? "Show map reference"
+                    : "Hide map reference"
+                }
+                className={actionBtnClass}
+                onClick={() =>
+                  setMapReferenceVisibility(reference.visible === false)
+                }
+              >
+                {reference.visible === false ? (
+                  <Eye className="size-3" />
+                ) : (
+                  <EyeOff className="size-3" />
+                )}
+                <span>{reference.visible === false ? "Show" : "Hide"}</span>
+              </button>
+              <button
+                type="button"
+                title="Remove map reference"
+                aria-label="Remove map reference"
+                className={`${actionBtnClass} border-red-500/20 bg-red-500/6 text-red-500 hover:bg-red-500/12`}
+                onClick={clearMapReference}
+              >
+                <Trash2 className="size-3" />
+                <span>Remove</span>
+              </button>
+            </>
+          ) : null}
+        </div>
+        {dialogOpen ? (
+          <MapReferenceDialog
+            field={design.field}
+            initialReference={reference}
+            open={dialogOpen}
+            onOpenChange={setDialogOpen}
+            onConfirm={setMapReference}
+          />
+        ) : null}
+      </div>
+    </Section>
+  );
 }
 
 function RouteNumberingOverview({
@@ -139,6 +264,11 @@ export interface ProjectLayoutInspectorViewProps {
   setSelection: (ids: string[]) => void;
   updateField: (patch: Partial<FieldSpec>) => void;
   updateDesignMeta: (patch: DesignMetaPatch) => void;
+  setMapReference: (reference: MapReference) => void;
+  clearMapReference: () => void;
+  setMapReferenceVisibility: (visible: boolean) => void;
+  setMapReferenceOpacity: (opacity: number) => void;
+  setMapReferenceRotation: (rotationDeg: number) => void;
   removeShapes: (ids: string[]) => void;
   setHoveredShapeId: (shapeId: string | null) => void;
   mobileInline?: boolean;
@@ -151,6 +281,11 @@ export function ProjectLayoutInspectorView({
   setSelection,
   updateField,
   updateDesignMeta,
+  setMapReference,
+  clearMapReference,
+  setMapReferenceVisibility,
+  setMapReferenceOpacity,
+  setMapReferenceRotation,
   removeShapes,
   setHoveredShapeId,
   mobileInline = false,
@@ -317,6 +452,14 @@ export function ProjectLayoutInspectorView({
           />
         </Row>
       </Section>
+      <MapReferenceSection
+        design={design}
+        setMapReference={setMapReference}
+        clearMapReference={clearMapReference}
+        setMapReferenceVisibility={setMapReferenceVisibility}
+        setMapReferenceOpacity={setMapReferenceOpacity}
+        setMapReferenceRotation={setMapReferenceRotation}
+      />
       {inventoryContent}
     </>
   );

--- a/src/components/map-reference/MapReferenceDialog.tsx
+++ b/src/components/map-reference/MapReferenceDialog.tsx
@@ -1,0 +1,929 @@
+"use client";
+
+/* eslint-disable @next/next/no-img-element */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { LocateFixed, Minus, Plus, RotateCcw, Search } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { MobileDrawer } from "@/components/MobileDrawer";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useIsDesktopInspector } from "@/components/inspector/views/layout";
+import {
+  clampLatitude,
+  globalPixelToLatLng,
+  getMapTileZoom,
+  latLngToGlobalPixel,
+  metersPerPixelAtLatitude,
+  normalizeLongitude,
+  panLatLngByPixels,
+  screenDeltaToMapPixelDelta,
+  type LatLng,
+} from "@/lib/map-reference/geometry";
+import {
+  MAP_REFERENCE_DEFAULT_ZOOM,
+  MAP_REFERENCE_MAX_ZOOM,
+  MAP_REFERENCE_MIN_ZOOM,
+  MAP_REFERENCE_TILE_SIZE,
+  mapReferenceProvider,
+} from "@/lib/map-reference/provider";
+import { getMapReferenceTileUrl } from "@/lib/map-reference/tiles";
+import type { FieldSpec, MapReference } from "@/lib/types";
+
+const PICKER_WIDTH = 760;
+const PICKER_HEIGHT = 430;
+const WHEEL_LINE_HEIGHT_PX = 16;
+const WHEEL_PAGE_HEIGHT_PX = 420;
+const WHEEL_PAN_FACTOR = 0.65;
+const PINCH_ZOOM_FACTOR = 0.008;
+const LOCATION_SEARCH_DEBOUNCE_MS = 350;
+const LOCATION_SEARCH_MIN_LENGTH = 3;
+
+function clampValue(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function normalizeWheelDelta(delta: number, deltaMode: number) {
+  if (deltaMode === 1) return delta * WHEEL_LINE_HEIGHT_PX;
+  if (deltaMode === 2) return delta * WHEEL_PAGE_HEIGHT_PX;
+  return delta;
+}
+
+type WebKitGestureEvent = Event & {
+  clientX?: number;
+  clientY?: number;
+  scale?: number;
+};
+
+interface LocationSearchResult {
+  address: string;
+  id: string;
+  lat: number;
+  lng: number;
+  score: number;
+}
+
+function parseCoordinateQuery(query: string): LatLng | null {
+  const matches = query.match(/-?\d+(?:[.,]\d+)?/g);
+  if (!matches || matches.length < 2) return null;
+
+  const first = Number(matches[0].replace(",", "."));
+  const second = Number(matches[1].replace(",", "."));
+  if (!Number.isFinite(first) || !Number.isFinite(second)) return null;
+
+  if (Math.abs(first) <= 90 && Math.abs(second) <= 180) {
+    return {
+      lat: clampLatitude(first),
+      lng: normalizeLongitude(second),
+    };
+  }
+
+  if (Math.abs(first) <= 180 && Math.abs(second) <= 90) {
+    return {
+      lat: clampLatitude(second),
+      lng: normalizeLongitude(first),
+    };
+  }
+
+  return null;
+}
+
+function createReference({
+  center,
+  rotationDeg,
+  zoom,
+}: {
+  center: LatLng;
+  rotationDeg: number;
+  zoom: number;
+}): MapReference {
+  return {
+    type: "map",
+    provider: "esri-world-imagery",
+    mapStyle: "satellite",
+    centerLat: center.lat,
+    centerLng: center.lng,
+    zoom,
+    rotationDeg,
+    opacity: 0.35,
+    visible: true,
+    locked: true,
+  };
+}
+
+function getVisibleTiles({
+  center,
+  height,
+  width,
+  zoom,
+  coverageHeight = height,
+  coverageWidth = width,
+}: {
+  coverageHeight?: number;
+  coverageWidth?: number;
+  center: LatLng;
+  height: number;
+  width: number;
+  zoom: number;
+}) {
+  const tileZoom = getMapTileZoom(zoom);
+  const tileScale = 2 ** (zoom - tileZoom);
+  const centerPixel = latLngToGlobalPixel(center.lat, center.lng, tileZoom);
+  const minTileX = Math.floor(
+    (centerPixel.x - coverageWidth / tileScale / 2) / MAP_REFERENCE_TILE_SIZE
+  );
+  const maxTileX = Math.floor(
+    (centerPixel.x + coverageWidth / tileScale / 2) / MAP_REFERENCE_TILE_SIZE
+  );
+  const minTileY = Math.floor(
+    (centerPixel.y - coverageHeight / tileScale / 2) / MAP_REFERENCE_TILE_SIZE
+  );
+  const maxTileY = Math.floor(
+    (centerPixel.y + coverageHeight / tileScale / 2) / MAP_REFERENCE_TILE_SIZE
+  );
+  const maxTile = 2 ** tileZoom;
+  const tiles: Array<{
+    key: string;
+    left: number;
+    size: number;
+    top: number;
+    url: string;
+  }> = [];
+
+  for (let y = minTileY - 1; y <= maxTileY + 1; y += 1) {
+    if (y < 0 || y >= maxTile) continue;
+
+    for (let x = minTileX - 1; x <= maxTileX + 1; x += 1) {
+      const wrappedX = ((x % maxTile) + maxTile) % maxTile;
+      const left =
+        (x * MAP_REFERENCE_TILE_SIZE - centerPixel.x) * tileScale + width / 2;
+      const top =
+        (y * MAP_REFERENCE_TILE_SIZE - centerPixel.y) * tileScale + height / 2;
+
+      tiles.push({
+        key: `${tileZoom}-${x}-${wrappedX}-${y}`,
+        left,
+        size: MAP_REFERENCE_TILE_SIZE * tileScale,
+        top,
+        url: getMapReferenceTileUrl({ x: wrappedX, y, z: tileZoom }),
+      });
+    }
+  }
+
+  return tiles;
+}
+
+export function MapReferenceDialog({
+  field,
+  initialReference,
+  open,
+  onOpenChange,
+  onConfirm,
+}: {
+  field: Pick<FieldSpec, "width" | "height">;
+  initialReference?: MapReference | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (reference: MapReference) => void;
+}) {
+  const isDesktop = useIsDesktopInspector();
+  const [center, setCenter] = useState<LatLng>({
+    lat: initialReference?.centerLat ?? 52.1326,
+    lng: initialReference?.centerLng ?? 5.2913,
+  });
+  const [zoom, setZoom] = useState(
+    initialReference?.zoom ?? MAP_REFERENCE_DEFAULT_ZOOM
+  );
+  const [rotationDeg, setRotationDeg] = useState(
+    initialReference?.rotationDeg ?? 0
+  );
+  const [latInput, setLatInput] = useState(String(center.lat.toFixed(6)));
+  const [lngInput, setLngInput] = useState(String(center.lng.toFixed(6)));
+  const [locationQuery, setLocationQuery] = useState("");
+  const [locationResults, setLocationResults] = useState<
+    LocationSearchResult[]
+  >([]);
+  const [locationSearchError, setLocationSearchError] = useState<string | null>(
+    null
+  );
+  const [locationSearchPending, setLocationSearchPending] = useState(false);
+  const [selectedLocationLabel, setSelectedLocationLabel] = useState("");
+  const dragRef = useRef<{
+    lastX: number;
+    lastY: number;
+    moved: boolean;
+    totalDx: number;
+    totalDy: number;
+  } | null>(null);
+  const tileLayerRef = useRef<HTMLDivElement | null>(null);
+  const centerRef = useRef(center);
+  const zoomRef = useRef(zoom);
+  const rotationRef = useRef(rotationDeg);
+  const gestureScaleRef = useRef(1);
+  const searchPanelRef = useRef<HTMLDivElement | null>(null);
+  const locationSearchAbortRef = useRef<AbortController | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const [pickerElement, setPickerElement] = useState<HTMLDivElement | null>(
+    null
+  );
+  const [pickerSize, setPickerSize] = useState({
+    width: PICKER_WIDTH,
+    height: PICKER_HEIGHT,
+  });
+
+  const metersPerPixel = metersPerPixelAtLatitude(center.lat, zoom);
+  const fieldWidthPx = field.width / metersPerPixel;
+  const fieldHeightPx = field.height / metersPerPixel;
+  const tiles = useMemo(
+    () =>
+      getVisibleTiles({
+        coverageHeight: Math.ceil(
+          Math.hypot(pickerSize.width, pickerSize.height)
+        ),
+        coverageWidth: Math.ceil(
+          Math.hypot(pickerSize.width, pickerSize.height)
+        ),
+        center,
+        height: pickerSize.height,
+        width: pickerSize.width,
+        zoom,
+      }),
+    [center, pickerSize.height, pickerSize.width, zoom]
+  );
+
+  const setPickerNode = useCallback((node: HTMLDivElement | null) => {
+    resizeObserverRef.current?.disconnect();
+    resizeObserverRef.current = null;
+    setPickerElement(node);
+
+    if (!node) return;
+
+    const updatePickerSize = () => {
+      setPickerSize({
+        width: Math.max(1, node.clientWidth),
+        height: Math.max(1, node.clientHeight),
+      });
+    };
+
+    updatePickerSize();
+    resizeObserverRef.current = new ResizeObserver(updatePickerSize);
+    resizeObserverRef.current.observe(node);
+  }, []);
+
+  const syncCenter = useCallback((nextCenter: LatLng) => {
+    centerRef.current = nextCenter;
+    setCenter(nextCenter);
+    setLatInput(nextCenter.lat.toFixed(6));
+    setLngInput(nextCenter.lng.toFixed(6));
+  }, []);
+
+  const syncZoom = useCallback((nextZoom: number) => {
+    const safeZoom = clampValue(
+      nextZoom,
+      MAP_REFERENCE_MIN_ZOOM,
+      MAP_REFERENCE_MAX_ZOOM
+    );
+    zoomRef.current = safeZoom;
+    setZoom(safeZoom);
+  }, []);
+
+  const syncRotation = useCallback((nextRotationDeg: number) => {
+    const safeRotation = ((nextRotationDeg % 360) + 360) % 360;
+    rotationRef.current = safeRotation;
+    setRotationDeg(safeRotation);
+  }, []);
+
+  const applyTypedCenter = () => {
+    const lat = Number(latInput);
+    const lng = Number(lngInput);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
+    syncCenter({ lat: clampLatitude(lat), lng: normalizeLongitude(lng) });
+  };
+
+  const panByScreenPixels = useCallback(
+    ({ dx, dy }: { dx: number; dy: number }) => {
+      const panDelta = screenDeltaToMapPixelDelta({
+        dx,
+        dy,
+        rotationDeg: rotationRef.current,
+      });
+      syncCenter(
+        panLatLngByPixels({
+          center: centerRef.current,
+          dx: panDelta.dx,
+          dy: panDelta.dy,
+          zoom: zoomRef.current,
+        })
+      );
+    },
+    [syncCenter]
+  );
+
+  useEffect(() => {
+    if (!pickerElement) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const deltaX = normalizeWheelDelta(event.deltaX, event.deltaMode);
+      const deltaY = normalizeWheelDelta(event.deltaY, event.deltaMode);
+
+      if (event.ctrlKey) {
+        syncZoom(zoomRef.current - deltaY * PINCH_ZOOM_FACTOR);
+        return;
+      }
+
+      panByScreenPixels({
+        dx: -deltaX * WHEEL_PAN_FACTOR,
+        dy: -deltaY * WHEEL_PAN_FACTOR,
+      });
+    };
+
+    const handleGestureStart = (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      gestureScaleRef.current = 1;
+    };
+
+    const handleGestureChange = (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const gestureEvent = event as WebKitGestureEvent;
+      const nextScale = gestureEvent.scale ?? 1;
+      const zoomDelta = Math.log2(nextScale / gestureScaleRef.current);
+      gestureScaleRef.current = nextScale;
+      if (!Number.isFinite(zoomDelta) || zoomDelta === 0) return;
+
+      syncZoom(zoomRef.current + zoomDelta);
+    };
+
+    const handleGestureEnd = (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      gestureScaleRef.current = 1;
+    };
+
+    pickerElement.addEventListener("wheel", handleWheel, { passive: false });
+    pickerElement.addEventListener("gesturestart", handleGestureStart, {
+      passive: false,
+    });
+    pickerElement.addEventListener("gesturechange", handleGestureChange, {
+      passive: false,
+    });
+    pickerElement.addEventListener("gestureend", handleGestureEnd, {
+      passive: false,
+    });
+
+    return () => {
+      pickerElement.removeEventListener("wheel", handleWheel);
+      pickerElement.removeEventListener("gesturestart", handleGestureStart);
+      pickerElement.removeEventListener("gesturechange", handleGestureChange);
+      pickerElement.removeEventListener("gestureend", handleGestureEnd);
+    };
+  }, [panByScreenPixels, pickerElement, syncZoom]);
+
+  useEffect(() => {
+    if (!pickerElement) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      pickerElement.setPointerCapture(event.pointerId);
+      const pointerId = event.pointerId;
+      dragRef.current = {
+        lastX: event.clientX,
+        lastY: event.clientY,
+        moved: false,
+        totalDx: 0,
+        totalDy: 0,
+      };
+
+      const handleMove = (e: PointerEvent) => {
+        if (e.pointerId !== pointerId || !dragRef.current) return;
+        const dx = e.clientX - dragRef.current.lastX;
+        const dy = e.clientY - dragRef.current.lastY;
+        if (Math.abs(dx) + Math.abs(dy) > 1) dragRef.current.moved = true;
+        dragRef.current.lastX = e.clientX;
+        dragRef.current.lastY = e.clientY;
+        dragRef.current.totalDx += dx;
+        dragRef.current.totalDy += dy;
+        if (tileLayerRef.current) {
+          tileLayerRef.current.style.transform = `translate(${dragRef.current.totalDx}px, ${dragRef.current.totalDy}px) rotate(${-rotationRef.current}deg)`;
+        }
+      };
+
+      const finish = (e: PointerEvent) => {
+        if (e.pointerId !== pointerId) return;
+        pickerElement.removeEventListener("pointermove", handleMove);
+        pickerElement.removeEventListener("pointerup", finish);
+        pickerElement.removeEventListener("pointercancel", finish);
+
+        const dragState = dragRef.current;
+        dragRef.current = null;
+        if (tileLayerRef.current) {
+          tileLayerRef.current.style.transform = `rotate(${-rotationRef.current}deg)`;
+        }
+        if (!dragState) return;
+        if (dragState.moved) {
+          panByScreenPixels({ dx: dragState.totalDx, dy: dragState.totalDy });
+          return;
+        }
+        const rect = pickerElement.getBoundingClientRect();
+        const centerPixel = latLngToGlobalPixel(
+          centerRef.current.lat,
+          centerRef.current.lng,
+          zoomRef.current
+        );
+        const clickDelta = screenDeltaToMapPixelDelta({
+          dx: e.clientX - rect.left - rect.width / 2,
+          dy: e.clientY - rect.top - rect.height / 2,
+          rotationDeg: rotationRef.current,
+        });
+        syncCenter(
+          globalPixelToLatLng(
+            {
+              x: centerPixel.x + clickDelta.dx,
+              y: centerPixel.y + clickDelta.dy,
+            },
+            zoomRef.current
+          )
+        );
+      };
+
+      pickerElement.addEventListener("pointermove", handleMove);
+      pickerElement.addEventListener("pointerup", finish);
+      pickerElement.addEventListener("pointercancel", finish);
+    };
+
+    pickerElement.addEventListener("pointerdown", handlePointerDown);
+    return () =>
+      pickerElement.removeEventListener("pointerdown", handlePointerDown);
+  }, [panByScreenPixels, pickerElement, syncCenter]);
+
+  useEffect(() => {
+    if (!locationSearchError && locationResults.length === 0) return;
+
+    const closeSearchResults = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && searchPanelRef.current?.contains(target)) {
+        return;
+      }
+
+      setLocationResults([]);
+      setLocationSearchError(null);
+    };
+
+    document.addEventListener("pointerdown", closeSearchResults);
+    return () =>
+      document.removeEventListener("pointerdown", closeSearchResults);
+  }, [locationResults.length, locationSearchError]);
+
+  const handleLocate = () => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition((position) => {
+      syncCenter({
+        lat: position.coords.latitude,
+        lng: position.coords.longitude,
+      });
+      syncZoom(Math.max(zoomRef.current, 18));
+    });
+  };
+
+  const jumpToLocation = (location: LatLng, nextZoom = 18) => {
+    syncCenter({
+      lat: clampLatitude(location.lat),
+      lng: normalizeLongitude(location.lng),
+    });
+    syncZoom(Math.max(zoomRef.current, nextZoom));
+  };
+
+  const searchLocations = useCallback(
+    async (query: string, signal?: AbortSignal) => {
+      const params = new URLSearchParams({
+        f: "json",
+        SingleLine: query,
+        maxLocations: "5",
+        outFields: "PlaceName,City,Region,Country",
+        location: `${centerRef.current.lng},${centerRef.current.lat}`,
+      });
+      const response = await fetch(
+        `https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?${params.toString()}`,
+        { signal }
+      );
+      if (!response.ok) {
+        throw new Error("Location search failed");
+      }
+
+      const payload = (await response.json()) as {
+        candidates?: Array<{
+          address?: unknown;
+          location?: { x?: unknown; y?: unknown };
+          score?: unknown;
+        }>;
+      };
+
+      return (payload.candidates ?? [])
+        .filter(
+          (candidate) =>
+            typeof candidate.location?.x === "number" &&
+            typeof candidate.location.y === "number"
+        )
+        .map((candidate, index) => ({
+          address:
+            typeof candidate.address === "string"
+              ? candidate.address
+              : "Unknown location",
+          id: `${candidate.location?.x}-${candidate.location?.y}-${index}`,
+          lat: clampLatitude(candidate.location?.y as number),
+          lng: normalizeLongitude(candidate.location?.x as number),
+          score: typeof candidate.score === "number" ? candidate.score : 0,
+        }));
+    },
+    []
+  );
+
+  useEffect(() => {
+    const query = locationQuery.trim();
+    locationSearchAbortRef.current?.abort();
+
+    if (!query) {
+      setLocationResults([]);
+      setLocationSearchError(null);
+      setLocationSearchPending(false);
+      return;
+    }
+
+    if (query === selectedLocationLabel) return;
+
+    const coordinateLocation = parseCoordinateQuery(query);
+    if (coordinateLocation) {
+      setLocationResults([]);
+      setLocationSearchError(null);
+      setLocationSearchPending(false);
+      return;
+    }
+
+    if (query.length < LOCATION_SEARCH_MIN_LENGTH) {
+      setLocationResults([]);
+      setLocationSearchError(null);
+      setLocationSearchPending(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    locationSearchAbortRef.current = controller;
+    setLocationSearchError(null);
+    setLocationSearchPending(true);
+
+    const timeout = window.setTimeout(() => {
+      void searchLocations(query, controller.signal)
+        .then((results) => {
+          setLocationResults(results);
+          setLocationSearchError(
+            results.length === 0 ? "No locations found." : null
+          );
+        })
+        .catch((error: unknown) => {
+          if (error instanceof DOMException && error.name === "AbortError") {
+            return;
+          }
+          setLocationResults([]);
+          setLocationSearchError("Location search is unavailable.");
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setLocationSearchPending(false);
+          }
+        });
+    }, LOCATION_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [locationQuery, searchLocations, selectedLocationLabel]);
+
+  const handleLocationSearch = async () => {
+    const query = locationQuery.trim();
+    if (!query || locationSearchPending) return;
+
+    const coordinateLocation = parseCoordinateQuery(query);
+    if (coordinateLocation) {
+      setLocationResults([]);
+      setLocationSearchError(null);
+      jumpToLocation(coordinateLocation);
+      return;
+    }
+
+    if (query.length < LOCATION_SEARCH_MIN_LENGTH) return;
+
+    locationSearchAbortRef.current?.abort();
+    setLocationSearchPending(true);
+    setLocationSearchError(null);
+
+    try {
+      const results = await searchLocations(query);
+      setLocationResults(results);
+      if (results.length === 0) {
+        setLocationSearchError("No locations found.");
+      }
+    } catch {
+      setLocationSearchError("Location search is unavailable.");
+    } finally {
+      setLocationSearchPending(false);
+    }
+  };
+
+  const mapEditor = (
+    <div className="grid min-h-0 gap-0 overflow-y-auto p-3 lg:grid-cols-[minmax(0,1fr)_210px] lg:overflow-hidden">
+      <div className="min-w-0 space-y-2 lg:pr-3">
+        <div
+          ref={searchPanelRef}
+          className="relative z-20"
+          onPointerDown={(event) => event.stopPropagation()}
+          onPointerMove={(event) => event.stopPropagation()}
+          onPointerUp={(event) => event.stopPropagation()}
+        >
+          <div className="relative">
+            <Search className="text-muted-foreground/65 pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+            <Input
+              value={locationQuery}
+              onChange={(event) => setLocationQuery(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  void handleLocationSearch();
+                }
+                if (event.key === "Escape") {
+                  setLocationResults([]);
+                  setLocationSearchError(null);
+                  event.currentTarget.blur();
+                }
+              }}
+              placeholder="Search place or paste coordinates"
+              className="border-border/45 bg-muted/30 focus-visible:bg-background h-8 rounded-md pr-16 pl-8 text-[12px] shadow-none"
+            />
+            <span className="text-muted-foreground/65 pointer-events-none absolute top-1/2 right-2 -translate-y-1/2 text-[10px] font-medium">
+              {locationSearchPending ? "Searching" : "Enter"}
+            </span>
+          </div>
+          {locationSearchError || locationResults.length > 0 ? (
+            <div className="border-border/45 bg-background absolute top-[calc(100%+0.25rem)] right-0 left-0 z-30 max-h-56 overflow-y-auto rounded-md border shadow-lg">
+              {locationSearchError ? (
+                <p className="text-muted-foreground px-3 py-2 text-[11px] leading-relaxed">
+                  {locationSearchError}
+                </p>
+              ) : null}
+              {locationResults.map((result) => (
+                <button
+                  key={result.id}
+                  type="button"
+                  className="hover:bg-muted/35 flex w-full flex-col items-start px-3 py-2 text-left transition-colors"
+                  onClick={() => {
+                    setLocationQuery(result.address);
+                    setSelectedLocationLabel(result.address);
+                    setLocationResults([]);
+                    jumpToLocation({
+                      lat: result.lat,
+                      lng: result.lng,
+                    });
+                  }}
+                >
+                  <span className="text-foreground line-clamp-2 text-[11px] font-medium">
+                    {result.address}
+                  </span>
+                  <span className="text-muted-foreground/70 mt-0.5 font-mono text-[10px]">
+                    {result.lat.toFixed(5)}, {result.lng.toFixed(5)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+        <div
+          ref={setPickerNode}
+          data-vaul-no-drag
+          className="border-border/55 bg-muted/30 relative h-[min(56vh,430px)] min-h-70 cursor-grab overflow-hidden rounded-lg border active:cursor-grabbing lg:h-125"
+          style={{ touchAction: "none" }}
+        >
+          <div
+            ref={tileLayerRef}
+            className="pointer-events-none absolute inset-0"
+            style={{
+              transform: `rotate(${-rotationDeg}deg)`,
+              transformOrigin: "50% 50%",
+            }}
+          >
+            {tiles.map((tile) => (
+              <img
+                key={tile.key}
+                src={tile.url}
+                alt=""
+                draggable={false}
+                className="pointer-events-none absolute select-none"
+                style={{
+                  left: tile.left,
+                  top: tile.top,
+                  width: tile.size,
+                  height: tile.size,
+                }}
+              />
+            ))}
+          </div>
+          <div
+            className="pointer-events-none absolute top-1/2 left-1/2 border-2 border-sky-400/90 bg-sky-400/10 shadow-[0_0_0_9999px_rgba(15,23,42,0.12)]"
+            style={{
+              width: fieldWidthPx,
+              height: fieldHeightPx,
+              transform: "translate(-50%, -50%)",
+            }}
+          />
+          <div className="pointer-events-none absolute top-1/2 left-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-sky-500 shadow" />
+          <div className="bg-background/92 text-muted-foreground absolute right-2 bottom-2 left-2 rounded-md px-2 py-1 text-[9px] leading-snug shadow-sm backdrop-blur-sm lg:right-auto lg:max-w-[70%] lg:text-[10px]">
+            {mapReferenceProvider.styles.satellite.attribution}
+          </div>
+        </div>
+      </div>
+
+      <div className="border-border/40 mt-3 space-y-4 lg:mt-0 lg:border-l lg:pl-3">
+        <div className="space-y-2">
+          <div className="text-muted-foreground text-[11px] font-medium">
+            View
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => syncZoom(zoomRef.current - 1)}
+              aria-label="Zoom out"
+            >
+              <Minus />
+              Out
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => syncZoom(zoomRef.current + 1)}
+              aria-label="Zoom in"
+            >
+              <Plus />
+              In
+            </Button>
+          </div>
+          <div className="bg-muted/35 text-muted-foreground flex h-8 items-center justify-center rounded-lg text-xs">
+            Preview zoom {zoom.toFixed(1)}
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-muted-foreground text-[11px] font-medium">
+            Center
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={handleLocate}
+          >
+            <LocateFixed />
+            Use location
+          </Button>
+
+          <div className="hidden space-y-2 lg:block">
+            <label className="text-muted-foreground text-[11px] font-medium">
+              Latitude
+            </label>
+            <Input
+              value={latInput}
+              onChange={(event) => setLatInput(event.target.value)}
+              onBlur={applyTypedCenter}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") applyTypedCenter();
+              }}
+            />
+            <label className="text-muted-foreground text-[11px] font-medium">
+              Longitude
+            </label>
+            <Input
+              value={lngInput}
+              onChange={(event) => setLngInput(event.target.value)}
+              onBlur={applyTypedCenter}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") applyTypedCenter();
+              }}
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <label className="text-muted-foreground text-[11px] font-medium">
+              Rotation
+            </label>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => syncRotation(0)}
+              aria-label="Reset rotation"
+            >
+              <RotateCcw />
+            </Button>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={359}
+            step={1}
+            value={rotationDeg}
+            onChange={(event) => syncRotation(Number(event.target.value))}
+            className="accent-primary w-full"
+          />
+          <Input
+            type="number"
+            min={0}
+            max={359}
+            value={Math.round(rotationDeg)}
+            onChange={(event) => syncRotation(Number(event.target.value))}
+          />
+        </div>
+      </div>
+    </div>
+  );
+
+  const actions = (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => onOpenChange(false)}
+      >
+        Cancel
+      </Button>
+      <Button
+        type="button"
+        onClick={() => {
+          const nextReference = createReference({ center, rotationDeg, zoom });
+          onConfirm({
+            ...nextReference,
+            opacity: initialReference?.opacity ?? nextReference.opacity,
+            visible: initialReference?.visible ?? nextReference.visible,
+          });
+          onOpenChange(false);
+        }}
+      >
+        Save map
+      </Button>
+    </>
+  );
+
+  if (!isDesktop) {
+    return (
+      <MobileDrawer
+        open={open}
+        onOpenChange={onOpenChange}
+        title="Map reference"
+        subtitle="Choose the field center and align the field footprint."
+        contentClassName="data-[vaul-drawer-direction=bottom]:mt-8 data-[vaul-drawer-direction=bottom]:max-h-[94dvh]"
+        bodyClassName="p-0"
+      >
+        {mapEditor}
+        <div className="border-border/40 bg-muted/35 flex flex-col-reverse gap-2 border-t px-4 py-3 sm:flex-row sm:justify-end">
+          {actions}
+        </div>
+      </MobileDrawer>
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        size="auto"
+        className="max-h-[min(92vh,760px)] w-[min(94vw,920px)] grid-rows-[auto_minmax(0,1fr)_auto] gap-0 overflow-hidden p-0"
+      >
+        <DialogHeader className="border-border/40 border-b px-4 py-3 pr-12">
+          <DialogTitle>Map reference</DialogTitle>
+          <DialogDescription>
+            Choose the field center and align the field footprint.
+          </DialogDescription>
+        </DialogHeader>
+
+        {mapEditor}
+
+        <DialogFooter className="bg-muted/35 mx-0 mb-0 rounded-none border-t px-4 py-3">
+          {actions}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/editor/store-types.ts
+++ b/src/lib/editor/store-types.ts
@@ -1,5 +1,6 @@
 import type {
   FieldSpec,
+  MapReference,
   PolylinePoint,
   SerializedTrackDesign,
   Shape,
@@ -89,10 +90,20 @@ export interface EditorTrackActions {
     patch: Partial<
       Pick<
         TrackDesign,
-        "title" | "description" | "authorName" | "tags" | "inventory"
+        | "title"
+        | "description"
+        | "authorName"
+        | "tags"
+        | "inventory"
+        | "mapReference"
       >
     >
   ) => void;
+  setMapReference: (reference: MapReference) => void;
+  clearMapReference: () => void;
+  setMapReferenceVisibility: (visible: boolean) => void;
+  setMapReferenceOpacity: (opacity: number) => void;
+  setMapReferenceRotation: (rotationDeg: number) => void;
   replaceDesign: (design: TrackDesign | SerializedTrackDesign) => void;
   newProject: () => void;
   bringForward: (id: string) => void;

--- a/src/lib/map-reference/geometry.ts
+++ b/src/lib/map-reference/geometry.ts
@@ -1,0 +1,247 @@
+import { clamp } from "@/lib/canvas/shared";
+import {
+  MAP_REFERENCE_DEFAULT_ZOOM,
+  MAP_REFERENCE_MAX_ZOOM,
+  MAP_REFERENCE_MIN_ZOOM,
+  MAP_REFERENCE_TILE_SIZE,
+} from "@/lib/map-reference/provider";
+import type { FieldSpec, MapReference } from "@/lib/types";
+
+const EARTH_RADIUS_METERS = 6378137;
+const EARTH_CIRCUMFERENCE_METERS = 2 * Math.PI * EARTH_RADIUS_METERS;
+const MAX_MERCATOR_LAT = 85.05112878;
+
+export interface GlobalPixel {
+  x: number;
+  y: number;
+}
+
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+export interface TileCoordinate {
+  x: number;
+  y: number;
+  z: number;
+}
+
+export interface MapReferenceTile extends TileCoordinate {
+  canvasX: number;
+  canvasY: number;
+  canvasSize: number;
+}
+
+export interface PixelDelta {
+  dx: number;
+  dy: number;
+}
+
+export function normalizeLongitude(lng: number) {
+  if (!Number.isFinite(lng)) return 0;
+  return ((((lng + 180) % 360) + 360) % 360) - 180;
+}
+
+export function clampLatitude(lat: number) {
+  if (!Number.isFinite(lat)) return 0;
+  return clamp(lat, -MAX_MERCATOR_LAT, MAX_MERCATOR_LAT);
+}
+
+export function normalizeMapReference(value: unknown): MapReference | null {
+  if (typeof value !== "object" || value === null) return null;
+
+  const record = value as Record<string, unknown>;
+  if (record.type !== "map") return null;
+  if (record.provider !== "esri-world-imagery") return null;
+
+  const centerLat = clampLatitude(
+    typeof record.centerLat === "number" ? record.centerLat : 0
+  );
+  const centerLng = normalizeLongitude(
+    typeof record.centerLng === "number" ? record.centerLng : 0
+  );
+  const zoom =
+    typeof record.zoom === "number" && Number.isFinite(record.zoom)
+      ? clamp(record.zoom, MAP_REFERENCE_MIN_ZOOM, MAP_REFERENCE_MAX_ZOOM)
+      : MAP_REFERENCE_DEFAULT_ZOOM;
+  const rotationDeg =
+    typeof record.rotationDeg === "number" &&
+    Number.isFinite(record.rotationDeg)
+      ? ((record.rotationDeg % 360) + 360) % 360
+      : 0;
+  const opacity =
+    typeof record.opacity === "number" && Number.isFinite(record.opacity)
+      ? clamp(record.opacity, 0.05, 1)
+      : 0.35;
+
+  return {
+    type: "map",
+    provider: "esri-world-imagery",
+    mapStyle: "satellite",
+    centerLat,
+    centerLng,
+    zoom,
+    rotationDeg,
+    opacity,
+    visible: typeof record.visible === "boolean" ? record.visible : true,
+    locked: true,
+  };
+}
+
+export function getMapTileZoom(zoom: number) {
+  if (!Number.isFinite(zoom)) return MAP_REFERENCE_DEFAULT_ZOOM;
+  return Math.round(
+    clamp(zoom, MAP_REFERENCE_MIN_ZOOM, MAP_REFERENCE_MAX_ZOOM)
+  );
+}
+
+export function latLngToGlobalPixel(
+  lat: number,
+  lng: number,
+  zoom: number
+): GlobalPixel {
+  const safeLat = clampLatitude(lat);
+  const safeLng = normalizeLongitude(lng);
+  const sinLat = Math.sin((safeLat * Math.PI) / 180);
+  const scale = MAP_REFERENCE_TILE_SIZE * 2 ** zoom;
+
+  return {
+    x: ((safeLng + 180) / 360) * scale,
+    y: (0.5 - Math.log((1 + sinLat) / (1 - sinLat)) / (4 * Math.PI)) * scale,
+  };
+}
+
+export function globalPixelToLatLng(pixel: GlobalPixel, zoom: number): LatLng {
+  const scale = MAP_REFERENCE_TILE_SIZE * 2 ** zoom;
+  const lng = (pixel.x / scale) * 360 - 180;
+  const n = Math.PI - (2 * Math.PI * pixel.y) / scale;
+  const lat = (180 / Math.PI) * Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
+
+  return {
+    lat: clampLatitude(lat),
+    lng: normalizeLongitude(lng),
+  };
+}
+
+export function metersPerPixelAtLatitude(lat: number, zoom: number) {
+  return (
+    (Math.cos((clampLatitude(lat) * Math.PI) / 180) *
+      EARTH_CIRCUMFERENCE_METERS) /
+    (MAP_REFERENCE_TILE_SIZE * 2 ** zoom)
+  );
+}
+
+export function getMapReferenceRenderZoom({
+  lat,
+  ppm,
+}: {
+  lat: number;
+  ppm: number;
+}) {
+  if (!Number.isFinite(ppm) || ppm <= 0) return MAP_REFERENCE_DEFAULT_ZOOM;
+
+  const latitudeScale = Math.max(
+    0.000001,
+    Math.cos((clampLatitude(lat) * Math.PI) / 180)
+  );
+  const zoom = Math.log2(
+    (latitudeScale * EARTH_CIRCUMFERENCE_METERS * ppm) / MAP_REFERENCE_TILE_SIZE
+  );
+
+  return Math.round(
+    clamp(zoom, MAP_REFERENCE_MIN_ZOOM, MAP_REFERENCE_MAX_ZOOM)
+  );
+}
+
+export function getFieldMapTileCoverage({
+  field,
+  mapReference,
+}: {
+  field: Pick<FieldSpec, "width" | "height" | "ppm">;
+  mapReference: MapReference;
+}): MapReferenceTile[] {
+  const tileZoom = getMapReferenceRenderZoom({
+    lat: mapReference.centerLat,
+    ppm: field.ppm,
+  });
+  const centerPixel = latLngToGlobalPixel(
+    mapReference.centerLat,
+    mapReference.centerLng,
+    tileZoom
+  );
+  const metersPerPixel = metersPerPixelAtLatitude(
+    mapReference.centerLat,
+    tileZoom
+  );
+  const tileCanvasSize = MAP_REFERENCE_TILE_SIZE * metersPerPixel * field.ppm;
+  const fieldDiagonalMeters = Math.hypot(field.width, field.height);
+  const halfFieldDiagonalMapPx = fieldDiagonalMeters / metersPerPixel / 2;
+  const minTileX = Math.floor(
+    (centerPixel.x - halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
+  );
+  const maxTileX = Math.floor(
+    (centerPixel.x + halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
+  );
+  const minTileY = Math.floor(
+    (centerPixel.y - halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
+  );
+  const maxTileY = Math.floor(
+    (centerPixel.y + halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
+  );
+  const maxTile = 2 ** tileZoom;
+  const tiles: MapReferenceTile[] = [];
+
+  for (let tileY = minTileY - 1; tileY <= maxTileY + 1; tileY += 1) {
+    if (tileY < 0 || tileY >= maxTile) continue;
+
+    for (let tileX = minTileX - 1; tileX <= maxTileX + 1; tileX += 1) {
+      const wrappedTileX = ((tileX % maxTile) + maxTile) % maxTile;
+      const tilePixelX = tileX * MAP_REFERENCE_TILE_SIZE;
+      const tilePixelY = tileY * MAP_REFERENCE_TILE_SIZE;
+
+      tiles.push({
+        x: wrappedTileX,
+        y: tileY,
+        z: tileZoom,
+        canvasX: (tilePixelX - centerPixel.x) * metersPerPixel * field.ppm,
+        canvasY: (tilePixelY - centerPixel.y) * metersPerPixel * field.ppm,
+        canvasSize: tileCanvasSize,
+      });
+    }
+  }
+
+  return tiles;
+}
+
+export function panLatLngByPixels({
+  center,
+  dx,
+  dy,
+  zoom,
+}: {
+  center: LatLng;
+  dx: number;
+  dy: number;
+  zoom: number;
+}) {
+  const pixel = latLngToGlobalPixel(center.lat, center.lng, zoom);
+  return globalPixelToLatLng({ x: pixel.x - dx, y: pixel.y - dy }, zoom);
+}
+
+export function screenDeltaToMapPixelDelta({
+  dx,
+  dy,
+  rotationDeg,
+}: PixelDelta & {
+  rotationDeg: number;
+}): PixelDelta {
+  const rotationRad = (rotationDeg * Math.PI) / 180;
+  const cos = Math.cos(rotationRad);
+  const sin = Math.sin(rotationRad);
+
+  return {
+    dx: cos * dx - sin * dy,
+    dy: sin * dx + cos * dy,
+  };
+}

--- a/src/lib/map-reference/provider.ts
+++ b/src/lib/map-reference/provider.ts
@@ -1,0 +1,18 @@
+export const mapReferenceProvider = {
+  id: "esri-world-imagery",
+  name: "Esri World Imagery",
+  defaultStyle: "satellite",
+  styles: {
+    satellite: {
+      tileUrl:
+        "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+      attribution:
+        "Sources: Esri, Maxar, Earthstar Geographics, and the GIS User Community",
+    },
+  },
+} as const;
+
+export const MAP_REFERENCE_DEFAULT_ZOOM = 18;
+export const MAP_REFERENCE_MIN_ZOOM = 1;
+export const MAP_REFERENCE_MAX_ZOOM = 20;
+export const MAP_REFERENCE_TILE_SIZE = 256;

--- a/src/lib/map-reference/tiles.ts
+++ b/src/lib/map-reference/tiles.ts
@@ -1,0 +1,9 @@
+import { mapReferenceProvider } from "@/lib/map-reference/provider";
+import type { TileCoordinate } from "@/lib/map-reference/geometry";
+
+export function getMapReferenceTileUrl(tile: TileCoordinate) {
+  return mapReferenceProvider.styles.satellite.tileUrl
+    .replace("{z}", String(tile.z))
+    .replace("{x}", String(tile.x))
+    .replace("{y}", String(tile.y));
+}

--- a/src/lib/server/shares.ts
+++ b/src/lib/server/shares.ts
@@ -4,7 +4,7 @@ import { customAlphabet } from "nanoid";
 import {
   getDesignShapes,
   normalizeDesign,
-  serializeDesign,
+  serializeDesignForShare,
 } from "@/lib/track/design";
 import {
   createUnlistedGalleryEntry,
@@ -329,7 +329,7 @@ export async function createShare(
   options: CreateShareOptions = {}
 ) {
   const normalized = normalizeDesign(design);
-  const serialized = serializeDesign(normalized);
+  const serialized = serializeDesignForShare(normalized);
   const serializedJson = JSON.stringify(serialized);
   const title = getShareTitle(normalized);
   const description = getShareDescription(normalized);

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,5 +1,5 @@
 import LZString from "lz-string";
-import { normalizeDesign, serializeDesign } from "@/lib/track/design";
+import { normalizeDesign, serializeDesignForShare } from "@/lib/track/design";
 import type { TrackDesign } from "./types";
 import type { EditorView } from "./view";
 
@@ -15,7 +15,7 @@ function normalizeShareToken(token: string): string {
 }
 
 export function encodeDesign(design: TrackDesign): string {
-  const json = JSON.stringify(serializeDesign(design));
+  const json = JSON.stringify(serializeDesignForShare(design));
   return LZString.compressToEncodedURIComponent(json);
 }
 

--- a/src/lib/track/design.ts
+++ b/src/lib/track/design.ts
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import { normalizeMapReference } from "@/lib/map-reference/geometry";
 import { normalizeInventoryProfile } from "@/lib/planning/inventory";
 import type {
   PolylineShape,
@@ -113,7 +114,10 @@ export function getDesignShapeById(design: TrackDesign, id: string) {
   return null;
 }
 
-export function serializeDesign(design: TrackDesign): SerializedTrackDesign {
+export function serializeDesign(
+  design: TrackDesign,
+  options: { includeMapReference?: boolean } = {}
+): SerializedTrackDesign {
   return {
     id: design.id,
     version: design.version,
@@ -123,10 +127,20 @@ export function serializeDesign(design: TrackDesign): SerializedTrackDesign {
     authorName: design.authorName,
     inventory: normalizeInventoryProfile(design.inventory),
     field: design.field,
+    mapReference:
+      options.includeMapReference === false
+        ? null
+        : normalizeMapReference(design.mapReference),
     shapes: getDesignShapes(design),
     createdAt: design.createdAt,
     updatedAt: design.updatedAt,
   };
+}
+
+export function serializeDesignForShare(
+  design: TrackDesign
+): SerializedTrackDesign {
+  return serializeDesign(design, { includeMapReference: false });
 }
 
 export function normalizeDesign(
@@ -138,6 +152,9 @@ export function normalizeDesign(
     version: 1,
     inventory: normalizeInventoryProfile(
       (design as Partial<TrackDesign>).inventory
+    ),
+    mapReference: normalizeMapReference(
+      (design as Partial<TrackDesign>).mapReference
     ),
     shapeById,
     shapeOrder,
@@ -155,6 +172,7 @@ export function createDefaultDesign(): TrackDesign {
     authorName: "",
     inventory: normalizeInventoryProfile(),
     field: { width: 60, height: 40, origin: "tl", gridStep: 1, ppm: 20 },
+    mapReference: null,
     shapeOrder: [],
     shapeById: {},
     createdAt: timestamp,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -114,6 +114,19 @@ export interface FieldSpec {
   ppm: number; // pixels per meter
 }
 
+export interface MapReference {
+  type: "map";
+  provider: "esri-world-imagery";
+  mapStyle: "satellite";
+  centerLat: number;
+  centerLng: number;
+  zoom: number;
+  rotationDeg: number;
+  opacity: number;
+  visible: boolean;
+  locked: boolean;
+}
+
 export interface TrackDesign {
   id: UUID;
   version: 1;
@@ -123,6 +136,7 @@ export interface TrackDesign {
   authorName?: string;
   inventory: InventoryProfile;
   field: FieldSpec;
+  mapReference?: MapReference | null;
   shapeOrder: UUID[];
   shapeById: Record<UUID, Shape>;
   createdAt: string; // ISO-8601
@@ -138,6 +152,7 @@ export interface SerializedTrackDesign {
   authorName?: string;
   inventory: InventoryProfile;
   field: FieldSpec;
+  mapReference?: MapReference | null;
   shapes: Shape[];
   createdAt: string;
   updatedAt: string;

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -25,6 +25,17 @@ export function useTrackActions() {
   const nudgeShapes = useEditor((state) => state.nudgeShapes);
   const updateField = useEditor((state) => state.updateField);
   const updateDesignMeta = useEditor((state) => state.updateDesignMeta);
+  const setMapReference = useEditor((state) => state.setMapReference);
+  const clearMapReference = useEditor((state) => state.clearMapReference);
+  const setMapReferenceVisibility = useEditor(
+    (state) => state.setMapReferenceVisibility
+  );
+  const setMapReferenceOpacity = useEditor(
+    (state) => state.setMapReferenceOpacity
+  );
+  const setMapReferenceRotation = useEditor(
+    (state) => state.setMapReferenceRotation
+  );
   const replaceDesign = useEditor((state) => state.replaceDesign);
   const newProject = useEditor((state) => state.newProject);
   const bringForward = useEditor((state) => state.bringForward);
@@ -53,6 +64,11 @@ export function useTrackActions() {
     nudgeShapes,
     updateField,
     updateDesignMeta,
+    setMapReference,
+    clearMapReference,
+    setMapReferenceVisibility,
+    setMapReferenceOpacity,
+    setMapReferenceRotation,
     replaceDesign,
     newProject,
     bringForward,

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -5,6 +5,8 @@ import { temporal } from "zundo";
 import { immer } from "zustand/middleware/immer";
 import { nanoid } from "nanoid";
 import type { PolylineShape, Shape, TrackDesign } from "@/lib/types";
+import { normalizeMapReference } from "@/lib/map-reference/geometry";
+import { clamp } from "@/lib/canvas/shared";
 import {
   getDesignShapeById,
   normalizeDesign,
@@ -74,6 +76,11 @@ interface EditorState {
   nudgeShapes: EditorTrackActions["nudgeShapes"];
   updateField: EditorTrackActions["updateField"];
   updateDesignMeta: EditorTrackActions["updateDesignMeta"];
+  setMapReference: EditorTrackActions["setMapReference"];
+  clearMapReference: EditorTrackActions["clearMapReference"];
+  setMapReferenceVisibility: EditorTrackActions["setMapReferenceVisibility"];
+  setMapReferenceOpacity: EditorTrackActions["setMapReferenceOpacity"];
+  setMapReferenceRotation: EditorTrackActions["setMapReferenceRotation"];
   replaceDesign: EditorTrackActions["replaceDesign"];
   newProject: EditorTrackActions["newProject"];
   bringForward: EditorTrackActions["bringForward"];
@@ -488,6 +495,41 @@ export const useEditor = create<EditorState>()(
       updateDesignMeta: (patch) =>
         set((draft) => {
           Object.assign(draft.track.design, patch);
+          touchTrackDesign(draft);
+        }),
+
+      setMapReference: (reference) =>
+        set((draft) => {
+          draft.track.design.mapReference = normalizeMapReference(reference);
+          touchTrackDesign(draft);
+        }),
+
+      clearMapReference: () =>
+        set((draft) => {
+          if (!draft.track.design.mapReference) return;
+          draft.track.design.mapReference = null;
+          touchTrackDesign(draft);
+        }),
+
+      setMapReferenceVisibility: (visible) =>
+        set((draft) => {
+          if (!draft.track.design.mapReference) return;
+          draft.track.design.mapReference.visible = visible;
+          touchTrackDesign(draft);
+        }),
+
+      setMapReferenceOpacity: (opacity) =>
+        set((draft) => {
+          if (!draft.track.design.mapReference) return;
+          draft.track.design.mapReference.opacity = clamp(opacity, 0.05, 1);
+          touchTrackDesign(draft);
+        }),
+
+      setMapReferenceRotation: (rotationDeg) =>
+        set((draft) => {
+          if (!draft.track.design.mapReference) return;
+          draft.track.design.mapReference.rotationDeg =
+            ((rotationDeg % 360) + 360) % 360;
           touchTrackDesign(draft);
         }),
 

--- a/tests/lib/map-reference/geometry.test.ts
+++ b/tests/lib/map-reference/geometry.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFieldMapTileCoverage,
+  getMapReferenceRenderZoom,
+  getMapTileZoom,
+  globalPixelToLatLng,
+  latLngToGlobalPixel,
+  metersPerPixelAtLatitude,
+  normalizeMapReference,
+  panLatLngByPixels,
+  screenDeltaToMapPixelDelta,
+} from "@/lib/map-reference/geometry";
+import type { MapReference } from "@/lib/types";
+
+const reference: MapReference = {
+  type: "map",
+  provider: "esri-world-imagery",
+  mapStyle: "satellite",
+  centerLat: 52.1,
+  centerLng: 5.2,
+  zoom: 18,
+  rotationDeg: 0,
+  opacity: 0.35,
+  visible: true,
+  locked: true,
+};
+
+describe("map reference geometry", () => {
+  it("round-trips lat/lng through global pixels", () => {
+    const pixel = latLngToGlobalPixel(52.1, 5.2, 18);
+    const latLng = globalPixelToLatLng(pixel, 18);
+
+    expect(latLng.lat).toBeCloseTo(52.1, 6);
+    expect(latLng.lng).toBeCloseTo(5.2, 6);
+  });
+
+  it("normalizes map reference metadata", () => {
+    expect(
+      normalizeMapReference({
+        type: "map",
+        provider: "esri-world-imagery",
+        mapStyle: "satellite",
+        centerLat: 95,
+        centerLng: 365,
+        zoom: 30,
+        rotationDeg: -10,
+        opacity: -1,
+      })
+    ).toMatchObject({
+      centerLat: 85.05112878,
+      centerLng: 5,
+      zoom: 20,
+      rotationDeg: 350,
+      opacity: 0.05,
+      visible: true,
+      locked: true,
+    });
+  });
+
+  it("keeps fractional zoom metadata while selecting an integer tile zoom", () => {
+    const normalized = normalizeMapReference({
+      type: "map",
+      provider: "esri-world-imagery",
+      centerLat: 52.1,
+      centerLng: 5.2,
+      zoom: 18.4,
+      rotationDeg: 0,
+      opacity: 0.35,
+    });
+
+    expect(normalized?.zoom).toBe(18.4);
+    expect(getMapTileZoom(normalized?.zoom ?? 0)).toBe(18);
+    expect(getMapTileZoom(18.6)).toBe(19);
+  });
+
+  it("calculates tile coverage from field dimensions", () => {
+    const tiles = getFieldMapTileCoverage({
+      field: { width: 60, height: 40, ppm: 20 },
+      mapReference: reference,
+    });
+
+    expect(tiles.length).toBeGreaterThan(0);
+    expect(tiles.every((tile) => tile.z === 20)).toBe(true);
+    expect(tiles.every((tile) => tile.canvasSize > 0)).toBe(true);
+    expect(
+      tiles.some(
+        (tile) =>
+          tile.canvasX <= 0 &&
+          tile.canvasX + tile.canvasSize >= 0 &&
+          tile.canvasY <= 0 &&
+          tile.canvasY + tile.canvasSize >= 0
+      )
+    ).toBe(true);
+  });
+
+  it("uses project scale instead of picker zoom for editor tile coverage", () => {
+    const lowPickerZoomTiles = getFieldMapTileCoverage({
+      field: { width: 60, height: 40, ppm: 20 },
+      mapReference: { ...reference, zoom: 12 },
+    });
+    const highPickerZoomTiles = getFieldMapTileCoverage({
+      field: { width: 60, height: 40, ppm: 20 },
+      mapReference: { ...reference, zoom: 19 },
+    });
+
+    expect(
+      getMapReferenceRenderZoom({ lat: reference.centerLat, ppm: 20 })
+    ).toBe(20);
+    expect(new Set(lowPickerZoomTiles.map((tile) => tile.z))).toEqual(
+      new Set([20])
+    );
+    expect(new Set(highPickerZoomTiles.map((tile) => tile.z))).toEqual(
+      new Set([20])
+    );
+    expect(lowPickerZoomTiles[0]?.canvasSize).toBeCloseTo(
+      highPickerZoomTiles[0]?.canvasSize ?? 0,
+      6
+    );
+  });
+
+  it("pans lat/lng by screen pixels", () => {
+    const center = { lat: 52.1, lng: 5.2 };
+    const eastMetersPerPixel = metersPerPixelAtLatitude(center.lat, 18);
+    const next = panLatLngByPixels({
+      center,
+      dx: 20,
+      dy: 0,
+      zoom: 18,
+    });
+
+    expect(eastMetersPerPixel).toBeGreaterThan(0);
+    expect(next.lng).toBeLessThan(center.lng);
+  });
+
+  it("converts screen pan deltas into rotated map pixel deltas", () => {
+    expect(
+      screenDeltaToMapPixelDelta({ dx: 12, dy: -4, rotationDeg: 0 })
+    ).toEqual({ dx: 12, dy: -4 });
+
+    const rightDragAtNinetyDegrees = screenDeltaToMapPixelDelta({
+      dx: 10,
+      dy: 0,
+      rotationDeg: 90,
+    });
+
+    expect(rightDragAtNinetyDegrees.dx).toBeCloseTo(0, 6);
+    expect(rightDragAtNinetyDegrees.dy).toBeCloseTo(10, 6);
+  });
+});

--- a/tests/lib/track/design.test.ts
+++ b/tests/lib/track/design.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeDesign,
   normalizeShape,
   parseDesign,
+  serializeDesignForShare,
   serializeDesign,
 } from "@/lib/track/design";
 import type { PolylineShape, SerializedTrackDesign } from "@/lib/types";
@@ -109,6 +110,42 @@ describe("track design helpers", () => {
 
     expect(serialized.shapes).toHaveLength(1);
     expect(serialized.shapes[0]?.id).toBe("gate-1");
+  });
+
+  it("keeps map references in project serialization and strips them from share serialization", () => {
+    const design = normalizeDesign({
+      id: "design-map",
+      version: 1,
+      title: "Layout",
+      description: "",
+      tags: [],
+      authorName: "",
+      inventory,
+      field: { width: 60, height: 40, origin: "tl", gridStep: 1, ppm: 20 },
+      mapReference: {
+        type: "map",
+        provider: "esri-world-imagery",
+        mapStyle: "satellite",
+        centerLat: 52.1,
+        centerLng: 5.2,
+        zoom: 18,
+        rotationDeg: 370,
+        opacity: 2,
+        visible: true,
+        locked: false,
+      },
+      shapes: [],
+      createdAt: "2026-04-13T10:00:00.000Z",
+      updatedAt: "2026-04-13T10:00:00.000Z",
+    });
+
+    expect(design.mapReference?.centerLat).toBe(52.1);
+    expect(design.mapReference?.centerLng).toBeCloseTo(5.2, 6);
+    expect(design.mapReference?.rotationDeg).toBe(10);
+    expect(design.mapReference?.opacity).toBe(1);
+    expect(design.mapReference?.locked).toBe(true);
+    expect(serializeDesign(design).mapReference?.centerLat).toBe(52.1);
+    expect(serializeDesignForShare(design).mapReference).toBeNull();
   });
 
   it("parses valid design-like values and rejects invalid ones", () => {


### PR DESCRIPTION
This adds an editor-only satellite map reference layer so a project can be lined up with a real venue. Users can search for a location, use their current position, choose the field center, adjust rotation and opacity, and keep the reference behind the 2D layout while designing.

The editor render now derives map scale from the project field scale instead of the picker zoom, so the background stays consistent with the real-world field dimensions. Map reference metadata is preserved in project JSON, but public shares and share exports strip it so location data does not leak into shared views.