### PR TITLE
feat: Improve map reference drawer and mobile map interactions

### DIFF
--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
 import {
-  Drawer,
   DrawerContent,
   DrawerDescription,
   DrawerHeader,
@@ -17,6 +17,9 @@ interface MobileDrawerProps {
   subtitle?: string;
   children: React.ReactNode;
   pinnedContent?: React.ReactNode;
+  footerContent?: React.ReactNode;
+  nested?: boolean;
+  repositionInputs?: boolean;
   bodyClassName?: string;
   contentClassName?: string;
 }
@@ -64,25 +67,47 @@ export function MobileDrawer({
   subtitle,
   children,
   pinnedContent,
+  footerContent,
+  nested = false,
+  repositionInputs = false,
   bodyClassName,
   contentClassName,
 }: MobileDrawerProps) {
-  return (
-    <Drawer open={open} direction="bottom" modal onOpenChange={onOpenChange}>
-      <DrawerContent
-        className={cn(
-          "border-border/50 bg-card max-h-[85dvh] gap-0 overflow-hidden rounded-t-[1.35rem] border shadow-[0_-16px_36px_rgba(0,0,0,0.14)] lg:hidden",
-          contentClassName
-        )}
+  const content = (
+    <DrawerContent
+      className={cn(
+        "border-border/50 bg-card max-h-[85dvh] gap-0 overflow-hidden rounded-t-[1.35rem] border shadow-[0_-16px_36px_rgba(0,0,0,0.14)] lg:hidden",
+        contentClassName
+      )}
+    >
+      <MobileDrawerHeader title={title} subtitle={subtitle} />
+      {pinnedContent}
+      <div
+        className={cn("flex-1 overflow-y-auto px-4 pt-3 pb-6", bodyClassName)}
       >
-        <MobileDrawerHeader title={title} subtitle={subtitle} />
-        {pinnedContent}
-        <div
-          className={cn("flex-1 overflow-y-auto px-4 pt-3 pb-6", bodyClassName)}
-        >
-          {children}
-        </div>
-      </DrawerContent>
-    </Drawer>
+        {children}
+      </div>
+      {footerContent}
+    </DrawerContent>
+  );
+
+  const drawerProps = {
+    direction: "bottom" as const,
+    modal: true,
+    onOpenChange,
+    open,
+    repositionInputs,
+  };
+
+  if (nested) {
+    return (
+      <DrawerPrimitive.NestedRoot {...drawerProps}>
+        {content}
+      </DrawerPrimitive.NestedRoot>
+    );
+  }
+
+  return (
+    <DrawerPrimitive.Root {...drawerProps}>{content}</DrawerPrimitive.Root>
   );
 }

--- a/src/components/map-reference/MapReferenceDialog.tsx
+++ b/src/components/map-reference/MapReferenceDialog.tsx
@@ -2,7 +2,13 @@
 
 /* eslint-disable @next/next/no-img-element */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { LocateFixed, Minus, Plus, RotateCcw, Search } from "lucide-react";
 import {
   Dialog,
@@ -18,17 +24,13 @@ import { Input } from "@/components/ui/input";
 import { useIsDesktopInspector } from "@/components/inspector/views/layout";
 import {
   clampLatitude,
-  globalPixelToLatLng,
   getMapTileZoom,
   latLngToGlobalPixel,
   metersPerPixelAtLatitude,
   normalizeLongitude,
-  panLatLngByPixels,
-  screenDeltaToMapPixelDelta,
   type LatLng,
 } from "@/lib/map-reference/geometry";
 import {
-  MAP_REFERENCE_DEFAULT_ZOOM,
   MAP_REFERENCE_MAX_ZOOM,
   MAP_REFERENCE_MIN_ZOOM,
   MAP_REFERENCE_TILE_SIZE,
@@ -36,63 +38,13 @@ import {
 } from "@/lib/map-reference/provider";
 import { getMapReferenceTileUrl } from "@/lib/map-reference/tiles";
 import type { FieldSpec, MapReference } from "@/lib/types";
+import { usePickerGesture } from "./usePickerGesture";
+import { useLocationSearch } from "./useLocationSearch";
 
-const PICKER_WIDTH = 760;
-const PICKER_HEIGHT = 430;
-const WHEEL_LINE_HEIGHT_PX = 16;
-const WHEEL_PAGE_HEIGHT_PX = 420;
-const WHEEL_PAN_FACTOR = 0.65;
-const PINCH_ZOOM_FACTOR = 0.008;
-const LOCATION_SEARCH_DEBOUNCE_MS = 350;
-const LOCATION_SEARCH_MIN_LENGTH = 3;
+const MAP_REFERENCE_PICKER_DEFAULT_ZOOM = 7;
 
 function clampValue(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value));
-}
-
-function normalizeWheelDelta(delta: number, deltaMode: number) {
-  if (deltaMode === 1) return delta * WHEEL_LINE_HEIGHT_PX;
-  if (deltaMode === 2) return delta * WHEEL_PAGE_HEIGHT_PX;
-  return delta;
-}
-
-type WebKitGestureEvent = Event & {
-  clientX?: number;
-  clientY?: number;
-  scale?: number;
-};
-
-interface LocationSearchResult {
-  address: string;
-  id: string;
-  lat: number;
-  lng: number;
-  score: number;
-}
-
-function parseCoordinateQuery(query: string): LatLng | null {
-  const matches = query.match(/-?\d+(?:[.,]\d+)?/g);
-  if (!matches || matches.length < 2) return null;
-
-  const first = Number(matches[0].replace(",", "."));
-  const second = Number(matches[1].replace(",", "."));
-  if (!Number.isFinite(first) || !Number.isFinite(second)) return null;
-
-  if (Math.abs(first) <= 90 && Math.abs(second) <= 180) {
-    return {
-      lat: clampLatitude(first),
-      lng: normalizeLongitude(second),
-    };
-  }
-
-  if (Math.abs(first) <= 180 && Math.abs(second) <= 90) {
-    return {
-      lat: clampLatitude(second),
-      lng: normalizeLongitude(first),
-    };
-  }
-
-  return null;
 }
 
 function createReference({
@@ -199,83 +151,19 @@ export function MapReferenceDialog({
     lng: initialReference?.centerLng ?? 5.2913,
   });
   const [zoom, setZoom] = useState(
-    initialReference?.zoom ?? MAP_REFERENCE_DEFAULT_ZOOM
+    initialReference?.zoom ?? MAP_REFERENCE_PICKER_DEFAULT_ZOOM
   );
   const [rotationDeg, setRotationDeg] = useState(
     initialReference?.rotationDeg ?? 0
   );
   const [latInput, setLatInput] = useState(String(center.lat.toFixed(6)));
   const [lngInput, setLngInput] = useState(String(center.lng.toFixed(6)));
-  const [locationQuery, setLocationQuery] = useState("");
-  const [locationResults, setLocationResults] = useState<
-    LocationSearchResult[]
-  >([]);
-  const [locationSearchError, setLocationSearchError] = useState<string | null>(
-    null
-  );
-  const [locationSearchPending, setLocationSearchPending] = useState(false);
-  const [selectedLocationLabel, setSelectedLocationLabel] = useState("");
-  const dragRef = useRef<{
-    lastX: number;
-    lastY: number;
-    moved: boolean;
-    totalDx: number;
-    totalDy: number;
-  } | null>(null);
-  const tileLayerRef = useRef<HTMLDivElement | null>(null);
+  const [locateError, setLocateError] = useState<string | null>(null);
+  const [locatePending, setLocatePending] = useState(false);
+
   const centerRef = useRef(center);
   const zoomRef = useRef(zoom);
   const rotationRef = useRef(rotationDeg);
-  const gestureScaleRef = useRef(1);
-  const searchPanelRef = useRef<HTMLDivElement | null>(null);
-  const locationSearchAbortRef = useRef<AbortController | null>(null);
-  const resizeObserverRef = useRef<ResizeObserver | null>(null);
-  const [pickerElement, setPickerElement] = useState<HTMLDivElement | null>(
-    null
-  );
-  const [pickerSize, setPickerSize] = useState({
-    width: PICKER_WIDTH,
-    height: PICKER_HEIGHT,
-  });
-
-  const metersPerPixel = metersPerPixelAtLatitude(center.lat, zoom);
-  const fieldWidthPx = field.width / metersPerPixel;
-  const fieldHeightPx = field.height / metersPerPixel;
-  const tiles = useMemo(
-    () =>
-      getVisibleTiles({
-        coverageHeight: Math.ceil(
-          Math.hypot(pickerSize.width, pickerSize.height)
-        ),
-        coverageWidth: Math.ceil(
-          Math.hypot(pickerSize.width, pickerSize.height)
-        ),
-        center,
-        height: pickerSize.height,
-        width: pickerSize.width,
-        zoom,
-      }),
-    [center, pickerSize.height, pickerSize.width, zoom]
-  );
-
-  const setPickerNode = useCallback((node: HTMLDivElement | null) => {
-    resizeObserverRef.current?.disconnect();
-    resizeObserverRef.current = null;
-    setPickerElement(node);
-
-    if (!node) return;
-
-    const updatePickerSize = () => {
-      setPickerSize({
-        width: Math.max(1, node.clientWidth),
-        height: Math.max(1, node.clientHeight),
-      });
-    };
-
-    updatePickerSize();
-    resizeObserverRef.current = new ResizeObserver(updatePickerSize);
-    resizeObserverRef.current.observe(node);
-  }, []);
 
   const syncCenter = useCallback((nextCenter: LatLng) => {
     centerRef.current = nextCenter;
@@ -300,6 +188,46 @@ export function MapReferenceDialog({
     setRotationDeg(safeRotation);
   }, []);
 
+  const { setPickerNode, tileLayerRef, pickerSize } = usePickerGesture({
+    centerRef,
+    zoomRef,
+    rotationRef,
+    syncCenter,
+    syncZoom,
+  });
+
+  const {
+    searchPanelRef,
+    locationQuery,
+    setLocationQuery,
+    locationResults,
+    locationSearchError,
+    locationSearchPending,
+    handleLocationSearch,
+    selectLocationResult,
+    clearResults,
+  } = useLocationSearch({ centerRef, zoomRef, syncCenter, syncZoom });
+
+  const metersPerPixel = metersPerPixelAtLatitude(center.lat, zoom);
+  const fieldWidthPx = field.width / metersPerPixel;
+  const fieldHeightPx = field.height / metersPerPixel;
+  const tiles = useMemo(
+    () =>
+      getVisibleTiles({
+        coverageHeight: Math.ceil(
+          Math.hypot(pickerSize.width, pickerSize.height)
+        ),
+        coverageWidth: Math.ceil(
+          Math.hypot(pickerSize.width, pickerSize.height)
+        ),
+        center,
+        height: pickerSize.height,
+        width: pickerSize.width,
+        zoom,
+      }),
+    [center, pickerSize.height, pickerSize.width, zoom]
+  );
+
   const applyTypedCenter = () => {
     const lat = Number(latInput);
     const lng = Number(lngInput);
@@ -307,449 +235,359 @@ export function MapReferenceDialog({
     syncCenter({ lat: clampLatitude(lat), lng: normalizeLongitude(lng) });
   };
 
-  const panByScreenPixels = useCallback(
-    ({ dx, dy }: { dx: number; dy: number }) => {
-      const panDelta = screenDeltaToMapPixelDelta({
-        dx,
-        dy,
-        rotationDeg: rotationRef.current,
-      });
-      syncCenter(
-        panLatLngByPixels({
-          center: centerRef.current,
-          dx: panDelta.dx,
-          dy: panDelta.dy,
-          zoom: zoomRef.current,
-        })
-      );
-    },
-    [syncCenter]
-  );
-
-  useEffect(() => {
-    if (!pickerElement) return;
-
-    const handleWheel = (event: WheelEvent) => {
-      event.preventDefault();
-      event.stopPropagation();
-
-      const deltaX = normalizeWheelDelta(event.deltaX, event.deltaMode);
-      const deltaY = normalizeWheelDelta(event.deltaY, event.deltaMode);
-
-      if (event.ctrlKey) {
-        syncZoom(zoomRef.current - deltaY * PINCH_ZOOM_FACTOR);
-        return;
-      }
-
-      panByScreenPixels({
-        dx: -deltaX * WHEEL_PAN_FACTOR,
-        dy: -deltaY * WHEEL_PAN_FACTOR,
-      });
-    };
-
-    const handleGestureStart = (event: Event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      gestureScaleRef.current = 1;
-    };
-
-    const handleGestureChange = (event: Event) => {
-      event.preventDefault();
-      event.stopPropagation();
-
-      const gestureEvent = event as WebKitGestureEvent;
-      const nextScale = gestureEvent.scale ?? 1;
-      const zoomDelta = Math.log2(nextScale / gestureScaleRef.current);
-      gestureScaleRef.current = nextScale;
-      if (!Number.isFinite(zoomDelta) || zoomDelta === 0) return;
-
-      syncZoom(zoomRef.current + zoomDelta);
-    };
-
-    const handleGestureEnd = (event: Event) => {
-      event.preventDefault();
-      event.stopPropagation();
-      gestureScaleRef.current = 1;
-    };
-
-    pickerElement.addEventListener("wheel", handleWheel, { passive: false });
-    pickerElement.addEventListener("gesturestart", handleGestureStart, {
-      passive: false,
-    });
-    pickerElement.addEventListener("gesturechange", handleGestureChange, {
-      passive: false,
-    });
-    pickerElement.addEventListener("gestureend", handleGestureEnd, {
-      passive: false,
-    });
-
-    return () => {
-      pickerElement.removeEventListener("wheel", handleWheel);
-      pickerElement.removeEventListener("gesturestart", handleGestureStart);
-      pickerElement.removeEventListener("gesturechange", handleGestureChange);
-      pickerElement.removeEventListener("gestureend", handleGestureEnd);
-    };
-  }, [panByScreenPixels, pickerElement, syncZoom]);
-
-  useEffect(() => {
-    if (!pickerElement) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      pickerElement.setPointerCapture(event.pointerId);
-      const pointerId = event.pointerId;
-      dragRef.current = {
-        lastX: event.clientX,
-        lastY: event.clientY,
-        moved: false,
-        totalDx: 0,
-        totalDy: 0,
-      };
-
-      const handleMove = (e: PointerEvent) => {
-        if (e.pointerId !== pointerId || !dragRef.current) return;
-        const dx = e.clientX - dragRef.current.lastX;
-        const dy = e.clientY - dragRef.current.lastY;
-        if (Math.abs(dx) + Math.abs(dy) > 1) dragRef.current.moved = true;
-        dragRef.current.lastX = e.clientX;
-        dragRef.current.lastY = e.clientY;
-        dragRef.current.totalDx += dx;
-        dragRef.current.totalDy += dy;
-        if (tileLayerRef.current) {
-          tileLayerRef.current.style.transform = `translate(${dragRef.current.totalDx}px, ${dragRef.current.totalDy}px) rotate(${-rotationRef.current}deg)`;
-        }
-      };
-
-      const finish = (e: PointerEvent) => {
-        if (e.pointerId !== pointerId) return;
-        pickerElement.removeEventListener("pointermove", handleMove);
-        pickerElement.removeEventListener("pointerup", finish);
-        pickerElement.removeEventListener("pointercancel", finish);
-
-        const dragState = dragRef.current;
-        dragRef.current = null;
-        if (tileLayerRef.current) {
-          tileLayerRef.current.style.transform = `rotate(${-rotationRef.current}deg)`;
-        }
-        if (!dragState) return;
-        if (dragState.moved) {
-          panByScreenPixels({ dx: dragState.totalDx, dy: dragState.totalDy });
-          return;
-        }
-        const rect = pickerElement.getBoundingClientRect();
-        const centerPixel = latLngToGlobalPixel(
-          centerRef.current.lat,
-          centerRef.current.lng,
-          zoomRef.current
-        );
-        const clickDelta = screenDeltaToMapPixelDelta({
-          dx: e.clientX - rect.left - rect.width / 2,
-          dy: e.clientY - rect.top - rect.height / 2,
-          rotationDeg: rotationRef.current,
-        });
-        syncCenter(
-          globalPixelToLatLng(
-            {
-              x: centerPixel.x + clickDelta.dx,
-              y: centerPixel.y + clickDelta.dy,
-            },
-            zoomRef.current
-          )
-        );
-      };
-
-      pickerElement.addEventListener("pointermove", handleMove);
-      pickerElement.addEventListener("pointerup", finish);
-      pickerElement.addEventListener("pointercancel", finish);
-    };
-
-    pickerElement.addEventListener("pointerdown", handlePointerDown);
-    return () =>
-      pickerElement.removeEventListener("pointerdown", handlePointerDown);
-  }, [panByScreenPixels, pickerElement, syncCenter]);
-
-  useEffect(() => {
-    if (!locationSearchError && locationResults.length === 0) return;
-
-    const closeSearchResults = (event: PointerEvent) => {
-      const target = event.target;
-      if (target instanceof Node && searchPanelRef.current?.contains(target)) {
-        return;
-      }
-
-      setLocationResults([]);
-      setLocationSearchError(null);
-    };
-
-    document.addEventListener("pointerdown", closeSearchResults);
-    return () =>
-      document.removeEventListener("pointerdown", closeSearchResults);
-  }, [locationResults.length, locationSearchError]);
-
   const handleLocate = () => {
-    if (typeof navigator === "undefined" || !navigator.geolocation) return;
-    navigator.geolocation.getCurrentPosition((position) => {
-      syncCenter({
-        lat: position.coords.latitude,
-        lng: position.coords.longitude,
-      });
-      syncZoom(Math.max(zoomRef.current, 18));
-    });
-  };
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      setLocateError("Location is unavailable in this browser.");
+      return;
+    }
 
-  const jumpToLocation = (location: LatLng, nextZoom = 18) => {
-    syncCenter({
-      lat: clampLatitude(location.lat),
-      lng: normalizeLongitude(location.lng),
-    });
-    syncZoom(Math.max(zoomRef.current, nextZoom));
-  };
+    setLocatePending(true);
+    setLocateError(null);
 
-  const searchLocations = useCallback(
-    async (query: string, signal?: AbortSignal) => {
-      const params = new URLSearchParams({
-        f: "json",
-        SingleLine: query,
-        maxLocations: "5",
-        outFields: "PlaceName,City,Region,Country",
-        location: `${centerRef.current.lng},${centerRef.current.lat}`,
-      });
-      const response = await fetch(
-        `https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?${params.toString()}`,
-        { signal }
-      );
-      if (!response.ok) {
-        throw new Error("Location search failed");
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        syncCenter({
+          lat: clampLatitude(position.coords.latitude),
+          lng: normalizeLongitude(position.coords.longitude),
+        });
+        syncZoom(Math.max(zoomRef.current, 18));
+        setLocatePending(false);
+      },
+      (error) => {
+        if (error.code === error.PERMISSION_DENIED) {
+          setLocateError("Location permission was denied.");
+        } else if (error.code === error.TIMEOUT) {
+          setLocateError("Location lookup timed out.");
+        } else {
+          setLocateError("Could not determine your location.");
+        }
+        setLocatePending(false);
+      },
+      {
+        enableHighAccuracy: true,
+        maximumAge: 60_000,
+        timeout: 12_000,
       }
+    );
+  };
 
-      const payload = (await response.json()) as {
-        candidates?: Array<{
-          address?: unknown;
-          location?: { x?: unknown; y?: unknown };
-          score?: unknown;
-        }>;
-      };
+  const stopPickerControlPointer = (event: ReactPointerEvent<HTMLElement>) => {
+    event.stopPropagation();
+  };
 
-      return (payload.candidates ?? [])
-        .filter(
-          (candidate) =>
-            typeof candidate.location?.x === "number" &&
-            typeof candidate.location.y === "number"
-        )
-        .map((candidate, index) => ({
-          address:
-            typeof candidate.address === "string"
-              ? candidate.address
-              : "Unknown location",
-          id: `${candidate.location?.x}-${candidate.location?.y}-${index}`,
-          lat: clampLatitude(candidate.location?.y as number),
-          lng: normalizeLongitude(candidate.location?.x as number),
-          score: typeof candidate.score === "number" ? candidate.score : 0,
-        }));
-    },
-    []
+  const handleSave = () => {
+    const nextReference = createReference({ center, rotationDeg, zoom });
+    onConfirm({
+      ...nextReference,
+      opacity: initialReference?.opacity ?? nextReference.opacity,
+      visible: initialReference?.visible ?? nextReference.visible,
+    });
+    onOpenChange(false);
+  };
+
+  const renderSearchPanel = (mobile = false) => (
+    <div
+      ref={searchPanelRef}
+      data-vaul-no-drag
+      className={mobile ? "relative z-30" : "relative z-20"}
+      onPointerDown={(event) => event.stopPropagation()}
+      onPointerMove={(event) => event.stopPropagation()}
+      onPointerUp={(event) => event.stopPropagation()}
+    >
+      <div className="relative">
+        <Search className="text-muted-foreground/65 pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+        <Input
+          value={locationQuery}
+          onChange={(event) => setLocationQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              void handleLocationSearch();
+            }
+            if (event.key === "Escape") {
+              clearResults();
+              event.currentTarget.blur();
+            }
+          }}
+          placeholder="Search place or paste coordinates"
+          className={
+            mobile
+              ? "border-border/45 bg-muted/30 focus-visible:bg-background h-9 rounded-md pr-16 pl-8 text-[13px] shadow-none"
+              : "border-border/45 bg-muted/30 focus-visible:bg-background h-8 rounded-md pr-16 pl-8 text-[12px] shadow-none"
+          }
+        />
+        <span className="text-muted-foreground/65 pointer-events-none absolute top-1/2 right-2 -translate-y-1/2 text-[10px] font-medium">
+          {locationSearchPending ? "Searching" : "Enter"}
+        </span>
+      </div>
+      {locationSearchError || locationResults.length > 0 ? (
+        <div
+          className={`border-border/45 bg-background absolute top-[calc(100%+0.25rem)] right-0 left-0 z-30 overflow-y-auto rounded-md border shadow-lg ${
+            mobile ? "max-h-[min(16rem,42dvh)]" : "max-h-56"
+          }`}
+        >
+          {locationSearchError ? (
+            <p className="text-muted-foreground px-3 py-2 text-[11px] leading-relaxed">
+              {locationSearchError}
+            </p>
+          ) : null}
+          {locationResults.map((result) => (
+            <button
+              key={result.id}
+              type="button"
+              data-vaul-no-drag
+              className="hover:bg-muted/35 flex w-full flex-col items-start px-3 py-2 text-left transition-colors"
+              onClick={() => selectLocationResult(result)}
+            >
+              <span className="text-foreground line-clamp-2 text-[11px] font-medium">
+                {result.address}
+              </span>
+              <span className="text-muted-foreground/70 mt-0.5 font-mono text-[10px]">
+                {result.lat.toFixed(5)}, {result.lng.toFixed(5)}
+              </span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
   );
 
-  useEffect(() => {
-    const query = locationQuery.trim();
-    locationSearchAbortRef.current?.abort();
-
-    if (!query) {
-      setLocationResults([]);
-      setLocationSearchError(null);
-      setLocationSearchPending(false);
-      return;
-    }
-
-    if (query === selectedLocationLabel) return;
-
-    const coordinateLocation = parseCoordinateQuery(query);
-    if (coordinateLocation) {
-      setLocationResults([]);
-      setLocationSearchError(null);
-      setLocationSearchPending(false);
-      return;
-    }
-
-    if (query.length < LOCATION_SEARCH_MIN_LENGTH) {
-      setLocationResults([]);
-      setLocationSearchError(null);
-      setLocationSearchPending(false);
-      return;
-    }
-
-    const controller = new AbortController();
-    locationSearchAbortRef.current = controller;
-    setLocationSearchError(null);
-    setLocationSearchPending(true);
-
-    const timeout = window.setTimeout(() => {
-      void searchLocations(query, controller.signal)
-        .then((results) => {
-          setLocationResults(results);
-          setLocationSearchError(
-            results.length === 0 ? "No locations found." : null
-          );
-        })
-        .catch((error: unknown) => {
-          if (error instanceof DOMException && error.name === "AbortError") {
-            return;
-          }
-          setLocationResults([]);
-          setLocationSearchError("Location search is unavailable.");
-        })
-        .finally(() => {
-          if (!controller.signal.aborted) {
-            setLocationSearchPending(false);
-          }
-        });
-    }, LOCATION_SEARCH_DEBOUNCE_MS);
-
-    return () => {
-      window.clearTimeout(timeout);
-      controller.abort();
-    };
-  }, [locationQuery, searchLocations, selectedLocationLabel]);
-
-  const handleLocationSearch = async () => {
-    const query = locationQuery.trim();
-    if (!query || locationSearchPending) return;
-
-    const coordinateLocation = parseCoordinateQuery(query);
-    if (coordinateLocation) {
-      setLocationResults([]);
-      setLocationSearchError(null);
-      jumpToLocation(coordinateLocation);
-      return;
-    }
-
-    if (query.length < LOCATION_SEARCH_MIN_LENGTH) return;
-
-    locationSearchAbortRef.current?.abort();
-    setLocationSearchPending(true);
-    setLocationSearchError(null);
-
-    try {
-      const results = await searchLocations(query);
-      setLocationResults(results);
-      if (results.length === 0) {
-        setLocationSearchError("No locations found.");
-      }
-    } catch {
-      setLocationSearchError("Location search is unavailable.");
-    } finally {
-      setLocationSearchPending(false);
-    }
-  };
-
-  const mapEditor = (
-    <div className="grid min-h-0 gap-0 overflow-y-auto p-3 lg:grid-cols-[minmax(0,1fr)_210px] lg:overflow-hidden">
-      <div className="min-w-0 space-y-2 lg:pr-3">
-        <div
-          ref={searchPanelRef}
-          className="relative z-20"
-          onPointerDown={(event) => event.stopPropagation()}
-          onPointerMove={(event) => event.stopPropagation()}
-          onPointerUp={(event) => event.stopPropagation()}
-        >
-          <div className="relative">
-            <Search className="text-muted-foreground/65 pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
-            <Input
-              value={locationQuery}
-              onChange={(event) => setLocationQuery(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") {
-                  event.preventDefault();
-                  void handleLocationSearch();
-                }
-                if (event.key === "Escape") {
-                  setLocationResults([]);
-                  setLocationSearchError(null);
-                  event.currentTarget.blur();
-                }
-              }}
-              placeholder="Search place or paste coordinates"
-              className="border-border/45 bg-muted/30 focus-visible:bg-background h-8 rounded-md pr-16 pl-8 text-[12px] shadow-none"
-            />
-            <span className="text-muted-foreground/65 pointer-events-none absolute top-1/2 right-2 -translate-y-1/2 text-[10px] font-medium">
-              {locationSearchPending ? "Searching" : "Enter"}
-            </span>
-          </div>
-          {locationSearchError || locationResults.length > 0 ? (
-            <div className="border-border/45 bg-background absolute top-[calc(100%+0.25rem)] right-0 left-0 z-30 max-h-56 overflow-y-auto rounded-md border shadow-lg">
-              {locationSearchError ? (
-                <p className="text-muted-foreground px-3 py-2 text-[11px] leading-relaxed">
-                  {locationSearchError}
-                </p>
-              ) : null}
-              {locationResults.map((result) => (
-                <button
-                  key={result.id}
-                  type="button"
-                  className="hover:bg-muted/35 flex w-full flex-col items-start px-3 py-2 text-left transition-colors"
-                  onClick={() => {
-                    setLocationQuery(result.address);
-                    setSelectedLocationLabel(result.address);
-                    setLocationResults([]);
-                    jumpToLocation({
-                      lat: result.lat,
-                      lng: result.lng,
-                    });
-                  }}
-                >
-                  <span className="text-foreground line-clamp-2 text-[11px] font-medium">
-                    {result.address}
-                  </span>
-                  <span className="text-muted-foreground/70 mt-0.5 font-mono text-[10px]">
-                    {result.lat.toFixed(5)}, {result.lng.toFixed(5)}
-                  </span>
-                </button>
-              ))}
-            </div>
-          ) : null}
-        </div>
-        <div
-          ref={setPickerNode}
-          data-vaul-no-drag
-          className="border-border/55 bg-muted/30 relative h-[min(56vh,430px)] min-h-70 cursor-grab overflow-hidden rounded-lg border active:cursor-grabbing lg:h-125"
-          style={{ touchAction: "none" }}
-        >
-          <div
-            ref={tileLayerRef}
-            className="pointer-events-none absolute inset-0"
+  const renderPicker = (mobile = false) => (
+    <div
+      ref={setPickerNode}
+      data-vaul-no-drag
+      className={`border-border/55 bg-muted/30 relative cursor-grab overflow-hidden rounded-lg border active:cursor-grabbing ${
+        mobile
+          ? "h-[42dvh] max-h-[24rem] min-h-[15rem]"
+          : "h-[min(56vh,430px)] min-h-70 lg:h-125"
+      }`}
+      style={{ touchAction: "none" }}
+    >
+      <div
+        ref={tileLayerRef}
+        className="pointer-events-none absolute inset-0"
+        style={{
+          transform: `rotate(${-rotationDeg}deg)`,
+          transformOrigin: "50% 50%",
+        }}
+      >
+        {tiles.map((tile) => (
+          <img
+            key={tile.key}
+            src={tile.url}
+            alt=""
+            draggable={false}
+            className="pointer-events-none absolute select-none"
             style={{
-              transform: `rotate(${-rotationDeg}deg)`,
-              transformOrigin: "50% 50%",
-            }}
-          >
-            {tiles.map((tile) => (
-              <img
-                key={tile.key}
-                src={tile.url}
-                alt=""
-                draggable={false}
-                className="pointer-events-none absolute select-none"
-                style={{
-                  left: tile.left,
-                  top: tile.top,
-                  width: tile.size,
-                  height: tile.size,
-                }}
-              />
-            ))}
-          </div>
-          <div
-            className="pointer-events-none absolute top-1/2 left-1/2 border-2 border-sky-400/90 bg-sky-400/10 shadow-[0_0_0_9999px_rgba(15,23,42,0.12)]"
-            style={{
-              width: fieldWidthPx,
-              height: fieldHeightPx,
-              transform: "translate(-50%, -50%)",
+              left: tile.left,
+              top: tile.top,
+              width: tile.size,
+              height: tile.size,
             }}
           />
-          <div className="pointer-events-none absolute top-1/2 left-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-sky-500 shadow" />
-          <div className="bg-background/92 text-muted-foreground absolute right-2 bottom-2 left-2 rounded-md px-2 py-1 text-[9px] leading-snug shadow-sm backdrop-blur-sm lg:right-auto lg:max-w-[70%] lg:text-[10px]">
-            {mapReferenceProvider.styles.satellite.attribution}
+        ))}
+      </div>
+      <div
+        className="pointer-events-none absolute top-1/2 left-1/2 border-2 border-sky-400/90 bg-sky-400/10 shadow-[0_0_0_9999px_rgba(15,23,42,0.12)]"
+        style={{
+          width: fieldWidthPx,
+          height: fieldHeightPx,
+          transform: "translate(-50%, -50%)",
+        }}
+      />
+      <div className="pointer-events-none absolute top-1/2 left-1/2 size-3 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-sky-500 shadow" />
+      {mobile ? (
+        <>
+          <div className="bg-background/92 text-muted-foreground absolute top-2 left-2 z-10 rounded-md px-2 py-1 text-[10px] font-medium shadow-sm backdrop-blur-sm">
+            Zoom {zoom.toFixed(1)}
+          </div>
+          <div
+            className="absolute top-2 right-2 z-10 flex flex-col gap-1.5"
+            onPointerDown={stopPickerControlPointer}
+            onPointerMove={stopPickerControlPointer}
+            onPointerUp={stopPickerControlPointer}
+          >
+            <Button
+              type="button"
+              variant="outline"
+              size="icon-sm"
+              className="bg-background/92 shadow-sm backdrop-blur-sm"
+              onClick={() => syncZoom(zoomRef.current + 1)}
+              aria-label="Zoom in"
+            >
+              <Plus />
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="icon-sm"
+              className="bg-background/92 shadow-sm backdrop-blur-sm"
+              onClick={() => syncZoom(zoomRef.current - 1)}
+              aria-label="Zoom out"
+            >
+              <Minus />
+            </Button>
+          </div>
+        </>
+      ) : null}
+      <div className="bg-background/92 text-muted-foreground absolute right-2 bottom-2 left-2 rounded-md px-2 py-1 text-[9px] leading-snug shadow-sm backdrop-blur-sm lg:right-auto lg:max-w-[70%] lg:text-[10px]">
+        {mapReferenceProvider.styles.satellite.attribution}
+      </div>
+    </div>
+  );
+
+  const renderCoordinateInputs = () => (
+    <div className="space-y-2">
+      <label className="block space-y-2">
+        <span className="text-muted-foreground text-[11px] font-medium">
+          Latitude
+        </span>
+        <Input
+          value={latInput}
+          onChange={(event) => setLatInput(event.target.value)}
+          onBlur={applyTypedCenter}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") applyTypedCenter();
+          }}
+        />
+      </label>
+      <label className="block space-y-2">
+        <span className="text-muted-foreground text-[11px] font-medium">
+          Longitude
+        </span>
+        <Input
+          value={lngInput}
+          onChange={(event) => setLngInput(event.target.value)}
+          onBlur={applyTypedCenter}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") applyTypedCenter();
+          }}
+        />
+      </label>
+    </div>
+  );
+
+  const renderRotationControl = (mobile = false) => {
+    const nudgeRotation = (delta: number) => {
+      syncRotation(rotationRef.current + delta);
+    };
+
+    if (mobile) {
+      return (
+        <div className="space-y-2.5">
+          <div className="flex items-center justify-between gap-3">
+            <label className="text-muted-foreground text-[11px] font-medium">
+              Rotation
+            </label>
+            <div className="flex items-center gap-2">
+              <span className="bg-muted/35 text-muted-foreground flex h-7 min-w-16 items-center justify-center rounded-md px-2 font-mono text-[11px]">
+                {Math.round(rotationDeg)} deg
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => syncRotation(0)}
+                aria-label="Reset rotation"
+              >
+                <RotateCcw />
+              </Button>
+            </div>
+          </div>
+
+          <input
+            type="range"
+            min={0}
+            max={359}
+            step={1}
+            value={rotationDeg}
+            onChange={(event) => syncRotation(Number(event.target.value))}
+            className="accent-primary h-7 w-full"
+          />
+
+          <div className="grid grid-cols-4 gap-1.5">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => nudgeRotation(-15)}
+              aria-label="Rotate left 15 degrees"
+            >
+              -15
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => nudgeRotation(-1)}
+              aria-label="Rotate left 1 degree"
+            >
+              -1
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => nudgeRotation(1)}
+              aria-label="Rotate right 1 degree"
+            >
+              +1
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => nudgeRotation(15)}
+              aria-label="Rotate right 15 degrees"
+            >
+              +15
+            </Button>
           </div>
         </div>
+      );
+    }
+
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center justify-between gap-3">
+          <label className="text-muted-foreground text-[11px] font-medium">
+            Rotation
+          </label>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={() => syncRotation(0)}
+            aria-label="Reset rotation"
+          >
+            <RotateCcw />
+          </Button>
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={359}
+          step={1}
+          value={rotationDeg}
+          onChange={(event) => syncRotation(Number(event.target.value))}
+          className="accent-primary w-full"
+        />
+        <Input
+          type="number"
+          min={0}
+          max={359}
+          value={Math.round(rotationDeg)}
+          onChange={(event) => syncRotation(Number(event.target.value))}
+        />
+      </div>
+    );
+  };
+
+  const desktopMapEditor = (
+    <div className="grid min-h-0 gap-0 overflow-y-auto p-3 lg:grid-cols-[minmax(0,1fr)_210px] lg:overflow-hidden">
+      <div className="min-w-0 space-y-2 lg:pr-3">
+        {renderSearchPanel()}
+        {renderPicker()}
       </div>
 
       <div className="border-border/40 mt-3 space-y-4 lg:mt-0 lg:border-l lg:pl-3">
@@ -793,75 +631,60 @@ export function MapReferenceDialog({
             variant="outline"
             size="sm"
             className="w-full"
+            disabled={locatePending}
             onClick={handleLocate}
           >
             <LocateFixed />
-            Use location
+            {locatePending ? "Locating" : "Use location"}
           </Button>
-
-          <div className="hidden space-y-2 lg:block">
-            <label className="text-muted-foreground text-[11px] font-medium">
-              Latitude
-            </label>
-            <Input
-              value={latInput}
-              onChange={(event) => setLatInput(event.target.value)}
-              onBlur={applyTypedCenter}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") applyTypedCenter();
-              }}
-            />
-            <label className="text-muted-foreground text-[11px] font-medium">
-              Longitude
-            </label>
-            <Input
-              value={lngInput}
-              onChange={(event) => setLngInput(event.target.value)}
-              onBlur={applyTypedCenter}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") applyTypedCenter();
-              }}
-            />
-          </div>
+          {locateError ? (
+            <p className="text-muted-foreground text-[11px] leading-relaxed">
+              {locateError}
+            </p>
+          ) : null}
+          {renderCoordinateInputs()}
         </div>
 
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <label className="text-muted-foreground text-[11px] font-medium">
-              Rotation
-            </label>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              onClick={() => syncRotation(0)}
-              aria-label="Reset rotation"
-            >
-              <RotateCcw />
-            </Button>
-          </div>
-          <input
-            type="range"
-            min={0}
-            max={359}
-            step={1}
-            value={rotationDeg}
-            onChange={(event) => syncRotation(Number(event.target.value))}
-            className="accent-primary w-full"
-          />
-          <Input
-            type="number"
-            min={0}
-            max={359}
-            value={Math.round(rotationDeg)}
-            onChange={(event) => syncRotation(Number(event.target.value))}
-          />
-        </div>
+        {renderRotationControl()}
       </div>
     </div>
   );
 
-  const actions = (
+  const mobileMapEditor = (
+    <div data-vaul-no-drag className="min-h-0 space-y-3 p-3 pb-4">
+      {renderSearchPanel(true)}
+      {renderPicker(true)}
+
+      <div className="border-border/30 space-y-3 border-t pt-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-muted-foreground text-[11px] font-medium">
+            Center
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={locatePending}
+            onClick={handleLocate}
+          >
+            <LocateFixed />
+            {locatePending ? "Locating" : "Use location"}
+          </Button>
+        </div>
+        {locateError ? (
+          <p className="text-muted-foreground text-[11px] leading-relaxed">
+            {locateError}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="border-border/30 border-t pt-3">
+        {renderRotationControl(true)}
+      </div>
+    </div>
+  );
+
+  const desktopActions = (
     <>
       <Button
         type="button"
@@ -870,21 +693,21 @@ export function MapReferenceDialog({
       >
         Cancel
       </Button>
-      <Button
-        type="button"
-        onClick={() => {
-          const nextReference = createReference({ center, rotationDeg, zoom });
-          onConfirm({
-            ...nextReference,
-            opacity: initialReference?.opacity ?? nextReference.opacity,
-            visible: initialReference?.visible ?? nextReference.visible,
-          });
-          onOpenChange(false);
-        }}
-      >
+      <Button type="button" onClick={handleSave}>
         Save map
       </Button>
     </>
+  );
+
+  const mobileFooter = (
+    <div
+      data-vaul-no-drag
+      className="border-border/40 bg-card/96 shrink-0 border-t px-4 py-3 pb-[max(env(safe-area-inset-bottom),0.75rem)] backdrop-blur-xs"
+    >
+      <Button type="button" className="w-full" onClick={handleSave}>
+        Save map
+      </Button>
+    </div>
   );
 
   if (!isDesktop) {
@@ -895,12 +718,12 @@ export function MapReferenceDialog({
         title="Map reference"
         subtitle="Choose the field center and align the field footprint."
         contentClassName="data-[vaul-drawer-direction=bottom]:mt-8 data-[vaul-drawer-direction=bottom]:max-h-[94dvh]"
-        bodyClassName="p-0"
+        bodyClassName="min-h-0 overscroll-contain p-0"
+        footerContent={mobileFooter}
+        nested
+        repositionInputs={false}
       >
-        {mapEditor}
-        <div className="border-border/40 bg-muted/35 flex flex-col-reverse gap-2 border-t px-4 py-3 sm:flex-row sm:justify-end">
-          {actions}
-        </div>
+        {mobileMapEditor}
       </MobileDrawer>
     );
   }
@@ -918,10 +741,10 @@ export function MapReferenceDialog({
           </DialogDescription>
         </DialogHeader>
 
-        {mapEditor}
+        {desktopMapEditor}
 
         <DialogFooter className="bg-muted/35 mx-0 mb-0 rounded-none border-t px-4 py-3">
-          {actions}
+          {desktopActions}
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/map-reference/useLocationSearch.ts
+++ b/src/components/map-reference/useLocationSearch.ts
@@ -1,0 +1,264 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  clampLatitude,
+  normalizeLongitude,
+  type LatLng,
+} from "@/lib/map-reference/geometry";
+
+const LOCATION_SEARCH_DEBOUNCE_MS = 350;
+const LOCATION_SEARCH_MIN_LENGTH = 3;
+
+export interface LocationSearchResult {
+  address: string;
+  id: string;
+  lat: number;
+  lng: number;
+  score: number;
+}
+
+function parseCoordinateQuery(query: string): LatLng | null {
+  const matches = query.match(/-?\d+(?:[.,]\d+)?/g);
+  if (!matches || matches.length < 2) return null;
+
+  const first = Number(matches[0].replace(",", "."));
+  const second = Number(matches[1].replace(",", "."));
+  if (!Number.isFinite(first) || !Number.isFinite(second)) return null;
+
+  if (Math.abs(first) <= 90 && Math.abs(second) <= 180) {
+    return {
+      lat: clampLatitude(first),
+      lng: normalizeLongitude(second),
+    };
+  }
+
+  if (Math.abs(first) <= 180 && Math.abs(second) <= 90) {
+    return {
+      lat: clampLatitude(second),
+      lng: normalizeLongitude(first),
+    };
+  }
+
+  return null;
+}
+
+export function useLocationSearch({
+  centerRef,
+  zoomRef,
+  syncCenter,
+  syncZoom,
+}: {
+  centerRef: { readonly current: LatLng };
+  zoomRef: { readonly current: number };
+  syncCenter: (center: LatLng) => void;
+  syncZoom: (zoom: number) => void;
+}) {
+  const searchPanelRef = useRef<HTMLDivElement | null>(null);
+  const locationSearchAbortRef = useRef<AbortController | null>(null);
+  const [locationQuery, setLocationQuery] = useState("");
+  const [locationResults, setLocationResults] = useState<
+    LocationSearchResult[]
+  >([]);
+  const [locationSearchError, setLocationSearchError] = useState<string | null>(
+    null
+  );
+  const [locationSearchPending, setLocationSearchPending] = useState(false);
+  const [selectedLocationLabel, setSelectedLocationLabel] = useState("");
+
+  const jumpToLocation = useCallback(
+    (location: LatLng, nextZoom = 18) => {
+      syncCenter({
+        lat: clampLatitude(location.lat),
+        lng: normalizeLongitude(location.lng),
+      });
+      syncZoom(Math.max(zoomRef.current, nextZoom));
+    },
+    [syncCenter, syncZoom, zoomRef]
+  );
+
+  const searchLocations = useCallback(
+    async (query: string, signal?: AbortSignal) => {
+      const params = new URLSearchParams({
+        f: "json",
+        SingleLine: query,
+        maxLocations: "5",
+        outFields: "PlaceName,City,Region,Country",
+        location: `${centerRef.current.lng},${centerRef.current.lat}`,
+      });
+      const response = await fetch(
+        `https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/findAddressCandidates?${params.toString()}`,
+        { signal }
+      );
+      if (!response.ok) {
+        throw new Error("Location search failed");
+      }
+
+      const payload = (await response.json()) as {
+        candidates?: Array<{
+          address?: unknown;
+          location?: { x?: unknown; y?: unknown };
+          score?: unknown;
+        }>;
+      };
+
+      return (payload.candidates ?? [])
+        .filter(
+          (candidate) =>
+            typeof candidate.location?.x === "number" &&
+            typeof candidate.location.y === "number"
+        )
+        .map((candidate, index) => ({
+          address:
+            typeof candidate.address === "string"
+              ? candidate.address
+              : "Unknown location",
+          id: `${candidate.location?.x}-${candidate.location?.y}-${index}`,
+          lat: clampLatitude(candidate.location?.y as number),
+          lng: normalizeLongitude(candidate.location?.x as number),
+          score: typeof candidate.score === "number" ? candidate.score : 0,
+        }));
+    },
+    [centerRef]
+  );
+
+  useEffect(() => {
+    if (!locationSearchError && locationResults.length === 0) return;
+
+    const closeSearchResults = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && searchPanelRef.current?.contains(target)) {
+        return;
+      }
+
+      setLocationResults([]);
+      setLocationSearchError(null);
+    };
+
+    document.addEventListener("pointerdown", closeSearchResults);
+    return () =>
+      document.removeEventListener("pointerdown", closeSearchResults);
+  }, [locationResults.length, locationSearchError]);
+
+  useEffect(() => {
+    const query = locationQuery.trim();
+    locationSearchAbortRef.current?.abort();
+
+    if (!query) {
+      setLocationResults([]);
+      setLocationSearchError(null);
+      setLocationSearchPending(false);
+      return;
+    }
+
+    if (query === selectedLocationLabel) return;
+
+    const coordinateLocation = parseCoordinateQuery(query);
+    if (coordinateLocation) {
+      setLocationResults([]);
+      setLocationSearchError(null);
+      setLocationSearchPending(false);
+      return;
+    }
+
+    if (query.length < LOCATION_SEARCH_MIN_LENGTH) {
+      setLocationResults([]);
+      setLocationSearchError(null);
+      setLocationSearchPending(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    locationSearchAbortRef.current = controller;
+    setLocationSearchError(null);
+    setLocationSearchPending(true);
+
+    const timeout = window.setTimeout(() => {
+      void searchLocations(query, controller.signal)
+        .then((results) => {
+          setLocationResults(results);
+          setLocationSearchError(
+            results.length === 0 ? "No locations found." : null
+          );
+        })
+        .catch((error: unknown) => {
+          if (error instanceof DOMException && error.name === "AbortError") {
+            return;
+          }
+          setLocationResults([]);
+          setLocationSearchError("Location search is unavailable.");
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setLocationSearchPending(false);
+          }
+        });
+    }, LOCATION_SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      window.clearTimeout(timeout);
+      controller.abort();
+    };
+  }, [locationQuery, searchLocations, selectedLocationLabel]);
+
+  const handleLocationSearch = async () => {
+    const query = locationQuery.trim();
+    if (!query || locationSearchPending) return;
+
+    const coordinateLocation = parseCoordinateQuery(query);
+    if (coordinateLocation) {
+      setLocationResults([]);
+      setLocationSearchError(null);
+      jumpToLocation(coordinateLocation);
+      return;
+    }
+
+    if (query.length < LOCATION_SEARCH_MIN_LENGTH) return;
+
+    locationSearchAbortRef.current?.abort();
+    setLocationSearchPending(true);
+    setLocationSearchError(null);
+
+    try {
+      const results = await searchLocations(query);
+      setLocationResults(results);
+      if (results.length === 0) {
+        setLocationSearchError("No locations found.");
+      }
+    } catch {
+      setLocationSearchError("Location search is unavailable.");
+    } finally {
+      setLocationSearchPending(false);
+    }
+  };
+
+  const selectLocationResult = (result: LocationSearchResult) => {
+    setLocationQuery(result.address);
+    setSelectedLocationLabel(result.address);
+    setLocationResults([]);
+    setLocationSearchError(null);
+    jumpToLocation({ lat: result.lat, lng: result.lng });
+
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement) {
+      activeElement.blur();
+    }
+  };
+
+  const clearResults = () => {
+    setLocationResults([]);
+    setLocationSearchError(null);
+  };
+
+  return {
+    searchPanelRef,
+    locationQuery,
+    setLocationQuery,
+    locationResults,
+    locationSearchError,
+    locationSearchPending,
+    handleLocationSearch,
+    selectLocationResult,
+    clearResults,
+  };
+}

--- a/src/components/map-reference/usePickerGesture.ts
+++ b/src/components/map-reference/usePickerGesture.ts
@@ -1,0 +1,448 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  globalPixelToLatLng,
+  latLngToGlobalPixel,
+  panLatLngByPixels,
+  screenDeltaToMapPixelDelta,
+  type LatLng,
+} from "@/lib/map-reference/geometry";
+
+const PICKER_WIDTH = 760;
+const PICKER_HEIGHT = 430;
+const WHEEL_LINE_HEIGHT_PX = 16;
+const WHEEL_PAGE_HEIGHT_PX = 420;
+const WHEEL_PAN_FACTOR = 0.65;
+const PINCH_ZOOM_FACTOR = 0.008;
+
+interface PointerPosition {
+  x: number;
+  y: number;
+}
+
+interface PickerGestureState {
+  lastCentroid: PointerPosition | null;
+  lastDistance: number | null;
+  lastX: number;
+  lastY: number;
+  mode: "idle" | "single" | "multi";
+  moved: boolean;
+  pointers: Map<number, PointerPosition>;
+  suppressClick: boolean;
+  totalDx: number;
+  totalDy: number;
+}
+
+type WebKitGestureEvent = Event & {
+  clientX?: number;
+  clientY?: number;
+  scale?: number;
+};
+
+function normalizeWheelDelta(delta: number, deltaMode: number) {
+  if (deltaMode === 1) return delta * WHEEL_LINE_HEIGHT_PX;
+  if (deltaMode === 2) return delta * WHEEL_PAGE_HEIGHT_PX;
+  return delta;
+}
+
+function getPointerCentroid(
+  pointers: Map<number, PointerPosition>
+): PointerPosition | null {
+  if (pointers.size === 0) return null;
+
+  let x = 0;
+  let y = 0;
+  pointers.forEach((pointer) => {
+    x += pointer.x;
+    y += pointer.y;
+  });
+
+  return { x: x / pointers.size, y: y / pointers.size };
+}
+
+function getPointerDistance(pointers: Map<number, PointerPosition>) {
+  if (pointers.size < 2) return null;
+
+  const [first, second] = Array.from(pointers.values());
+  return Math.hypot(second.x - first.x, second.y - first.y);
+}
+
+export function usePickerGesture({
+  centerRef,
+  zoomRef,
+  rotationRef,
+  syncCenter,
+  syncZoom,
+}: {
+  centerRef: { readonly current: LatLng };
+  zoomRef: { readonly current: number };
+  rotationRef: { readonly current: number };
+  syncCenter: (center: LatLng) => void;
+  syncZoom: (zoom: number) => void;
+}) {
+  const pickerGestureRef = useRef<PickerGestureState>({
+    lastCentroid: null,
+    lastDistance: null,
+    lastX: 0,
+    lastY: 0,
+    mode: "idle",
+    moved: false,
+    pointers: new Map(),
+    suppressClick: false,
+    totalDx: 0,
+    totalDy: 0,
+  });
+  const tileLayerRef = useRef<HTMLDivElement | null>(null);
+  const gestureScaleRef = useRef(1);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const [pickerElement, setPickerElement] = useState<HTMLDivElement | null>(
+    null
+  );
+  const [pickerSize, setPickerSize] = useState({
+    width: PICKER_WIDTH,
+    height: PICKER_HEIGHT,
+  });
+
+  const setPickerNode = useCallback((node: HTMLDivElement | null) => {
+    resizeObserverRef.current?.disconnect();
+    resizeObserverRef.current = null;
+    setPickerElement(node);
+
+    if (!node) return;
+
+    const updatePickerSize = () => {
+      setPickerSize({
+        width: Math.max(1, node.clientWidth),
+        height: Math.max(1, node.clientHeight),
+      });
+    };
+
+    updatePickerSize();
+    resizeObserverRef.current = new ResizeObserver(updatePickerSize);
+    resizeObserverRef.current.observe(node);
+  }, []);
+
+  const panByScreenPixels = useCallback(
+    ({ dx, dy }: { dx: number; dy: number }) => {
+      const panDelta = screenDeltaToMapPixelDelta({
+        dx,
+        dy,
+        rotationDeg: rotationRef.current,
+      });
+      syncCenter(
+        panLatLngByPixels({
+          center: centerRef.current,
+          dx: panDelta.dx,
+          dy: panDelta.dy,
+          zoom: zoomRef.current,
+        })
+      );
+    },
+    [centerRef, rotationRef, syncCenter, zoomRef]
+  );
+
+  useEffect(() => {
+    if (!pickerElement) return;
+
+    const handleWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const deltaX = normalizeWheelDelta(event.deltaX, event.deltaMode);
+      const deltaY = normalizeWheelDelta(event.deltaY, event.deltaMode);
+
+      if (event.ctrlKey) {
+        syncZoom(zoomRef.current - deltaY * PINCH_ZOOM_FACTOR);
+        return;
+      }
+
+      panByScreenPixels({
+        dx: -deltaX * WHEEL_PAN_FACTOR,
+        dy: -deltaY * WHEEL_PAN_FACTOR,
+      });
+    };
+
+    const handleGestureStart = (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      gestureScaleRef.current = 1;
+    };
+
+    const handleGestureChange = (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const gestureEvent = event as WebKitGestureEvent;
+      const nextScale = gestureEvent.scale ?? 1;
+      const zoomDelta = Math.log2(nextScale / gestureScaleRef.current);
+      gestureScaleRef.current = nextScale;
+      if (!Number.isFinite(zoomDelta) || zoomDelta === 0) return;
+
+      syncZoom(zoomRef.current + zoomDelta);
+    };
+
+    const handleGestureEnd = (event: Event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      gestureScaleRef.current = 1;
+    };
+
+    pickerElement.addEventListener("wheel", handleWheel, { passive: false });
+    pickerElement.addEventListener("gesturestart", handleGestureStart, {
+      passive: false,
+    });
+    pickerElement.addEventListener("gesturechange", handleGestureChange, {
+      passive: false,
+    });
+    pickerElement.addEventListener("gestureend", handleGestureEnd, {
+      passive: false,
+    });
+
+    return () => {
+      pickerElement.removeEventListener("wheel", handleWheel);
+      pickerElement.removeEventListener("gesturestart", handleGestureStart);
+      pickerElement.removeEventListener("gesturechange", handleGestureChange);
+      pickerElement.removeEventListener("gestureend", handleGestureEnd);
+    };
+  }, [panByScreenPixels, pickerElement, syncZoom, zoomRef]);
+
+  useEffect(() => {
+    if (!pickerElement) return;
+
+    const resetTileLayerTransform = () => {
+      if (tileLayerRef.current) {
+        tileLayerRef.current.style.transform = `rotate(${-rotationRef.current}deg)`;
+      }
+    };
+
+    const commitSinglePointerPan = () => {
+      const gesture = pickerGestureRef.current;
+      if (gesture.totalDx !== 0 || gesture.totalDy !== 0) {
+        panByScreenPixels({ dx: gesture.totalDx, dy: gesture.totalDy });
+      }
+      gesture.totalDx = 0;
+      gesture.totalDy = 0;
+      resetTileLayerTransform();
+    };
+
+    const resetGesture = () => {
+      pickerGestureRef.current = {
+        lastCentroid: null,
+        lastDistance: null,
+        lastX: 0,
+        lastY: 0,
+        mode: "idle",
+        moved: false,
+        pointers: new Map(),
+        suppressClick: false,
+        totalDx: 0,
+        totalDy: 0,
+      };
+      resetTileLayerTransform();
+    };
+
+    const startSinglePointerGesture = (
+      pointer: PointerPosition,
+      suppressClick: boolean
+    ) => {
+      const gesture = pickerGestureRef.current;
+      gesture.lastCentroid = null;
+      gesture.lastDistance = null;
+      gesture.lastX = pointer.x;
+      gesture.lastY = pointer.y;
+      gesture.mode = "single";
+      gesture.moved = suppressClick;
+      gesture.suppressClick = suppressClick;
+      gesture.totalDx = 0;
+      gesture.totalDy = 0;
+    };
+
+    const startMultiPointerGesture = () => {
+      const gesture = pickerGestureRef.current;
+      gesture.lastCentroid = getPointerCentroid(gesture.pointers);
+      gesture.lastDistance = getPointerDistance(gesture.pointers);
+      gesture.mode = "multi";
+      gesture.moved = true;
+      gesture.suppressClick = true;
+      gesture.totalDx = 0;
+      gesture.totalDy = 0;
+      resetTileLayerTransform();
+    };
+
+    const handleSinglePointerTap = (event: PointerEvent) => {
+      const rect = pickerElement.getBoundingClientRect();
+      const centerPixel = latLngToGlobalPixel(
+        centerRef.current.lat,
+        centerRef.current.lng,
+        zoomRef.current
+      );
+      const clickDelta = screenDeltaToMapPixelDelta({
+        dx: event.clientX - rect.left - rect.width / 2,
+        dy: event.clientY - rect.top - rect.height / 2,
+        rotationDeg: rotationRef.current,
+      });
+      syncCenter(
+        globalPixelToLatLng(
+          {
+            x: centerPixel.x + clickDelta.dx,
+            y: centerPixel.y + clickDelta.dy,
+          },
+          zoomRef.current
+        )
+      );
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      pickerElement.setPointerCapture(event.pointerId);
+
+      const gesture = pickerGestureRef.current;
+      gesture.pointers.set(event.pointerId, {
+        x: event.clientX,
+        y: event.clientY,
+      });
+
+      if (gesture.pointers.size === 1) {
+        startSinglePointerGesture(
+          { x: event.clientX, y: event.clientY },
+          gesture.suppressClick
+        );
+        return;
+      }
+
+      if (gesture.mode === "single") {
+        commitSinglePointerPan();
+      }
+      startMultiPointerGesture();
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const gesture = pickerGestureRef.current;
+      if (!gesture.pointers.has(event.pointerId)) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      gesture.pointers.set(event.pointerId, {
+        x: event.clientX,
+        y: event.clientY,
+      });
+
+      if (gesture.pointers.size >= 2) {
+        const centroid = getPointerCentroid(gesture.pointers);
+        const distance = getPointerDistance(gesture.pointers);
+        if (!centroid || !distance) return;
+
+        if (gesture.lastCentroid) {
+          const dx = centroid.x - gesture.lastCentroid.x;
+          const dy = centroid.y - gesture.lastCentroid.y;
+          if (Math.abs(dx) + Math.abs(dy) > 0) {
+            panByScreenPixels({ dx, dy });
+          }
+        }
+
+        if (gesture.lastDistance && gesture.lastDistance > 0 && distance > 0) {
+          const zoomDelta = Math.log2(distance / gesture.lastDistance);
+          if (Number.isFinite(zoomDelta) && zoomDelta !== 0) {
+            syncZoom(zoomRef.current + zoomDelta);
+          }
+        }
+
+        gesture.lastCentroid = centroid;
+        gesture.lastDistance = distance;
+        gesture.mode = "multi";
+        gesture.moved = true;
+        gesture.suppressClick = true;
+        return;
+      }
+
+      if (gesture.mode !== "single") return;
+
+      const dx = event.clientX - gesture.lastX;
+      const dy = event.clientY - gesture.lastY;
+      if (Math.abs(dx) + Math.abs(dy) > 1) gesture.moved = true;
+      gesture.lastX = event.clientX;
+      gesture.lastY = event.clientY;
+      gesture.totalDx += dx;
+      gesture.totalDy += dy;
+
+      if (tileLayerRef.current) {
+        tileLayerRef.current.style.transform = `translate(${gesture.totalDx}px, ${gesture.totalDy}px) rotate(${-rotationRef.current}deg)`;
+      }
+    };
+
+    const finishPointer = (event: PointerEvent) => {
+      const gesture = pickerGestureRef.current;
+      if (!gesture.pointers.has(event.pointerId)) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (pickerElement.hasPointerCapture(event.pointerId)) {
+        pickerElement.releasePointerCapture(event.pointerId);
+      }
+
+      const wasSingle = gesture.mode === "single";
+      const wasMulti = gesture.mode === "multi";
+      const moved = gesture.moved;
+      const suppressClick = gesture.suppressClick;
+      gesture.pointers.delete(event.pointerId);
+
+      if (wasSingle && gesture.pointers.size === 0) {
+        resetTileLayerTransform();
+        if (moved) {
+          commitSinglePointerPan();
+        } else if (!suppressClick) {
+          handleSinglePointerTap(event);
+        }
+        resetGesture();
+        return;
+      }
+
+      if (!wasMulti) {
+        resetGesture();
+        return;
+      }
+
+      resetTileLayerTransform();
+
+      if (gesture.pointers.size >= 2) {
+        startMultiPointerGesture();
+        return;
+      }
+
+      if (gesture.pointers.size === 1) {
+        const remainingPointer = Array.from(gesture.pointers.values())[0];
+        startSinglePointerGesture(remainingPointer, true);
+        return;
+      }
+
+      resetGesture();
+    };
+
+    pickerElement.addEventListener("pointerdown", handlePointerDown);
+    pickerElement.addEventListener("pointermove", handlePointerMove);
+    pickerElement.addEventListener("pointerup", finishPointer);
+    pickerElement.addEventListener("pointercancel", finishPointer);
+    return () => {
+      pickerElement.removeEventListener("pointerdown", handlePointerDown);
+      pickerElement.removeEventListener("pointermove", handlePointerMove);
+      pickerElement.removeEventListener("pointerup", finishPointer);
+      pickerElement.removeEventListener("pointercancel", finishPointer);
+      resetGesture();
+    };
+  }, [
+    centerRef,
+    panByScreenPixels,
+    pickerElement,
+    rotationRef,
+    syncCenter,
+    syncZoom,
+    zoomRef,
+  ]);
+
+  return { setPickerNode, tileLayerRef, pickerSize };
+}

--- a/tests/components/map-reference/useLocationSearch.test.tsx
+++ b/tests/components/map-reference/useLocationSearch.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment happy-dom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  act,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useLocationSearch } from "@/components/map-reference/useLocationSearch";
+import type { LatLng } from "@/lib/map-reference/geometry";
+
+type MutableRef<T> = {
+  current: T;
+};
+
+function LocationSearchHarness({
+  centerRef,
+  zoomRef,
+  onCenterChange,
+  onZoomChange,
+}: {
+  centerRef: MutableRef<LatLng>;
+  zoomRef: MutableRef<number>;
+  onCenterChange: (center: LatLng) => void;
+  onZoomChange: (zoom: number) => void;
+}) {
+  const {
+    handleLocationSearch,
+    locationQuery,
+    locationResults,
+    locationSearchError,
+    locationSearchPending,
+    searchPanelRef,
+    selectLocationResult,
+    setLocationQuery,
+  } = useLocationSearch({
+    centerRef,
+    zoomRef,
+    syncCenter: (center) => {
+      centerRef.current = center;
+      onCenterChange(center);
+    },
+    syncZoom: (zoom) => {
+      zoomRef.current = zoom;
+      onZoomChange(zoom);
+    },
+  });
+
+  return (
+    <div ref={searchPanelRef}>
+      <input
+        aria-label="Location"
+        value={locationQuery}
+        onChange={(event) => setLocationQuery(event.target.value)}
+      />
+      <button type="button" onClick={() => void handleLocationSearch()}>
+        Search
+      </button>
+      <output data-testid="search-error">{locationSearchError ?? ""}</output>
+      <output data-testid="search-pending">
+        {String(locationSearchPending)}
+      </output>
+      <ul>
+        {locationResults.map((result) => (
+          <li key={result.id}>
+            <button type="button" onClick={() => selectLocationResult(result)}>
+              {result.address}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function renderLocationSearchHarness() {
+  const centerRef: MutableRef<LatLng> = { current: { lat: 52.1, lng: 5.2 } };
+  const zoomRef: MutableRef<number> = { current: 7 };
+  const onCenterChange = vi.fn();
+  const onZoomChange = vi.fn();
+
+  render(
+    <LocationSearchHarness
+      centerRef={centerRef}
+      zoomRef={zoomRef}
+      onCenterChange={onCenterChange}
+      onZoomChange={onZoomChange}
+    />
+  );
+
+  return {
+    centerRef,
+    onCenterChange,
+    onZoomChange,
+    zoomRef,
+  };
+}
+
+const fetchMock = vi.fn();
+
+describe("useLocationSearch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("jumps directly to coordinate queries without calling geocoding", () => {
+    const { onCenterChange, onZoomChange } = renderLocationSearchHarness();
+
+    fireEvent.change(screen.getByLabelText("Location"), {
+      target: { value: "52.37, 4.9" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    const selectedCenter = onCenterChange.mock.calls[0]?.[0];
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(selectedCenter?.lat).toBeCloseTo(52.37);
+    expect(selectedCenter?.lng).toBeCloseTo(4.9);
+    expect(onZoomChange).toHaveBeenCalledWith(18);
+  });
+
+  it("normalizes geocoding results and jumps when a result is selected", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            address: "Amsterdam, Noord-Holland, Netherlands",
+            location: { x: 4.9, y: 52.37 },
+            score: 100,
+          },
+        ],
+      }),
+    });
+    const { onCenterChange, onZoomChange } = renderLocationSearchHarness();
+
+    fireEvent.change(screen.getByLabelText("Location"), {
+      target: { value: "Amsterdam" },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    const resultButton = screen.getByRole("button", {
+      name: "Amsterdam, Noord-Holland, Netherlands",
+    });
+    fireEvent.click(resultButton);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((screen.getByLabelText("Location") as HTMLInputElement).value).toBe(
+      "Amsterdam, Noord-Holland, Netherlands"
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: "Amsterdam, Noord-Holland, Netherlands",
+      })
+    ).toBeNull();
+    expect(screen.getByTestId("search-error").textContent).toBe("");
+    const selectedCenter = onCenterChange.mock.calls[0]?.[0];
+    expect(selectedCenter?.lat).toBeCloseTo(52.37);
+    expect(selectedCenter?.lng).toBeCloseTo(4.9);
+    expect(onZoomChange).toHaveBeenCalledWith(18);
+  });
+
+  it("surfaces an unavailable state when geocoding fails", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    });
+    renderLocationSearchHarness();
+
+    fireEvent.change(screen.getByLabelText("Location"), {
+      target: { value: "Broken search" },
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(350);
+    });
+
+    expect(screen.getByTestId("search-error").textContent).toBe(
+      "Location search is unavailable."
+    );
+    expect(screen.getByTestId("search-pending").textContent).toBe("false");
+  });
+});

--- a/tests/components/map-reference/usePickerGesture.test.tsx
+++ b/tests/components/map-reference/usePickerGesture.test.tsx
@@ -1,0 +1,244 @@
+// @vitest-environment happy-dom
+
+import { useCallback } from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePickerGesture } from "@/components/map-reference/usePickerGesture";
+import type { LatLng } from "@/lib/map-reference/geometry";
+
+type MutableRef<T> = {
+  current: T;
+};
+
+class ResizeObserverMock {
+  constructor(_callback: ResizeObserverCallback) {}
+
+  disconnect = vi.fn();
+  observe = vi.fn();
+  unobserve = vi.fn();
+}
+
+function configurePickerNode(node: HTMLDivElement) {
+  Object.defineProperties(node, {
+    clientHeight: { configurable: true, value: 200 },
+    clientWidth: { configurable: true, value: 300 },
+  });
+  node.getBoundingClientRect = () =>
+    ({
+      bottom: 200,
+      height: 200,
+      left: 0,
+      right: 300,
+      top: 0,
+      width: 300,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  node.hasPointerCapture = vi.fn(() => true);
+  node.releasePointerCapture = vi.fn();
+  node.setPointerCapture = vi.fn();
+}
+
+function createPointerEvent(
+  type: string,
+  {
+    clientX,
+    clientY,
+    pointerId,
+  }: {
+    clientX: number;
+    clientY: number;
+    pointerId: number;
+  }
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    button: { value: 0 },
+    buttons: { value: type === "pointerup" ? 0 : 1 },
+    clientX: { value: clientX },
+    clientY: { value: clientY },
+    isPrimary: { value: pointerId === 1 },
+    pageX: { value: clientX },
+    pageY: { value: clientY },
+    pointerId: { value: pointerId },
+    pointerType: { value: "touch" },
+  });
+
+  return event as PointerEvent;
+}
+
+function dispatchPointer(
+  target: HTMLElement,
+  type: string,
+  init: {
+    clientX: number;
+    clientY: number;
+    pointerId: number;
+  }
+) {
+  act(() => {
+    target.dispatchEvent(createPointerEvent(type, init));
+  });
+}
+
+function PickerGestureHarness({
+  centerRef,
+  rotationRef,
+  syncCenter,
+  syncZoom,
+  zoomRef,
+}: {
+  centerRef: MutableRef<LatLng>;
+  rotationRef: MutableRef<number>;
+  syncCenter: (center: LatLng) => void;
+  syncZoom: (zoom: number) => void;
+  zoomRef: MutableRef<number>;
+}) {
+  const { setPickerNode, tileLayerRef } = usePickerGesture({
+    centerRef,
+    rotationRef,
+    syncCenter,
+    syncZoom,
+    zoomRef,
+  });
+
+  const setNode = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node) {
+        configurePickerNode(node);
+      }
+      setPickerNode(node);
+    },
+    [setPickerNode]
+  );
+
+  return (
+    <div data-testid="picker" ref={setNode}>
+      <div data-testid="tile-layer" ref={tileLayerRef} />
+    </div>
+  );
+}
+
+function renderPickerGestureHarness() {
+  const centerRef: MutableRef<LatLng> = { current: { lat: 52.1, lng: 5.2 } };
+  const rotationRef: MutableRef<number> = { current: 0 };
+  const zoomRef: MutableRef<number> = { current: 10 };
+  const syncCenter = vi.fn((center: LatLng) => {
+    centerRef.current = center;
+  });
+  const syncZoom = vi.fn((zoom: number) => {
+    zoomRef.current = zoom;
+  });
+
+  render(
+    <PickerGestureHarness
+      centerRef={centerRef}
+      rotationRef={rotationRef}
+      syncCenter={syncCenter}
+      syncZoom={syncZoom}
+      zoomRef={zoomRef}
+    />
+  );
+
+  return {
+    centerRef,
+    picker: screen.getByTestId("picker"),
+    syncCenter,
+    syncZoom,
+    tileLayer: screen.getByTestId("tile-layer"),
+    zoomRef,
+  };
+}
+
+describe("usePickerGesture", () => {
+  beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("recenters the map on a single touch tap", async () => {
+    const { picker, syncCenter } = renderPickerGestureHarness();
+    await act(async () => {});
+
+    dispatchPointer(picker, "pointerdown", {
+      clientX: 210,
+      clientY: 100,
+      pointerId: 1,
+    });
+    dispatchPointer(picker, "pointerup", {
+      clientX: 210,
+      clientY: 100,
+      pointerId: 1,
+    });
+
+    expect(syncCenter).toHaveBeenCalledTimes(1);
+    expect(syncCenter.mock.calls[0]?.[0].lng).toBeGreaterThan(5.2);
+  });
+
+  it("keeps single-touch dragging visual until release, then commits the pan", async () => {
+    const { picker, syncCenter, syncZoom, tileLayer } =
+      renderPickerGestureHarness();
+    await act(async () => {});
+
+    dispatchPointer(picker, "pointerdown", {
+      clientX: 150,
+      clientY: 100,
+      pointerId: 1,
+    });
+    dispatchPointer(picker, "pointermove", {
+      clientX: 180,
+      clientY: 110,
+      pointerId: 1,
+    });
+
+    expect(tileLayer.style.transform).toBe(
+      "translate(30px, 10px) rotate(0deg)"
+    );
+    expect(syncCenter).not.toHaveBeenCalled();
+
+    dispatchPointer(picker, "pointerup", {
+      clientX: 180,
+      clientY: 110,
+      pointerId: 1,
+    });
+
+    expect(syncCenter).toHaveBeenCalledTimes(1);
+    expect(syncZoom).not.toHaveBeenCalled();
+    expect(tileLayer.style.transform).toBe("rotate(0deg)");
+  });
+
+  it("supports two-touch drag and pinch zoom gestures", async () => {
+    const { picker, syncCenter, syncZoom } = renderPickerGestureHarness();
+    await act(async () => {});
+
+    dispatchPointer(picker, "pointerdown", {
+      clientX: 100,
+      clientY: 100,
+      pointerId: 1,
+    });
+    dispatchPointer(picker, "pointerdown", {
+      clientX: 200,
+      clientY: 100,
+      pointerId: 2,
+    });
+    dispatchPointer(picker, "pointermove", {
+      clientX: 90,
+      clientY: 100,
+      pointerId: 1,
+    });
+    dispatchPointer(picker, "pointermove", {
+      clientX: 210,
+      clientY: 100,
+      pointerId: 2,
+    });
+
+    expect(syncCenter).toHaveBeenCalled();
+    expect(syncZoom).toHaveBeenCalled();
+    expect(syncZoom.mock.calls.at(-1)?.[0]).toBeGreaterThan(10);
+  });
+});


### PR DESCRIPTION
This PR revises the map reference dialog for a better mobile experience. The drawer now uses more suitable mobile behavior, the map picker opens at zoom level 7 by default, latitude/longitude fields are hidden on mobile, and location search has been extracted into its own hook.

It also improves map interactions with support for single-touch drag, tap-to-center, two-finger drag, and pinch-to-zoom. The mobile rotation controls are more compact and easier to use.