### PR TITLE
Update metadata and descriptions for improved SEO

### DIFF
--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -14,7 +14,8 @@ import {
   getSiteUrl,
 } from "@/lib/seo";
 
-const title = "Gallery — TrackDraw";
+const title = "FPV Drone Race Track Gallery";
+const socialTitle = "TrackDraw | FPV Drone Race Track Gallery";
 const description =
   "Browse FPV drone race track designs shared by the TrackDraw community.";
 
@@ -26,7 +27,7 @@ export const metadata: Metadata = {
     canonical: "/gallery",
   },
   openGraph: {
-    title,
+    title: socialTitle,
     description,
     url: "/gallery",
     images: [
@@ -39,7 +40,7 @@ export const metadata: Metadata = {
     ],
   },
   twitter: {
-    title,
+    title: socialTitle,
     description,
     images: [DEFAULT_SOCIAL_IMAGE],
   },

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -12,6 +12,7 @@ import {
   SITE_AUTHOR,
   getSiteMediaUrl,
   getSiteUrl,
+  serializeJsonLd,
 } from "@/lib/seo";
 
 const title = "FPV Drone Race Track Gallery";
@@ -86,7 +87,7 @@ export default async function GalleryPage() {
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListJsonLd) }}
+        dangerouslySetInnerHTML={{ __html: serializeJsonLd(itemListJsonLd) }}
       />
 
       <div className="bg-background min-h-screen overflow-x-clip">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import {
   getLandingDemoVideoUrl,
   getSiteMediaUrl,
   getSiteUrl,
+  serializeJsonLd,
 } from "@/lib/seo";
 
 export const metadata: Metadata = {
@@ -272,21 +273,21 @@ export default function Home() {
         id="software-application-jsonld"
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(softwareApplicationJsonLd),
+          __html: serializeJsonLd(softwareApplicationJsonLd),
         }}
       />
       <script
         id="video-object-jsonld"
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(videoObjectJsonLd),
+          __html: serializeJsonLd(videoObjectJsonLd),
         }}
       />
       <script
         id="faq-page-jsonld"
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(faqPageJsonLd),
+          __html: serializeJsonLd(faqPageJsonLd),
         }}
       />
       {/* ── Nav ─────────────────────────────────────────────── */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,19 +16,19 @@ import {
 
 export const metadata: Metadata = {
   title: {
-    absolute: "TrackDraw | Drone Race Track Planner",
+    absolute: "TrackDraw | Drone Race Track Builder",
   },
   description:
-    "TrackDraw is a drone race track planner for FPV race directors. Design tracks to scale, review track flow in 3D, and share read-only race-day layouts.",
+    "TrackDraw is a drone race track builder for FPV race directors. Design tracks to scale, review track flow in 3D, and share read-only race-day layouts.",
   keywords: SITE_KEYWORDS,
   authors: [SITE_AUTHOR],
   alternates: {
     canonical: "/",
   },
   openGraph: {
-    title: "TrackDraw | Drone Race Track Planner",
+    title: "TrackDraw | Drone Race Track Builder",
     description:
-      "Plan drone race tracks to scale, review FPV track flow in 3D, and share read-only race-day layouts.",
+      "Use TrackDraw as a drone race track builder to plan FPV layouts to scale, review track flow in 3D, and share read-only race-day plans.",
     url: "/",
     images: [
       {
@@ -40,9 +40,9 @@ export const metadata: Metadata = {
     ],
   },
   twitter: {
-    title: "TrackDraw | Drone Race Track Planner",
+    title: "TrackDraw | Drone Race Track Builder",
     description:
-      "Plan drone race tracks to scale, review FPV track flow in 3D, and share read-only race-day layouts.",
+      "Use TrackDraw as a drone race track builder to plan FPV layouts to scale, review track flow in 3D, and share read-only race-day plans.",
     images: [DEFAULT_SOCIAL_IMAGE],
   },
 };
@@ -157,6 +157,10 @@ const features = [
 
 const faq = [
   {
+    q: "Is TrackDraw a drone race track builder?",
+    a: "Yes. TrackDraw is a browser-based drone race track builder for FPV race directors who need scale-accurate layouts, 3D review, sharing, and export in one workflow.",
+  },
+  {
     q: "What is the best way to plan an FPV race track?",
     a: "Start with the field dimensions, place the obstacles you actually have, then review the route in 3D before sharing or exporting the plan. TrackDraw is built around that exact sequence.",
   },
@@ -188,6 +192,7 @@ const faq = [
 
 const landingDemoVideoSrc = getLandingDemoVideoUrl();
 const landingDemoPosterSrc = DEFAULT_LANDING_DEMO_POSTER;
+const landingPageUrl = getSiteUrl();
 
 const softwareApplicationJsonLd = {
   "@context": "https://schema.org",
@@ -196,7 +201,7 @@ const softwareApplicationJsonLd = {
   applicationCategory: "DesignApplication",
   operatingSystem: "Web",
   description: SITE_DESCRIPTION,
-  url: getSiteUrl(),
+  url: landingPageUrl,
   author: {
     "@type": "Organization",
     name: SITE_AUTHOR.name,
@@ -207,6 +212,30 @@ const softwareApplicationJsonLd = {
     price: "0",
     priceCurrency: "EUR",
   },
+};
+
+const videoObjectJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  name: "TrackDraw drone race track builder demo",
+  description:
+    "A quick product demo showing how TrackDraw helps FPV race directors build a drone race track layout, review it in 3D, and share it with pilots and crew.",
+  thumbnailUrl: [landingDemoPosterSrc],
+  contentUrl: landingDemoVideoSrc,
+  embedUrl: landingPageUrl,
+};
+
+const faqPageJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faq.map((item) => ({
+    "@type": "Question",
+    name: item.q,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: item.a,
+    },
+  })),
 };
 
 function LandingVideo({ className = "" }: { className?: string }) {
@@ -244,6 +273,20 @@ export default function Home() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(softwareApplicationJsonLd),
+        }}
+      />
+      <script
+        id="video-object-jsonld"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(videoObjectJsonLd),
+        }}
+      />
+      <script
+        id="faq-page-jsonld"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(faqPageJsonLd),
         }}
       />
       {/* ── Nav ─────────────────────────────────────────────── */}
@@ -284,7 +327,7 @@ export default function Home() {
 
               <Reveal delay={0.13} className="mt-5">
                 <p className="text-muted-foreground max-w-sm text-[15px] leading-7">
-                  TrackDraw is a browser-based drone race track planner for FPV
+                  TrackDraw is a browser-based drone race track builder for FPV
                   race directors. Draw to scale in 2D, review the flow in 3D,
                   share a read-only layout with pilots and crew, and keep the
                   plan usable from desktop or mobile.

--- a/src/app/share/[token]/layout.tsx
+++ b/src/app/share/[token]/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 import { getShareDescription, getShareTitle } from "@/lib/share";
-import { getGalleryEntryByShareToken } from "@/lib/server/gallery";
+import {
+  getGalleryEntryByShareToken,
+  isPublicGalleryState,
+} from "@/lib/server/gallery";
 import { resolveShareView } from "@/lib/server/share-resolution";
 import {
   DEFAULT_OG_IMAGE_ALT,
@@ -17,10 +20,6 @@ type ShareTokenLayoutProps = {
     token: string;
   }>;
 };
-
-function isPublicGalleryState(state: string | null | undefined) {
-  return state === "listed" || state === "featured";
-}
 
 function resolveSocialImageUrl(previewImage: string | null | undefined) {
   if (!previewImage) return DEFAULT_SOCIAL_IMAGE;

--- a/src/app/share/[token]/layout.tsx
+++ b/src/app/share/[token]/layout.tsx
@@ -90,9 +90,7 @@ export async function generateMetadata({
     resolvedShare.source === "stored"
       ? await getGalleryEntryByShareToken(token)
       : null;
-  const isPublicGalleryShare = isPublicGalleryState(
-    galleryEntry?.galleryState
-  );
+  const isPublicGalleryShare = isPublicGalleryState(galleryEntry?.galleryState);
 
   const title =
     isPublicGalleryShare && galleryEntry

--- a/src/app/share/[token]/layout.tsx
+++ b/src/app/share/[token]/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { getShareDescription, getShareTitle } from "@/lib/share";
+import { getGalleryEntryByShareToken } from "@/lib/server/gallery";
 import { resolveShareView } from "@/lib/server/share-resolution";
 import {
   DEFAULT_OG_IMAGE_ALT,
@@ -7,6 +8,7 @@ import {
   DEFAULT_SOCIAL_IMAGE_HEIGHT,
   DEFAULT_SOCIAL_IMAGE_WIDTH,
   SITE_NAME,
+  getSiteMediaUrl,
 } from "@/lib/seo";
 
 type ShareTokenLayoutProps = {
@@ -15,6 +17,32 @@ type ShareTokenLayoutProps = {
     token: string;
   }>;
 };
+
+function isPublicGalleryState(state: string | null | undefined) {
+  return state === "listed" || state === "featured";
+}
+
+function resolveSocialImageUrl(previewImage: string | null | undefined) {
+  if (!previewImage) return DEFAULT_SOCIAL_IMAGE;
+  if (previewImage.startsWith("http")) return previewImage;
+
+  return getSiteMediaUrl(previewImage);
+}
+
+function buildShareMetadataDescription(params: {
+  description: string;
+  fieldWidth: number;
+  fieldHeight: number;
+  shapeCount: number;
+}) {
+  const base = params.description.trim();
+  const fieldLabel = `${params.fieldWidth} x ${params.fieldHeight} m`;
+  const obstacleLabel =
+    params.shapeCount === 1 ? "1 obstacle" : `${params.shapeCount} obstacles`;
+  const detail = `FPV drone race track layout built with TrackDraw on a ${fieldLabel} field with ${obstacleLabel}.`;
+
+  return base ? `${base} ${detail}` : detail;
+}
 
 export async function generateMetadata({
   params,
@@ -27,6 +55,10 @@ export async function generateMetadata({
       title: "Expired Track Share",
       description:
         "This TrackDraw share link has expired. Ask the sender to publish a fresh link.",
+      robots: {
+        index: false,
+        follow: true,
+      },
     };
   }
 
@@ -35,6 +67,10 @@ export async function generateMetadata({
       title: "Unsupported Track Share",
       description:
         "This older TrackDraw share format is no longer supported. Ask the sender to publish a fresh link.",
+      robots: {
+        index: false,
+        follow: true,
+      },
     };
   }
 
@@ -42,25 +78,51 @@ export async function generateMetadata({
     return {
       title: "View Track",
       description: "View this FPV race track designed with TrackDraw.",
+      robots: {
+        index: false,
+        follow: true,
+      },
     };
   }
 
   const design = resolvedShare.design;
+  const galleryEntry =
+    resolvedShare.source === "stored"
+      ? await getGalleryEntryByShareToken(token)
+      : null;
+  const isPublicGalleryShare = isPublicGalleryState(
+    galleryEntry?.galleryState
+  );
 
   const title =
-    resolvedShare.source === "stored"
-      ? resolvedShare.title
-      : getShareTitle(design);
+    isPublicGalleryShare && galleryEntry
+      ? `${galleryEntry.galleryTitle} | FPV Drone Race Track`
+      : resolvedShare.source === "stored"
+        ? resolvedShare.title
+        : getShareTitle(design);
   const description =
-    resolvedShare.source === "stored"
-      ? resolvedShare.description
-      : getShareDescription(design);
+    isPublicGalleryShare && galleryEntry
+      ? buildShareMetadataDescription({
+          description: galleryEntry.galleryDescription,
+          fieldWidth: design.field.width,
+          fieldHeight: design.field.height,
+          shapeCount: design.shapeOrder.length,
+        })
+      : resolvedShare.source === "stored"
+        ? resolvedShare.description
+        : getShareDescription(design);
   const encodedToken = encodeURIComponent(token);
+  const socialImageUrl = isPublicGalleryShare
+    ? resolveSocialImageUrl(galleryEntry?.galleryPreviewImage)
+    : DEFAULT_SOCIAL_IMAGE;
   const socialImage = {
-    url: DEFAULT_SOCIAL_IMAGE,
+    url: socialImageUrl,
     width: DEFAULT_SOCIAL_IMAGE_WIDTH,
     height: DEFAULT_SOCIAL_IMAGE_HEIGHT,
-    alt: DEFAULT_OG_IMAGE_ALT,
+    alt:
+      isPublicGalleryShare && galleryEntry
+        ? `${galleryEntry.galleryTitle} track preview`
+        : DEFAULT_OG_IMAGE_ALT,
   };
 
   return {
@@ -81,7 +143,11 @@ export async function generateMetadata({
       card: "summary_large_image",
       title,
       description,
-      images: [DEFAULT_SOCIAL_IMAGE],
+      images: [socialImageUrl],
+    },
+    robots: {
+      index: isPublicGalleryShare,
+      follow: true,
     },
   };
 }

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -1,5 +1,7 @@
 import { notFound } from "next/navigation";
+import { getGalleryEntryByShareToken } from "@/lib/server/gallery";
 import { resolveShareView } from "@/lib/server/share-resolution";
+import { SITE_AUTHOR, getSiteMediaUrl, getSiteUrl } from "@/lib/seo";
 import { parseEditorView } from "@/lib/view";
 import ShareViewer from "../ShareViewer";
 import ShareError from "../ShareError";
@@ -14,6 +16,17 @@ type ShareTokenPageProps = {
   }>;
 };
 
+function isPublicGalleryState(state: string | null | undefined) {
+  return state === "listed" || state === "featured";
+}
+
+function resolvePreviewImageUrl(previewImage: string | null | undefined) {
+  if (!previewImage) return undefined;
+  if (previewImage.startsWith("http")) return previewImage;
+
+  return getSiteMediaUrl(previewImage);
+}
+
 export default async function ShareTokenPage({
   params,
   searchParams,
@@ -23,12 +36,54 @@ export default async function ShareTokenPage({
   const resolvedShare = await resolveShareView(token);
 
   if (resolvedShare.status === "available") {
+    const galleryEntry =
+      resolvedShare.source === "stored"
+        ? await getGalleryEntryByShareToken(token)
+        : null;
+    const isPublicGalleryShare = isPublicGalleryState(
+      galleryEntry?.galleryState
+    );
+    const trackJsonLd =
+      isPublicGalleryShare && galleryEntry
+        ? {
+            "@context": "https://schema.org",
+            "@type": "CreativeWork",
+            name: galleryEntry.galleryTitle,
+            description: galleryEntry.galleryDescription,
+            url: `${getSiteUrl()}/share/${encodeURIComponent(token)}`,
+            image: resolvePreviewImageUrl(galleryEntry.galleryPreviewImage),
+            creator: {
+              "@type": "Organization",
+              name: SITE_AUTHOR.name,
+              url: SITE_AUTHOR.url,
+            },
+            about: [
+              "FPV drone race track",
+              "drone race track builder",
+              "drone racing layout",
+            ],
+            spatialCoverage: {
+              "@type": "Place",
+              name: `${resolvedShare.design.field.width} x ${resolvedShare.design.field.height} m field`,
+            },
+          }
+        : null;
+
     return (
-      <ShareViewer
-        design={resolvedShare.design}
-        studioSeedToken={resolvedShare.studioSeedToken}
-        initialTab={parseEditorView(resolvedSearchParams?.view) ?? "2d"}
-      />
+      <>
+        {trackJsonLd ? (
+          <script
+            id="track-share-jsonld"
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(trackJsonLd) }}
+          />
+        ) : null}
+        <ShareViewer
+          design={resolvedShare.design}
+          studioSeedToken={resolvedShare.studioSeedToken}
+          initialTab={parseEditorView(resolvedSearchParams?.view) ?? "2d"}
+        />
+      </>
     );
   }
 

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -1,7 +1,12 @@
 import { notFound } from "next/navigation";
 import { getGalleryEntryByShareToken } from "@/lib/server/gallery";
 import { resolveShareView } from "@/lib/server/share-resolution";
-import { SITE_AUTHOR, getSiteMediaUrl, getSiteUrl } from "@/lib/seo";
+import {
+  SITE_AUTHOR,
+  getSiteMediaUrl,
+  getSiteUrl,
+  serializeJsonLd,
+} from "@/lib/seo";
 import { parseEditorView } from "@/lib/view";
 import ShareViewer from "../ShareViewer";
 import ShareError from "../ShareError";
@@ -75,7 +80,7 @@ export default async function ShareTokenPage({
           <script
             id="track-share-jsonld"
             type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(trackJsonLd) }}
+            dangerouslySetInnerHTML={{ __html: serializeJsonLd(trackJsonLd) }}
           />
         ) : null}
         <ShareViewer

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -1,5 +1,8 @@
 import { notFound } from "next/navigation";
-import { getGalleryEntryByShareToken } from "@/lib/server/gallery";
+import {
+  getGalleryEntryByShareToken,
+  isPublicGalleryState,
+} from "@/lib/server/gallery";
 import { resolveShareView } from "@/lib/server/share-resolution";
 import {
   SITE_AUTHOR,
@@ -20,10 +23,6 @@ type ShareTokenPageProps = {
     view?: string;
   }>;
 };
-
-function isPublicGalleryState(state: string | null | undefined) {
-  return state === "listed" || state === "featured";
-}
 
 function resolvePreviewImageUrl(previewImage: string | null | undefined) {
   if (!previewImage) return undefined;

--- a/src/app/share/layout.tsx
+++ b/src/app/share/layout.tsx
@@ -3,10 +3,6 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "View Track",
   description: "View this FPV race track designed with TrackDraw.",
-  robots: {
-    index: false,
-    follow: true,
-  },
 };
 
 export default function ShareLayout({

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 import { listPublicGalleryEntries } from "@/lib/server/gallery";
 import { getSiteUrl } from "@/lib/seo";
 
-export const dynamic = "force-dynamic";
+export const revalidate = 3600;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const siteUrl = getSiteUrl();

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,9 +1,13 @@
 import type { MetadataRoute } from "next";
+import { listPublicGalleryEntries } from "@/lib/server/gallery";
 import { getSiteUrl } from "@/lib/seo";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export const dynamic = "force-dynamic";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const siteUrl = getSiteUrl();
   const now = new Date();
+  const galleryEntries = await listPublicGalleryEntries(100).catch(() => []);
 
   return [
     {
@@ -18,5 +22,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "daily",
       priority: 0.7,
     },
+    {
+      url: `${siteUrl}/studio`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    ...galleryEntries.map((entry) => ({
+      url: `${siteUrl}/share/${encodeURIComponent(entry.shareToken)}`,
+      lastModified: new Date(
+        entry.galleryPublishedAt ?? entry.updatedAt ?? entry.createdAt
+      ),
+      changeFrequency: "weekly" as const,
+      priority: entry.galleryState === "featured" ? 0.75 : 0.65,
+    })),
   ];
 }

--- a/src/app/studio/layout.tsx
+++ b/src/app/studio/layout.tsx
@@ -7,13 +7,16 @@ import {
 } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: "Studio",
+  title: "Drone Race Track Builder",
   description:
-    "Design your FPV race track to scale, add gates and obstacles, and preview in 3D.",
+    "Open the TrackDraw drone race track builder to design FPV layouts to scale, add gates and obstacles, and preview track flow in 3D.",
+  alternates: {
+    canonical: "/studio",
+  },
   openGraph: {
-    title: "TrackDraw Studio",
+    title: "TrackDraw | Drone Race Track Builder",
     description:
-      "Design your FPV race track to scale, add gates and obstacles, and preview in 3D.",
+      "Design FPV drone race tracks to scale, add gates and obstacles, and preview track flow in 3D.",
     url: "/studio",
     images: [
       {
@@ -25,14 +28,14 @@ export const metadata: Metadata = {
     ],
   },
   twitter: {
-    title: "TrackDraw Studio",
+    title: "TrackDraw | Drone Race Track Builder",
     description:
-      "Design your FPV race track to scale, add gates and obstacles, and preview in 3D.",
+      "Design FPV drone race tracks to scale, add gates and obstacles, and preview track flow in 3D.",
     images: [DEFAULT_SOCIAL_IMAGE],
   },
   robots: {
-    index: false,
-    follow: false,
+    index: true,
+    follow: true,
   },
 };
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,11 +1,12 @@
 export const SITE_NAME = "TrackDraw";
 export const SITE_TITLE = "TrackDraw";
 export const SITE_DESCRIPTION =
-  "Plan drone race tracks to scale, review FPV track flow in 3D, and share read-only race-day layouts with pilots and crew.";
-export const SITE_TAGLINE = "Drone Race Track Planner";
+  "TrackDraw is a browser-based drone race track builder for planning FPV race tracks to scale, reviewing flow in 3D, and sharing race-day layouts.";
+export const SITE_TAGLINE = "Drone Race Track Builder";
 export const SITE_KEYWORDS = [
   "FPV",
   "drone racing",
+  "drone race track builder",
   "track design",
   "race track planner",
   "FPV track builder",

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -27,6 +27,14 @@ export const DEFAULT_LANDING_DEMO_POSTER =
   "https://media.trackdraw.app/landing/screenshots/editor-3d-flythroug.png";
 export const LANDING_DEMO_VIDEO_PATH = "/landing/video-demo.webm";
 
+const JSON_LD_ESCAPE_LOOKUP: Record<string, string> = {
+  "<": "\\u003c",
+  ">": "\\u003e",
+  "&": "\\u0026",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029",
+};
+
 export function getSiteUrl() {
   return process.env.NEXT_PUBLIC_SITE_URL ?? "https://trackdraw.app";
 }
@@ -41,6 +49,18 @@ export function getSiteMediaUrl(path: string) {
 
 export function getLandingDemoVideoUrl() {
   return getSiteMediaUrl(LANDING_DEMO_VIDEO_PATH);
+}
+
+export function serializeJsonLd(value: unknown) {
+  const json = JSON.stringify(value);
+  if (typeof json !== "string") {
+    throw new Error("JSON-LD value must be serializable");
+  }
+
+  return json.replace(
+    /[<>&\u2028\u2029]/g,
+    (character) => JSON_LD_ESCAPE_LOOKUP[character]
+  );
 }
 
 export const DEFAULT_SOCIAL_IMAGE = getSiteMediaUrl(DEFAULT_SOCIAL_IMAGE_PATH);

--- a/src/lib/server/gallery.ts
+++ b/src/lib/server/gallery.ts
@@ -108,6 +108,12 @@ export type GalleryOverviewStats = {
   unlisted: number;
 };
 
+export function isPublicGalleryState(
+  state: GalleryState | string | null | undefined
+) {
+  return state === "listed" || state === "featured";
+}
+
 export function parseGalleryState(value: string | null): GalleryState {
   if (!value) return "unlisted";
   if (value === "link_only") return "unlisted";

--- a/tests/lib/seo.test.ts
+++ b/tests/lib/seo.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { serializeJsonLd } from "@/lib/seo";
+
+describe("seo helpers", () => {
+  it("escapes JSON-LD characters that can break out of script tags", () => {
+    const serialized = serializeJsonLd({
+      name: '</script><script>alert("xss")</script>',
+      description: "A & B > C",
+    });
+
+    expect(serialized).not.toContain("</script>");
+    expect(serialized).toContain("\\u003c/script\\u003e");
+    expect(serialized).toContain("\\u0026");
+    expect(serialized).toContain("\\u003e");
+  });
+});


### PR DESCRIPTION
Improve how TrackDraw is presented to search engines and link previews for users looking for a drone race track builder, while keeping the public product copy focused and avoiding a thin standalone SEO page.

## Changes

- Reposition public metadata around “drone race track builder” across the landing page and Studio.
- Keep the landing hero message as “Race day starts with a plan.”
- Improve gallery and Studio page titles for cleaner search results and social previews.
- Make listed/featured public share pages indexable with richer metadata and preview images, while keeping unlisted, expired, and unsupported shares out of the index.
- Expand the sitemap with Studio and public gallery share URLs.