### PR TITLE
fix: Restore map reference wheel zoom

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,14 @@ Use `README.md` for the product-facing repository overview and `CONTRIBUTING.md`
 
 Run `npm run lint` and `npm run type` after non-trivial code changes when the environment allows it. Use `npm run preview` when validating D1-backed, auth-backed, or Cloudflare-runtime behavior.
 
+## Pull Requests
+
+- Use Conventional Commit-style PR titles, such as `feat: Improve map reference controls` or `fix: Restore map reference wheel zoom`.
+- Keep PR bodies compact and product-facing. Prefer one or two short paragraphs or a short bullet list that explains what changed and how it was validated.
+- Use `SSIA` only for very small PRs where the title fully explains the change.
+- Apply the `enhancement` label for product/code improvements and the `dependencies` label for dependency-only PRs.
+- When this workflow matures, prefer an agentic PR template with consistent sections for intent, changes, validation, risk, and follow-up instead of ad hoc prose.
+
 ## Change Heuristics
 
 - For landing-page work, protect SEO metadata, structured data, and conversion paths into `/studio`.

--- a/src/components/map-reference/usePickerGesture.ts
+++ b/src/components/map-reference/usePickerGesture.ts
@@ -15,6 +15,7 @@ const WHEEL_LINE_HEIGHT_PX = 16;
 const WHEEL_PAGE_HEIGHT_PX = 420;
 const WHEEL_PAN_FACTOR = 0.65;
 const PINCH_ZOOM_FACTOR = 0.008;
+const TRACKPAD_HORIZONTAL_SCROLL_WINDOW_MS = 400;
 
 interface PointerPosition {
   x: number;
@@ -95,6 +96,7 @@ export function usePickerGesture({
   });
   const tileLayerRef = useRef<HTMLDivElement | null>(null);
   const gestureScaleRef = useRef(1);
+  const lastHorizontalWheelTimeRef = useRef(0);
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const [pickerElement, setPickerElement] = useState<HTMLDivElement | null>(
     null
@@ -151,8 +153,21 @@ export function usePickerGesture({
 
       const deltaX = normalizeWheelDelta(event.deltaX, event.deltaMode);
       const deltaY = normalizeWheelDelta(event.deltaY, event.deltaMode);
+      const hasHorizontalScroll = Math.abs(event.deltaX) > 0.01;
+      const now = Date.now();
+      if (hasHorizontalScroll) {
+        lastHorizontalWheelTimeRef.current = now;
+      }
+      const isTrackpadPan =
+        event.deltaMode === 0 &&
+        !event.ctrlKey &&
+        !event.metaKey &&
+        !event.altKey &&
+        (hasHorizontalScroll ||
+          now - lastHorizontalWheelTimeRef.current <
+            TRACKPAD_HORIZONTAL_SCROLL_WINDOW_MS);
 
-      if (event.ctrlKey) {
+      if (!isTrackpadPan) {
         syncZoom(zoomRef.current - deltaY * PINCH_ZOOM_FACTOR);
         return;
       }

--- a/tests/components/map-reference/usePickerGesture.test.tsx
+++ b/tests/components/map-reference/usePickerGesture.test.tsx
@@ -82,6 +82,29 @@ function dispatchPointer(
   });
 }
 
+function dispatchWheel(
+  target: HTMLElement,
+  init: {
+    ctrlKey?: boolean;
+    deltaMode?: number;
+    deltaX?: number;
+    deltaY?: number;
+  }
+) {
+  act(() => {
+    target.dispatchEvent(
+      new WheelEvent("wheel", {
+        bubbles: true,
+        cancelable: true,
+        ctrlKey: init.ctrlKey ?? false,
+        deltaMode: init.deltaMode ?? 0,
+        deltaX: init.deltaX ?? 0,
+        deltaY: init.deltaY ?? 0,
+      })
+    );
+  });
+}
+
 function PickerGestureHarness({
   centerRef,
   rotationRef,
@@ -240,5 +263,33 @@ describe("usePickerGesture", () => {
     expect(syncCenter).toHaveBeenCalled();
     expect(syncZoom).toHaveBeenCalled();
     expect(syncZoom.mock.calls.at(-1)?.[0]).toBeGreaterThan(10);
+  });
+
+  it("zooms with a mouse wheel", async () => {
+    const { picker, syncCenter, syncZoom } = renderPickerGestureHarness();
+    await act(async () => {});
+
+    dispatchWheel(picker, {
+      deltaMode: 1,
+      deltaY: 3,
+    });
+
+    expect(syncZoom).toHaveBeenCalledTimes(1);
+    expect(syncZoom.mock.calls[0]?.[0]).toBeLessThan(10);
+    expect(syncCenter).not.toHaveBeenCalled();
+  });
+
+  it("keeps horizontal trackpad wheel movement as map pan", async () => {
+    const { picker, syncCenter, syncZoom } = renderPickerGestureHarness();
+    await act(async () => {});
+
+    dispatchWheel(picker, {
+      deltaMode: 0,
+      deltaX: 20,
+      deltaY: 5,
+    });
+
+    expect(syncCenter).toHaveBeenCalledTimes(1);
+    expect(syncZoom).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This PR restores mouse wheel zooming in the map reference picker while keeping horizontal trackpad wheel movement as map panning. Existing touch drag and pinch zoom behavior remains covered.
