### PR TITLE
feat: Add TrackDraw REST API v1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,14 @@ npm run build
 
 Also verify the relevant user flow, especially for `/studio`, `/share/[token]`, mobile editing, import/export, recovery, and preview-mode auth/share behavior.
 
+For REST API changes, validate the preview-mode flow with D1 when the change touches auth, API keys, project serialization, OpenAPI docs, or scheduled cleanup:
+
+1. run `npm run preview`
+2. sign in and create an API key from account settings
+3. call `/api/v1/me`, `/api/v1/projects`, one project `/track`, and one project `/overlay` with `Authorization: Bearer <api_key>`
+4. open `/api/docs` and confirm the documented endpoints match the shipped routes
+5. revoke the key and confirm bearer requests no longer authenticate
+
 For 3D editor interaction work, also sanity-check live inspector feedback and direct-manipulation controls such as path elevation handles, floating ladder placement, and rotation handles.
 
 ## Pull requests

--- a/custom-worker.ts
+++ b/custom-worker.ts
@@ -1,5 +1,6 @@
 // @ts-ignore `.open-next/worker.js` is generated at build time
 import { default as handler } from "./.open-next/worker.js";
+import { cleanupExpiredApiKeys } from "./src/lib/server/api-key-retention";
 import { cleanupExpiredShares } from "./src/lib/server/share-retention";
 
 type D1PreparedStatement = {
@@ -32,7 +33,9 @@ const worker = {
     env: WorkerEnv,
     ctx: WorkerExecutionContext
   ) {
-    ctx.waitUntil(cleanupExpiredShares(env.DB));
+    ctx.waitUntil(
+      Promise.all([cleanupExpiredShares(env.DB), cleanupExpiredApiKeys(env.DB)])
+    );
   },
 };
 

--- a/docs/deployment/deployment-setup.md
+++ b/docs/deployment/deployment-setup.md
@@ -178,14 +178,16 @@ Recommended local auth test flow:
 6. copy the link from the local server log
 7. confirm Studio shows the signed-in state and authenticated APIs stop returning `401`
 
-## Share retention
+## Retention Cleanup
 
 Shares become invalid when `expires_at` is reached, but they are not deleted immediately.
+API keys are managed by Better Auth. Revoked keys are deleted through the API Key plugin, and expired key records are removed by scheduled cleanup after the retention window.
 
 The Worker runs a daily cron cleanup and removes:
 
 - revoked shares
 - shares that have been expired for more than 30 days
+- API keys that have been expired for more than 90 days
 
 The cron schedule is configured in `wrangler.jsonc`. To test the scheduled cleanup locally, run Wrangler with scheduled testing enabled and hit the scheduled route manually.
 

--- a/docs/pva/live-race-overlay-pva.md
+++ b/docs/pva/live-race-overlay-pva.md
@@ -12,7 +12,7 @@ Recommended decision:
 - treat the first version as a TrackDraw-to-`rh-stream-overlays` integration, not a TrackDraw-owned overlay runtime
 - model drone position as estimated route progress from timing events, not exact spatial tracking
 - require real RotorHazard race data for the actual feature
-- require explicit export/import contracts between TrackDraw and `rh-stream-overlays`
+- use the TrackDraw REST API as the primary course-data contract between TrackDraw and `rh-stream-overlays`
 - require explicit timing-role mapping such as start/finish and split anchors before live RotorHazard integration
 
 For the full product evaluation and rationale, see [docs/research/live-race-overlay-evaluation.md](../research/live-race-overlay-evaluation.md).
@@ -21,13 +21,13 @@ For the full product evaluation and rationale, see [docs/research/live-race-over
 
 TrackDraw should approve this feature for build preparation if the team is comfortable with the following first-version shape:
 
-- TrackDraw owns track preparation, route mapping, and export
+- TrackDraw owns track preparation, route mapping, and the REST course-data endpoint
 - `rh-stream-overlays` owns OBS-facing overlay rendering
 - 2D minimap only
 - TrackDraw route used as the motion path
 - explicit timing-role mapping for start/finish and split anchors
 - RotorHazard-fed pilot markers with estimated movement between anchors
-- a defined import contract that `rh-stream-overlays` can consume reliably
+- a defined REST contract that `rh-stream-overlays` can consume reliably
 
 TrackDraw should not approve this feature yet if the team expects any of these to be part of v1:
 
@@ -40,9 +40,9 @@ TrackDraw should not approve this feature yet if the team expects any of these t
 ## Delivery Checklist
 
 - [ ] Phase 0: lock the product model and truth boundaries
-- [ ] Phase 1: define the TrackDraw export contract and `rh-stream-overlays` import contract
+- [ ] Phase 1: define and harden the TrackDraw REST overlay contract
 - [ ] Phase 2: add timing-role mapping in TrackDraw
-- [ ] Phase 3: drive a minimap overlay in `rh-stream-overlays` from imported track data
+- [ ] Phase 3: drive a minimap overlay in `rh-stream-overlays` from REST track data
 - [ ] Phase 4: connect RotorHazard live race events and harden estimation behavior
 
 ## Go / No-Go Criteria
@@ -53,7 +53,7 @@ Go for implementation planning if:
 - OBS overlay is the clear primary use case
 - `rh-stream-overlays` is accepted as the preferred overlay runtime
 - explicit timing-role mapping is considered acceptable race-day setup work
-- the team is willing to define and maintain an export/import contract between repos
+- the team is willing to define and maintain a REST contract between repos
 
 No-go or keep parked if:
 
@@ -65,27 +65,26 @@ No-go or keep parked if:
 
 ## Codebase Anchor
 
-### JSON Hardening Checklist
+### REST Overlay Contract Checklist
 
-The following TrackDraw files are the primary places to review or adjust for the JSON-hardening work that enables this integration.
+The TrackDraw REST API is the only supported course-data contract for the live minimap integration. Do not use manual JSON export/import as the integration path for `rh-stream-overlays`.
 
-Export and serialization:
+Implemented REST contract:
 
-- [src/components/dialogs/ExportDialog.tsx](../../src/components/dialogs/ExportDialog.tsx)
-  Change JSON export to write `serializeDesign(design)` rather than the raw editor object.
-- [src/components/editor/EditorShell.tsx](../../src/components/editor/EditorShell.tsx)
-  Update project-manager JSON export to use the same serialized path so all JSON downloads are consistent.
-- [src/lib/track/design.ts](../../src/lib/track/design.ts)
-  Treat `serializeDesign()` as the canonical export shape and keep `parseDesign()` as the canonical import path.
+- [src/app/api/v1/projects/[projectId]/overlay/route.ts](../../src/app/api/v1/projects/[projectId]/overlay/route.ts)
+  Serves `GET /api/v1/projects/{projectId}/overlay` for account-owned projects through bearer API-key auth.
+- [src/lib/server/api-projects.ts](../../src/lib/server/api-projects.ts)
+  Builds the `trackdraw.overlay.v1` package with field dimensions, route geometry, route status, numbered route obstacles, timing markers, and route positions.
+- [src/lib/api/openapi.ts](../../src/lib/api/openapi.ts)
+  Documents the RotorHazard integration endpoint under the REST API docs.
 
-Import and validation:
+REST contract follow-up:
 
-- [src/components/dialogs/ImportDialog.tsx](../../src/components/dialogs/ImportDialog.tsx)
-  Replace the current ad hoc `data.shapes` gate with `parseDesign()` so import preview and actual import use the same validation rules.
-- [src/app/api/projects/route.ts](../../src/app/api/projects/route.ts)
-  Confirm project-save APIs continue to accept the same normalized serialized form.
-- [src/app/api/shares/route.ts](../../src/app/api/shares/route.ts)
-  Confirm share-publish APIs continue to accept the same normalized serialized form.
+- [ ] add explicit active race route selection instead of relying on the first valid polyline
+- [ ] add overlay validation output for missing route, duplicate timing roles, missing split identifiers, and timing markers that cannot be mapped onto route progress
+- [ ] add minimap viewport or bounds hints for stable overlay framing
+- [ ] confirm the timing identifier naming and semantics with the `rh-stream-overlays`/RotorHazard side
+- [ ] document a sample `trackdraw.overlay.v1` payload in this PVA once the consumer contract is confirmed
 
 Timing metadata and typing:
 
@@ -99,7 +98,7 @@ Timing metadata and typing:
 Primary route behavior:
 
 - [src/store/selectors.ts](../../src/store/selectors.ts)
-  Today `selectPrimaryPolyline()` falls back to the first polyline. Decide whether that remains acceptable for overlay export or whether TrackDraw needs an explicit active race route marker.
+  Today route-related behavior falls back to the first polyline. Decide where TrackDraw stores an explicit active race route marker.
 - [src/lib/track/polyline-derived.ts](../../src/lib/track/polyline-derived.ts)
   Reuse this layer for route length and progress calculations rather than duplicating geometry logic elsewhere.
 
@@ -112,20 +111,20 @@ Editor UX follow-up for timing roles:
 
 Recommended implementation order:
 
-1. Standardize JSON export on `serializeDesign()`.
-2. Standardize JSON import on `parseDesign()`.
-3. Define and document `meta.timing`.
-4. Decide how TrackDraw identifies the active race route.
-5. Only then begin cross-repo import work in `rh-stream-overlays`.
+1. Treat `/api/v1/projects/{projectId}/overlay` as the primary TrackDraw course-data contract.
+2. Confirm the `trackdraw.overlay.v1` payload with `rh-stream-overlays`.
+3. Add validation output for route and timing readiness.
+4. Add explicit active race route selection.
+5. Begin cross-repo consumption work in `rh-stream-overlays`.
 
 ## Phase Plan
 
 ### Top-Level Checklist
 
 - [ ] Phase 0 complete: product boundaries and data truth are locked
-- [ ] Phase 1 complete: export/import contract is defined
+- [ ] Phase 1 complete: REST overlay contract is defined and documented
 - [ ] Phase 2 complete: timing-role model and setup flow are defined in TrackDraw
-- [ ] Phase 3 complete: `rh-stream-overlays` renders imported minimap data
+- [ ] Phase 3 complete: `rh-stream-overlays` renders REST-backed minimap data
 - [ ] Phase 4 complete: RotorHazard live race data drives estimated position on the minimap
 
 ### Phase 0: Lock Product And Data Boundaries
@@ -142,32 +141,33 @@ Work:
 - define the exact meaning of `estimated position`
 - define the first supported RotorHazard event contract
 - decide where timing-role configuration belongs
-- decide the export/import schema and ownership
+- decide the REST overlay schema and ownership
 - define unsupported states for v1
 
 Done state:
 
 - feature boundary is explicit
 - no one expects exact telemetry from v1
-- mapping, export, and overlay-runtime responsibilities are clear
+- mapping, REST data, and overlay-runtime responsibilities are clear
 
-### Phase 1: Define Export And Import Contract
+### Phase 1: Define REST Overlay Contract
 
 Start state:
 
 - no shared schema exists between TrackDraw and `rh-stream-overlays`
-- import and export expectations are still implicit
+- REST consumption expectations are still implicit
 
 Work:
 
-- define the JSON package shape
+- define the `trackdraw.overlay.v1` package shape
 - define how timing-point identifiers map to RotorHazard concepts
-- define versioning and failure behavior for bad imports
+- define versioning and failure behavior for bad or incomplete overlay packages
+- document the endpoint, response example, and validation semantics in OpenAPI and this PVA
 
 Done state:
 
 - both repos can target the same contract
-- import/export work can proceed without ambiguity
+- REST consumption work can proceed without ambiguity
 
 ### Phase 2: Add Timing Roles And Mapping In TrackDraw
 
@@ -187,16 +187,16 @@ Done state:
 - a track can be prepared for live race use
 - timing points have an explicit place on the TrackDraw route
 
-### Phase 3: Import And Render In `rh-stream-overlays`
+### Phase 3: Consume And Render In `rh-stream-overlays`
 
 Start state:
 
 - TrackDraw can describe the course
-- `rh-stream-overlays` does not yet render imported minimap data
+- `rh-stream-overlays` does not yet render TrackDraw REST minimap data
 
 Work:
 
-- import TrackDraw packages
+- consume TrackDraw overlay packages
 - render the minimap route and timing markers
 - validate OBS browser-source behavior and transparency
 
@@ -209,7 +209,7 @@ Done state:
 
 Start state:
 
-- imported minimap rendering works
+- REST-backed minimap rendering works
 - live position behavior is not yet connected or not yet robust
 
 Work:
@@ -229,7 +229,7 @@ Done state:
 
 Before TrackDraw treats this as implementation-ready, validate at least:
 
-- export/import round-trip on at least one real TrackDraw course
+- REST overlay package output on at least one real TrackDraw course
 - schema validation behavior for missing or bad timing markers
 - track rendering readability at common stream resolutions
 - multi-pilot visibility on crowded layouts
@@ -240,4 +240,4 @@ Before TrackDraw treats this as release-ready, validate at least:
 - one real or replayed RotorHazard-driven race session
 - disconnect and reconnect handling
 - end-of-heat behavior
-- that existing editor, share, and export flows remain unaffected
+- that existing editor and share flows remain unaffected

--- a/docs/pva/trackdraw-rest-api-pva.md
+++ b/docs/pva/trackdraw-rest-api-pva.md
@@ -48,8 +48,8 @@ TrackDraw should not approve this work yet if the expected v1 includes:
 - [x] Phase 1: add Better Auth API Key plugin integration and API key management surface
 - [x] Phase 2: add bearer API key auth and first account-owned read endpoints
 - [x] Phase 3: add OpenAPI schema and API docs page
-- [ ] Phase 4: add livestream overlay package for integration consumers
-- [ ] Phase 5: harden throttling, audit events, tests, and docs
+- [x] Phase 4: add livestream overlay package for integration consumers
+- [x] Phase 5: harden throttling, audit events, tests, and docs
 
 ## Go / No-Go Criteria
 
@@ -483,8 +483,8 @@ These are the recommended defaults for Phase 0. They optimize for a small safe v
 - [x] Phase 1 complete: account users can create, list, and revoke expiring API keys
 - [x] Phase 2 complete: bearer auth resolves an API key owner and serves first project reads
 - [x] Phase 3 complete: OpenAPI schema and docs page are available
-- [ ] Phase 4 complete: livestream overlay package supports first integration consumers
-- [ ] Phase 5 complete: validation, tests, audit, and docs are complete
+- [x] Phase 4 complete: livestream overlay package supports first integration consumers
+- [x] Phase 5 complete: validation, tests, audit, and docs are complete
 
 ### Phase 0: Lock Product Boundary
 
@@ -598,16 +598,18 @@ Start state:
 
 Work:
 
-- finalize throttling for `/api/v1/*`
-- add stricter budgets for package endpoints than metadata endpoints if usage requires it
-- return stable `429` errors and `Retry-After` headers
-- add tests for API key creation, expiry, revoke, owner scoping, and bad bearer keys
-- add tests for throttled requests
-- add tests for project and overlay endpoint authorization
-- add a cleanup path for expired and revoked API key records after the visible retention window
-- update `CONTRIBUTING.md` with preview-mode validation notes if needed
-- update user-facing docs if API docs are linked from account settings
-- confirm existing editor, share, gallery, and embed behavior is unchanged
+- [x] finalize Better Auth API-key throttling for `/api/v1/*`
+- [x] keep a single Better Auth API-key budget for v1; add stricter package endpoint budgets later only if real usage requires it
+- [x] return stable `429` errors and `Retry-After` headers when Better Auth reports a retry window
+- [x] add tests for API key creation, expiry, revoke, owner scoping, and bad bearer keys
+- [x] add tests for v1 response envelopes, compact error bodies, and throttled auth failures
+- [x] add tests for project and overlay endpoint authorization
+- [x] add tests for track and overlay package serializers
+- [x] add a cleanup path for expired API key records after the visible retention window
+- [x] document that revoked API keys are deleted by Better Auth's API Key plugin rather than retained as separate revoked rows
+- [x] update `CONTRIBUTING.md` with preview-mode validation notes
+- [x] update user-facing docs if API docs are linked from account settings
+- [x] confirm existing editor, share, gallery, and embed behavior is unchanged through the full test suite
 
 Done state:
 

--- a/docs/pva/trackdraw-rest-api-pva.md
+++ b/docs/pva/trackdraw-rest-api-pva.md
@@ -1,0 +1,653 @@
+# TrackDraw REST API PVA
+
+Date: April 28, 2026
+
+Status: proposed
+
+## Decision Summary
+
+Recommended decision:
+
+- approve a versioned TrackDraw REST API for implementation planning
+- make v1 account-backed and read-only
+- require users to create an account before generating API keys
+- require expiring bearer API keys for `/api/v1/*` track data
+- require throttling and rate limiting for v1 API endpoints
+- keep API key management behind the existing browser account session
+- prefer Better Auth's API Key plugin for API key lifecycle, storage, verification, permissions, and base rate limiting
+- publish OpenAPI documentation from the first implementation slice
+- defer unauthenticated public REST reads until a clear consumer needs them
+- defer write APIs until read integrations are proven
+
+For the product evaluation and rationale, see [docs/research/trackdraw-rest-api.md](../research/trackdraw-rest-api.md).
+
+## Approval Recommendation
+
+TrackDraw should approve this work if the team accepts the following first-version shape:
+
+- the REST API is for tools and automation, not for replacing `/share/[token]`, `/embed/[token]`, `/gallery`, or `/studio`
+- API users must have a TrackDraw account
+- API keys are permissioned, expiring, revocable, and only shown once
+- API keys have enforced request budgets, with room for stricter limits on expensive package endpoints
+- v1 reads only the API key owner's account-backed projects and derived overlay packages
+- the first useful external data shape is JSON, with preview/image endpoints deferred unless needed
+- OpenAPI docs are part of the API, not an afterthought
+
+TrackDraw should not approve this work yet if the expected v1 includes:
+
+- anonymous API access to arbitrary share tokens
+- editing or creating tracks through the API
+- non-expiring API keys
+- team, club, or organization ownership
+- broad public search/discovery endpoints
+- server-side PDF/PNG/SVG rendering as a first requirement
+
+## Delivery Checklist
+
+- [x] Phase 0: lock API product boundaries and endpoint auth policy
+- [x] Phase 1: add Better Auth API Key plugin integration and API key management surface
+- [x] Phase 2: add bearer API key auth and first account-owned read endpoints
+- [x] Phase 3: add OpenAPI schema and API docs page
+- [ ] Phase 4: add livestream overlay package for integration consumers
+- [ ] Phase 5: harden throttling, audit events, tests, and docs
+
+## Go / No-Go Criteria
+
+Go for implementation if:
+
+- account-only API key auth is accepted for v1
+- read-only API permissions are enough for the first integration consumers
+- API docs can ship with the first endpoint set
+- rate limiting is treated as a release requirement, not a post-launch cleanup task
+- the team accepts that public REST reads are deferred
+- Better Auth session management and API Key plugin storage/verification remain the foundation
+
+No-go or keep in planning if:
+
+- write access is considered mandatory for v1
+- API keys need organization/team ownership before individual account keys are useful
+- the first consumer requires unauthenticated data access
+- the team is not ready to maintain an API contract and deprecation path
+
+## Codebase Anchor
+
+### Existing Auth And Ownership
+
+- [src/lib/server/auth-session.ts](../../src/lib/server/auth-session.ts)
+  Existing Better Auth session resolver for browser-session API calls.
+- [src/lib/server/auth.ts](../../src/lib/server/auth.ts)
+  Better Auth server configuration. Add the API Key plugin here so key lifecycle, permissions, expiry, verification, and base rate limiting stay inside the auth layer instead of a parallel TrackDraw token system.
+- [src/lib/server/authorization.ts](../../src/lib/server/authorization.ts)
+  Existing ownership/capability helpers. API key authorization should stay separate from dashboard role checks, but reuse the ownership posture.
+- [src/app/api/account/session/route.ts](../../src/app/api/account/session/route.ts)
+  Existing account-session API pattern.
+
+### Existing Project And Share APIs
+
+- [src/app/api/projects/route.ts](../../src/app/api/projects/route.ts)
+  Existing account-only project list/save behavior.
+- [src/app/api/projects/[projectId]/route.ts](../../src/app/api/projects/[projectId]/route.ts)
+  Existing account-owned project read/archive behavior.
+- [src/app/api/shares/route.ts](../../src/app/api/shares/route.ts)
+  Existing publish and owned-share listing behavior.
+- [src/app/api/shares/[token]/route.ts](../../src/app/api/shares/[token]/route.ts)
+  Existing owner-authorized share revoke/gallery behavior.
+
+### Existing Data Helpers
+
+- [src/lib/server/projects.ts](../../src/lib/server/projects.ts)
+  Account-owned project persistence and read helpers.
+- [src/lib/server/shares.ts](../../src/lib/server/shares.ts)
+  Share resolution, ownership, expiry, revoke, and published-share behavior.
+- [src/lib/track/design.ts](../../src/lib/track/design.ts)
+  Canonical design normalization and serialization.
+- [src/lib/track/timing.ts](../../src/lib/track/timing.ts)
+  Timing metadata normalization used by race-day and future overlay integration work.
+- [src/lib/types.ts](../../src/lib/types.ts)
+  Track, shape, and serialized design types.
+
+### Database
+
+- [migrations/0002_accounts_and_projects.sql](../../migrations/0002_accounts_and_projects.sql)
+  Existing Better Auth and account project tables.
+- [migrations/0008_share_lifecycle.sql](../../migrations/0008_share_lifecycle.sql)
+  Existing published/temporary share lifecycle model.
+
+Recommended schema path:
+
+- Use Better Auth's API Key plugin migration/schema as the source of truth.
+- If the Better Auth CLI cannot generate a D1-compatible migration in this repo, add the plugin's required table and indexes manually in `migrations/` while preserving Better Auth's expected model/field names.
+- Avoid creating a separate TrackDraw-owned API key table unless plugin compatibility blocks the preferred path.
+
+Recommended indexes:
+
+- plugin-required key lookup index
+- user id / owner index
+- expiry/revoked cleanup indexes where the plugin schema supports them
+
+Recommended rate-limit storage:
+
+- start with Better Auth API Key plugin rate limiting where it can express the required budgets
+- keep TrackDraw route-class throttling separate from key verification if package endpoints need stricter budgets than metadata reads
+- keep room to add Cloudflare-native rate limits for broad path/IP abuse later
+
+## Technical Model
+
+### API Key Storage Shape
+
+Preferred implementation:
+
+- install and configure Better Auth's API Key plugin
+- use plugin-generated or plugin-compatible D1 schema
+- configure key prefix, expiry bounds, required name, permissions, and base rate limits in the Better Auth server config
+- verify keys through the plugin from `/api/v1/*` server handlers
+
+Fallback only if plugin compatibility blocks the preferred path:
+
+```sql
+CREATE TABLE IF NOT EXISTS api_keys (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  key_hash TEXT NOT NULL UNIQUE,
+  key_prefix TEXT NOT NULL,
+  key_preview TEXT NOT NULL,
+  permissions_json TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  revoked_at TEXT,
+  last_used_at TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+```
+
+Do not store raw key secrets outside the Better Auth plugin's supported storage model. If fallback storage is unavoidable, do not store raw secrets.
+
+### API Key Management Surface
+
+Browser-session only:
+
+```txt
+GET /api/account/api-keys
+POST /api/account/api-keys
+DELETE /api/account/api-keys/{keyId}
+```
+
+The `POST` response is the only place that returns the full API key secret.
+
+These routes can be implemented as thin TrackDraw wrappers around Better Auth API Key plugin server methods, or the UI can call Better Auth's generated API key endpoints directly if that keeps behavior and naming clear. Prefer wrappers if TrackDraw needs product-specific defaults, audit events, response copy, or scope-to-permission mapping.
+
+### Endpoint Inventory
+
+Recommended v1 endpoint set:
+
+| Phase | Endpoint                                   | Auth            | Permission    | Purpose                                                                                   |
+| ----- | ------------------------------------------ | --------------- | ------------- | ----------------------------------------------------------------------------------------- |
+| 1     | `GET /api/account/api-keys`                | Browser session | n/a           | List the signed-in user's API keys without exposing secrets.                              |
+| 1     | `POST /api/account/api-keys`               | Browser session | n/a           | Create a permissioned expiring API key and return the secret once.                        |
+| 1     | `DELETE /api/account/api-keys/{keyId}`     | Browser session | n/a           | Revoke one of the signed-in user's API keys.                                              |
+| 2     | `GET /api/v1/me`                           | Bearer key      | n/a           | Return minimal account identity and bearer-key capabilities for integration setup checks. |
+| 2     | `GET /api/v1/projects`                     | Bearer key      | `tracks:read` | List the key owner's active account-backed projects.                                      |
+| 2     | `GET /api/v1/projects/{projectId}`         | Bearer key      | `tracks:read` | Return project metadata and ownership-safe summary fields.                                |
+| 2     | `GET /api/v1/projects/{projectId}/track`   | Bearer key      | `tracks:read` | Return the integration-stable track package for an owned project.                         |
+| 3     | `GET /api/v1/openapi.json`                 | Public          | n/a           | Serve the OpenAPI 3.1 schema.                                                             |
+| 3     | `GET /api/docs`                            | Public          | n/a           | Render interactive API documentation from the OpenAPI schema.                             |
+| 4     | `GET /api/v1/projects/{projectId}/overlay` | Bearer key      | `tracks:read` | Return compact route, obstacle, and timing data for livestream minimaps.                  |
+
+Do not use a generic `tracks/{trackRef}` route in v1. Project ids and share tokens should stay on separate routes so ownership checks, error messages, and OpenAPI docs stay clear.
+
+### Endpoint Details
+
+#### API Key Management
+
+```txt
+GET /api/account/api-keys
+```
+
+Returns API key records for the signed-in user:
+
+- id
+- name
+- key prefix and preview
+- permissions
+- createdAt
+- expiresAt
+- revokedAt
+- lastUsedAt
+
+```txt
+POST /api/account/api-keys
+```
+
+Creates an API key from:
+
+- name
+- permissions
+- expiresInDays
+
+Returns the raw API key secret once. Better Auth stores only its supported non-secret representation.
+
+```txt
+DELETE /api/account/api-keys/{keyId}
+```
+
+Revokes the API key if it belongs to the signed-in user.
+
+#### API Identity
+
+```txt
+GET /api/v1/me
+```
+
+Returns minimal integration identity:
+
+- account id
+- display name
+- key permissions
+- key expiry
+
+#### Projects
+
+```txt
+GET /api/v1/projects
+```
+
+Returns cursor-paginated project summaries:
+
+- id
+- title
+- updated_at
+- field dimensions
+- shape count
+
+```txt
+GET /api/v1/projects/{projectId}
+```
+
+Returns metadata for one owned project. This is useful when an integration needs to confirm a project exists without downloading the full track package.
+
+```txt
+GET /api/v1/projects/{projectId}/track
+```
+
+Returns the integration-stable track package for one owned project.
+
+#### Documentation
+
+```txt
+GET /api/v1/openapi.json
+GET /api/docs
+```
+
+`/api/v1/openapi.json` can remain public if simpler, but must not leak private runtime state. `/api/docs` should render the OpenAPI schema as an interactive API documentation page.
+
+#### Live Overlay
+
+```txt
+GET /api/v1/projects/{projectId}/overlay
+```
+
+Returns a compact `trackdraw.overlay.v1` package for livestream minimaps and timing overlays:
+
+- field dimensions and coordinate origin
+- primary route waypoints and sampled route points
+- route status from existing obstacle-numbering validation
+- numbered route obstacles with route positions
+- timing markers with route positions
+
+Keep this endpoint project-based for v1. Livestream tools should target durable account projects rather than published share snapshots unless a concrete workflow needs exact published-share parity.
+
+#### Deferred Share Endpoints
+
+Do not ship share endpoints in v1 until a concrete consumer needs share-token lookup or exact published snapshot parity. Project reads and the overlay package cover the first integration target without widening the API surface.
+
+Potential later endpoints:
+
+```txt
+GET /api/v1/shares
+GET /api/v1/shares/{shareToken}
+GET /api/v1/shares/{shareToken}/track
+```
+
+Share endpoints must only return account-published shares owned by the API key account. Temporary anonymous shares, expired shares, revoked shares, and shares owned by another account must not resolve through the REST API.
+
+### Explicitly Out Of V1
+
+- `POST /api/v1/projects`
+- `PATCH /api/v1/projects/{projectId}`
+- `DELETE /api/v1/projects/{projectId}`
+- public unauthenticated `GET /api/v1/shares/{shareToken}`
+- public gallery search/list endpoints
+- PNG, SVG, PDF, or video rendering endpoints
+- webhooks
+- OAuth application registration
+
+### Response Standards
+
+Use a stricter response standard for `/api/v1/*` than the older internal app routes.
+
+Recommended convention:
+
+- JSON success responses use `application/json`
+- error responses use compact Problem Details-style JSON with `application/problem+json`
+- timestamps use ISO 8601 strings in UTC
+- `/api/v1/*` response fields use `snake_case`
+- ids, share tokens, and API key previews are strings
+- list endpoints use cursor pagination
+- rate-limited responses return HTTP `429` with `Retry-After`
+
+Success responses should use a stable top-level envelope:
+
+```json
+{
+  "data": {
+    "id": "project-id",
+    "type": "project"
+  },
+  "meta": {
+    "api_version": "v1"
+  }
+}
+```
+
+List responses should include pagination metadata:
+
+```json
+{
+  "data": [],
+  "pagination": {
+    "limit": 50,
+    "next_cursor": "opaque-cursor",
+    "has_more": true
+  },
+  "meta": {
+    "api_version": "v1"
+  }
+}
+```
+
+### Error Model
+
+Use a compact Problem Details-style model for errors:
+
+```json
+{
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "A valid API bearer key is required.",
+  "code": "unauthorized"
+}
+```
+
+Existing app routes use string errors today. The REST API can define a stricter model under `/api/v1/*` without changing old routes. Keep the v1 error body small: do not add TrackDraw problem-document URLs or request ids until there is a concrete support workflow that uses them.
+
+Throttle responses should use the same model:
+
+```json
+{
+  "title": "Too Many Requests",
+  "status": 429,
+  "detail": "Too many requests for this API key. Try again later.",
+  "code": "rate_limited"
+}
+```
+
+Return HTTP `429` and a `Retry-After` header when the retry window is known.
+
+### Track Package
+
+The first detailed track response should be integration-stable:
+
+```json
+{
+  "data": {
+    "type": "track",
+    "schema": "trackdraw.track.v1",
+    "source": {
+      "type": "project",
+      "id": "project-id"
+    },
+    "title": "Race layout",
+    "field": {
+      "width": 60,
+      "height": 40,
+      "origin": "tl",
+      "unit": "m"
+    },
+    "shape_count": 0,
+    "timing_markers": [],
+    "updated_at": "2026-04-28T00:00:00.000Z",
+    "shapes": []
+  },
+  "meta": {
+    "api_version": "v1"
+  }
+}
+```
+
+The track package should stay smaller than full editor serialization: include field dimensions, integration-safe shapes, and a top-level timing marker summary, while excluding map references, inventory, author metadata, tags, shape locks, front-offset guide metadata, shape metadata, and editor grid settings.
+
+## Recommended Decisions Before Build
+
+These are the recommended defaults for Phase 0. They optimize for a small safe v1 while leaving room for public APIs, richer integrations, and heavier export formats later.
+
+### Product And Rollout
+
+- API key access should be available to every signed-in user, but surfaced from an account/developer settings area rather than promoted as a primary product feature.
+- The first target should be project reads plus a compact overlay package for `rh-stream-overlays`, without making the broader API overlay-specific.
+- The v1 account UI should show API key creation, expiry, revoke, permissions, key preview, and `lastUsedAt`. Detailed usage logs can wait until real users need debugging or audit trails.
+- API docs should be public at `/api/docs` and linked from account/developer settings. Public docs are useful, while actual data remains token-protected.
+
+### Auth And Scopes
+
+- Ship expiry options of 7 days, 30 days, 90 days, and 1 year. Default to 90 days. Do not ship non-expiring keys.
+- Enforce permissions from day one. Starting with real permission checks avoids a future breaking migration when integrations already exist.
+- Require key names. Allow duplicate names, because the key preview, creation date, permissions, and expiry identify the actual key.
+- Keep revoked and expired keys visible in the account UI for 90 days, then hide them from default views. Audit records can remain longer according to the existing audit-log retention posture.
+
+### Rate Limits
+
+- Start with separate budgets for metadata reads and package endpoints if traffic patterns need it.
+- Recommended initial metadata budget: 600 requests per hour per key with a short burst cap of 60 requests per minute.
+- Recommended initial package budget, if separate budgets are needed: 60 requests per hour per key with a short burst cap of 10 requests per minute.
+- Prefer Better Auth API Key plugin rate limiting first. Add a small TrackDraw limiter only where route class budgets need behavior the plugin cannot express cleanly. Cloudflare-native controls should also protect broad path/IP abuse.
+- Guarantee `Retry-After` on throttled responses when the retry window is known. Prefer standard `RateLimit-Limit`, `RateLimit-Remaining`, and `RateLimit-Reset` headers when the limiter can report them accurately.
+
+### Response Contract
+
+- Include `meta.api_version` on every successful `/api/v1/*` JSON response. Consistency is worth the small payload cost.
+- Keep error bodies compact with `title`, `status`, `detail`, and `code`; defer request ids until support tooling needs them.
+- Use cursor pagination with `limit` defaulting to 50 and a maximum of 100.
+- Use opaque signed cursors rather than exposing raw sort keys. This keeps pagination internals changeable.
+
+### Data Contract
+
+- `/track` should be the integration-stable package: metadata, field dimensions, normalized objects needed by external tools, route/timing summaries when available, and schema version.
+- `/overlay` should be the livestream minimap package: route waypoints, sampled route points, numbered route obstacles, timing markers, and route positions.
+- API packages should follow the share-safe privacy boundary by default and exclude map references. A future private owner-only map-reference permission can be added later if there is a strong venue workflow.
+- Use schema names `trackdraw.track.v1` and `trackdraw.overlay.v1` for the shipped v1 packages.
+
+### Public API Boundary
+
+- Keep unauthenticated share reads out of v1. Existing `/share/[token]` and `/embed/[token]` routes already cover public human consumption.
+- Do not reserve future public endpoints in the OpenAPI schema until they are ready to be supported.
+- Public gallery metadata can be reconsidered later as a separate public API surface, not bundled into the account-key v1.
+- Treat v1 as server-to-server/plugin oriented. Keep browser CORS restrictive at first, then open specific origins or documented CORS behavior once browser-based third-party clients are a real requirement.
+
+## Phase Plan
+
+### Top-Level Checklist
+
+- [x] Phase 0 complete: API boundary and auth matrix are accepted
+- [x] Phase 1 complete: account users can create, list, and revoke expiring API keys
+- [x] Phase 2 complete: bearer auth resolves an API key owner and serves first project reads
+- [x] Phase 3 complete: OpenAPI schema and docs page are available
+- [ ] Phase 4 complete: livestream overlay package supports first integration consumers
+- [ ] Phase 5 complete: validation, tests, audit, and docs are complete
+
+### Phase 0: Lock Product Boundary
+
+Start state:
+
+- TrackDraw has account-backed projects and shares
+- REST API permissions and endpoint auth policy are not formalized
+- external integrations are still file/share-link oriented
+
+Work:
+
+- approve account-only API key model
+- approve read-only v1
+- approve public-versus-authenticated endpoint matrix
+- verify Better Auth API Key plugin package/import path, Cloudflare runtime compatibility, and D1 migration strategy
+- decide whether API keys are visible to all users immediately or gated behind account settings
+- decide first key expiry choices and permissions
+
+Done state:
+
+- API permissions are explicit
+- Better Auth API Key plugin integration path is known before code work starts
+- v1 does not accidentally become a write API or public data API
+- implementation can proceed without reopening auth policy on every endpoint
+
+### Phase 1: Better Auth API Key Integration And Management
+
+Start state:
+
+- users can sign in but cannot create API credentials
+
+Work:
+
+- install and configure the Better Auth API Key plugin
+- add plugin-generated or plugin-compatible D1 migration/schema
+- configure key prefix, expiry bounds, required names, default permissions, and base rate limits
+- add API key list/create/revoke browser-session endpoints or a TrackDraw wrapper around the plugin endpoints
+- add minimal account UI entry point if this phase includes UI
+- add audit events for API key created and revoked
+
+Done state:
+
+- signed-in users can create expiring read-only API keys
+- API key secrets are only shown once
+- revoked keys cannot be used later
+
+### Phase 2: Bearer API Key Auth And First Read Endpoints
+
+Start state:
+
+- API keys exist but no `/api/v1/*` data endpoint trusts them
+
+Work:
+
+- add `getApiUserFromBearerKey()` style helper backed by Better Auth API key verification
+- validate expiry, revocation, and permissions on every request
+- enforce a conservative per-key read limit
+- add `GET /api/v1/me`
+- add `GET /api/v1/projects`
+- add `GET /api/v1/projects/{projectId}`
+- add `GET /api/v1/projects/{projectId}/track`
+- keep project reads owner-scoped
+
+Done state:
+
+- an external tool can authenticate and retrieve the user's own normalized project data
+
+### Phase 3: OpenAPI And Docs
+
+Start state:
+
+- first endpoints exist but external contract is not yet self-describing
+
+Work:
+
+- add OpenAPI 3.1 schema for shipped endpoints
+- serve `GET /api/v1/openapi.json`
+- add `/api/docs` page that renders the schema
+- include bearer auth, permissions, expiry, response examples, Problem Details error examples, pagination, and rate-limit headers
+
+Done state:
+
+- developers can discover and test the API contract from TrackDraw itself
+
+### Phase 4: Livestream Overlay Package
+
+Start state:
+
+- project reads work
+- livestream minimap consumers still need a stable package
+
+Work:
+
+- add `GET /api/v1/projects/{projectId}/overlay`
+- include field dimensions and coordinate origin
+- include the primary route, sampled route points, route status, numbered route obstacles, and timing markers
+- include route positions where a marker or obstacle can be projected onto the route
+- defer share endpoints until a concrete consumer needs them
+- document the difference between `/track` and `/overlay`
+
+Done state:
+
+- `rh-stream-overlays` has a clear target endpoint and package shape
+- share endpoints remain out of v1 unless a real consumer need appears
+
+### Phase 5: Hardening And Validation
+
+Start state:
+
+- the core API works but production behavior needs tightening
+
+Work:
+
+- finalize throttling for `/api/v1/*`
+- add stricter budgets for package endpoints than metadata endpoints if usage requires it
+- return stable `429` errors and `Retry-After` headers
+- add tests for API key creation, expiry, revoke, owner scoping, and bad bearer keys
+- add tests for throttled requests
+- add tests for project and overlay endpoint authorization
+- add a cleanup path for expired and revoked API key records after the visible retention window
+- update `CONTRIBUTING.md` with preview-mode validation notes if needed
+- update user-facing docs if API docs are linked from account settings
+- confirm existing editor, share, gallery, and embed behavior is unchanged
+
+Done state:
+
+- API is safe enough for practical external use
+- docs and tests cover the auth and ownership boundaries
+
+## Validation Expectations
+
+Before treating the API as implementation-ready:
+
+- confirm v1 endpoint list and auth matrix
+- confirm API key expiry options
+- confirm whether OpenAPI docs are public
+- confirm response envelope, Problem Details errors, and cursor pagination
+- confirm the first integration data package shape
+
+Before treating the API as release-ready:
+
+- API key creation returns the full secret only once
+- raw API keys are not stored outside Better Auth's supported plugin storage model
+- expired and revoked keys return `401`
+- throttled keys return `429` with a stable error code
+- error responses use Problem Details consistently under `/api/v1/*`
+- owner scoping blocks access to another user's project/share
+- `/api/v1/openapi.json` matches shipped endpoints
+- `/api/docs` loads in local dev and preview
+- `npm run lint` passes
+- `npm run type` passes
+- preview-mode auth/API flow is tested with D1
+
+## Risks
+
+- API keys expand the security surface beyond browser sessions.
+- Long-lived integrations can make stale or overbroad data access harder to notice.
+- Public REST endpoints could accidentally bypass the existing share and public-output privacy boundary.
+- OpenAPI documentation can drift if it is not maintained with endpoint changes.
+- Rendering endpoints can become expensive if image/PDF generation is added too early.
+
+## Recommended Next Step
+
+Approve Phase 0 and build Phase 1 first.
+
+Do not start with every endpoint. Start by making account-owned, expiring API keys real through the Better Auth API Key plugin, then prove one bearer-authenticated read path before adding the livestream overlay package. Defer shares and full exports until a real consumer needs them.

--- a/docs/research/trackdraw-rest-api.md
+++ b/docs/research/trackdraw-rest-api.md
@@ -1,0 +1,467 @@
+# TrackDraw REST API Research
+
+Date: April 28, 2026
+
+Status: proposed product direction
+
+## Purpose
+
+This document evaluates whether TrackDraw should add a real REST API and how that API should fit the existing product model.
+
+The original integration prompt came from moving TrackDraw data into `rh-stream-overlays` and RotorHazard-adjacent workflows. The broader opportunity is larger: make account-backed TrackDraw projects and published tracks consumable by external tools without making the browser editor itself account-mandatory.
+
+## Product Thesis
+
+TrackDraw should add a versioned REST API as an account-backed integration surface.
+
+The API should let users create an account, generate a permissioned API key with an expiry, and allow external tools to read their TrackDraw projects, published tracks, share metadata, and export-friendly track data.
+
+This should not replace the existing public web surfaces:
+
+- `/share/[token]` remains the canonical no-account read-only view for pilots and crew
+- `/embed/[token]` remains the account-published iframe surface for websites
+- `/gallery` remains the public discovery surface
+- `/studio` remains usable without an account for core editing, autosave, import/export, and temporary sharing
+
+The REST API is for tools and automation. The public web routes are for humans.
+
+## Why Build It
+
+### 1. External Tooling
+
+TrackDraw already stores useful structured course data:
+
+- real-scale field dimensions
+- obstacle geometry
+- route paths
+- timing marker metadata
+- inventory/buildability data
+- share/gallery metadata
+- published snapshots that can be opened read-only
+
+That data becomes more valuable when external tools can consume it reliably.
+
+Likely consumers:
+
+- `rh-stream-overlays`
+- club websites
+- event dashboards
+- OBS/browser-source tooling
+- briefing and PDF generators
+- Discord or event bots
+- archive and results systems
+- future RotorHazard plugins
+
+### 2. Better Account Value
+
+Accounts currently add ownership, project continuity, durable shares, gallery publishing, and embeds. API keys are a natural account-only addition because they depend on identity, revocation, expiry, and user-controlled access. TrackDraw should prefer Better Auth's API Key plugin for this foundation instead of building a parallel token system.
+
+### 3. Safer Than Sharing Raw Project Files
+
+JSON import/export is still useful, but it is manual and file-oriented. A REST API can provide:
+
+- stable schema versions
+- explicit auth
+- rate limits
+- permissioned API keys
+- predictable error responses
+- future deprecation windows
+- integrations that can refresh data without users downloading files repeatedly
+
+## Recommended Product Boundary
+
+### In Scope For V1
+
+- account-only API key creation and management, backed by Better Auth's API Key plugin
+- expiring bearer API keys
+- API key revocation
+- plugin-backed hashed key storage
+- plugin-backed permissions and rate limiting for `/api/v1/*`
+- read-only access to the owner's projects and account-published shares
+- read-only export endpoints for JSON-oriented integration data
+- OpenAPI documentation
+- clear public-versus-authenticated endpoint policy
+- audit log entries for API key lifecycle events
+
+### Out Of Scope For V1
+
+- write APIs for creating or editing tracks
+- anonymous API keys
+- public unauthenticated API reads for arbitrary share tokens
+- team or club-owned API keys
+- OAuth app marketplace behavior
+- webhooks
+- per-key billing or usage quotas beyond basic rate limiting
+- server-side rendering of every export format
+
+## API Auth Model
+
+### Account Session Versus API Key
+
+TrackDraw should keep two auth modes distinct:
+
+- Browser account session: used by the app UI to manage projects, shares, gallery state, account profile, and API keys.
+- API bearer key: used by external tools to call `/api/v1/*`.
+
+The account session can create and revoke API keys. API keys should not be allowed to create more API keys.
+
+Better Auth's API Key plugin should provide key creation, storage, verification, expiry, permissions, and rate limiting. TrackDraw should still keep API bearer authorization explicit in `/api/v1/*` instead of enabling API keys to become full browser sessions. In other words, do not use session impersonation as the default REST API model; verify keys and map them to the limited integration identity needed by each endpoint.
+
+### API Key Format
+
+Use opaque bearer keys with a visible prefix:
+
+```txt
+td_live_<random secret>
+td_dev_<random secret>
+```
+
+Let the Better Auth API Key plugin store and verify the key secret. Store or expose only plugin-supported safe previews/metadata in TrackDraw UI so users can identify keys later without exposing the full value again.
+
+### Expiry
+
+Every key should have an expiry.
+
+Recommended initial choices:
+
+- 7 days
+- 30 days
+- 90 days
+- 1 year
+
+Do not ship non-expiring keys in v1. Long-lived integrations can rotate yearly.
+
+### Permissions
+
+Start with read-only permissions using the Better Auth API Key plugin permission model. Map the product-facing permission labels consistently:
+
+- `tracks:read`: read normalized track/project data
+- `shares:read`: read account-published share metadata and share-backed track data
+- `exports:read`: read export-oriented JSON packages and lightweight previews
+- `gallery:read`: read public gallery metadata through authenticated calls
+
+Defer write permissions until there is a specific integration that needs them.
+
+### Ownership Rules
+
+An API key acts as the account that created it.
+
+It can read:
+
+- that account's active projects
+- that account's account-published shares
+- public gallery metadata if the endpoint allows it
+
+It cannot read:
+
+- another user's private project
+- anonymous temporary shares owned by nobody
+- expired or revoked shares
+- map references that are intentionally stripped from public share/export serialization
+- account profile data beyond a minimal `/me` response
+
+## Public Versus Authenticated Endpoint Policy
+
+The safest v1 is authenticated by default.
+
+Recommended boundary:
+
+| Endpoint class                 | Auth            | V1 recommendation                                                                                      |
+| ------------------------------ | --------------- | ------------------------------------------------------------------------------------------------------ |
+| Account API key management     | Browser session | Required                                                                                               |
+| Owner projects                 | API bearer key  | Required                                                                                               |
+| Owner published shares         | API bearer key  | Required                                                                                               |
+| Export packages                | API bearer key  | Required                                                                                               |
+| OpenAPI JSON                   | Public          | Allowed                                                                                                |
+| API docs page                  | Public          | Allowed                                                                                                |
+| Gallery metadata               | Optional later  | Keep authenticated in first slice unless product needs public API discovery                            |
+| Published share by share token | Optional later  | Defer public REST access; `/share/[token]` and `/embed/[token]` already cover public human consumption |
+
+This keeps v1 simple: if a machine is calling the REST API for track data, it presents an API key.
+
+Public API reads can come later if there is a clear use case, such as a static club site pulling listed gallery entries without a token. That should be a deliberate expansion, not the default.
+
+## Candidate Endpoints
+
+### Documentation
+
+```txt
+GET /api/v1/openapi.json
+GET /api/docs
+```
+
+The docs page should render the OpenAPI schema. It can be branded as API docs even if users call it a Swagger page.
+
+### API Key Management
+
+Browser-session endpoints:
+
+```txt
+GET /api/account/api-keys
+POST /api/account/api-keys
+DELETE /api/account/api-keys/{keyId}
+```
+
+These endpoints should use the existing Better Auth browser session and never accept API bearer auth. They can either call the Better Auth API Key plugin endpoints directly from the client or wrap the plugin server methods behind TrackDraw-owned routes if the product needs custom naming, defaults, or audit events.
+
+### API Identity
+
+```txt
+GET /api/v1/me
+```
+
+Returns a minimal identity and API key metadata:
+
+- account id
+- display name
+- key id
+- key permissions
+- key expiry
+
+### Projects
+
+```txt
+GET /api/v1/projects
+GET /api/v1/projects/{projectId}
+GET /api/v1/projects/{projectId}/track
+```
+
+`/track` should return an integration-stable shape, not necessarily the same object used internally by the editor.
+
+### Published Shares
+
+```txt
+GET /api/v1/shares
+GET /api/v1/shares/{shareToken}
+GET /api/v1/shares/{shareToken}/track
+```
+
+Only return shares owned by the API key's account. A share token is a public URL identifier, not an API credential.
+
+### Export-Oriented Data
+
+```txt
+GET /api/v1/projects/{projectId}/exports/trackdraw
+GET /api/v1/projects/{projectId}/exports/overlay
+```
+
+Keep export routes project-first in v1. Account projects are the durable source of truth for integrations, while share tokens are public URL identifiers for human-facing published views. Share-backed export routes should only be added later if a real consumer starts from a share token or needs the exact published snapshot rather than the owner's current project data.
+
+Do not use file extensions in v1 API endpoint paths. The route should identify the export resource, and the response should declare the representation through `Content-Type`. Download filenames can be handled through `Content-Disposition` when needed.
+
+First export formats:
+
+- `exports/trackdraw`: normalized TrackDraw project data with schema versioning
+- `exports/overlay`: smaller route/timing/marker package for `rh-stream-overlays`
+
+Defer PNG/SVG/PDF export endpoints until there is a proven consumer. Existing browser exports can continue to serve human workflows.
+
+### Explicitly Out Of V1
+
+```txt
+POST /api/v1/projects
+PATCH /api/v1/projects/{projectId}
+DELETE /api/v1/projects/{projectId}
+GET /api/v1/shares/{shareToken} without bearer auth
+GET /api/v1/gallery/tracks
+```
+
+Write APIs, unauthenticated share reads, and public gallery API discovery should be deliberate later expansions rather than part of the first REST API.
+
+## OpenAPI Direction
+
+TrackDraw should maintain an OpenAPI 3.1 document as a first-class artifact.
+
+Recommended shape:
+
+- source schema lives in `src/lib/api/openapi.ts` or a static JSON file if that stays simpler
+- `GET /api/v1/openapi.json` serves the schema
+- `/api/docs` renders the schema as an interactive documentation page
+- endpoint handlers and docs share response/error types where practical
+
+The first docs version can be lightweight. The important v1 requirement is that external developers can see:
+
+- auth scheme
+- key expiry behavior
+- permissions
+- endpoint list
+- response examples
+- error model
+- pagination model
+- rate limit headers
+
+## Response Standards
+
+TrackDraw should use a small, explicit REST response convention instead of copying the older internal app-route response style everywhere.
+
+Recommended standards:
+
+- JSON responses use `application/json` unless an error is returned as Problem Details
+- error responses use RFC 9457 Problem Details with `application/problem+json`
+- timestamps use ISO 8601 strings in UTC
+- response fields use `camelCase`
+- ids, share tokens, and API key previews are strings
+- list endpoints use cursor pagination, not page-number pagination
+- rate-limited responses return HTTP `429` with `Retry-After`
+- rate-limit headers should be documented in OpenAPI when implemented
+
+Success responses should use a stable top-level envelope:
+
+```json
+{
+  "data": {
+    "id": "project-id",
+    "type": "project"
+  },
+  "meta": {
+    "apiVersion": "v1"
+  }
+}
+```
+
+List responses should use the same envelope with cursor metadata:
+
+```json
+{
+  "data": [],
+  "pagination": {
+    "limit": 50,
+    "nextCursor": "opaque-cursor",
+    "hasMore": true
+  },
+  "meta": {
+    "apiVersion": "v1"
+  }
+}
+```
+
+Error responses should use Problem Details:
+
+```json
+{
+  "type": "https://trackdraw.app/problems/unauthorized",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "A valid API bearer key is required.",
+  "code": "unauthorized",
+  "requestId": "req_123"
+}
+```
+
+This gives external consumers familiar HTTP semantics while keeping TrackDraw-specific fields such as `code` and `requestId`.
+
+## Data Contract Direction
+
+The API should not expose every editor implementation detail forever.
+
+Recommended response layers:
+
+### Metadata
+
+Small list responses:
+
+- id
+- title
+- description
+- updatedAt
+- publishedAt when relevant
+- field dimensions
+- shape count
+- gallery state when relevant
+
+### Track Package
+
+Detailed track responses:
+
+- schema version
+- source type: `project` or `share`
+- source id/token
+- title and description
+- field dimensions and units
+- normalized shapes safe for external consumption
+- primary route when available
+- timing markers when available
+- export metadata
+
+### Internal Editor Data
+
+Only expose raw serialized project data through an explicit format such as `exports/trackdraw`, and document that it is more complete but less integration-minimal than the overlay package.
+
+## Security And Abuse Considerations
+
+### API Key Storage
+
+- use Better Auth's API Key plugin as the storage and verification source of truth
+- never store raw key secrets outside the plugin's supported model
+- show the full key only once at creation
+- support revoke by key id
+
+### API Key Use
+
+- require `Authorization: Bearer <key>` for TrackDraw `/api/v1/*` routes, even if the plugin also supports `x-api-key`
+- reject keys in query strings
+- check expiry on every request
+- let the Better Auth plugin update supported usage metadata/rate-limit counters
+- store additional last-used IP/user-agent metadata only if the privacy posture is accepted
+
+### Rate Limits
+
+V1 should include throttling and rate limiting before the API is considered release-ready. This is part of the API safety model, not an optional optimization.
+
+Recommended layers:
+
+- per-key limits for ordinary API reads
+- stricter per-key limits for export-oriented endpoints
+- per-IP fallback limits for unauthenticated public docs endpoints if they become noisy
+- Cloudflare-level protection for broad `/api/v1/*` abuse
+- a stable `429` error response with a machine-readable error code
+- `Retry-After` headers for throttled responses
+- standard rate-limit headers if the implementation can keep them accurate
+
+Do not let API export endpoints become unbounded server-side render jobs.
+
+Initial limits can be conservative and adjusted later. The important first decision is that every API key has an enforced budget, and that high-cost endpoints have a smaller budget than metadata reads.
+
+### Privacy
+
+API responses should follow the existing share/export boundary:
+
+- do not expose editor-only map references in share-backed public/export responses
+- do not expose account emails except perhaps `/me` if absolutely needed
+- avoid including private local-only data because the API should be account-backed only
+
+## Recommended First Slice
+
+Build the smallest useful authenticated API:
+
+1. Better Auth API Key plugin installation and schema/migration setup.
+2. Browser-session API key management surface.
+3. Bearer API key resolver helper.
+4. `GET /api/v1/me`.
+5. `GET /api/v1/projects`.
+6. `GET /api/v1/projects/{projectId}/track`.
+7. `GET /api/v1/openapi.json`.
+8. `/api/docs` page.
+9. Conservative per-key throttling for the shipped `/api/v1/*` endpoints.
+
+This proves the Better Auth API Key plugin integration, docs model, and account ownership model before adding share metadata or overlay-specific packages.
+
+## Recommended Defaults
+
+- Make API keys available to every signed-in user through account/developer settings.
+- Default API keys to 90 days, with 7-day, 30-day, 90-day, and 1-year options. Do not offer non-expiring keys.
+- Enforce read permissions from the first implementation.
+- Treat the first API as generic project/share access, with `rh-stream-overlays` as the first concrete integration consumer rather than the whole API shape.
+- Keep unauthenticated share reads and public gallery API discovery out of v1.
+- Use separate per-key budgets for metadata and export endpoints. Start with 600 metadata requests per hour and 60 export requests per hour, with lower burst caps for exports.
+- Prefer Better Auth API Key plugin rate limiting first. Add a TrackDraw-specific limiter abstraction only where route class budgets, export throttles, or Cloudflare-native controls need behavior the plugin cannot express cleanly.
+- Use `meta.apiVersion` on successful `/api/v1/*` responses, Problem Details for errors, opaque signed cursors, and a default list limit of 50 with a maximum of 100.
+- Keep API export packages share-safe by default and exclude map references.
+- Treat `exports/overlay` as a planned Phase 4 endpoint that should ship only after the `rh-stream-overlays` import contract is specific enough to validate.
+- Keep browser CORS restrictive in v1 and target server-to-server/plugin integrations first.
+
+## Recommendation
+
+Proceed to PVA.
+
+Build the REST API as an account-backed, read-only, API-key-authenticated integration surface first. Prefer Better Auth's API Key plugin for key lifecycle, verification, permissions, and base rate limiting. Keep public REST reads and write APIs out of v1. Add OpenAPI docs from the first implementation slice so the contract is explicit from day one.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -112,7 +112,7 @@ These items are now follow-up work rather than intentionally blocked. The first 
 
 #### REST API And Integration Surface
 
-TrackDraw should add a versioned REST API as an account-backed integration surface for external tools, starting with read-only access to account projects and owned published shares.
+TrackDraw should add a versioned REST API as an account-backed integration surface for external tools, starting with read-only access to account projects and compact livestream overlay data.
 
 Supporting documents:
 
@@ -127,14 +127,14 @@ Why:
 
 Focus:
 
-- Shipped first slice: Better Auth API Key plugin integration, plugin-compatible D1 `apikey` storage, browser-session API key management routes, bearer-authenticated project reads at `/api/v1/me`, `/api/v1/projects`, `/api/v1/projects/[projectId]`, and `/api/v1/projects/[projectId]/track`, plus OpenAPI docs at `/api/v1/openapi.json` and `/api/docs`
+- Shipped first slice: Better Auth API Key plugin integration, plugin-compatible D1 `apikey` storage, browser-session API key management routes, bearer-authenticated project reads at `/api/v1/me`, `/api/v1/projects`, `/api/v1/projects/[projectId]`, and `/api/v1/projects/[projectId]/track`, livestream minimap data at `/api/v1/projects/[projectId]/overlay`, plus OpenAPI docs at `/api/v1/openapi.json` and `/api/docs`
 - Add browser-session API key management for signed-in users
 - Use Better Auth API Key plugin storage and verification, with explicit expiry and revocation
 - Clean up expired and revoked API keys after the visible retention window
-- Enforce throttling and rate limits for `/api/v1/*`, with stricter budgets for export endpoints
+- Enforce throttling and rate limits for `/api/v1/*`
 - Keep `/api/v1/*` authenticated by default for v1
-- Start with read-only project data and owned-share metadata
-- Defer public unauthenticated REST reads, write APIs, and share export endpoints until concrete integrations require them
+- Start with read-only project data and overlay/minimap metadata
+- Defer public unauthenticated REST reads, write APIs, and share endpoints until concrete integrations require them
 
 #### Share Lifecycle Follow-up
 
@@ -219,9 +219,8 @@ The same start/finish and split timing markers should first serve TrackDraw's ow
 
 Current state:
 
-- Stable project JSON export/import already exists through `serializeDesign()` and `parseDesign()`
-- The existing project JSON is the preferred first integration format for `rh-stream-overlays`
-- TrackDraw still lacks explicit race-route and timing-role authoring, so overlay preparation is not yet release-ready from this repo alone
+- The REST API now exposes a compact project overlay package for route, numbered obstacle, and timing marker data
+- Route and timing-role authoring exists, but overlay preparation still needs consumer-side validation against the `rh-stream-overlays` runtime expectations
 
 TrackDraw scope:
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -127,13 +127,13 @@ Why:
 
 Focus:
 
-- Shipped first slice: Better Auth API Key plugin integration, plugin-compatible D1 `apikey` storage, browser-session API key management routes, and bearer-authenticated project reads at `/api/v1/me`, `/api/v1/projects`, `/api/v1/projects/[projectId]`, and `/api/v1/projects/[projectId]/track`
+- Shipped first slice: Better Auth API Key plugin integration, plugin-compatible D1 `apikey` storage, browser-session API key management routes, bearer-authenticated project reads at `/api/v1/me`, `/api/v1/projects`, `/api/v1/projects/[projectId]`, and `/api/v1/projects/[projectId]/track`, plus OpenAPI docs at `/api/v1/openapi.json` and `/api/docs`
 - Add browser-session API key management for signed-in users
 - Use Better Auth API Key plugin storage and verification, with explicit expiry and revocation
+- Clean up expired and revoked API keys after the visible retention window
 - Enforce throttling and rate limits for `/api/v1/*`, with stricter budgets for export endpoints
 - Keep `/api/v1/*` authenticated by default for v1
 - Start with read-only project data and owned-share metadata
-- Publish `GET /api/v1/openapi.json` and an API docs page from the first endpoint slice
 - Defer public unauthenticated REST reads, write APIs, and share export endpoints until concrete integrations require them
 
 #### Share Lifecycle Follow-up

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -38,8 +38,8 @@ The v1.6.0 release-sized work is archived below. The remaining active work stays
         Add bearer-authenticated project reads such as `/api/v1/me`, `/api/v1/projects`, and project track data.
   - [x] OpenAPI docs
         Serve an OpenAPI schema and API docs page so external tools can integrate against an explicit contract.
-  - [ ] Share and export integration endpoints
-        Add owned published-share reads and project export JSON packages once the first project read path is proven; defer share export endpoints until a concrete consumer needs share-token lookup or published snapshot parity.
+  - [x] RotorHazard livestream data endpoint
+        Add a compact account-project `/api/v1/projects/[projectId]/overlay` package for route, numbered obstacle, and timing marker data; defer shares and full project exports until a concrete non-overlay consumer needs them.
 
 - [x] Base UI to Radix UI migration
       Replace `@base-ui/react` with Radix UI primitives across all UI components to fix mobile touch handling inside dialogs. The immediate trigger is that Base UI's `Select` and `Menu` primitives fail to respond to touch events on mobile inside a dialog focus trap.
@@ -109,9 +109,9 @@ The v1.6.0 release-sized work is archived below. The remaining active work stays
   - [ ] Timing setup validation
         Warn or block overlay-oriented export when the race route is missing, timing roles are duplicated, or marked timing points cannot be mapped onto route progress.
   - [ ] TrackDraw JSON contract pass
-        Keep the existing serialized project JSON as the first integration format and document the fields `rh-stream-overlays` should consume.
-  - [ ] Overlay package export decision
-        Only add a dedicated overlay package export if the RH plugin proves the full project JSON is too broad or ambiguous.
+        Document the compact REST overlay package and the fields `rh-stream-overlays` should consume.
+  - [x] Overlay package endpoint
+        Added an account-project `/api/v1/projects/[projectId]/overlay` endpoint for route, numbered obstacle, and timing marker data without exposing full editor JSON.
 
 ## Backlog And Research
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -33,10 +33,10 @@ The v1.6.0 release-sized work is archived below. The remaining active work stays
   - [x] API key management
         Let signed-in users create, list, and revoke permissioned expiring API keys through the Better Auth API Key plugin.
   - [ ] Throttling and rate limits
-        Enforce per-key API budgets, stable `429` responses, and stricter limits for export-oriented endpoints.
+        Enforce per-key API budgets, stable `429` responses, stricter limits for export-oriented endpoints, and cleanup for expired or revoked API keys after the visible retention window.
   - [x] First authenticated read endpoints
         Add bearer-authenticated project reads such as `/api/v1/me`, `/api/v1/projects`, and project track data.
-  - [ ] OpenAPI docs
+  - [x] OpenAPI docs
         Serve an OpenAPI schema and API docs page so external tools can integrate against an explicit contract.
   - [ ] Share and export integration endpoints
         Add owned published-share reads and project export JSON packages once the first project read path is proven; defer share export endpoints until a concrete consumer needs share-token lookup or published snapshot parity.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
+        "@scalar/nextjs-api-reference": "^0.10.11",
         "@tanstack/react-table": "^8.21.3",
         "better-auth": "^1.6.0",
         "class-variance-authority": "^0.7.1",
@@ -5952,6 +5953,58 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@scalar/client-side-rendering": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.1.4.tgz",
+      "integrity": "sha512-xriPrHrKs/FNQbMJTPWiP7bIualAobbJlzrDM5Tl+7nSgKMUUgpR60IcOphCsJ+iFcdOU/VTmjufBcOaVigDPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/types": "0.9.3"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/helpers": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.5.3.tgz",
+      "integrity": "sha512-PgQmhuV0oRoHtaqH0OhyCcSY9t35qm8ThNeuUMEAKeN+hW1ijBnJiUADpxaIfXPbLrpN9sjyYza0A16WFbLttg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@scalar/nextjs-api-reference": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/@scalar/nextjs-api-reference/-/nextjs-api-reference-0.10.11.tgz",
+      "integrity": "sha512-wp7FRjQdSjjlV53mKmL00gQ/4u7xQS4uYRt+JiavzSIHDRyVDjjJdjKacfDGFeEUY6o29VEFEOY1/2Ies6fLfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/client-side-rendering": "0.1.4"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "next": "^15.0.0 || ^16.0.0",
+        "react": "^19.0.0"
+      }
+    },
+    "node_modules/@scalar/types": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.9.3.tgz",
+      "integrity": "sha512-/cEFjVa8PxRIDyhcWKh7McT8pm5O0kbafzd1jvpVq69sgIIq0gJ0P1sCcPye6qJ2k478PK7VmpK9FxZcr6D4Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@scalar/helpers": "0.5.3",
+        "nanoid": "^5.1.6",
+        "type-fest": "^5.3.1",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
+    "@scalar/nextjs-api-reference": "^0.10.11",
     "@tanstack/react-table": "^8.21.3",
     "better-auth": "^1.6.0",
     "class-variance-authority": "^0.7.1",

--- a/src/app/api/account/api-keys/[keyId]/route.ts
+++ b/src/app/api/account/api-keys/[keyId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { deleteApiKeyForSession } from "@/lib/server/api-keys";
+import { createAuditEvent } from "@/lib/server/audit";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 
 type ApiKeyRouteContext = {
@@ -34,6 +35,21 @@ export async function DELETE(request: Request, context: ApiKeyRouteContext) {
       headers: request.headers,
       keyId,
     });
+
+    try {
+      await createAuditEvent({
+        actorUserId: user.id,
+        targetUserId: user.id,
+        eventType: "api_key.revoked",
+        entityType: "api_key",
+        entityId: keyId,
+      });
+    } catch (auditError) {
+      console.error("[TrackDraw API keys] Failed to audit key revoke", {
+        keyId,
+        error: auditError,
+      });
+    }
 
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/src/app/api/account/api-keys/route.ts
+++ b/src/app/api/account/api-keys/route.ts
@@ -8,6 +8,7 @@ import {
   normalizeApiKeyRecord,
   normalizeCreatedApiKey,
 } from "@/lib/server/api-keys";
+import { createAuditEvent } from "@/lib/server/audit";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 
 const createApiKeyRequestSchema = z.object({
@@ -64,11 +65,32 @@ export async function POST(request: Request) {
       name: body.name,
       expiresInDays: normalizeApiKeyExpiryDays(body.expiresInDays),
     });
+    const normalizedApiKey = normalizeCreatedApiKey(apiKey);
+
+    try {
+      await createAuditEvent({
+        actorUserId: user.id,
+        targetUserId: user.id,
+        eventType: "api_key.created",
+        entityType: "api_key",
+        entityId: normalizedApiKey.id,
+        metadata: {
+          name: normalizedApiKey.name,
+          expiresAt: normalizedApiKey.expiresAt,
+          permissions: normalizedApiKey.permissions,
+        },
+      });
+    } catch (auditError) {
+      console.error("[TrackDraw API keys] Failed to audit key creation", {
+        keyId: normalizedApiKey.id,
+        error: auditError,
+      });
+    }
 
     return NextResponse.json(
       {
         ok: true,
-        apiKey: normalizeCreatedApiKey(apiKey),
+        apiKey: normalizedApiKey,
       },
       { status: 201 }
     );

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -1,0 +1,16 @@
+import { ApiReference } from "@scalar/nextjs-api-reference";
+
+export const GET = ApiReference({
+  url: "/api/v1/openapi.json",
+  pageTitle: "TrackDraw API Docs",
+  theme: "default",
+  layout: "modern",
+  showSidebar: true,
+  defaultOpenFirstTag: true,
+  defaultOpenAllTags: true,
+  expandAllResponses: true,
+  orderSchemaPropertiesBy: "preserve",
+  orderRequiredPropertiesFirst: true,
+  documentDownloadType: "json",
+  showOperationId: true,
+});

--- a/src/app/api/v1/me/route.ts
+++ b/src/app/api/v1/me/route.ts
@@ -1,5 +1,5 @@
 import { apiSuccess, authenticateApiRequest } from "@/lib/server/api-v1";
-import { normalizeApiKeyRecord } from "@/lib/server/api-keys";
+import { normalizeApiKeyPermissions } from "@/lib/server/api-keys";
 
 export async function GET(request: Request) {
   const auth = await authenticateApiRequest(request);
@@ -8,10 +8,15 @@ export async function GET(request: Request) {
   }
 
   return apiSuccess({
-    type: "account",
-    id: auth.identity.user.id,
-    email: auth.identity.user.email,
-    name: auth.identity.user.name,
-    apiKey: normalizeApiKeyRecord(auth.identity.key),
+    type: "api_identity",
+    account: {
+      id: auth.identity.user.id,
+      name: auth.identity.user.name,
+    },
+    permissions: normalizeApiKeyPermissions(auth.identity.key.permissions),
+    expires_at:
+      auth.identity.key.expiresAt instanceof Date
+        ? auth.identity.key.expiresAt.toISOString()
+        : (auth.identity.key.expiresAt ?? null),
   });
 }

--- a/src/app/api/v1/openapi.json/route.ts
+++ b/src/app/api/v1/openapi.json/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { trackdrawOpenApiSchema } from "@/lib/api/openapi";
+
+export function GET() {
+  return NextResponse.json(trackdrawOpenApiSchema, {
+    headers: {
+      "cache-control": "public, max-age=300",
+    },
+  });
+}

--- a/src/app/api/v1/projects/[projectId]/overlay/route.ts
+++ b/src/app/api/v1/projects/[projectId]/overlay/route.ts
@@ -1,0 +1,46 @@
+import {
+  apiProblem,
+  apiSuccess,
+  authenticateApiRequest,
+} from "@/lib/server/api-v1";
+import { trackReadPermission } from "@/lib/server/api-keys";
+import { toApiOverlayPackage } from "@/lib/server/api-projects";
+import { getProjectForUser } from "@/lib/server/projects";
+
+type ProjectOverlayRouteContext = {
+  params: Promise<{
+    projectId: string;
+  }>;
+};
+
+export async function GET(
+  request: Request,
+  context: ProjectOverlayRouteContext
+) {
+  const auth = await authenticateApiRequest(request, trackReadPermission);
+  if (!auth.ok) {
+    return auth.response;
+  }
+
+  const { projectId } = await context.params;
+  if (!projectId.trim()) {
+    return apiProblem({
+      status: 400,
+      code: "bad_request",
+      title: "Bad Request",
+      detail: "Missing project id.",
+    });
+  }
+
+  const project = await getProjectForUser(projectId, auth.identity.user.id);
+  if (!project) {
+    return apiProblem({
+      status: 404,
+      code: "not_found",
+      title: "Not Found",
+      detail: "Project not found.",
+    });
+  }
+
+  return apiSuccess(toApiOverlayPackage(project));
+}

--- a/src/app/api/v1/projects/route.ts
+++ b/src/app/api/v1/projects/route.ts
@@ -29,8 +29,8 @@ export async function GET(request: Request) {
 
     return apiListSuccess(page.map(toApiProjectSummary), {
       limit,
-      nextCursor: null,
-      hasMore: false,
+      next_cursor: null,
+      has_more: false,
     });
   } catch (error) {
     return apiProblem({

--- a/src/components/dialogs/AccountDialog/ApiKeysView.tsx
+++ b/src/components/dialogs/AccountDialog/ApiKeysView.tsx
@@ -1,11 +1,20 @@
+import Link from "next/link";
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import {
   Braces,
   Clipboard,
+  ExternalLink,
   LoaderCircle,
   Plus,
   RefreshCw,
   Trash2,
 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/AppTooltip";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -23,6 +32,23 @@ import {
 } from "./shared";
 import type { AccountApiKey, CreatedAccountApiKey } from "./types";
 import { formatDate, getPermissionLabel } from "./utils";
+
+function ActionTooltip({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactElement;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
 
 type ApiKeysViewProps = {
   isPending: boolean;
@@ -63,6 +89,10 @@ export function AccountApiKeysView({
   onDeleteApiKey,
   onRefreshApiKeys,
 }: ApiKeysViewProps) {
+  const [confirmRevokeKeyId, setConfirmRevokeKeyId] = useState<string | null>(
+    null
+  );
+
   if (isPending) {
     return <AccountDialogLoading />;
   }
@@ -181,8 +211,17 @@ export function AccountApiKeysView({
         >
           <div>
             <p className="text-sm font-medium">Active API keys</p>
-            <p className="text-muted-foreground mt-1 text-sm">
-              Keys use bearer authentication for `/api/v1`.
+            <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
+              Use these keys to connect external tools to your TrackDraw data.{" "}
+              <Link
+                href="/api/docs"
+                target="_blank"
+                rel="noreferrer"
+                className="text-foreground inline-flex items-center gap-1 font-medium underline-offset-4 hover:underline"
+              >
+                API docs
+                <ExternalLink className="size-3" />
+              </Link>
             </p>
           </div>
           <Button
@@ -222,11 +261,12 @@ export function AccountApiKeysView({
           <div className="space-y-3">
             {apiKeys.map((apiKey) => {
               const isDeleting = deletingApiKeyId === apiKey.id;
+              const isConfirming = confirmRevokeKeyId === apiKey.id;
 
               return (
                 <div
                   key={apiKey.id}
-                  className="bg-muted/20 border-border/60 rounded-2xl border px-4 py-4"
+                  className="group bg-muted/20 border-border/60 relative overflow-hidden rounded-2xl border px-4 py-4"
                 >
                   <div
                     className={cn(
@@ -255,24 +295,77 @@ export function AccountApiKeysView({
                       </p>
                     </div>
 
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      onClick={() => onDeleteApiKey(apiKey.id)}
-                      disabled={isDeleting}
-                      className={cn(
-                        "text-muted-foreground hover:text-foreground h-8 rounded-lg px-2.5",
-                        isMobile && "w-full justify-center"
-                      )}
-                    >
-                      {isDeleting ? (
-                        <LoaderCircle className="size-4 animate-spin" />
-                      ) : (
-                        <Trash2 className="size-4" />
-                      )}
-                      Revoke
-                    </Button>
+                    {isMobile ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => setConfirmRevokeKeyId(apiKey.id)}
+                        disabled={isDeleting}
+                        className="border-destructive/30 text-destructive hover:bg-destructive/10 hover:text-destructive focus-visible:ring-destructive/30 h-8 w-full justify-center rounded-lg px-2.5"
+                      >
+                        {isDeleting ? (
+                          <LoaderCircle className="size-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="size-4" />
+                        )}
+                        Revoke
+                      </Button>
+                    ) : (
+                      <ActionTooltip label="Revoke">
+                        <button
+                          type="button"
+                          onClick={() => setConfirmRevokeKeyId(apiKey.id)}
+                          disabled={isDeleting}
+                          className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg opacity-0 transition-[opacity,colors] group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-50"
+                          aria-label={`Revoke ${apiKey.name?.trim() || "API key"}`}
+                        >
+                          {isDeleting ? (
+                            <LoaderCircle className="size-3.5 animate-spin" />
+                          ) : (
+                            <Trash2 className="size-3.5" />
+                          )}
+                        </button>
+                      </ActionTooltip>
+                    )}
                   </div>
+
+                  <AnimatePresence>
+                    {isConfirming && (
+                      <motion.div
+                        className="bg-background/97 absolute inset-0 flex items-center justify-between gap-2 rounded-2xl px-4 backdrop-blur-sm"
+                        initial={{ x: "100%", opacity: 0 }}
+                        animate={{ x: 0, opacity: 1 }}
+                        exit={{ x: "100%", opacity: 0 }}
+                        transition={{ duration: 0.18, ease: "easeOut" }}
+                        onClick={(event) => event.stopPropagation()}
+                      >
+                        <p className="text-foreground truncate text-sm font-medium">
+                          Revoke this key?
+                        </p>
+                        <div className="flex shrink-0 items-center gap-1">
+                          <button
+                            type="button"
+                            onClick={() => {
+                              onDeleteApiKey(apiKey.id);
+                              setConfirmRevokeKeyId(null);
+                            }}
+                            disabled={isDeleting}
+                            className="bg-destructive/10 hover:bg-destructive/20 text-destructive disabled:text-destructive/60 cursor-pointer rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed"
+                          >
+                            {isDeleting ? "Revoking..." : "Revoke"}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setConfirmRevokeKeyId(null)}
+                            disabled={isDeleting}
+                            className="text-muted-foreground hover:text-foreground disabled:text-muted-foreground/50 cursor-pointer rounded-lg px-2 py-1.5 text-xs transition-colors disabled:cursor-not-allowed"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
                 </div>
               );
             })}

--- a/src/components/dialogs/AccountDialog/index.tsx
+++ b/src/components/dialogs/AccountDialog/index.tsx
@@ -434,14 +434,6 @@ export default function AccountDialog({
   };
 
   const handleDeleteApiKey = async (keyId: string) => {
-    const apiKey = apiKeys.find((item) => item.id === keyId);
-    const confirmed = window.confirm(
-      `Revoke ${apiKey?.name?.trim() || "this API key"}?\n\nExisting integrations using this key will stop working.`
-    );
-    if (!confirmed) {
-      return;
-    }
-
     setDeletingApiKeyId(keyId);
     setError(null);
 
@@ -629,7 +621,7 @@ export default function AccountDialog({
       }}
       contentTitle={current.title}
       contentDescription={current.description}
-      maxWidth="max-w-3xl"
+      maxWidth="max-w-4xl"
     >
       {current.content}
     </SidebarDialog>

--- a/src/lib/api/openapi.ts
+++ b/src/lib/api/openapi.ts
@@ -90,6 +90,55 @@ const trackPackageExample = {
   shapes: [],
 };
 
+const overlayPackageExample = {
+  type: "overlay_track",
+  schema: "trackdraw.overlay.v1",
+  source: { type: "project", id: "project_123" },
+  title: "Club race layout",
+  field: {
+    width: 60,
+    height: 40,
+    origin: "tl",
+    unit: "m",
+  },
+  route: {
+    shape_id: "route_123",
+    closed: false,
+    length_m: 126.4,
+    waypoints: [
+      { x: 8, y: 20, z: 0 },
+      { x: 28, y: 12, z: 1.5 },
+    ],
+    sampled_points: [
+      { x: 8, y: 20 },
+      { x: 12.4, y: 18.2 },
+    ],
+  },
+  route_status: "ready",
+  route_obstacles: [
+    {
+      id: "gate_1",
+      kind: "gate",
+      name: "Gate 1",
+      x: 12,
+      y: 18,
+      rotation: 90,
+      route_number: 1,
+      route_position: {
+        distance_m: 14.2,
+        progress: 0.112,
+        x: 12.1,
+        y: 18.1,
+        offset_m: 0.2,
+      },
+      width: 3,
+      height: 1.8,
+    },
+  ],
+  timing_markers: [],
+  updated_at: "2026-04-28T12:29:48.000Z",
+};
+
 export const trackdrawOpenApiSchema = {
   openapi: "3.1.0",
   info: {
@@ -97,11 +146,11 @@ export const trackdrawOpenApiSchema = {
     version: "1.0.0",
     summary: "Read-only TrackDraw integration API.",
     description: [
-      "The v1 REST API provides bearer-authenticated access to account identity checks and read-only project track data.",
+      "The TrackDraw REST API gives external tools a stable way to read account-backed track data and integration packages.",
       "",
-      "API keys are expiring bearer tokens created from account settings. Use `Authorization: Bearer <api_key>` for `/api/v1/*` endpoints.",
+      "Use it to connect project metadata, track geometry, timing markers, and livestream overlay data to tools outside TrackDraw.",
       "",
-      "Successful `/api/v1/*` responses use a `{ data, meta }` envelope. List endpoints add a `pagination` object. Errors use a compact `application/problem+json` body with `title`, `status`, `detail`, and a stable TrackDraw `code`.",
+      "The API is versioned, read-only in v1, and designed around explicit account ownership and expiring API keys.",
     ].join("\n"),
     contact: {
       name: "TrackDraw",
@@ -125,6 +174,11 @@ export const trackdrawOpenApiSchema = {
       description:
         "Bearer-authenticated read endpoints for active projects owned by the API key account. These endpoints require the `tracks:read` permission.",
     },
+    {
+      name: "RotorHazard",
+      description:
+        "Small bearer-authenticated packages for RotorHazard livestream minimaps and timing overlays.",
+    },
   ],
   "x-tagGroups": [
     {
@@ -134,6 +188,10 @@ export const trackdrawOpenApiSchema = {
     {
       name: "Track data",
       tags: ["Projects"],
+    },
+    {
+      name: "Integrations",
+      tags: ["RotorHazard"],
     },
   ],
   paths: {
@@ -270,6 +328,34 @@ export const trackdrawOpenApiSchema = {
                 data: {
                   ...trackPackageExample,
                 },
+                meta: { api_version: "v1" },
+              }
+            ),
+          },
+          "400": { $ref: "#/components/responses/BadRequest" },
+          "401": { $ref: "#/components/responses/Unauthorized" },
+          "404": { $ref: "#/components/responses/NotFound" },
+          "429": { $ref: "#/components/responses/RateLimited" },
+          "500": { $ref: "#/components/responses/InternalError" },
+        },
+      },
+    },
+    "/api/v1/projects/{projectId}/overlay": {
+      get: {
+        tags: ["RotorHazard"],
+        operationId: "getProjectOverlay",
+        summary: "Get livestream data",
+        description:
+          "Returns a compact route, obstacle, and timing package for livestream minimaps. This endpoint is designed for overlay consumers and excludes full editor JSON.",
+        security: [{ bearerAuth: [] }],
+        parameters: [{ $ref: "#/components/parameters/ProjectId" }],
+        responses: {
+          "200": {
+            description: "Livestream overlay package for one project.",
+            content: jsonContent(
+              envelope({ $ref: "#/components/schemas/OverlayPackage" }),
+              {
+                data: overlayPackageExample,
                 meta: { api_version: "v1" },
               }
             ),
@@ -538,6 +624,85 @@ export const trackdrawOpenApiSchema = {
             description:
               "Integration-safe shape geometry. Editor-only fields such as map references, inventory, author name, tags, shape locks, front-offset guide metadata, and shape metadata are excluded.",
           },
+        },
+      },
+      OverlayPackage: {
+        type: "object",
+        description:
+          "Compact livestream minimap package with route geometry, numbered route obstacles, timing markers, and route positions.",
+        required: [
+          "type",
+          "schema",
+          "source",
+          "title",
+          "field",
+          "route",
+          "route_status",
+          "route_obstacles",
+          "timing_markers",
+          "updated_at",
+        ],
+        properties: {
+          type: { type: "string", const: "overlay_track" },
+          schema: { type: "string", const: "trackdraw.overlay.v1" },
+          source: {
+            type: "object",
+            required: ["type", "id"],
+            properties: {
+              type: { type: "string", const: "project" },
+              id: { type: "string" },
+            },
+          },
+          title: { type: "string" },
+          field: { $ref: "#/components/schemas/TrackField" },
+          route: {
+            anyOf: [
+              {
+                type: "object",
+                required: [
+                  "shape_id",
+                  "closed",
+                  "length_m",
+                  "waypoints",
+                  "sampled_points",
+                ],
+                properties: {
+                  shape_id: { type: "string" },
+                  closed: { type: "boolean" },
+                  length_m: { type: "number", minimum: 0 },
+                  waypoints: {
+                    type: "array",
+                    items: { type: "object", additionalProperties: true },
+                  },
+                  sampled_points: {
+                    type: "array",
+                    items: { type: "object", additionalProperties: true },
+                  },
+                },
+              },
+              { type: "null" },
+            ],
+          },
+          route_status: {
+            type: "string",
+            enum: [
+              "empty",
+              "missing-route",
+              "no-numbered-obstacles",
+              "no-route-matches",
+              "partial",
+              "ready",
+            ],
+          },
+          route_obstacles: {
+            type: "array",
+            items: { type: "object", additionalProperties: true },
+          },
+          timing_markers: {
+            type: "array",
+            items: { type: "object", additionalProperties: true },
+          },
+          updated_at: { type: "string", format: "date-time" },
         },
       },
     },

--- a/src/lib/api/openapi.ts
+++ b/src/lib/api/openapi.ts
@@ -1,0 +1,545 @@
+const jsonMediaType = "application/json";
+const problemMediaType = "application/problem+json";
+
+function jsonContent(schema: object, example?: object) {
+  return {
+    [jsonMediaType]: {
+      schema,
+      ...(example ? { example } : {}),
+    },
+  };
+}
+
+function problemContent(example: object) {
+  return {
+    [problemMediaType]: {
+      schema: { $ref: "#/components/schemas/ProblemDetails" },
+      example,
+    },
+  };
+}
+
+function envelope(schema: object) {
+  return {
+    type: "object",
+    required: ["data", "meta"],
+    properties: {
+      data: schema,
+      meta: { $ref: "#/components/schemas/ApiMeta" },
+    },
+  };
+}
+
+function listEnvelope(itemSchema: object) {
+  return {
+    type: "object",
+    required: ["data", "pagination", "meta"],
+    properties: {
+      data: {
+        type: "array",
+        items: itemSchema,
+      },
+      pagination: { $ref: "#/components/schemas/Pagination" },
+      meta: { $ref: "#/components/schemas/ApiMeta" },
+    },
+  };
+}
+
+const unauthorizedExample = {
+  title: "Unauthorized",
+  status: 401,
+  detail: "A valid API bearer key is required.",
+  code: "unauthorized",
+};
+
+const rateLimitedExample = {
+  title: "Too Many Requests",
+  status: 429,
+  detail: "Too many requests for this API key. Try again later.",
+  code: "rate_limited",
+};
+
+const projectExample = {
+  type: "project",
+  id: "project_123",
+  title: "Club race layout",
+  field: {
+    width: 60,
+    height: 40,
+    unit: "m",
+  },
+  shape_count: 18,
+  created_at: "2026-04-28T09:00:00.000Z",
+  updated_at: "2026-04-28T12:30:00.000Z",
+};
+
+const trackPackageExample = {
+  type: "track",
+  schema: "trackdraw.track.v1",
+  source: { type: "project", id: "project_123" },
+  title: "Club race layout",
+  field: {
+    width: 60,
+    height: 40,
+    origin: "tl",
+    unit: "m",
+  },
+  shape_count: 18,
+  timing_markers: [],
+  updated_at: "2026-04-28T12:29:48.000Z",
+  shapes: [],
+};
+
+export const trackdrawOpenApiSchema = {
+  openapi: "3.1.0",
+  info: {
+    title: "TrackDraw REST API",
+    version: "1.0.0",
+    summary: "Read-only TrackDraw integration API.",
+    description: [
+      "The v1 REST API provides bearer-authenticated access to account identity checks and read-only project track data.",
+      "",
+      "API keys are expiring bearer tokens created from account settings. Use `Authorization: Bearer <api_key>` for `/api/v1/*` endpoints.",
+      "",
+      "Successful `/api/v1/*` responses use a `{ data, meta }` envelope. List endpoints add a `pagination` object. Errors use a compact `application/problem+json` body with `title`, `status`, `detail`, and a stable TrackDraw `code`.",
+    ].join("\n"),
+    contact: {
+      name: "TrackDraw",
+      url: "https://trackdraw.app",
+    },
+  },
+  servers: [
+    {
+      url: "/",
+      description: "Current TrackDraw origin",
+    },
+  ],
+  tags: [
+    {
+      name: "Identity",
+      description:
+        "Bearer-authenticated setup and diagnostics endpoints for external integrations.",
+    },
+    {
+      name: "Projects",
+      description:
+        "Bearer-authenticated read endpoints for active projects owned by the API key account. These endpoints require the `tracks:read` permission.",
+    },
+  ],
+  "x-tagGroups": [
+    {
+      name: "Account setup",
+      tags: ["Identity"],
+    },
+    {
+      name: "Track data",
+      tags: ["Projects"],
+    },
+  ],
+  paths: {
+    "/api/v1/me": {
+      get: {
+        tags: ["Identity"],
+        operationId: "getApiIdentity",
+        summary: "Get API identity",
+        description:
+          "Returns minimal account identity and bearer-key capabilities. Use this endpoint to verify that an integration has a valid key before requesting project data.",
+        security: [{ bearerAuth: [] }],
+        responses: {
+          "200": {
+            description:
+              "Account identity and current bearer-key capabilities.",
+            headers: {
+              "RateLimit-Limit": {
+                $ref: "#/components/headers/RateLimitLimit",
+              },
+              "RateLimit-Remaining": {
+                $ref: "#/components/headers/RateLimitRemaining",
+              },
+              "RateLimit-Reset": {
+                $ref: "#/components/headers/RateLimitReset",
+              },
+            },
+            content: jsonContent(
+              envelope({ $ref: "#/components/schemas/ApiIdentity" }),
+              {
+                data: {
+                  type: "api_identity",
+                  account: {
+                    id: "user_123",
+                    name: "Race Director",
+                  },
+                  permissions: { tracks: ["read"] },
+                  expires_at: "2026-07-27T09:00:00.000Z",
+                },
+                meta: { api_version: "v1" },
+              }
+            ),
+          },
+          "401": { $ref: "#/components/responses/Unauthorized" },
+          "429": { $ref: "#/components/responses/RateLimited" },
+          "500": { $ref: "#/components/responses/InternalError" },
+        },
+      },
+    },
+    "/api/v1/projects": {
+      get: {
+        tags: ["Projects"],
+        operationId: "listProjects",
+        summary: "List projects",
+        description:
+          "Lists active account-backed projects owned by the API key account. The endpoint does not include archived projects and does not expose projects owned by other accounts.",
+        security: [{ bearerAuth: [] }],
+        parameters: [{ $ref: "#/components/parameters/Limit" }],
+        responses: {
+          "200": {
+            description: "Cursor-paginated project summaries.",
+            headers: {
+              "RateLimit-Limit": {
+                $ref: "#/components/headers/RateLimitLimit",
+              },
+              "RateLimit-Remaining": {
+                $ref: "#/components/headers/RateLimitRemaining",
+              },
+              "RateLimit-Reset": {
+                $ref: "#/components/headers/RateLimitReset",
+              },
+            },
+            content: jsonContent(
+              listEnvelope({ $ref: "#/components/schemas/ProjectSummary" }),
+              {
+                data: [projectExample],
+                pagination: {
+                  limit: 50,
+                  next_cursor: null,
+                  has_more: false,
+                },
+                meta: { api_version: "v1" },
+              }
+            ),
+          },
+          "401": { $ref: "#/components/responses/Unauthorized" },
+          "429": { $ref: "#/components/responses/RateLimited" },
+          "500": { $ref: "#/components/responses/InternalError" },
+        },
+      },
+    },
+    "/api/v1/projects/{projectId}": {
+      get: {
+        tags: ["Projects"],
+        operationId: "getProject",
+        summary: "Get project metadata",
+        description:
+          "Returns ownership-safe metadata for one project owned by the API key account. Use this before downloading a full track package when an integration only needs project identity and timestamps.",
+        security: [{ bearerAuth: [] }],
+        parameters: [{ $ref: "#/components/parameters/ProjectId" }],
+        responses: {
+          "200": {
+            description: "One project summary.",
+            content: jsonContent(
+              envelope({ $ref: "#/components/schemas/ProjectSummary" }),
+              {
+                data: projectExample,
+                meta: { api_version: "v1" },
+              }
+            ),
+          },
+          "400": { $ref: "#/components/responses/BadRequest" },
+          "401": { $ref: "#/components/responses/Unauthorized" },
+          "404": { $ref: "#/components/responses/NotFound" },
+          "429": { $ref: "#/components/responses/RateLimited" },
+          "500": { $ref: "#/components/responses/InternalError" },
+        },
+      },
+    },
+    "/api/v1/projects/{projectId}/track": {
+      get: {
+        tags: ["Projects"],
+        operationId: "getProjectTrack",
+        summary: "Get project track package",
+        description:
+          "Returns the integration-stable track package for one project owned by the API key account. The package includes sanitized shape geometry and excludes editor-only data.",
+        security: [{ bearerAuth: [] }],
+        parameters: [{ $ref: "#/components/parameters/ProjectId" }],
+        responses: {
+          "200": {
+            description: "Track package for one project.",
+            content: jsonContent(
+              envelope({ $ref: "#/components/schemas/TrackPackage" }),
+              {
+                data: {
+                  ...trackPackageExample,
+                },
+                meta: { api_version: "v1" },
+              }
+            ),
+          },
+          "400": { $ref: "#/components/responses/BadRequest" },
+          "401": { $ref: "#/components/responses/Unauthorized" },
+          "404": { $ref: "#/components/responses/NotFound" },
+          "429": { $ref: "#/components/responses/RateLimited" },
+          "500": { $ref: "#/components/responses/InternalError" },
+        },
+      },
+    },
+  },
+  components: {
+    parameters: {
+      ProjectId: {
+        name: "projectId",
+        in: "path",
+        required: true,
+        description: "Account-backed TrackDraw project id.",
+        schema: { type: "string" },
+        example: "project_123",
+      },
+      Limit: {
+        name: "limit",
+        in: "query",
+        required: false,
+        description:
+          "Maximum number of records to return. The v1 default is 50 and the maximum is 100.",
+        schema: { type: "integer", minimum: 1, maximum: 100, default: 50 },
+        example: 50,
+      },
+    },
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "TrackDraw API key",
+        description:
+          "Use `Authorization: Bearer <api_key>` for `/api/v1/*` data endpoints. API keys expire and can be revoked from account settings.",
+      },
+    },
+    headers: {
+      RetryAfter: {
+        description: "Seconds to wait before retrying a throttled request.",
+        schema: { type: "integer", minimum: 1, example: 60 },
+      },
+      RateLimitLimit: {
+        description: "Request budget for the current rate-limit window.",
+        schema: { type: "integer", example: 600 },
+      },
+      RateLimitRemaining: {
+        description: "Requests remaining in the current rate-limit window.",
+        schema: { type: "integer", example: 599 },
+      },
+      RateLimitReset: {
+        description: "Seconds until the current rate-limit window resets.",
+        schema: { type: "integer", example: 3600 },
+      },
+    },
+    responses: {
+      BadRequest: {
+        description: "The request was invalid.",
+        content: problemContent({
+          title: "Bad Request",
+          status: 400,
+          detail: "Missing project id.",
+          code: "bad_request",
+        }),
+      },
+      Unauthorized: {
+        description:
+          "The bearer key is missing, invalid, expired, disabled, or lacks the required permission.",
+        content: problemContent(unauthorizedExample),
+      },
+      NotFound: {
+        description:
+          "The requested resource does not exist or is not owned by the API key account.",
+        content: problemContent({
+          title: "Not Found",
+          status: 404,
+          detail: "Project not found.",
+          code: "not_found",
+        }),
+      },
+      RateLimited: {
+        description: "The API key has exceeded its request budget.",
+        headers: {
+          "Retry-After": { $ref: "#/components/headers/RetryAfter" },
+          "RateLimit-Limit": { $ref: "#/components/headers/RateLimitLimit" },
+          "RateLimit-Remaining": {
+            $ref: "#/components/headers/RateLimitRemaining",
+          },
+          "RateLimit-Reset": { $ref: "#/components/headers/RateLimitReset" },
+        },
+        content: problemContent(rateLimitedExample),
+      },
+      InternalError: {
+        description: "The server could not complete the request.",
+        content: problemContent({
+          title: "Internal Server Error",
+          status: 500,
+          detail: "Failed to list projects.",
+          code: "internal_error",
+        }),
+      },
+    },
+    schemas: {
+      ApiMeta: {
+        type: "object",
+        required: ["api_version"],
+        properties: {
+          api_version: {
+            type: "string",
+            const: "v1",
+          },
+        },
+      },
+      Pagination: {
+        type: "object",
+        required: ["limit", "next_cursor", "has_more"],
+        properties: {
+          limit: { type: "integer", minimum: 1, maximum: 100, example: 50 },
+          next_cursor: {
+            type: ["string", "null"],
+            description: "Opaque cursor for the next page.",
+          },
+          has_more: { type: "boolean" },
+        },
+      },
+      ProblemDetails: {
+        type: "object",
+        required: ["title", "status", "detail", "code"],
+        properties: {
+          title: { type: "string" },
+          status: { type: "integer" },
+          detail: { type: "string" },
+          code: { type: "string" },
+        },
+      },
+      ApiKeyPermissions: {
+        type: "object",
+        description:
+          "Permission map stored on an API key. v1 project reads require `tracks:read`.",
+        additionalProperties: {
+          type: "array",
+          items: { type: "string" },
+        },
+        example: { tracks: ["read"] },
+      },
+      ApiIdentity: {
+        type: "object",
+        description:
+          "Minimal account and bearer-key capability metadata for integration setup checks.",
+        required: ["type", "account", "permissions", "expires_at"],
+        properties: {
+          type: { type: "string", const: "api_identity" },
+          account: {
+            type: "object",
+            required: ["id", "name"],
+            properties: {
+              id: { type: "string" },
+              name: { type: ["string", "null"] },
+            },
+          },
+          permissions: {
+            anyOf: [
+              { $ref: "#/components/schemas/ApiKeyPermissions" },
+              { type: "null" },
+            ],
+          },
+          expires_at: { type: ["string", "null"], format: "date-time" },
+        },
+      },
+      ProjectSummary: {
+        type: "object",
+        description:
+          "Ownership-safe project metadata. Shape geometry is only returned by the project track package endpoint.",
+        required: [
+          "type",
+          "id",
+          "title",
+          "field",
+          "shape_count",
+          "created_at",
+          "updated_at",
+        ],
+        properties: {
+          type: { type: "string", const: "project" },
+          id: { type: "string", description: "TrackDraw project id." },
+          title: { type: "string", description: "Project title." },
+          field: { $ref: "#/components/schemas/ProjectField" },
+          shape_count: {
+            type: "integer",
+            minimum: 0,
+            description: "Number of design shapes in the project.",
+          },
+          created_at: { type: "string", format: "date-time" },
+          updated_at: { type: "string", format: "date-time" },
+        },
+      },
+      ProjectField: {
+        type: "object",
+        description: "Project field dimensions in meters.",
+        required: ["width", "height", "unit"],
+        properties: {
+          width: { type: "number", description: "Field width." },
+          height: { type: "number", description: "Field height." },
+          unit: { type: "string", const: "m" },
+        },
+      },
+      TrackField: {
+        allOf: [
+          { $ref: "#/components/schemas/ProjectField" },
+          {
+            type: "object",
+            required: ["origin"],
+            properties: {
+              origin: {
+                type: "string",
+                enum: ["tl", "bl"],
+                description:
+                  "Field origin used by TrackDraw coordinates: top-left or bottom-left.",
+              },
+            },
+          },
+        ],
+      },
+      TrackPackage: {
+        type: "object",
+        description:
+          "Integration-stable track package for one account-owned project. The package excludes private map-reference data.",
+        required: [
+          "type",
+          "schema",
+          "source",
+          "title",
+          "field",
+          "shape_count",
+          "timing_markers",
+          "updated_at",
+          "shapes",
+        ],
+        properties: {
+          type: { type: "string", const: "track" },
+          schema: { type: "string", const: "trackdraw.track.v1" },
+          source: {
+            type: "object",
+            required: ["type", "id"],
+            properties: {
+              type: { type: "string", const: "project" },
+              id: { type: "string" },
+            },
+          },
+          title: { type: "string" },
+          field: { $ref: "#/components/schemas/TrackField" },
+          shape_count: { type: "integer", minimum: 0 },
+          timing_markers: {
+            type: "array",
+            items: { type: "object", additionalProperties: true },
+          },
+          updated_at: { type: "string", format: "date-time" },
+          shapes: {
+            type: "array",
+            items: { type: "object", additionalProperties: true },
+            description:
+              "Integration-safe shape geometry. Editor-only fields such as map references, inventory, author name, tags, shape locks, front-offset guide metadata, and shape metadata are excluded.",
+          },
+        },
+      },
+    },
+  },
+} as const;

--- a/src/lib/server/api-key-retention.ts
+++ b/src/lib/server/api-key-retention.ts
@@ -1,0 +1,26 @@
+type D1PreparedStatement = {
+  bind(...values: unknown[]): D1PreparedStatement;
+  run<T = unknown>(): Promise<T>;
+};
+
+type D1Database = {
+  prepare(query: string): D1PreparedStatement;
+};
+
+export async function cleanupExpiredApiKeys(
+  db: D1Database,
+  retentionDays = 90
+) {
+  const days = Math.max(1, Math.trunc(retentionDays));
+
+  return db
+    .prepare(
+      `
+      delete from apikey
+      where expiresAt is not null
+        and datetime(expiresAt) < datetime('now', ?)
+    `
+    )
+    .bind(`-${days} days`)
+    .run();
+}

--- a/src/lib/server/api-keys.ts
+++ b/src/lib/server/api-keys.ts
@@ -30,6 +30,13 @@ export type ApiIdentity = {
   key: VerifiedApiKey;
 };
 
+type ApiKeyVerificationError = {
+  code?: string;
+  details?: {
+    tryAgainIn?: unknown;
+  };
+};
+
 type UserRow = {
   id: string;
   email: string | null;
@@ -148,6 +155,23 @@ export async function deleteApiKeyForSession(options: {
   });
 }
 
+function isRateLimitError(code: string) {
+  return (
+    code === "RATE_LIMITED" ||
+    code === "RATE_LIMIT_EXCEEDED" ||
+    code === "USAGE_EXCEEDED"
+  );
+}
+
+function getRetryAfterSeconds(error: ApiKeyVerificationError | null) {
+  const tryAgainIn = error?.details?.tryAgainIn;
+  if (typeof tryAgainIn !== "number" || !Number.isFinite(tryAgainIn)) {
+    return null;
+  }
+
+  return Math.max(1, Math.ceil(tryAgainIn / 1000));
+}
+
 async function getUserById(userId: string) {
   const db = await getDatabase();
   return db
@@ -186,15 +210,17 @@ export async function getApiIdentityFromBearerKey(options: {
   });
 
   if (!verified.valid || !verified.key) {
-    const code = verified.error?.code ?? "invalid_api_key";
+    const error = verified.error as ApiKeyVerificationError | null;
+    const code = error?.code ?? "invalid_api_key";
+    const rateLimited = isRateLimitError(code);
     return {
       ok: false as const,
-      status: code === "RATE_LIMIT_EXCEEDED" ? 429 : 401,
-      code: code === "RATE_LIMIT_EXCEEDED" ? "rate_limited" : "invalid_api_key",
-      detail:
-        code === "RATE_LIMIT_EXCEEDED"
-          ? "Too many requests for this API key. Try again later."
-          : "The API bearer key is invalid, expired, disabled, or lacks the required permission.",
+      status: rateLimited ? 429 : 401,
+      code: rateLimited ? "rate_limited" : "invalid_api_key",
+      detail: rateLimited
+        ? "Too many requests for this API key. Try again later."
+        : "The API bearer key is invalid, expired, disabled, or lacks the required permission.",
+      retryAfterSeconds: rateLimited ? getRetryAfterSeconds(error) : null,
     };
   }
 

--- a/src/lib/server/api-keys.ts
+++ b/src/lib/server/api-keys.ts
@@ -62,6 +62,10 @@ function normalizePermissions(value: unknown): ApiKeyPermissionSet | null {
   return permissions;
 }
 
+export function normalizeApiKeyPermissions(value: unknown) {
+  return normalizePermissions(value);
+}
+
 export function normalizeApiKeyRecord(key: ApiKeyListItem | VerifiedApiKey) {
   return {
     id: key.id,

--- a/src/lib/server/api-projects.ts
+++ b/src/lib/server/api-projects.ts
@@ -1,31 +1,64 @@
 import "server-only";
 
-import {
-  getDesignShapes,
-  serializeDesign,
-  serializeDesignForShare,
-} from "@/lib/track/design";
+import { getDesignShapes, serializeDesign } from "@/lib/track/design";
+import { getDesignTimingMarkers } from "@/lib/track/timing";
 import type { StoredProject } from "@/lib/server/projects";
+import type { Shape } from "@/lib/types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toSnakeCaseKey(key: string) {
+  return key.replace(/[A-Z]/g, (match) => `_${match.toLowerCase()}`);
+}
+
+function toSnakeCaseValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(toSnakeCaseValue);
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      toSnakeCaseKey(key),
+      toSnakeCaseValue(entry),
+    ])
+  );
+}
 
 export function toApiProjectSummary(project: StoredProject) {
   return {
     type: "project" as const,
     id: project.id,
     title: project.title,
-    description: project.description,
     field: {
-      width: project.fieldWidth,
-      height: project.fieldHeight,
+      width: project.fieldWidth ?? project.design.field.width,
+      height: project.fieldHeight ?? project.design.field.height,
       unit: "m" as const,
     },
-    shapeCount: project.shapeCount,
-    createdAt: project.createdAt,
-    updatedAt: project.updatedAt,
-    designUpdatedAt: project.designUpdatedAt,
+    shape_count: project.shapeCount,
+    created_at: project.createdAt,
+    updated_at: project.updatedAt,
   };
 }
 
+function toApiShape(shape: Shape) {
+  const {
+    locked: _locked,
+    frontOffsetDeg: _frontOffsetDeg,
+    meta: _meta,
+    ...shapeData
+  } = shape;
+  return toSnakeCaseValue(shapeData) as Record<string, unknown>;
+}
+
 export function toApiTrackPackage(project: StoredProject) {
+  const shapes = getDesignShapes(project.design);
+
   return {
     type: "track" as const,
     schema: "trackdraw.track.v1" as const,
@@ -34,18 +67,21 @@ export function toApiTrackPackage(project: StoredProject) {
       id: project.id,
     },
     title: project.title,
-    description: project.description,
     field: {
       width: project.design.field.width,
       height: project.design.field.height,
       origin: project.design.field.origin,
-      gridStep: project.design.field.gridStep,
       unit: "m" as const,
     },
-    shapeCount: getDesignShapes(project.design).length,
-    timingMarkers: [],
-    updatedAt: project.designUpdatedAt,
-    design: serializeDesignForShare(project.design),
+    shape_count: shapes.length,
+    timing_markers: getDesignTimingMarkers(project.design).map((marker) => ({
+      shape_id: marker.shape.id,
+      role: marker.marker.role,
+      timing_id: marker.marker.timingId ?? null,
+      title: marker.title,
+    })),
+    updated_at: project.designUpdatedAt,
+    shapes: shapes.map(toApiShape),
   };
 }
 
@@ -58,7 +94,7 @@ export function toApiTrackDrawExport(project: StoredProject) {
       id: project.id,
     },
     title: project.title,
-    updatedAt: project.designUpdatedAt,
+    updated_at: project.designUpdatedAt,
     design: serializeDesign(project.design),
   };
 }

--- a/src/lib/server/api-projects.ts
+++ b/src/lib/server/api-projects.ts
@@ -1,9 +1,14 @@
 import "server-only";
 
 import { getDesignShapes, serializeDesign } from "@/lib/track/design";
+import {
+  getObstacleNumberingReport,
+  isNumberedObstacle,
+} from "@/lib/track/obstacleNumbering";
+import { getPolyline2DDerived } from "@/lib/track/polyline-derived";
 import { getDesignTimingMarkers } from "@/lib/track/timing";
 import type { StoredProject } from "@/lib/server/projects";
-import type { Shape } from "@/lib/types";
+import type { PolylineShape, Shape, TrackDesign } from "@/lib/types";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -56,6 +61,143 @@ function toApiShape(shape: Shape) {
   return toSnakeCaseValue(shapeData) as Record<string, unknown>;
 }
 
+function toApiPoint(point: { x: number; y: number; z?: number }) {
+  return {
+    x: point.x,
+    y: point.y,
+    ...(typeof point.z === "number" ? { z: point.z } : {}),
+  };
+}
+
+function getPrimaryRoute(design: TrackDesign) {
+  return (
+    getDesignShapes(design).find(
+      (shape): shape is PolylineShape =>
+        shape.kind === "polyline" && shape.points.length >= 2
+    ) ?? null
+  );
+}
+
+function getPointSequenceLength(points: Array<{ x: number; y: number }>) {
+  let length = 0;
+
+  for (let index = 1; index < points.length; index += 1) {
+    const start = points[index - 1];
+    const end = points[index];
+    length += Math.hypot(end.x - start.x, end.y - start.y);
+  }
+
+  return length;
+}
+
+function projectPointOntoRoute(
+  point: { x: number; y: number },
+  routePoints: Array<{ x: number; y: number }>,
+  routeLength: number
+) {
+  if (routePoints.length < 2 || routeLength <= 0) {
+    return null;
+  }
+
+  let bestDistance = Number.POSITIVE_INFINITY;
+  let bestDistanceAlongRoute = 0;
+  let bestProjectedPoint = routePoints[0];
+  let runningLength = 0;
+
+  for (let index = 1; index < routePoints.length; index += 1) {
+    const start = routePoints[index - 1];
+    const end = routePoints[index];
+    const dx = end.x - start.x;
+    const dy = end.y - start.y;
+    const lengthSquared = dx * dx + dy * dy;
+    const segmentLength = Math.sqrt(lengthSquared);
+
+    if (lengthSquared <= 1e-9) {
+      continue;
+    }
+
+    const segmentProgress = Math.max(
+      0,
+      Math.min(
+        1,
+        ((point.x - start.x) * dx + (point.y - start.y) * dy) / lengthSquared
+      )
+    );
+    const projectedPoint = {
+      x: start.x + dx * segmentProgress,
+      y: start.y + dy * segmentProgress,
+    };
+    const distance = Math.hypot(
+      point.x - projectedPoint.x,
+      point.y - projectedPoint.y
+    );
+    const distanceAlongRoute = runningLength + segmentLength * segmentProgress;
+
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestDistanceAlongRoute = distanceAlongRoute;
+      bestProjectedPoint = projectedPoint;
+    }
+
+    runningLength += segmentLength;
+  }
+
+  if (!Number.isFinite(bestDistance)) {
+    return null;
+  }
+
+  return {
+    distance_m: bestDistanceAlongRoute,
+    progress: bestDistanceAlongRoute / routeLength,
+    x: bestProjectedPoint.x,
+    y: bestProjectedPoint.y,
+    offset_m: bestDistance,
+  };
+}
+
+function toOverlayObstacle(
+  shape: Shape,
+  routeNumber: number | null,
+  routePosition: ReturnType<typeof projectPointOntoRoute>
+) {
+  const base = {
+    id: shape.id,
+    kind: shape.kind,
+    name: shape.name ?? null,
+    x: shape.x,
+    y: shape.y,
+    rotation: shape.rotation,
+    route_number: routeNumber,
+    route_position: routePosition,
+  };
+
+  switch (shape.kind) {
+    case "gate":
+      return {
+        ...base,
+        width: shape.width,
+        height: shape.height,
+      };
+    case "ladder":
+      return {
+        ...base,
+        width: shape.width,
+        height: shape.height,
+        rungs: shape.rungs,
+        elevation: shape.elevation ?? 0,
+      };
+    case "divegate":
+      return {
+        ...base,
+        size: shape.size,
+        tilt: shape.tilt ?? 0,
+        elevation: shape.elevation ?? 3,
+      };
+    default:
+      return base;
+  }
+}
+
 export function toApiTrackPackage(project: StoredProject) {
   const shapes = getDesignShapes(project.design);
 
@@ -82,6 +224,65 @@ export function toApiTrackPackage(project: StoredProject) {
     })),
     updated_at: project.designUpdatedAt,
     shapes: shapes.map(toApiShape),
+  };
+}
+
+export function toApiOverlayPackage(project: StoredProject) {
+  const route = getPrimaryRoute(project.design);
+  const routeMetrics = route ? getPolyline2DDerived(route) : null;
+  const routePoints = routeMetrics?.smoothPoints ?? [];
+  const routeLength = getPointSequenceLength(routePoints);
+  const obstacleReport = getObstacleNumberingReport(project.design);
+  const shapes = getDesignShapes(project.design);
+  const routeObstacles = shapes.filter(isNumberedObstacle);
+
+  return {
+    type: "overlay_track" as const,
+    schema: "trackdraw.overlay.v1" as const,
+    source: {
+      type: "project" as const,
+      id: project.id,
+    },
+    title: project.title,
+    field: {
+      width: project.design.field.width,
+      height: project.design.field.height,
+      origin: project.design.field.origin,
+      unit: "m" as const,
+    },
+    route: route
+      ? {
+          shape_id: route.id,
+          closed: Boolean(route.closed),
+          length_m: routeLength,
+          waypoints: route.points.map(toApiPoint),
+          sampled_points: routePoints,
+        }
+      : null,
+    route_status: obstacleReport.status,
+    route_obstacles: routeObstacles.map((shape) =>
+      toOverlayObstacle(
+        shape,
+        obstacleReport.obstacleNumberMap.get(shape.id) ?? null,
+        projectPointOntoRoute(shape, routePoints, routeLength)
+      )
+    ),
+    timing_markers: getDesignTimingMarkers(project.design).map((marker) => ({
+      shape_id: marker.shape.id,
+      role: marker.marker.role,
+      timing_id: marker.marker.timingId ?? null,
+      title: marker.title,
+      position: {
+        x: marker.shape.x,
+        y: marker.shape.y,
+      },
+      route_position: projectPointOntoRoute(
+        marker.shape,
+        routePoints,
+        routeLength
+      ),
+    })),
+    updated_at: project.designUpdatedAt,
   };
 }
 

--- a/src/lib/server/api-projects.ts
+++ b/src/lib/server/api-projects.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { getDesignShapes, serializeDesign } from "@/lib/track/design";
+import { getDesignShapes } from "@/lib/track/design";
 import {
   getObstacleNumberingReport,
   isNumberedObstacle,
@@ -283,19 +283,5 @@ export function toApiOverlayPackage(project: StoredProject) {
       ),
     })),
     updated_at: project.designUpdatedAt,
-  };
-}
-
-export function toApiTrackDrawExport(project: StoredProject) {
-  return {
-    type: "export" as const,
-    schema: "trackdraw.export.v1" as const,
-    source: {
-      type: "project" as const,
-      id: project.id,
-    },
-    title: project.title,
-    updated_at: project.designUpdatedAt,
-    design: serializeDesign(project.design),
   };
 }

--- a/src/lib/server/api-v1.ts
+++ b/src/lib/server/api-v1.ts
@@ -87,6 +87,10 @@ export async function authenticateApiRequest(
       code: result.code,
       title: result.status === 429 ? "Too Many Requests" : "Unauthorized",
       detail: result.detail,
+      headers:
+        result.status === 429 && result.retryAfterSeconds
+          ? { "Retry-After": String(result.retryAfterSeconds) }
+          : undefined,
     }),
   };
 }

--- a/src/lib/server/api-v1.ts
+++ b/src/lib/server/api-v1.ts
@@ -10,16 +10,12 @@ export type ApiAuthResult =
   | { ok: true; identity: ApiIdentity }
   | { ok: false; response: NextResponse };
 
-function createRequestId() {
-  return `req_${crypto.randomUUID().replaceAll("-", "")}`;
-}
-
 export function apiSuccess<T>(data: T, init?: ResponseInit) {
   return NextResponse.json(
     {
       data,
       meta: {
-        apiVersion: API_VERSION,
+        api_version: API_VERSION,
       },
     },
     init
@@ -30,8 +26,8 @@ export function apiListSuccess<T>(
   data: T[],
   pagination: {
     limit: number;
-    nextCursor: string | null;
-    hasMore: boolean;
+    next_cursor: string | null;
+    has_more: boolean;
   },
   init?: ResponseInit
 ) {
@@ -40,7 +36,7 @@ export function apiListSuccess<T>(
       data,
       pagination,
       meta: {
-        apiVersion: API_VERSION,
+        api_version: API_VERSION,
       },
     },
     init
@@ -54,19 +50,15 @@ export function apiProblem(options: {
   detail: string;
   headers?: HeadersInit;
 }) {
-  const requestId = createRequestId();
   const headers = new Headers(options.headers);
   headers.set("content-type", "application/problem+json");
-  headers.set("x-request-id", requestId);
 
   return NextResponse.json(
     {
-      type: `https://trackdraw.app/problems/${options.code}`,
       title: options.title,
       status: options.status,
       detail: options.detail,
       code: options.code,
-      requestId,
     },
     {
       status: options.status,

--- a/tests/app/api/account/api-keys.route.test.ts
+++ b/tests/app/api/account/api-keys.route.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/server/auth-session", () => ({
+  getCurrentUserFromHeaders: vi.fn(),
+}));
+
+vi.mock("@/lib/server/api-keys", () => ({
+  apiKeyExpiryDayOptions: [7, 30, 90, 365],
+  createApiKeyForSession: vi.fn(),
+  deleteApiKeyForSession: vi.fn(),
+  listApiKeysForSession: vi.fn(),
+  normalizeApiKeyExpiryDays: vi.fn((value: unknown) => value ?? 90),
+  normalizeApiKeyRecord: vi.fn((key: unknown) => key),
+  normalizeCreatedApiKey: vi.fn((key: unknown) => key),
+}));
+
+vi.mock("@/lib/server/audit", () => ({
+  createAuditEvent: vi.fn(),
+}));
+
+import { GET, POST } from "@/app/api/account/api-keys/route";
+import { DELETE } from "@/app/api/account/api-keys/[keyId]/route";
+import {
+  createApiKeyForSession,
+  deleteApiKeyForSession,
+  listApiKeysForSession,
+} from "@/lib/server/api-keys";
+import { createAuditEvent } from "@/lib/server/audit";
+import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
+
+const user = {
+  id: "user-1",
+  email: "pilot@trackdraw.local",
+  name: "Pilot",
+  image: null,
+  role: "user" as const,
+};
+
+const apiKey = {
+  id: "key-1",
+  name: "Overlay",
+  start: "td_abc",
+  enabled: true,
+  permissions: { tracks: ["read"] },
+  createdAt: "2026-04-20T10:00:00.000Z",
+  expiresAt: "2026-07-19T10:00:00.000Z",
+  lastRequest: null,
+  key: "td_secret",
+};
+
+function postRequest(body: unknown) {
+  return new Request("http://localhost/api/account/api-keys", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("account API key routes", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requires a browser session before listing keys", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
+
+    const response = await GET(
+      new Request("http://localhost/api/account/api-keys")
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Authentication required",
+    });
+    expect(listApiKeysForSession).not.toHaveBeenCalled();
+  });
+
+  it("lists only keys visible through the signed-in user's Better Auth session", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(user);
+    vi.mocked(listApiKeysForSession).mockResolvedValue({
+      apiKeys: [apiKey],
+      total: 1,
+    } as never);
+
+    const request = new Request("http://localhost/api/account/api-keys");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      apiKeys: [apiKey],
+      total: 1,
+    });
+    expect(listApiKeysForSession).toHaveBeenCalledWith(request.headers);
+  });
+
+  it("creates expiring API keys and writes an audit event without logging the secret", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(user);
+    vi.mocked(createApiKeyForSession).mockResolvedValue(apiKey as never);
+
+    const response = await POST(
+      postRequest({ name: "Overlay", expiresInDays: 30 })
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      apiKey,
+    });
+    expect(createApiKeyForSession).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+      name: "Overlay",
+      expiresInDays: 30,
+    });
+    expect(createAuditEvent).toHaveBeenCalledWith({
+      actorUserId: user.id,
+      targetUserId: user.id,
+      eventType: "api_key.created",
+      entityType: "api_key",
+      entityId: "key-1",
+      metadata: {
+        name: "Overlay",
+        expiresAt: "2026-07-19T10:00:00.000Z",
+        permissions: { tracks: ["read"] },
+      },
+    });
+    expect(createAuditEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ key: "td_secret" }),
+      })
+    );
+  });
+
+  it("rejects invalid create payloads before calling Better Auth", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(user);
+
+    const response = await POST(postRequest({ name: "", expiresInDays: 30 }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Invalid API key payload",
+    });
+    expect(createApiKeyForSession).not.toHaveBeenCalled();
+    expect(createAuditEvent).not.toHaveBeenCalled();
+  });
+
+  it("still returns the one-time secret when audit logging fails after creation", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(user);
+    vi.mocked(createApiKeyForSession).mockResolvedValue(apiKey as never);
+    vi.mocked(createAuditEvent).mockRejectedValue(new Error("audit failed"));
+
+    const response = await POST(
+      postRequest({ name: "Overlay", expiresInDays: 30 })
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      apiKey,
+    });
+  });
+
+  it("revokes a signed-in user's key and writes an audit event", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(user);
+    vi.mocked(deleteApiKeyForSession).mockResolvedValue({
+      success: true,
+    } as never);
+
+    const request = new Request("http://localhost/api/account/api-keys/key-1", {
+      method: "DELETE",
+    });
+    const response = await DELETE(request, {
+      params: Promise.resolve({ keyId: "key-1" }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(deleteApiKeyForSession).toHaveBeenCalledWith({
+      headers: request.headers,
+      keyId: "key-1",
+    });
+    expect(createAuditEvent).toHaveBeenCalledWith({
+      actorUserId: user.id,
+      targetUserId: user.id,
+      eventType: "api_key.revoked",
+      entityType: "api_key",
+      entityId: "key-1",
+    });
+  });
+
+  it("does not revoke keys without a browser session", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
+
+    const response = await DELETE(
+      new Request("http://localhost/api/account/api-keys/key-1", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ keyId: "key-1" }) }
+    );
+
+    expect(response.status).toBe(401);
+    expect(deleteApiKeyForSession).not.toHaveBeenCalled();
+    expect(createAuditEvent).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app/api/v1/projects.route.test.ts
+++ b/tests/app/api/v1/projects.route.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+import { createDefaultDesign } from "@/lib/track/design";
+import type { StoredProject } from "@/lib/server/projects";
+
+vi.mock("@/lib/server/api-keys", () => ({
+  trackReadPermission: { tracks: ["read"] },
+}));
+
+vi.mock("@/lib/server/api-v1", () => ({
+  authenticateApiRequest: vi.fn(),
+  apiSuccess: vi.fn((data: unknown) =>
+    Response.json({ data, meta: { api_version: "v1" } })
+  ),
+  apiListSuccess: vi.fn((data: unknown[], pagination: object) =>
+    Response.json({ data, pagination, meta: { api_version: "v1" } })
+  ),
+  apiProblem: vi.fn(
+    (options: {
+      status: number;
+      code: string;
+      title: string;
+      detail: string;
+    }) =>
+      Response.json(
+        {
+          title: options.title,
+          status: options.status,
+          detail: options.detail,
+          code: options.code,
+        },
+        {
+          status: options.status,
+          headers: { "content-type": "application/problem+json" },
+        }
+      )
+  ),
+}));
+
+vi.mock("@/lib/server/projects", () => ({
+  getProjectForUser: vi.fn(),
+  listProjectsForUser: vi.fn(),
+}));
+
+vi.mock("@/lib/server/api-projects", () => ({
+  toApiProjectSummary: vi.fn((project: StoredProject) => ({
+    type: "project",
+    id: project.id,
+    title: project.title,
+  })),
+  toApiOverlayPackage: vi.fn((project: StoredProject) => ({
+    type: "overlay_track",
+    source: { type: "project", id: project.id },
+  })),
+}));
+
+import * as projectRoute from "@/app/api/v1/projects/[projectId]/route";
+import * as overlayRoute from "@/app/api/v1/projects/[projectId]/overlay/route";
+import * as projectsRoute from "@/app/api/v1/projects/route";
+import { authenticateApiRequest } from "@/lib/server/api-v1";
+import { trackReadPermission } from "@/lib/server/api-keys";
+import { getProjectForUser, listProjectsForUser } from "@/lib/server/projects";
+import {
+  toApiOverlayPackage,
+  toApiProjectSummary,
+} from "@/lib/server/api-projects";
+
+const apiIdentity = {
+  user: { id: "user-1", email: null, name: "Race Director" },
+  key: {},
+};
+
+function makeProject(id = "project-1"): StoredProject {
+  const design = createDefaultDesign();
+  return {
+    id,
+    ownerUserId: "user-1",
+    title: "Race layout",
+    description: "",
+    design,
+    designUpdatedAt: design.updatedAt,
+    fieldWidth: design.field.width,
+    fieldHeight: design.field.height,
+    shapeCount: 0,
+    createdAt: "2026-04-28T09:00:00.000Z",
+    updatedAt: "2026-04-28T12:30:00.000Z",
+    archivedAt: null,
+  };
+}
+
+function projectContext(projectId: string) {
+  return { params: Promise.resolve({ projectId }) };
+}
+
+describe("v1 project API routes", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(authenticateApiRequest).mockResolvedValue({
+      ok: true,
+      identity: apiIdentity,
+    } as never);
+  });
+
+  it("lists only projects for the API key owner", async () => {
+    const project = makeProject();
+    vi.mocked(listProjectsForUser).mockResolvedValue([project]);
+
+    const response = await projectsRoute.GET(
+      new Request("http://localhost/api/v1/projects?limit=200")
+    );
+
+    expect(authenticateApiRequest).toHaveBeenCalledWith(
+      expect.any(Request),
+      trackReadPermission
+    );
+    expect(listProjectsForUser).toHaveBeenCalledWith("user-1");
+    expect(vi.mocked(toApiProjectSummary).mock.calls[0]?.[0]).toBe(project);
+    await expect(response.json()).resolves.toEqual({
+      data: [{ type: "project", id: "project-1", title: "Race layout" }],
+      pagination: {
+        limit: 100,
+        next_cursor: null,
+        has_more: false,
+      },
+      meta: { api_version: "v1" },
+    });
+  });
+
+  it("returns 404 for project metadata when the project is not owned by the key owner", async () => {
+    vi.mocked(getProjectForUser).mockResolvedValue(null);
+
+    const response = await projectRoute.GET(
+      new Request("http://localhost/api/v1/projects/project-2"),
+      projectContext("project-2")
+    );
+
+    expect(getProjectForUser).toHaveBeenCalledWith("project-2", "user-1");
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      title: "Not Found",
+      status: 404,
+      detail: "Project not found.",
+      code: "not_found",
+    });
+  });
+
+  it("returns overlay data only after loading a project for the API key owner", async () => {
+    const project = makeProject();
+    vi.mocked(getProjectForUser).mockResolvedValue(project);
+
+    const response = await overlayRoute.GET(
+      new Request("http://localhost/api/v1/projects/project-1/overlay"),
+      projectContext("project-1")
+    );
+
+    expect(authenticateApiRequest).toHaveBeenCalledWith(
+      expect.any(Request),
+      trackReadPermission
+    );
+    expect(getProjectForUser).toHaveBeenCalledWith("project-1", "user-1");
+    expect(toApiOverlayPackage).toHaveBeenCalledWith(project);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        type: "overlay_track",
+        source: { type: "project", id: "project-1" },
+      },
+      meta: { api_version: "v1" },
+    });
+  });
+
+  it("returns auth failures before reading project data", async () => {
+    const authResponse = NextResponse.json(
+      {
+        title: "Unauthorized",
+        status: 401,
+        detail: "A valid API bearer key is required.",
+        code: "unauthorized",
+      },
+      { status: 401 }
+    );
+    vi.mocked(authenticateApiRequest).mockResolvedValue({
+      ok: false,
+      response: authResponse,
+    });
+
+    const response = await overlayRoute.GET(
+      new Request("http://localhost/api/v1/projects/project-1/overlay"),
+      projectContext("project-1")
+    );
+
+    expect(response.status).toBe(401);
+    expect(getProjectForUser).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/dashboard/GalleryManager.test.tsx
+++ b/tests/components/dashboard/GalleryManager.test.tsx
@@ -34,9 +34,13 @@ vi.mock("@/components/ui/dialog", () => ({
     open?: boolean;
     children: React.ReactNode;
   }) => (open ? <div>{children}</div> : null),
-  DialogClose: ({ children }: { children: React.ReactNode }) => (
-    <button type="button">{children}</button>
-  ),
+  DialogClose: ({
+    asChild,
+    children,
+  }: {
+    asChild?: boolean;
+    children: React.ReactNode;
+  }) => (asChild ? <>{children}</> : <button type="button">{children}</button>),
   DialogContent: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),

--- a/tests/lib/auth-client.test.ts
+++ b/tests/lib/auth-client.test.ts
@@ -9,6 +9,31 @@ const deleteUserMock = vi.fn();
 const updateUserMock = vi.fn();
 const magicLinkMock = vi.fn();
 const passkeySignInMock = vi.fn();
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "localStorage"
+);
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>();
+
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+  };
+}
 
 vi.mock("@better-auth/passkey/client", () => ({
   passkeyClient: vi.fn(() => ({})),
@@ -35,6 +60,10 @@ describe("authClient session resolution", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createMemoryStorage(),
+    });
 
     useSessionMock.mockReturnValue({
       data: {
@@ -67,6 +96,13 @@ describe("authClient session resolution", () => {
 
   afterEach(() => {
     cleanup();
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(
+        window,
+        "localStorage",
+        originalLocalStorageDescriptor
+      );
+    }
     vi.unstubAllGlobals();
   });
 

--- a/tests/lib/server/api-key-retention.test.ts
+++ b/tests/lib/server/api-key-retention.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { cleanupExpiredApiKeys } from "@/lib/server/api-key-retention";
+
+describe("API key retention", () => {
+  it("deletes expired Better Auth API key records after the retention window", async () => {
+    const run = vi.fn(async () => ({}));
+    const statement = {
+      bind: vi.fn(() => statement),
+      run,
+    };
+    const prepare = vi.fn((query: string) => {
+      void query;
+      return statement;
+    });
+
+    await cleanupExpiredApiKeys(
+      { prepare } as Parameters<typeof cleanupExpiredApiKeys>[0],
+      90
+    );
+
+    const sql = prepare.mock.calls[0][0];
+    expect(sql).toContain("delete from apikey");
+    expect(sql).toContain("expiresAt is not null");
+    expect(sql).toContain("datetime(expiresAt) < datetime('now', ?)");
+    expect(statement.bind).toHaveBeenCalledWith("-90 days");
+    expect(run).toHaveBeenCalled();
+  });
+});

--- a/tests/lib/server/api-keys.test.ts
+++ b/tests/lib/server/api-keys.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/server/auth", () => ({
+  getAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/server/db", () => ({
+  getDatabase: vi.fn(),
+}));
+
+import {
+  createApiKeyForSession,
+  deleteApiKeyForSession,
+  getApiIdentityFromBearerKey,
+  getBearerApiKey,
+  listApiKeysForSession,
+  normalizeApiKeyExpiryDays,
+  trackReadPermission,
+} from "@/lib/server/api-keys";
+import { getAuth } from "@/lib/server/auth";
+import { getDatabase } from "@/lib/server/db";
+
+const apiKeyRecord = {
+  id: "key-1",
+  name: "Overlay",
+  prefix: "td_",
+  start: "td_abc",
+  enabled: true,
+  permissions: { tracks: ["read"] },
+  createdAt: new Date("2026-04-20T10:00:00.000Z"),
+  updatedAt: new Date("2026-04-20T10:00:00.000Z"),
+  expiresAt: new Date("2026-07-19T10:00:00.000Z"),
+  lastRequest: null,
+  rateLimitEnabled: true,
+  rateLimitMax: 600,
+  rateLimitTimeWindow: 3_600_000,
+  requestCount: 0,
+  referenceId: "user-1",
+};
+
+describe("API key server helpers", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("parses strict bearer authorization headers", () => {
+    expect(getBearerApiKey(new Headers())).toBeNull();
+    expect(
+      getBearerApiKey(new Headers({ authorization: "Basic abc" }))
+    ).toBeNull();
+    expect(
+      getBearerApiKey(new Headers({ authorization: "Bearer td_test extra" }))
+    ).toBeNull();
+    expect(
+      getBearerApiKey(new Headers({ authorization: "Bearer td_test" }))
+    ).toBe("td_test");
+  });
+
+  it("normalizes expiry options to the supported product choices", () => {
+    expect(normalizeApiKeyExpiryDays(7)).toBe(7);
+    expect(normalizeApiKeyExpiryDays(365)).toBe(365);
+    expect(normalizeApiKeyExpiryDays(999)).toBe(90);
+    expect(normalizeApiKeyExpiryDays(undefined)).toBe(90);
+  });
+
+  it("uses Better Auth session APIs for list, create, and revoke", async () => {
+    const listApiKeys = vi.fn(async () => ({ apiKeys: [], total: 0 }));
+    const createApiKey = vi.fn(async () => ({
+      ...apiKeyRecord,
+      key: "td_secret",
+    }));
+    const deleteApiKey = vi.fn(async () => ({ success: true }));
+    vi.mocked(getAuth).mockResolvedValue({
+      api: { listApiKeys, createApiKey, deleteApiKey },
+    } as never);
+
+    const headers = new Headers({ cookie: "better-auth.session_token=abc" });
+    await listApiKeysForSession(headers);
+    await createApiKeyForSession({
+      headers,
+      name: "Overlay",
+      expiresInDays: 30,
+    });
+    await deleteApiKeyForSession({ headers, keyId: "key-1" });
+
+    expect(listApiKeys).toHaveBeenCalledWith({
+      headers,
+      query: {
+        limit: 100,
+        offset: 0,
+        sortBy: "createdAt",
+        sortDirection: "desc",
+      },
+    });
+    expect(createApiKey).toHaveBeenCalledWith({
+      headers,
+      body: {
+        name: "Overlay",
+        expiresIn: 30 * 24 * 60 * 60,
+      },
+    });
+    expect(deleteApiKey).toHaveBeenCalledWith({
+      headers,
+      body: { keyId: "key-1" },
+    });
+  });
+
+  it("resolves a valid bearer key to the owning account", async () => {
+    const verifyApiKey = vi.fn(async () => ({
+      valid: true,
+      error: null,
+      key: apiKeyRecord,
+    }));
+    const first = vi.fn(async () => ({
+      id: "user-1",
+      email: "pilot@trackdraw.local",
+      name: "Pilot",
+    }));
+    const bind = vi.fn(() => ({ first }));
+    const prepare = vi.fn(() => ({ bind }));
+    vi.mocked(getAuth).mockResolvedValue({ api: { verifyApiKey } } as never);
+    vi.mocked(getDatabase).mockResolvedValue({ prepare } as never);
+
+    const result = await getApiIdentityFromBearerKey({
+      headers: new Headers({ authorization: "Bearer td_secret" }),
+      permissions: trackReadPermission,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error("Expected a valid API identity");
+    }
+    expect(result.identity.user).toEqual({
+      id: "user-1",
+      email: "pilot@trackdraw.local",
+      name: "Pilot",
+    });
+    expect(verifyApiKey).toHaveBeenCalledWith({
+      body: {
+        key: "td_secret",
+        permissions: trackReadPermission,
+      },
+    });
+    expect(bind).toHaveBeenCalledWith("user-1");
+  });
+
+  it("returns 401 for bad, expired, disabled, and orphaned bearer keys", async () => {
+    const verifyApiKey = vi.fn();
+    const first = vi.fn();
+    const bind = vi.fn(() => ({ first }));
+    const prepare = vi.fn(() => ({ bind }));
+    vi.mocked(getAuth).mockResolvedValue({ api: { verifyApiKey } } as never);
+    vi.mocked(getDatabase).mockResolvedValue({ prepare } as never);
+
+    for (const code of ["INVALID_API_KEY", "KEY_EXPIRED", "KEY_DISABLED"]) {
+      verifyApiKey.mockResolvedValueOnce({
+        valid: false,
+        error: { code },
+        key: null,
+      });
+
+      await expect(
+        getApiIdentityFromBearerKey({
+          headers: new Headers({ authorization: "Bearer td_secret" }),
+        })
+      ).resolves.toMatchObject({
+        ok: false,
+        status: 401,
+        code: "invalid_api_key",
+      });
+    }
+
+    verifyApiKey.mockResolvedValueOnce({
+      valid: true,
+      error: null,
+      key: apiKeyRecord,
+    });
+    first.mockResolvedValueOnce(null);
+
+    await expect(
+      getApiIdentityFromBearerKey({
+        headers: new Headers({ authorization: "Bearer td_secret" }),
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 401,
+      code: "invalid_api_key",
+    });
+  });
+
+  it("maps Better Auth API key throttling to 429 with retry timing", async () => {
+    const verifyApiKey = vi.fn(async () => ({
+      valid: false,
+      error: {
+        code: "RATE_LIMITED",
+        details: { tryAgainIn: 1250 },
+      },
+      key: null,
+    }));
+    vi.mocked(getAuth).mockResolvedValue({ api: { verifyApiKey } } as never);
+
+    const result = await getApiIdentityFromBearerKey({
+      headers: new Headers({ authorization: "Bearer td_secret" }),
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 429,
+      code: "rate_limited",
+      retryAfterSeconds: 2,
+    });
+  });
+});

--- a/tests/lib/server/api-projects.test.ts
+++ b/tests/lib/server/api-projects.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from "vitest";
+import { normalizeDesign } from "@/lib/track/design";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  toApiOverlayPackage,
+  toApiProjectSummary,
+  toApiTrackPackage,
+} from "@/lib/server/api-projects";
+import type { StoredProject } from "@/lib/server/projects";
+import type { Shape, TrackDesign } from "@/lib/types";
+
+const inventory = {
+  gate: 4,
+  flag: 0,
+  cone: 0,
+  startfinish: 0,
+  ladder: 0,
+  divegate: 0,
+};
+
+function makeDesign(shapes: Shape[]): TrackDesign {
+  return normalizeDesign({
+    id: "design-1",
+    version: 1,
+    title: "API test",
+    description: "Editor-only description",
+    tags: ["private"],
+    authorName: "Author",
+    inventory,
+    field: { width: 60, height: 40, origin: "tl", gridStep: 5, ppm: 20 },
+    shapes,
+    createdAt: "2026-04-28T09:00:00.000Z",
+    updatedAt: "2026-04-28T12:29:48.000Z",
+  });
+}
+
+function makeProject(design: TrackDesign): StoredProject {
+  return {
+    id: "project-1",
+    ownerUserId: "user-1",
+    title: "Race layout",
+    description: "Project description",
+    design,
+    designUpdatedAt: design.updatedAt,
+    fieldWidth: null,
+    fieldHeight: null,
+    shapeCount: design.shapeOrder.length,
+    createdAt: "2026-04-28T09:00:00.000Z",
+    updatedAt: "2026-04-28T12:30:00.000Z",
+    archivedAt: null,
+  };
+}
+
+const raceLine: Shape = {
+  id: "route-1",
+  kind: "polyline",
+  x: 0,
+  y: 0,
+  rotation: 0,
+  points: [
+    { x: 0, y: 5, z: 0 },
+    { x: 30, y: 5, z: 1.5 },
+  ],
+  showArrows: true,
+  strokeWidth: 0.3,
+};
+
+function gate(id: string, x: number, timingId?: string): Shape {
+  return {
+    id,
+    kind: "gate",
+    name: id,
+    x,
+    y: 5,
+    rotation: 90,
+    width: 3,
+    height: 1.8,
+    locked: true,
+    frontOffsetDeg: 0,
+    meta: timingId
+      ? { timing: { role: "split", timingId }, unknown: "hidden" }
+      : { unknown: "hidden" },
+  };
+}
+
+describe("API project serializers", () => {
+  it("returns minimal project summaries with field metadata fallback", () => {
+    const project = makeProject(makeDesign([]));
+
+    expect(toApiProjectSummary(project)).toEqual({
+      type: "project",
+      id: "project-1",
+      title: "Race layout",
+      field: {
+        width: 60,
+        height: 40,
+        unit: "m",
+      },
+      shape_count: 0,
+      created_at: "2026-04-28T09:00:00.000Z",
+      updated_at: "2026-04-28T12:30:00.000Z",
+    });
+  });
+
+  it("strips editor-only shape fields from track packages", () => {
+    const project = makeProject(makeDesign([gate("gate-1", 5, "split-a")]));
+
+    const trackPackage = toApiTrackPackage(project);
+    const shape = trackPackage.shapes[0];
+
+    expect(trackPackage).toMatchObject({
+      type: "track",
+      schema: "trackdraw.track.v1",
+      source: { type: "project", id: "project-1" },
+      field: {
+        width: 60,
+        height: 40,
+        origin: "tl",
+        unit: "m",
+      },
+      shape_count: 1,
+    });
+    expect(trackPackage.field).not.toHaveProperty("grid_step");
+    expect(shape).toMatchObject({
+      id: "gate-1",
+      kind: "gate",
+      x: 5,
+      y: 5,
+      rotation: 90,
+      width: 3,
+      height: 1.8,
+    });
+    expect(shape).not.toHaveProperty("locked");
+    expect(shape).not.toHaveProperty("front_offset_deg");
+    expect(shape).not.toHaveProperty("meta");
+  });
+
+  it("builds compact overlay data with route progress for obstacles and timing markers", () => {
+    const project = makeProject(
+      makeDesign([
+        raceLine,
+        gate("gate-early", 5),
+        gate("gate-late", 20, "split-a"),
+      ])
+    );
+
+    const overlayPackage = toApiOverlayPackage(project);
+
+    expect(overlayPackage).toMatchObject({
+      type: "overlay_track",
+      schema: "trackdraw.overlay.v1",
+      source: { type: "project", id: "project-1" },
+      route_status: "ready",
+      field: {
+        width: 60,
+        height: 40,
+        origin: "tl",
+        unit: "m",
+      },
+    });
+    expect(overlayPackage.route).toMatchObject({
+      shape_id: "route-1",
+      closed: false,
+      waypoints: [
+        { x: 0, y: 5, z: 0 },
+        { x: 30, y: 5, z: 1.5 },
+      ],
+    });
+    expect(overlayPackage.route?.length_m).toBeCloseTo(30, 1);
+    expect(overlayPackage.route?.sampled_points.length).toBeGreaterThanOrEqual(
+      2
+    );
+
+    expect(
+      overlayPackage.route_obstacles.map((obstacle) => ({
+        id: obstacle.id,
+        route_number: obstacle.route_number,
+      }))
+    ).toEqual([
+      { id: "gate-early", route_number: 1 },
+      { id: "gate-late", route_number: 2 },
+    ]);
+
+    const lateGate = overlayPackage.route_obstacles.find(
+      (obstacle) => obstacle.id === "gate-late"
+    );
+    expect(lateGate?.route_position).toMatchObject({
+      x: expect.any(Number),
+      y: expect.any(Number),
+      offset_m: expect.any(Number),
+    });
+    expect(lateGate?.route_position?.distance_m).toBeCloseTo(20, 1);
+    expect(lateGate?.route_position?.progress).toBeCloseTo(2 / 3, 1);
+
+    expect(overlayPackage.timing_markers).toHaveLength(1);
+    expect(overlayPackage.timing_markers[0]).toMatchObject({
+      shape_id: "gate-late",
+      role: "split",
+      timing_id: "split-a",
+      route_position: {
+        distance_m: expect.any(Number),
+        progress: expect.any(Number),
+      },
+    });
+  });
+});

--- a/tests/lib/server/api-v1.test.ts
+++ b/tests/lib/server/api-v1.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/server/api-keys", () => ({
+  getApiIdentityFromBearerKey: vi.fn(),
+}));
+
+import {
+  apiListSuccess,
+  apiProblem,
+  apiSuccess,
+  authenticateApiRequest,
+} from "@/lib/server/api-v1";
+import { getApiIdentityFromBearerKey } from "@/lib/server/api-keys";
+
+describe("v1 API response helpers", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("wraps successful responses with API metadata", async () => {
+    const response = apiSuccess({ type: "example" });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      data: { type: "example" },
+      meta: { api_version: "v1" },
+    });
+  });
+
+  it("wraps list responses with pagination and API metadata", async () => {
+    const response = apiListSuccess([{ id: "project-1" }], {
+      limit: 50,
+      next_cursor: null,
+      has_more: false,
+    });
+
+    await expect(response.json()).resolves.toEqual({
+      data: [{ id: "project-1" }],
+      pagination: {
+        limit: 50,
+        next_cursor: null,
+        has_more: false,
+      },
+      meta: { api_version: "v1" },
+    });
+  });
+
+  it("returns compact problem details without request ids or problem URLs", async () => {
+    const response = apiProblem({
+      status: 401,
+      code: "unauthorized",
+      title: "Unauthorized",
+      detail: "A valid API bearer key is required.",
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toContain(
+      "application/problem+json"
+    );
+    await expect(response.json()).resolves.toEqual({
+      title: "Unauthorized",
+      status: 401,
+      detail: "A valid API bearer key is required.",
+      code: "unauthorized",
+    });
+  });
+
+  it("passes permissions into bearer-key verification", async () => {
+    const identity = {
+      user: { id: "user-1", email: null, name: "Race Director" },
+      key: {},
+    };
+    vi.mocked(getApiIdentityFromBearerKey).mockResolvedValue({
+      ok: true,
+      identity,
+    } as never);
+
+    const result = await authenticateApiRequest(
+      new Request("http://localhost/api/v1/projects", {
+        headers: { authorization: "Bearer td_test" },
+      }),
+      { tracks: ["read"] }
+    );
+
+    expect(result).toEqual({ ok: true, identity });
+    expect(getApiIdentityFromBearerKey).toHaveBeenCalledWith({
+      headers: expect.any(Headers),
+      permissions: { tracks: ["read"] },
+    });
+  });
+
+  it("returns stable 429 errors for throttled API keys", async () => {
+    vi.mocked(getApiIdentityFromBearerKey).mockResolvedValue({
+      ok: false,
+      status: 429,
+      code: "rate_limited",
+      detail: "Too many requests for this API key. Try again later.",
+      retryAfterSeconds: 2,
+    });
+
+    const result = await authenticateApiRequest(
+      new Request("http://localhost/api/v1/projects")
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error("Expected authentication to fail");
+    }
+
+    expect(result.response.status).toBe(429);
+    expect(result.response.headers.get("retry-after")).toBe("2");
+    await expect(result.response.json()).resolves.toEqual({
+      title: "Too Many Requests",
+      status: 429,
+      detail: "Too many requests for this API key. Try again later.",
+      code: "rate_limited",
+    });
+  });
+});


### PR DESCRIPTION
Adds the first versioned TrackDraw REST API for account-backed integrations. API keys can now be created, listed, and revoked from account settings, and bearer-authenticated `/api/v1/*` endpoints expose identity, owned project data, track packages, and compact RotorHazard livestream overlay data.

This also adds OpenAPI/Scalar docs, compact API error responses, API-key audit events, scheduled cleanup for expired API-key records, and focused coverage for auth, ownership scoping, serializers, docs contracts, and route behavior.