### PR TITLE
feat: Enhance Race Pack with QR code sharing functionality

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -1,6 +1,6 @@
 # TrackDraw Roadmap
 
-This roadmap reflects the current state of TrackDraw. The core design loop is now in place across desktop, shared read-only viewing, public gallery discovery, practical mobile use, and export/share handoff. Recent release work also strengthened shared review, route warnings, snapping, cinematic FPV export, and the editor foundation. The roadmap should now focus primarily on workflow depth and the next product surfaces that build cleanly on the shipped foundation.
+This roadmap reflects the current state of TrackDraw. The core design loop is now in place across desktop, shared read-only viewing, public gallery discovery, practical mobile use, venue-aligned editing, account-published embeds, and export/share handoff. The roadmap should now focus primarily on workflow depth and small product surfaces that build cleanly on the shipped foundation.
 
 ## Current Focus
 
@@ -11,19 +11,19 @@ TrackDraw is now strong in these areas:
 - Share-first collaboration through read-only links
 - Public gallery discovery through opt-in published shares
 - Account-published embeds through a dedicated read-only `/embed/[token]` route
+- Real venue alignment through editor-only satellite map references
 - Practical mobile editing for quick venue-side changes
 - Portable outputs through PNG, SVG, PDF, 3D render capture, and JSON project files
 
 The most useful next product moves are:
 
+- Race Pack QR codes that connect printed or on-screen briefings back to canonical shared views
+- Timing gate markers that improve Race Pack, race director planning, and future overlay preparation
 - A sharper decision on how far account-backed project continuity should go after the shipped account and authorization foundation
 - A clearer separation between local-first workflows and account-backed follow-up
 - Versioned publish history for account-backed shares
 - Curated gallery collections that improve discovery without social mechanics
-- More deliberate editor workflow follow-up around route readability, numbering confidence, and precision placement
 - Operator-facing dashboard polish for published share and gallery lifecycle visibility
-- A stronger shared-view review experience, especially on mobile and in 3D
-- Deliberate follow-up on race-day outputs after the ownership boundary is settled
 
 ## Product Principles
 
@@ -44,20 +44,20 @@ Labels used below:
 - `Account-backed`: depends on ownership, sync, identity, or shared persistence
 - `Research`: still primarily exploratory
 
-### 1. Embeddable Shared Views (`Account-backed`) ✓
+### 1. Race-Day Handoff Next Slice (`No account required`)
 
-Account-backed published shares can now travel beyond TrackDraw links when a club, organizer, or venue wants to place a read-only layout directly on another site.
+The next release-sized work should build on the shipped Race Pack, published shares, map/reference work, and route numbering without turning TrackDraw into a race-control product.
 
-Shipped:
+Focus:
 
-- Added `/embed/[token]`, a lightweight read-only embed route that reuses stored share resolution and the shared viewer foundation
-- Made embeds account-only: only active `published` shares render track data in embed context
-- Kept anonymous shares temporary and non-embeddable, including when someone manually constructs an `/embed/[token]` URL
-- Added clear unavailable states for temporary, expired, revoked, and missing embeds
-- Added a dedicated Embed section in ShareDialog with copyable iframe code, 2D layout / 3D preview initial view selection, and a larger default iframe height
-- Kept gallery discovery separate from share lifecycle, so listing, unlisting, featuring, and hiding do not change share expiry
-- Added automated coverage for share lifecycle, embed authorization, gallery expiry independence, and cleanup targeting
-- Validated the current embed container behavior for mobile and desktop, including iframe sizing and compact mobile controls
+- Add timing gate markers for start/finish and split hardware placement
+- Surface timing markers in the editor and Race Pack before treating them as overlay metadata
+- Keep the future race director page behind these smaller foundations
+
+Suggested first slices:
+
+- Shipped: shared view QR code in Race Pack, tied to an active published account-project share with a clear no-share fallback
+- Timing gate markers
 
 ### 2. Accounts And Ownership Model (`Research`)
 
@@ -201,7 +201,7 @@ Focus:
 
 ### 4. Race-Day Follow-up (`No account required`)
 
-TrackDraw now has a real Race Pack and numbering handoff. The next work here is follow-up, not the main roadmap driver.
+TrackDraw now has a real Race Pack and numbering handoff. The immediate QR/timing-marker slice is tracked at the top of the active roadmap; the remaining work here is broader race-day operations follow-up.
 
 Current first pass:
 
@@ -210,7 +210,6 @@ Current first pass:
 
 Later slices:
 
-- Timing gate markers for identifying start/finish and split hardware placement directly in the editor, Race Pack, and future race director views
 - Race director page once TrackDraw can extend the existing start/finish and timing-marker foundation with the supporting race-day metadata and ops elements it depends on, including pilot line, director position, timing/start box placement, cable routing, and ops notes
 - Live race overlay preparation once the `rh-stream-overlays` side is ready to consume TrackDraw-authored route and timing metadata
 
@@ -256,23 +255,7 @@ Suggested first slices:
 - Add overlay-preparation validation that can be reused by export and future setup UI
 - Keep using full TrackDraw project JSON until the RH plugin proves a dedicated overlay package is necessary
 
-### 5. Editor Workflow Follow-up (`No account required`)
-
-TrackDraw now ships the editor workflow follow-up: visible snapping, route-aware object snapping, smaller waypoint-aware snap targets, route numbering in export and Race Pack handoff, stronger route warnings, and editor-visible numbering validation.
-
-Focus:
-
-- Keep any future follow-up limited to real-world polish found during layout authoring
-- Preserve the derived route-order model until explicit race-route metadata becomes necessary
-- Keep advanced guidance non-intrusive on both desktop and mobile
-
-Suggested first slices:
-
-- Shipped: numbering follow-up that keeps the current derived route-order model but adds clearer issue states and layout-level confidence cues
-- Shipped: flow-aware and alignment-aware snapping follow-up for route-line alignment, path-waypoint snapping, and nearby-object x/y alignment, with grid snapping remaining available as the fallback
-- Performance guardrails so richer snapping and overlays do not degrade drag responsiveness on larger layouts
-
-### 6. Real-Time Collaboration Evaluation (`Research`)
+### 5. Real-Time Collaboration Evaluation (`Research`)
 
 Evaluate whether TrackDraw should support shared real-time editing for race track design, but do not actively invest in enabling collaboration until the sync, presence, and conflict model clearly justify the editor complexity.
 
@@ -284,20 +267,9 @@ Suggested first slices:
 - Treat host-led review with optional presence as the strongest smaller step if TrackDraw wants live collaboration-adjacent value before full co-editing
 - Only revisit active co-editing investment after the editor state, persistence, and undo boundaries are stronger for the solo workflow too
 
-### 7. Backlog And Research Tracks
+### 6. Backlog And Research Tracks
 
 These remain valuable, but they are not the current build target.
-
-#### Bundle Size Reduction (`No account required`)
-
-TrackDraw is now feature-rich enough that bundle size needs to be handled as an explicit product-quality track instead of only incidental cleanup. The first startup-focused reductions are already in place, so the next pass should stay measurement-led and target the heaviest remaining Studio, 2D, 3D, and export chunks without adding unnecessary code duplication.
-
-Suggested first slices:
-
-- Done: reduce avoidable weight in the main Studio toolbar so secondary controls do not all ship in the first editor load
-- Done: keep separating editor-only interaction code from the base 2D canvas path where that lowers startup cost without risking core editing behavior
-- Done: re-audit the remaining 3D preview chunk and only continue splitting it where a concrete hotspot still justifies the extra module boundary
-- Done: verify that heavier export dependencies remain fully deferred behind the export flow instead of leaking into normal editor or shared-view startup
 
 #### 3D Editor Interaction Polish (`No account required`)
 
@@ -396,7 +368,7 @@ Suggested first slices:
   - Clarify how browse, duplicate, insert, and fork flows should work without overlapping confusingly with starter layouts or ordinary projects
   - Define ownership and visibility boundaries for private, club, team, or published template libraries
 
-### 8. Accounts Boundary
+### 7. Accounts Boundary
 
 Be deliberate about what should stay usable without an account versus what actually benefits from account identity and continuity.
 
@@ -420,7 +392,7 @@ Likely account-backed follow-up:
 ## v1.5.0 Archive
 
 <details>
-<summary>Completed gallery work archived with v1.5.0</summary>
+<summary>Completed release work archived with v1.5.0</summary>
 
 ### Published Gallery (`Account-backed`)
 
@@ -433,6 +405,55 @@ Included:
 - Gallery preview images are generated and stored as public media
 - The public gallery includes featured and recent entries, empty and failure states, public metadata, and sitemap coverage
 - Moderators and admins can view, feature, hide, restore, and delete gallery entries from the dashboard
+
+### Durable Shares And Embeds (`Account-backed`)
+
+Account-backed published shares now stay live until revoked, while anonymous shares remain temporary. Published account shares can also travel beyond TrackDraw links through a lightweight embed viewer.
+
+Included:
+
+- Explicit temporary versus published share lifecycle
+- Account project publishing reuses the active published share token instead of creating unbounded duplicate shares
+- Anonymous shares keep explicit expiry and are never embeddable
+- `/embed/[token]` renders only active published shares and shows unavailable states for temporary, expired, revoked, or missing embeds
+- The Share dialog includes a dedicated Embed section with iframe code and 2D layout / 3D preview start modes
+- Gallery visibility is independent from share expiry, so listing, unlisting, featuring, and hiding do not change whether a share or embed stays live
+
+### Editor Workflow Follow-up (`No account required`)
+
+Route editing and layout review now have clearer editor feedback without replacing the current lightweight workflow.
+
+Included:
+
+- Route-derived obstacle numbering validation and layout inspector status
+- Missing-route, off-route, and partial-numbering cues in the layout review surface
+- Route-line snapping, waypoint-aware snapping, and x/y object-alignment snapping
+- Smaller waypoint snap targets so route editing stays precise
+- Inspector cleanup that keeps project settings, layout review, and selection editing easier to scan
+
+### Map Field Reference (`No account required`)
+
+TrackDraw now supports an editor-only satellite map reference for lining a project up with a real venue.
+
+Included:
+
+- Desktop dialog and mobile drawer for choosing the field center
+- Esri World Imagery tiles, typeahead location search, current-location jump, touch/pointer panning, and wheel/pinch zoom
+- A field footprint derived from project dimensions
+- Non-interactive Konva tile rendering behind the 2D layout
+- Layout inspector controls for add/edit, show/hide, opacity, rotation, and remove
+- Project JSON keeps map reference metadata, while public shares and share/export payloads strip map imagery and location data
+
+### Bundle Size Reduction (`No account required`)
+
+TrackDraw now keeps more heavy code behind the workflows that need it instead of loading everything with the first editor surface.
+
+Included:
+
+- Reduced avoidable weight in the main Studio toolbar so secondary controls do not all ship in the first editor load
+- Kept editor-only interaction code separated from the base 2D canvas path where that lowers startup cost without risking core viewing behavior
+- Re-measured the shared 3D preview stack and kept further splitting limited to concrete hotspots
+- Confirmed that heavier export dependencies stay fully deferred behind export flows
 
 </details>
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -22,51 +22,21 @@ Labels used below:
 
 ## Current Priority
 
+- [ ] Race-day handoff next slice (`No account required`)
+      Build on the shipped Race Pack, published shares, and editor numbering work with small release-sized improvements that make briefing and setup easier without turning TrackDraw into a race-control product.
+  - [x] Shared view QR code in Race Pack
+        Embed a QR code linking to the canonical published shared view in the Race Pack PDF, so pilots and crew can scan directly from a printed or on-screen briefing.
+  - [ ] Timing gate markers
+        Let specific gates be marked as start/finish or split timing points so race directors can identify timing hardware placement clearly in the editor, Race Pack, and future overlay preparation.
+
+## Follow-up
+
 - [ ] Velocidrone experimental export stabilization (`No account required`)
-      The first experimental `.trk` export is already shipped. The remaining work here is narrowing the gap between "importable" and "dependable" by validating more real layouts and tightening the remaining prefab mapping and orientation edge cases before this can be treated as a more supported workflow.
+      The first experimental `.trk` export is already shipped. Keep this parked until there is appetite to validate more real layouts and tighten prefab mapping and orientation edge cases.
   - [ ] Validate the current `.trk` export on more layouts
         Test the shipped export across a wider range of real track layouts so the current best-effort mapping is grounded in repeatable validation instead of one-off success cases.
   - [ ] Resolve remaining mapping and orientation edge cases
         Tighten the current export where prefab substitutions, facing direction, or rotation assumptions still produce avoidable cleanup work after import.
-
-- [x] Editor workflow follow-up (`No account required`)
-      Shipped route-derived numbering validation, route-line and waypoint-aware snapping, x/y object-alignment snapping, and lightweight inspector cues without replacing the current derived workflow model.
-  - [x] Obstacle numbering validation and controls
-        Added shared route-derived numbering validation, layout inspector status, missing-route/off-route issue states, and item-list cues without replacing the current derived model.
-  - [x] Advanced snapping follow-up
-        Added route-line snapping, x/y object-alignment snapping, and kept the existing angle/grid behavior on the same lightweight snap resolver.
-
-- [x] Map field reference (`No account required`)
-      Shipped an editor-only satellite map reference for lining a project up with a real venue. Users can search for a location, choose the field center, align rotation, adjust opacity, and render the saved reference behind the 2D layout through a non-interactive Konva tile layer. Project JSON keeps map metadata, while share/export payloads stay free of map imagery and location data.
-  - [x] Map picker and field footprint
-        Added a desktop dialog and mobile drawer with Esri World Imagery tiles, typeahead location search, current-location jump, center selection, touch/pointer panning, pinch/wheel zoom, and a field footprint derived from project dimensions.
-  - [x] Editor rendering and inspector controls
-        Added a locked, non-interactive Konva tile renderer plus Project inspector controls for add/edit, show/hide, opacity, rotation, and remove.
-  - [x] Persistence and share/export boundary
-        Persisted map reference metadata in project JSON and stripped it from share/export serialization so public outputs do not expose map references in v1.
-
-## Shipped Foundation
-
-- [x] Account and authorization foundation (`Account-backed`)
-      The first account foundation is now in place, including sign-in, profile management, role-aware dashboard access, and internal role management.
-
-- [x] Published gallery (`Account-backed`)
-      TrackDraw now has an opt-in public gallery at `/gallery` built on published shares. Signed-in owners can list and remove gallery entries, visitors can browse community tracks, and moderators/admins can manage gallery visibility from the dashboard.
-
-- [x] Embeddable shared views (`Account-backed`)
-      Account-backed published layouts can now be embedded on external sites through a lightweight read-only viewer that reuses the current share model.
-  - [x] Account-only durable share lifecycle
-        Account-backed shares are durable published links that stay live until revoked, while anonymous shares remain temporary with explicit expiry.
-  - [x] Embed code in share flow
-        The Share dialog has a dedicated Embed section with iframe code, copy-to-clipboard, and 2D layout / 3D preview initial view selection.
-  - [x] Lightweight embed viewer
-        `/embed/[token]` reuses stored share resolution and only renders active published shares; temporary, expired, revoked, and missing embeds show unavailable states.
-  - [x] Gallery lifecycle independence
-        Gallery visibility is decoupled from share expiry, so listing, unlisting, featuring, and hiding do not change whether the share or embed stays live.
-  - [x] Embed container validation
-        Desktop and mobile embed behavior is validated for the current iframe sizing, compact mobile controls, and unavailable states.
-
-## Follow-up
 
 - [ ] Venue library and constraints (`Account-backed`)
       Support reusable venue records with boundaries, constraints, and venue-specific profiles.
@@ -108,11 +78,7 @@ Labels used below:
 ## Later Product Follow-up
 
 - [ ] Race-day communication and briefing (`No account required`)
-      The first race-day handoff release is shipped. Further work here is follow-up.
-  - [ ] Shared view QR code in Race Pack
-        Embed a QR code linking to the published shared view in the Race Pack PDF, so pilots can scan directly from a printed or on-screen briefing.
-  - [ ] Timing gate markers
-        Let specific gates be marked as start/finish or split timing points so race directors can identify timing hardware placement clearly in the editor, Race Pack, and future overlay preparation.
+      The first Race Pack release is shipped, and the immediate QR/timing-marker slice now lives in Current Priority. The remaining work here is larger race-day operations follow-up.
   - [ ] Race director page in Race Pack
         Add a race-director-oriented page to the Race Pack.
     - [ ] Race-day ops elements around the existing start area
@@ -138,17 +104,6 @@ Labels used below:
         Only add a dedicated overlay package export if the RH plugin proves the full project JSON is too broad or ambiguous.
 
 ## Backlog And Research
-
-- [x] Bundle size reduction (`No account required`)
-      Keep reducing startup weight now that the first lazy-loading and share-shell splits are in place. The next work here should stay measurement-led and focus on the heaviest remaining client chunks instead of treating bundle size as one broad cleanup bucket.
-  - [x] Studio toolbar chunk reduction
-        Reduce avoidable weight in the main Studio toolbar so rarely used controls or secondary tool surfaces do not all ship in the first editor load.
-  - [x] TrackCanvas editor-only interaction split
-        Keep separating editor-only interaction code from the base 2D rendering path where that meaningfully lowers the Studio startup chunk without regressing drawing and selection behavior.
-  - [x] 3D preview hotspot audit
-        Re-measure the shared 3D preview stack and only keep splitting it further if a specific scene, geometry, or overlay module proves to be a worthwhile remaining hotspot.
-  - [x] Export dependency audit
-        Confirm that heavier export dependencies stay fully behind the export flow and are not leaking back into normal editor or shared-view startup paths.
 
 - [ ] Track DNA and layout analysis (`Research`)
       Evaluate whether route and layout analysis should become reusable signals that help compare tracks, explain style, and support later recommendation or assistive tooling.
@@ -234,6 +189,46 @@ Labels used below:
   - [ ] Relationship to starter layouts
         Keep templates distinct from starter layouts, project duplication, and saved projects.
 
+## v1.5.0 Archive
+
+<details>
+<summary>Completed release work archived with v1.5.0</summary>
+
+- [x] Published gallery (`Account-backed`)
+      Shipped opt-in public gallery discovery for account-published tracks, including owner-managed listings and moderator/admin dashboard controls.
+
+- [x] Embeddable shared views (`Account-backed`)
+      Shipped account-only published embeds through `/embed/[token]`, including iframe copy, 2D/3D start modes, unavailable states, and lifecycle rules that keep anonymous shares temporary and non-embeddable.
+
+- [x] Editor workflow follow-up (`No account required`)
+      Shipped route-derived numbering validation, route-line and waypoint-aware snapping, x/y object-alignment snapping, and lightweight inspector cues without replacing the current derived workflow model.
+  - [x] Obstacle numbering validation and controls
+        Added shared route-derived numbering validation, layout inspector status, missing-route/off-route issue states, and item-list cues without replacing the current derived model.
+  - [x] Advanced snapping follow-up
+        Added route-line snapping, waypoint-aware snapping, x/y object-alignment snapping, and kept the existing angle/grid behavior on the same lightweight snap resolver.
+
+- [x] Map field reference (`No account required`)
+      Shipped an editor-only satellite map reference for lining a project up with a real venue. Users can search for a location, choose the field center, align rotation, adjust opacity, and render the saved reference behind the 2D layout through a non-interactive Konva tile layer.
+  - [x] Map picker and field footprint
+        Added a desktop dialog and mobile drawer with Esri World Imagery tiles, typeahead location search, current-location jump, center selection, touch/pointer panning, pinch/wheel zoom, and a field footprint derived from project dimensions.
+  - [x] Editor rendering and inspector controls
+        Added a locked, non-interactive Konva tile renderer plus Layout inspector controls for add/edit, show/hide, opacity, rotation, and remove.
+  - [x] Persistence and share/export boundary
+        Persisted map reference metadata in project JSON and stripped it from share/export serialization so public outputs do not expose map references in v1.
+
+- [x] Bundle size reduction (`No account required`)
+      Shipped measured startup-weight reductions and verified that heavier editor, 3D, and export paths stay behind the workflows that need them.
+  - [x] Studio toolbar chunk reduction
+        Reduced avoidable weight in the main Studio toolbar so secondary controls do not all ship in the first editor load.
+  - [x] TrackCanvas editor-only interaction split
+        Kept editor-only interaction code separated from the base 2D canvas path where that lowers startup cost without risking core viewing behavior.
+  - [x] 3D preview hotspot audit
+        Re-measured the shared 3D preview stack and kept further splitting limited to concrete hotspots.
+  - [x] Export dependency audit
+        Confirmed that heavier export dependencies stay fully deferred behind export flows.
+
+</details>
+
 ## v1.4.0 Archive
 
 <details>
@@ -306,45 +301,5 @@ Labels used below:
         Break up any remaining oversized files identified in the audit, especially where editor composition and mobile/desktop orchestration still live together.
   - [x] Reduce cross-module coupling in editor state
         Moved shared editor-store state shapes into dedicated types, centralized UI/session reset profiles, and reduced duplicated store wiring so state changes stay more local to the editor boundary.
-
-</details>
-
-## v1.3.0 Archive
-
-<details>
-<summary>Completed release work archived with v1.3.0</summary>
-
-- [x] Velocidrone export compatibility research (`Research`)
-      The core compatibility question is answered: TrackDraw can generate an experimental `.trk` export that imports into Velocidrone.
-
-- [x] Velocidrone experimental export first pass (`No account required`)
-      Ship the first importable Velocidrone `.trk` export with best-effort prefab mapping, a centralized orientation model, and first-pass 2D/3D editor cues.
-  - [x] First experimental `.trk` export
-        Ship the first importable Velocidrone `.trk` export from TrackDraw.
-  - [x] First object mapping slice
-        Export the core track items into a usable first-pass Velocidrone layout with best-effort prefab mapping.
-  - [x] Experimental product framing
-        Ship the export as an explicitly experimental workflow in the UI and product messaging.
-  - [x] Gate front/back orientation model
-        Centralize front-facing rules so export, 2D guides, and 3D guides use the same per-shape orientation mapping.
-  - [x] Clear 2D front/back affordance
-        Add a first-pass 2D front indicator by anchoring the `Front` cue to the rotation guide instead of the obstacle itself.
-  - [x] Faster 3D orientation validation
-        Add a first-pass 3D orientation guide pass so rotation handles follow the same central orientation mapping as the exporter.
-
-- [x] Accounts and cross-device project evaluation (`Research`)
-      Better Auth, magic-link sign-in, profile management, passkeys, and account entry points are now in place. The account model is established and validated across devices.
-  - [x] Passkey sign-in
-        Add passkeys as a follow-up to magic-link sign-in once the current account model feels stable.
-    - [x] Passkey sign-in on the login screen
-          Add passkey sign-in to the main login flow without replacing magic links.
-    - [x] Passkey enrollment for existing accounts
-          Let signed-in users add a passkey from account settings.
-    - [x] Passkey management in account settings
-          Support review, rename, and remove flows for registered passkeys.
-    - [x] Fallback and recovery UX
-          Keep magic link as the fallback and handle unsupported browsers and failed prompts cleanly.
-    - [x] Cross-device and mobile validation
-          Validated the passkey and account flow across practical desktop and mobile scenarios.
 
 </details>

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { MobileDrawer } from "@/components/MobileDrawer";
 import { DesktopModal } from "@/components/DesktopModal";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { buildStoredSharePath } from "@/lib/share";
 import { serializeDesign } from "@/lib/track/design";
 import { useEditor } from "@/store/editor";
 import type { FlythroughProgress, FlythroughTheme } from "@/lib/export/shared";
@@ -21,6 +22,7 @@ export interface ExportDialogProps {
   preview3DRef?: React.RefObject<TrackPreview3DHandle | null>;
   activeTab?: "2d" | "3d";
   onRequest3DView?: () => void;
+  projectId?: string | null;
 }
 
 type Theme = FlythroughTheme;
@@ -232,6 +234,7 @@ export default function ExportDialog({
   preview3DRef,
   activeTab,
   onRequest3DView,
+  projectId = null,
 }: ExportDialogProps) {
   const design = useEditor((s) => s.track.design);
   const currentTheme = useTheme();
@@ -257,6 +260,38 @@ export default function ExportDialog({
 
   const safeName = ({ theme, view }: { theme?: Theme; view: "2d" | "3d" }) => {
     return [baseName, view, theme].filter(Boolean).join("_");
+  };
+
+  const getRacePackShareUrl = async () => {
+    if (!projectId) return null;
+
+    try {
+      const response = await fetch(
+        `/api/shares?projectId=${encodeURIComponent(projectId)}`
+      );
+      const payload = (await response.json()) as {
+        ok: boolean;
+        share?: {
+          shareType: "temporary" | "published";
+          token: string;
+        } | null;
+      };
+
+      if (
+        !response.ok ||
+        !payload.ok ||
+        payload.share?.shareType !== "published"
+      ) {
+        return null;
+      }
+
+      return new URL(
+        buildStoredSharePath(payload.share.token, "2d"),
+        window.location.origin
+      ).toString();
+    } catch {
+      return null;
+    }
   };
 
   const run = async <T,>(
@@ -514,6 +549,7 @@ export default function ExportDialog({
                 const stage = canvasRef.current?.getStage();
                 if (!stage) throw new Error("Canvas not ready");
                 const { exportPdf } = await import("@/lib/export/exportPdf");
+                const shareUrl = await getRacePackShareUrl();
                 await exportPdf(
                   stage,
                   design,
@@ -522,6 +558,7 @@ export default function ExportDialog({
                   {
                     includeObstacleNumbers,
                     preset: "race-day",
+                    shareUrl,
                   }
                 );
               })
@@ -742,6 +779,7 @@ export default function ExportDialog({
                 const stage = canvasRef.current?.getStage();
                 if (!stage) throw new Error("Canvas not ready");
                 const { exportPdf } = await import("@/lib/export/exportPdf");
+                const shareUrl = await getRacePackShareUrl();
                 await exportPdf(
                   stage,
                   design,
@@ -750,6 +788,7 @@ export default function ExportDialog({
                   {
                     includeObstacleNumbers,
                     preset: "race-day",
+                    shareUrl,
                   }
                 );
               })

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -1162,6 +1162,7 @@ export default function EditorShell({
             preview3DRef={preview3DRef}
             activeTab={tab}
             onRequest3DView={() => handleTabChange("3d")}
+            projectId={isAccountProject ? design.id : null}
           />
         ) : null}
         {shortcutsOpen ? (

--- a/src/lib/export/exportPdf.ts
+++ b/src/lib/export/exportPdf.ts
@@ -5,12 +5,17 @@ import {
   getRequiredInventoryCounts,
 } from "@/lib/planning/inventory";
 import { buildSetupPlan } from "@/lib/planning/setup-estimate";
+import { createQrCode } from "@/lib/qr-code";
 import type { TrackDesign } from "../types";
 import {
   designToSvg,
   type Export2DOptions,
   type ExportTheme,
 } from "./exportSvg";
+
+export type ExportPdfOptions = Export2DOptions & {
+  shareUrl?: string | null;
+};
 
 const PRINT_BG: [number, number, number] = [255, 255, 255];
 const INK: [number, number, number] = [24, 39, 60];
@@ -168,6 +173,110 @@ function drawInfoCard(
   pdf.text(value, x + 4, y + 14);
 }
 
+function drawQrCode(
+  pdf: jsPDF,
+  {
+    size,
+    url,
+    x,
+    y,
+  }: {
+    size: number;
+    url: string;
+    x: number;
+    y: number;
+  }
+) {
+  const quietZoneModules = 4;
+  const qr = createQrCode(url);
+  const totalModules = qr.size + quietZoneModules * 2;
+  const moduleSize = size / totalModules;
+
+  pdf.setFillColor(255, 255, 255);
+  pdf.rect(x, y, size, size, "F");
+  pdf.setFillColor(...INK);
+
+  qr.modules.forEach((row, rowIndex) => {
+    row.forEach((dark, columnIndex) => {
+      if (!dark) return;
+      pdf.rect(
+        x + (columnIndex + quietZoneModules) * moduleSize,
+        y + (rowIndex + quietZoneModules) * moduleSize,
+        moduleSize,
+        moduleSize,
+        "F"
+      );
+    });
+  });
+}
+
+function drawSharedViewBlock(
+  pdf: jsPDF,
+  {
+    shareUrl,
+    w,
+    x,
+    y,
+  }: {
+    shareUrl?: string | null;
+    w: number;
+    x: number;
+    y: number;
+  }
+) {
+  const h = 35;
+  const qrSize = 25;
+
+  pdf.setFillColor(...PANEL);
+  pdf.setDrawColor(...BORDER);
+  pdf.setLineWidth(0.25);
+  pdf.roundedRect(x, y, w, h, 3, 3, "FD");
+
+  pdf.setFont("helvetica", "bold");
+  pdf.setFontSize(8);
+  pdf.setTextColor(...MUTED);
+  pdf.text("SHARED VIEW", x + 4, y + 6.5);
+
+  if (shareUrl) {
+    try {
+      drawQrCode(pdf, {
+        size: qrSize,
+        url: shareUrl,
+        x: x + w - qrSize - 4,
+        y: y + 5,
+      });
+      pdf.setFont("helvetica", "bold");
+      pdf.setFontSize(11);
+      pdf.setTextColor(...INK);
+      pdf.text("Scan to open the track", x + 4, y + 14);
+      pdf.setFont("helvetica", "normal");
+      pdf.setFontSize(7.2);
+      pdf.setTextColor(...MUTED);
+      const lines = pdf.splitTextToSize(
+        "Opens the canonical TrackDraw share link for mobile review and briefing.",
+        w - qrSize - 13
+      );
+      pdf.text(lines, x + 4, y + 20);
+      return;
+    } catch {
+      /* fall through to the no-QR text below */
+    }
+  }
+
+  pdf.setFont("helvetica", "bold");
+  pdf.setFontSize(10);
+  pdf.setTextColor(...INK);
+  pdf.text("No published share linked", x + 4, y + 14);
+  pdf.setFont("helvetica", "normal");
+  pdf.setFontSize(7.5);
+  pdf.setTextColor(...MUTED);
+  const lines = pdf.splitTextToSize(
+    "Publish this project first if you want the Race Pack to include a scan code.",
+    w - 8
+  );
+  pdf.text(lines, x + 4, y + 20);
+}
+
 function buildRacePackContext(design: TrackDesign, options?: Export2DOptions) {
   const required = getRequiredInventoryCounts(design);
   const inventoryComparison = getInventoryComparison(design);
@@ -199,7 +308,8 @@ function drawRacePackCover(
   design: TrackDesign,
   logoDataUrl: string,
   dateText: string,
-  context: ReturnType<typeof buildRacePackContext>
+  context: ReturnType<typeof buildRacePackContext>,
+  options?: ExportPdfOptions
 ) {
   setPageBackground(pdf);
   const pageW = pdf.internal.pageSize.getWidth();
@@ -300,6 +410,14 @@ function drawRacePackCover(
       : "This layout is currently buildable with the saved inventory profile. Use the following pages as the race-day setup and handoff reference.";
   const summaryLines = pdf.splitTextToSize(summary, pageW - margin * 2);
   pdf.text(summaryLines, margin, y);
+  y += summaryLines.length * 5 + 10;
+
+  drawSharedViewBlock(pdf, {
+    shareUrl: options?.shareUrl ?? null,
+    w: pageW - margin * 2,
+    x: margin,
+    y,
+  });
 }
 
 function drawRacePackMapPage(
@@ -530,7 +648,7 @@ async function exportRacePackPdf(
   design: TrackDesign,
   filename: string,
   theme: ExportTheme,
-  options?: Export2DOptions
+  options?: ExportPdfOptions
 ) {
   const pdf = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
   const dateText = new Date().toLocaleDateString("en-GB", {
@@ -545,7 +663,7 @@ async function exportRacePackPdf(
   }
 
   const context = buildRacePackContext(design, options);
-  drawRacePackCover(pdf, design, logoDataUrl, dateText, context);
+  drawRacePackCover(pdf, design, logoDataUrl, dateText, context, options);
   drawRacePackMapPage(pdf, design, mapDataUrl, logoDataUrl, dateText, context);
   drawRacePackBuildSheet(pdf, design, logoDataUrl, dateText, context);
 
@@ -635,7 +753,7 @@ export async function exportPdf(
   design: TrackDesign,
   filename = "track.pdf",
   theme: ExportTheme = "dark",
-  options?: Export2DOptions
+  options?: ExportPdfOptions
 ): Promise<void> {
   void stage;
   if ((options?.preset ?? "standard") === "race-day") {

--- a/src/lib/qr-code.ts
+++ b/src/lib/qr-code.ts
@@ -1,0 +1,420 @@
+const BYTE_MODE = 0b0100;
+const ECC_FORMAT_BITS_LOW = 0b01;
+const FORMAT_MASK = 0x5412;
+const FORMAT_POLY = 0x537;
+const GF_PRIMITIVE = 0x11d;
+const PAD_CODEWORDS = [0xec, 0x11] as const;
+
+const VERSION_CONFIGS = [
+  { version: 1, dataCodewords: 19, eccCodewords: 7, byteCapacity: 17 },
+  { version: 2, dataCodewords: 34, eccCodewords: 10, byteCapacity: 32 },
+  { version: 3, dataCodewords: 55, eccCodewords: 15, byteCapacity: 53 },
+  { version: 4, dataCodewords: 80, eccCodewords: 20, byteCapacity: 78 },
+  { version: 5, dataCodewords: 108, eccCodewords: 26, byteCapacity: 106 },
+] as const;
+
+type VersionConfig = (typeof VERSION_CONFIGS)[number];
+
+export interface QrCodeMatrix {
+  modules: boolean[][];
+  size: number;
+  version: number;
+}
+
+function appendBits(buffer: number[], value: number, length: number) {
+  for (let i = length - 1; i >= 0; i -= 1) {
+    buffer.push((value >>> i) & 1);
+  }
+}
+
+function bitsToCodewords(bits: number[]) {
+  const codewords: number[] = [];
+  for (let i = 0; i < bits.length; i += 8) {
+    let value = 0;
+    for (let j = 0; j < 8; j += 1) {
+      value = (value << 1) | (bits[i + j] ?? 0);
+    }
+    codewords.push(value);
+  }
+  return codewords;
+}
+
+function gfMultiply(x: number, y: number) {
+  let result = 0;
+  let a = x;
+  let b = y;
+
+  while (b > 0) {
+    if ((b & 1) !== 0) result ^= a;
+    a <<= 1;
+    if ((a & 0x100) !== 0) a ^= GF_PRIMITIVE;
+    b >>>= 1;
+  }
+
+  return result & 0xff;
+}
+
+function reedSolomonDivisor(degree: number) {
+  const result = new Array(degree).fill(0) as number[];
+  result[degree - 1] = 1;
+
+  let root = 1;
+  for (let i = 0; i < degree; i += 1) {
+    for (let j = 0; j < degree; j += 1) {
+      result[j] = gfMultiply(result[j], root);
+      if (j + 1 < degree) result[j] ^= result[j + 1];
+    }
+    root = gfMultiply(root, 0x02);
+  }
+
+  return result;
+}
+
+function reedSolomonRemainder(data: number[], degree: number) {
+  const divisor = reedSolomonDivisor(degree);
+  const result = new Array(degree).fill(0) as number[];
+
+  for (const value of data) {
+    const factor = value ^ result.shift()!;
+    result.push(0);
+    for (let i = 0; i < divisor.length; i += 1) {
+      result[i] ^= gfMultiply(divisor[i], factor);
+    }
+  }
+
+  return result;
+}
+
+function selectVersion(byteLength: number): VersionConfig {
+  const config = VERSION_CONFIGS.find((item) => byteLength <= item.byteCapacity);
+  if (!config) throw new Error("QR payload is too large");
+  return config;
+}
+
+function encodeDataCodewords(text: string, config: VersionConfig) {
+  const bytes = Array.from(new TextEncoder().encode(text));
+  const bits: number[] = [];
+
+  appendBits(bits, BYTE_MODE, 4);
+  appendBits(bits, bytes.length, 8);
+  for (const byte of bytes) appendBits(bits, byte, 8);
+
+  const capacityBits = config.dataCodewords * 8;
+  appendBits(bits, 0, Math.min(4, capacityBits - bits.length));
+  while (bits.length % 8 !== 0) bits.push(0);
+
+  const codewords = bitsToCodewords(bits);
+  let padIndex = 0;
+  while (codewords.length < config.dataCodewords) {
+    codewords.push(PAD_CODEWORDS[padIndex % PAD_CODEWORDS.length]);
+    padIndex += 1;
+  }
+
+  return codewords;
+}
+
+function createMatrix(size: number, value: boolean) {
+  return Array.from({ length: size }, () => Array(size).fill(value) as boolean[]);
+}
+
+function setModule(
+  modules: boolean[][],
+  reserved: boolean[][],
+  x: number,
+  y: number,
+  value: boolean,
+  reserve = true
+) {
+  if (x < 0 || y < 0 || y >= modules.length || x >= modules.length) return;
+  modules[y][x] = value;
+  if (reserve) reserved[y][x] = true;
+}
+
+function drawFinder(
+  modules: boolean[][],
+  reserved: boolean[][],
+  x: number,
+  y: number
+) {
+  for (let dy = -1; dy <= 7; dy += 1) {
+    for (let dx = -1; dx <= 7; dx += 1) {
+      const xx = x + dx;
+      const yy = y + dy;
+      if (xx < 0 || yy < 0 || yy >= modules.length || xx >= modules.length) {
+        continue;
+      }
+
+      const inPattern = dx >= 0 && dx <= 6 && dy >= 0 && dy <= 6;
+      const dark =
+        inPattern &&
+        (dx === 0 ||
+          dx === 6 ||
+          dy === 0 ||
+          dy === 6 ||
+          (dx >= 2 && dx <= 4 && dy >= 2 && dy <= 4));
+
+      setModule(modules, reserved, xx, yy, dark);
+    }
+  }
+}
+
+function drawAlignment(
+  modules: boolean[][],
+  reserved: boolean[][],
+  centerX: number,
+  centerY: number
+) {
+  for (let dy = -2; dy <= 2; dy += 1) {
+    for (let dx = -2; dx <= 2; dx += 1) {
+      const distance = Math.max(Math.abs(dx), Math.abs(dy));
+      setModule(
+        modules,
+        reserved,
+        centerX + dx,
+        centerY + dy,
+        distance === 2 || distance === 0
+      );
+    }
+  }
+}
+
+function alignmentPatternPositions(version: number) {
+  return version === 1 ? [] : [6, 4 * version + 10];
+}
+
+function drawFunctionPatterns(
+  modules: boolean[][],
+  reserved: boolean[][],
+  version: number
+) {
+  const size = modules.length;
+  drawFinder(modules, reserved, 0, 0);
+  drawFinder(modules, reserved, size - 7, 0);
+  drawFinder(modules, reserved, 0, size - 7);
+
+  for (let i = 8; i < size - 8; i += 1) {
+    const dark = i % 2 === 0;
+    setModule(modules, reserved, i, 6, dark);
+    setModule(modules, reserved, 6, i, dark);
+  }
+
+  const positions = alignmentPatternPositions(version);
+  for (const y of positions) {
+    for (const x of positions) {
+      const overlapsFinder =
+        (x === 6 && y === 6) ||
+        (x === size - 7 && y === 6) ||
+        (x === 6 && y === size - 7);
+      if (!overlapsFinder) drawAlignment(modules, reserved, x, y);
+    }
+  }
+
+  for (let i = 0; i < 9; i += 1) {
+    if (i !== 6) {
+      reserved[8][i] = true;
+      reserved[i][8] = true;
+    }
+  }
+  for (let i = 0; i < 8; i += 1) {
+    reserved[8][size - 1 - i] = true;
+    reserved[size - 1 - i][8] = true;
+  }
+  setModule(modules, reserved, 8, size - 8, true);
+}
+
+function getMaskBit(mask: number, x: number, y: number) {
+  switch (mask) {
+    case 0:
+      return (x + y) % 2 === 0;
+    case 1:
+      return y % 2 === 0;
+    case 2:
+      return x % 3 === 0;
+    case 3:
+      return (x + y) % 3 === 0;
+    case 4:
+      return (Math.floor(y / 2) + Math.floor(x / 3)) % 2 === 0;
+    case 5:
+      return ((x * y) % 2) + ((x * y) % 3) === 0;
+    case 6:
+      return (((x * y) % 2) + ((x * y) % 3)) % 2 === 0;
+    case 7:
+      return (((x + y) % 2) + ((x * y) % 3)) % 2 === 0;
+    default:
+      return false;
+  }
+}
+
+function drawCodewords(
+  modules: boolean[][],
+  reserved: boolean[][],
+  codewords: number[],
+  mask: number
+) {
+  const size = modules.length;
+  const bits = codewords.flatMap((codeword) =>
+    Array.from({ length: 8 }, (_, index) => (codeword >>> (7 - index)) & 1)
+  );
+  let bitIndex = 0;
+  let upward = true;
+
+  for (let right = size - 1; right >= 1; right -= 2) {
+    if (right === 6) right -= 1;
+    for (let vertical = 0; vertical < size; vertical += 1) {
+      const y = upward ? size - 1 - vertical : vertical;
+      for (let column = 0; column < 2; column += 1) {
+        const x = right - column;
+        if (reserved[y][x]) continue;
+        const bit = (bits[bitIndex] ?? 0) !== 0;
+        modules[y][x] = bit !== getMaskBit(mask, x, y);
+        bitIndex += 1;
+      }
+    }
+    upward = !upward;
+  }
+}
+
+function calculateFormatBits(mask: number) {
+  const data = (ECC_FORMAT_BITS_LOW << 3) | mask;
+  let remainder = data << 10;
+  for (let i = 14; i >= 10; i -= 1) {
+    if (((remainder >>> i) & 1) !== 0) {
+      remainder ^= FORMAT_POLY << (i - 10);
+    }
+  }
+  return ((data << 10) | remainder) ^ FORMAT_MASK;
+}
+
+function drawFormatBits(
+  modules: boolean[][],
+  reserved: boolean[][],
+  mask: number
+) {
+  const size = modules.length;
+  const bits = calculateFormatBits(mask);
+  const bit = (index: number) => ((bits >>> index) & 1) !== 0;
+
+  for (let i = 0; i <= 5; i += 1) setModule(modules, reserved, 8, i, bit(i));
+  setModule(modules, reserved, 8, 7, bit(6));
+  setModule(modules, reserved, 8, 8, bit(7));
+  setModule(modules, reserved, 7, 8, bit(8));
+  for (let i = 9; i < 15; i += 1) {
+    setModule(modules, reserved, 14 - i, 8, bit(i));
+  }
+
+  for (let i = 0; i < 8; i += 1) {
+    setModule(modules, reserved, size - 1 - i, 8, bit(i));
+  }
+  for (let i = 8; i < 15; i += 1) {
+    setModule(modules, reserved, 8, size - 15 + i, bit(i));
+  }
+  setModule(modules, reserved, 8, size - 8, true);
+}
+
+function cloneMatrix(matrix: boolean[][]) {
+  return matrix.map((row) => [...row]);
+}
+
+function getPenaltyScore(modules: boolean[][]) {
+  const size = modules.length;
+  let score = 0;
+
+  for (let y = 0; y < size; y += 1) {
+    let runColor = modules[y][0];
+    let runLength = 1;
+    for (let x = 1; x < size; x += 1) {
+      if (modules[y][x] === runColor) {
+        runLength += 1;
+      } else {
+        if (runLength >= 5) score += 3 + (runLength - 5);
+        runColor = modules[y][x];
+        runLength = 1;
+      }
+    }
+    if (runLength >= 5) score += 3 + (runLength - 5);
+  }
+
+  for (let x = 0; x < size; x += 1) {
+    let runColor = modules[0][x];
+    let runLength = 1;
+    for (let y = 1; y < size; y += 1) {
+      if (modules[y][x] === runColor) {
+        runLength += 1;
+      } else {
+        if (runLength >= 5) score += 3 + (runLength - 5);
+        runColor = modules[y][x];
+        runLength = 1;
+      }
+    }
+    if (runLength >= 5) score += 3 + (runLength - 5);
+  }
+
+  for (let y = 0; y < size - 1; y += 1) {
+    for (let x = 0; x < size - 1; x += 1) {
+      const color = modules[y][x];
+      if (
+        modules[y][x + 1] === color &&
+        modules[y + 1][x] === color &&
+        modules[y + 1][x + 1] === color
+      ) {
+        score += 3;
+      }
+    }
+  }
+
+  const pattern = [true, false, true, true, true, false, true];
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x <= size - pattern.length; x += 1) {
+      if (pattern.every((color, i) => modules[y][x + i] === color)) {
+        score += 40;
+      }
+    }
+  }
+  for (let x = 0; x < size; x += 1) {
+    for (let y = 0; y <= size - pattern.length; y += 1) {
+      if (pattern.every((color, i) => modules[y + i][x] === color)) {
+        score += 40;
+      }
+    }
+  }
+
+  const darkModules = modules.flat().filter(Boolean).length;
+  const percent = (darkModules * 100) / (size * size);
+  score += Math.floor(Math.abs(percent - 50) / 5) * 10;
+
+  return score;
+}
+
+export function createQrCode(text: string): QrCodeMatrix {
+  const byteLength = new TextEncoder().encode(text).length;
+  const config = selectVersion(byteLength);
+  const data = encodeDataCodewords(text, config);
+  const ecc = reedSolomonRemainder(data, config.eccCodewords);
+  const codewords = [...data, ...ecc];
+  const size = config.version * 4 + 17;
+
+  let bestModules: boolean[][] | null = null;
+  let bestScore = Number.POSITIVE_INFINITY;
+
+  for (let mask = 0; mask < 8; mask += 1) {
+    const modules = createMatrix(size, false);
+    const reserved = createMatrix(size, false);
+    drawFunctionPatterns(modules, reserved, config.version);
+    drawCodewords(modules, reserved, codewords, mask);
+    drawFormatBits(modules, reserved, mask);
+    const score = getPenaltyScore(modules);
+
+    if (score < bestScore) {
+      bestModules = modules;
+      bestScore = score;
+    }
+  }
+
+  if (!bestModules) throw new Error("QR render failed");
+
+  return {
+    modules: cloneMatrix(bestModules),
+    size,
+    version: config.version,
+  };
+}

--- a/src/lib/qr-code.ts
+++ b/src/lib/qr-code.ts
@@ -86,7 +86,9 @@ function reedSolomonRemainder(data: number[], degree: number) {
 }
 
 function selectVersion(byteLength: number): VersionConfig {
-  const config = VERSION_CONFIGS.find((item) => byteLength <= item.byteCapacity);
+  const config = VERSION_CONFIGS.find(
+    (item) => byteLength <= item.byteCapacity
+  );
   if (!config) throw new Error("QR payload is too large");
   return config;
 }
@@ -114,7 +116,10 @@ function encodeDataCodewords(text: string, config: VersionConfig) {
 }
 
 function createMatrix(size: number, value: boolean) {
-  return Array.from({ length: size }, () => Array(size).fill(value) as boolean[]);
+  return Array.from(
+    { length: size },
+    () => Array(size).fill(value) as boolean[]
+  );
 }
 
 function setModule(

--- a/tests/lib/qr-code.test.ts
+++ b/tests/lib/qr-code.test.ts
@@ -37,7 +37,8 @@ describe("createQrCode", () => {
   });
 
   it("throws when the payload is too large for the Race Pack QR", () => {
-    expect(() => createQrCode(`https://trackdraw.app/share/${"x".repeat(120)}`))
-      .toThrowError("QR payload is too large");
+    expect(() =>
+      createQrCode(`https://trackdraw.app/share/${"x".repeat(120)}`)
+    ).toThrowError("QR payload is too large");
   });
 });

--- a/tests/lib/qr-code.test.ts
+++ b/tests/lib/qr-code.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { createQrCode } from "@/lib/qr-code";
+
+describe("createQrCode", () => {
+  it("creates a deterministic matrix for a share URL", () => {
+    const first = createQrCode("https://trackdraw.app/share/abc123");
+    const second = createQrCode("https://trackdraw.app/share/abc123");
+
+    expect(first).toEqual(second);
+    expect(first.version).toBe(3);
+    expect(first.size).toBe(29);
+    expect(first.modules).toHaveLength(first.size);
+    expect(first.modules.every((row) => row.length === first.size)).toBe(true);
+  });
+
+  it("draws finder patterns in the expected corners", () => {
+    const qr = createQrCode("https://trackdraw.app/share/abc123");
+    const lastFinderX = qr.size - 7;
+    const lastFinderY = qr.size - 7;
+
+    expect(qr.modules[0][0]).toBe(true);
+    expect(qr.modules[0][6]).toBe(true);
+    expect(qr.modules[6][0]).toBe(true);
+    expect(qr.modules[6][6]).toBe(true);
+    expect(qr.modules[3][3]).toBe(true);
+    expect(qr.modules[0][lastFinderX]).toBe(true);
+    expect(qr.modules[lastFinderY][0]).toBe(true);
+  });
+
+  it("chooses a larger version for longer URLs", () => {
+    const shortUrl = createQrCode("https://trackdraw.app/share/abc123");
+    const longUrl = createQrCode(
+      "https://trackdraw.app/share/abcdefghijklmnopqrstuvwxyz0123456789"
+    );
+
+    expect(longUrl.version).toBeGreaterThan(shortUrl.version);
+  });
+
+  it("throws when the payload is too large for the Race Pack QR", () => {
+    expect(() => createQrCode(`https://trackdraw.app/share/${"x".repeat(120)}`))
+      .toThrowError("QR payload is too large");
+  });
+});


### PR DESCRIPTION
- Implemented QR code generation for shared views in the Race Pack PDF.
- Added a new `createQrCode` utility for generating QR codes.
- Integrated QR code into the Race Pack export process, allowing users to scan and access shared views directly.
- Updated `ExportDialog` to fetch the share URL and pass it to the PDF export options.
- Added tests for QR code generation to ensure deterministic output and correct functionality.