### PR TITLE
fix: Improve path editing and route review guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,7 @@ Snapping is now more visible and more consistent across the editor. You can keep
 
 ### Stronger route review warnings
 
-Route review now catches more uneven sections before export or sharing. It can flag abrupt spacing shifts, short rhythm-breaking corrections, and small alignment kinks while you refine the lap.
+Route review now catches more uneven sections before export or sharing. It can flag abrupt spacing shifts and short correction segments that interrupt the flow while you refine the lap.
 
 ## [1.3.0]
 

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -673,6 +673,7 @@ const TrackCanvas = memo(
           excludeIds?: Iterable<string>;
           snapToAxisAlignment?: boolean;
           snapToGrid?: boolean;
+          magneticRadiusMeters?: number;
           snapToRouteLines?: boolean;
           snapToRouteWaypoints?: boolean;
           snapToShapes?: boolean;
@@ -688,7 +689,8 @@ const TrackCanvas = memo(
           snapToShapes: options.snapToShapes ?? true,
           snapToAxisAlignment: options.snapToAxisAlignment,
           gridStep: design.field.gridStep,
-          magneticRadiusMeters: waypointSnapRadiusMeters,
+          magneticRadiusMeters:
+            options.magneticRadiusMeters ?? waypointSnapRadiusMeters,
           candidates: getWaypointSnapCandidates(posMeters),
           routeCandidates: routeSnapCandidates,
           snapToRouteLines: options.snapToRouteLines,
@@ -793,13 +795,26 @@ const TrackCanvas = memo(
       ): Vector2d => {
         const bounded = clampWaypointDragPosition(pos);
         if (!snapEnabled) return bounded;
+        const desktopWaypointSnapRadius = Math.min(
+          waypointSnapRadiusMeters,
+          Math.max(design.field.gridStep * 0.35, 0.15)
+        );
         return resolveCanvasSnapPosition(bounded, {
           excludeIds: sourcePathId ? [sourcePathId] : undefined,
+          magneticRadiusMeters: isMobile
+            ? waypointSnapRadiusMeters
+            : desktopWaypointSnapRadius,
           snapToRouteLines: false,
-          snapToRouteWaypoints: true,
+          snapToRouteWaypoints: isMobile,
         });
       },
-      [clampWaypointDragPosition, resolveCanvasSnapPosition]
+      [
+        clampWaypointDragPosition,
+        design.field.gridStep,
+        isMobile,
+        resolveCanvasSnapPosition,
+        waypointSnapRadiusMeters,
+      ]
     );
 
     const dragBound = useCallback(
@@ -1893,7 +1908,11 @@ const TrackCanvas = memo(
                   <span className="text-border">·</span>
                   <span>Grid {design.field.gridStep}m</span>
                   <span className="text-border">·</span>
-                  <span>{snapEnabled ? "Smart snap" : "Snap off"}</span>
+                  <span>
+                    {snapEnabled
+                      ? "Snap on: grid, objects, routes"
+                      : "Snap off: free placement"}
+                  </span>
                 </div>
               )}
             </div>

--- a/src/components/editor/StatusBar.tsx
+++ b/src/components/editor/StatusBar.tsx
@@ -9,6 +9,11 @@ import { getLayoutPresetById } from "@/lib/planning/layout-presets";
 import { getShapeGroupId, getShapeGroupName } from "@/lib/track/shape-groups";
 import { Magnet } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/AppTooltip";
 
 const toolLabel: Record<string, string> = {
   select: "Select",
@@ -98,32 +103,45 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
 
       {/* Snap indicator — desktop only */}
       <span className="text-muted-foreground/45">·</span>
-      <button
-        type="button"
-        onClick={toggleSnapEnabled}
-        className={cn(
-          "pointer-events-auto inline-flex h-5 items-center gap-1 rounded px-1.5 text-[11px] transition-colors",
-          snapEnabled
-            ? "text-foreground/70 hover:bg-muted hover:text-foreground"
-            : "hover:bg-muted text-amber-500/85 hover:text-amber-400"
-        )}
-        title={`Toggle snap (${snapEnabled ? "on" : "off"})`}
-        aria-pressed={snapEnabled}
-      >
-        <Magnet
-          className={cn(
-            "size-3",
-            snapEnabled && snapActive
-              ? "text-green-500/80"
-              : snapEnabled
-                ? "text-foreground/60"
-                : "text-amber-500/85"
-          )}
-        />
-        <span>
-          {snapEnabled ? (snapActive ? "Snap" : "Snap On") : "Snap Off"}
-        </span>
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={toggleSnapEnabled}
+            className={cn(
+              "pointer-events-auto inline-flex h-5 items-center gap-1 rounded px-1.5 text-[11px] transition-colors",
+              snapEnabled
+                ? "text-foreground/70 hover:bg-muted hover:text-foreground"
+                : "hover:bg-muted text-amber-500/85 hover:text-amber-400"
+            )}
+            aria-pressed={snapEnabled}
+          >
+            <Magnet
+              className={cn(
+                "size-3",
+                snapEnabled && snapActive
+                  ? "text-green-500/80"
+                  : snapEnabled
+                    ? "text-foreground/60"
+                    : "text-amber-500/85"
+              )}
+            />
+            <span>
+              {snapEnabled ? (snapActive ? "Snap" : "Snap On") : "Snap Off"}
+            </span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6} className="max-w-64">
+          <span className="block font-medium">
+            {snapEnabled ? "Snap is on" : "Snap is off"}
+          </span>
+          <span className="mt-1 block opacity-80">
+            {snapEnabled
+              ? "Points and drags lock to nearby grid positions, objects, and route points. Hold Alt while placing or dragging to bypass it once."
+              : "Placement and dragging stay freeform until you turn snap back on."}
+          </span>
+        </TooltipContent>
+      </Tooltip>
 
       <div className="flex-1" />
 

--- a/src/components/editor/mobile/EditorMobilePanels.tsx
+++ b/src/components/editor/mobile/EditorMobilePanels.tsx
@@ -744,7 +744,7 @@ export function EditorMobilePanels({
                     </p>
                     <p className="pt-1 text-[11px] leading-relaxed opacity-80">
                       {snapEnabled
-                        ? "Grid and shape snap stay active until you turn them off."
+                        ? "Points and drags lock to nearby grid positions, objects, and route points."
                         : "Place and drag freely until you turn snap back on."}
                     </p>
                   </div>

--- a/src/components/inspector/ElevationChart.tsx
+++ b/src/components/inspector/ElevationChart.tsx
@@ -57,37 +57,44 @@ const WARNING_DETAILS: Record<
 > = {
   stub: {
     title: "Route is incomplete",
-    problem: "The path needs at least two waypoints before TrackDraw can review it as a route.",
+    problem:
+      "The path needs at least two waypoints before TrackDraw can review it as a route.",
     fix: "Add another waypoint or finish drawing the race line.",
   },
   flat: {
     title: "No elevation has been set",
-    problem: "All waypoints are still at 0 m, so the 3D preview and elevation chart stay flat.",
+    problem:
+      "All waypoints are still at 0 m, so the 3D preview and elevation chart stay flat.",
     fix: "Set waypoint elevations in the inspector or 3D view if the route should climb or drop.",
   },
   steep: {
     title: "Grade changes too quickly",
-    problem: "One section climbs or drops sharply over a short distance, which can make the 3D line feel abrupt.",
+    problem:
+      "One section climbs or drops sharply over a short distance, which can make the 3D line feel abrupt.",
     fix: "Spread the height change across more distance or add an intermediate waypoint.",
   },
   hairpin: {
     title: "Turn is very tight",
-    problem: "A waypoint creates a sharp reversal that may be hard to fly cleanly at speed.",
+    problem:
+      "A waypoint creates a sharp reversal that may be hard to fly cleanly at speed.",
     fix: "Move the waypoint outward or add more room before and after the turn.",
   },
   "close-points": {
     title: "Waypoints are too close",
-    problem: "Two waypoints are so close together that they create a tiny route segment.",
+    problem:
+      "Two waypoints are so close together that they create a tiny route segment.",
     fix: "Delete one of the points or move it farther away from its neighbor.",
   },
   "spacing-shift": {
     title: "Gate rhythm changes abruptly",
-    problem: "The distance before and after a waypoint changes suddenly, which can make the route feel uneven.",
+    problem:
+      "The distance before and after a waypoint changes suddenly, which can make the route feel uneven.",
     fix: "Reposition nearby waypoints so the spacing changes more gradually.",
   },
   "rhythm-break": {
     title: "Short correction breaks the flow",
-    problem: "A short middle segment interrupts longer surrounding sections and can create an awkward wobble.",
+    problem:
+      "A short middle segment interrupts longer surrounding sections and can create an awkward wobble.",
     fix: "Smooth the correction by moving the point, deleting it, or adding a gentler transition.",
   },
 };
@@ -322,7 +329,11 @@ function ElevationSvg({
         />
       ))}
 
-      <path d={fillPath} fill={`url(#${fillId})`} clipPath={`url(#${clipId})`} />
+      <path
+        d={fillPath}
+        fill={`url(#${fillId})`}
+        clipPath={`url(#${clipId})`}
+      />
       {samples.slice(1).map((sample, index) => {
         const previous = samples[index];
         if (!previous) return null;
@@ -490,7 +501,10 @@ export default function ElevationChart({ className }: { className?: string }) {
     if (samples.length < 2) return null;
 
     const totalDist = getPolylineTotalLength2D(path);
-    const rawMinZ = samples.reduce((a, sample) => Math.min(a, sample.z), Infinity);
+    const rawMinZ = samples.reduce(
+      (a, sample) => Math.min(a, sample.z),
+      Infinity
+    );
     const rawMaxZ = samples.reduce(
       (a, sample) => Math.max(a, sample.z),
       -Infinity
@@ -647,7 +661,8 @@ export default function ElevationChart({ className }: { className?: string }) {
         </span>
         <div className="flex min-w-0 items-center gap-1.5">
           <span className="text-muted-foreground truncate text-[11px]">
-            {totalDist.toFixed(1)} m · {rawMinZ.toFixed(1)}–{rawMaxZ.toFixed(1)} m
+            {totalDist.toFixed(1)} m · {rawMinZ.toFixed(1)}–{rawMaxZ.toFixed(1)}{" "}
+            m
           </span>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -672,7 +687,9 @@ export default function ElevationChart({ className }: { className?: string }) {
       <RouteWarningSummary warnings={warnings} />
       <RouteColorKey kinds={warningKinds} />
       <ElevationSvg {...chartProps} height={VIEW_H} />
-      {portalRoot && detailsOpen ? createPortal(detailsOverlay, portalRoot) : null}
+      {portalRoot && detailsOpen
+        ? createPortal(detailsOverlay, portalRoot)
+        : null}
     </div>
   );
 }

--- a/src/components/inspector/ElevationChart.tsx
+++ b/src/components/inspector/ElevationChart.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useMemo } from "react";
+import { useId, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { Info } from "lucide-react";
 import { useEditor } from "@/store/editor";
 import {
   getPolylineElevationSamples,
@@ -13,13 +15,24 @@ import {
 } from "@/lib/track/polyline-derived";
 import { selectPrimaryPolyline } from "@/store/selectors";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { DesktopModal } from "@/components/DesktopModal";
+import { MobileDrawer } from "@/components/MobileDrawer";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/AppTooltip";
+import { useIsMobile } from "@/hooks/use-mobile";
+
+type SegmentWarningKind = Exclude<RouteWarningKind, "flat" | "stub">;
 
 const WARNING_LABELS: Record<
   RouteWarningKind,
   (count: number, first?: number) => string
 > = {
   stub: () => "Path needs at least 2 waypoints to form a route",
-  flat: () => "No elevation set — 3D preview will be flat",
+  flat: () => "No elevation set - 3D preview will be flat",
   steep: (n, first) =>
     n === 1
       ? `Steep grade near waypoint ${first}`
@@ -33,52 +46,195 @@ const WARNING_LABELS: Record<
       ? `Abrupt spacing shift near waypoint ${first}`
       : `${n} abrupt spacing shifts`,
   "rhythm-break": (n, first) =>
-    n === 1 ? `Rhythm break near waypoint ${first}` : `${n} rhythm breaks`,
-  "alignment-drift": (n, first) =>
     n === 1
-      ? `Small alignment kink near waypoint ${first}`
-      : `${n} small alignment kinks`,
+      ? `Short correction segment near waypoint ${first}`
+      : `${n} short correction segments`,
 };
 
-function RouteWarnings({ warnings }: { warnings: RouteWarning[] }) {
-  const grouped = useMemo(() => {
+const WARNING_DETAILS: Record<
+  RouteWarningKind,
+  { title: string; problem: string; fix: string }
+> = {
+  stub: {
+    title: "Route is incomplete",
+    problem: "The path needs at least two waypoints before TrackDraw can review it as a route.",
+    fix: "Add another waypoint or finish drawing the race line.",
+  },
+  flat: {
+    title: "No elevation has been set",
+    problem: "All waypoints are still at 0 m, so the 3D preview and elevation chart stay flat.",
+    fix: "Set waypoint elevations in the inspector or 3D view if the route should climb or drop.",
+  },
+  steep: {
+    title: "Grade changes too quickly",
+    problem: "One section climbs or drops sharply over a short distance, which can make the 3D line feel abrupt.",
+    fix: "Spread the height change across more distance or add an intermediate waypoint.",
+  },
+  hairpin: {
+    title: "Turn is very tight",
+    problem: "A waypoint creates a sharp reversal that may be hard to fly cleanly at speed.",
+    fix: "Move the waypoint outward or add more room before and after the turn.",
+  },
+  "close-points": {
+    title: "Waypoints are too close",
+    problem: "Two waypoints are so close together that they create a tiny route segment.",
+    fix: "Delete one of the points or move it farther away from its neighbor.",
+  },
+  "spacing-shift": {
+    title: "Gate rhythm changes abruptly",
+    problem: "The distance before and after a waypoint changes suddenly, which can make the route feel uneven.",
+    fix: "Reposition nearby waypoints so the spacing changes more gradually.",
+  },
+  "rhythm-break": {
+    title: "Short correction breaks the flow",
+    problem: "A short middle segment interrupts longer surrounding sections and can create an awkward wobble.",
+    fix: "Smooth the correction by moving the point, deleting it, or adding a gentler transition.",
+  },
+};
+
+const WARNING_SHORT_LABELS: Record<RouteWarningKind, string> = {
+  stub: "Incomplete route",
+  flat: "Flat elevation",
+  steep: "Steep grade",
+  hairpin: "Tight turn",
+  "close-points": "Close points",
+  "spacing-shift": "Spacing shift",
+  "rhythm-break": "Short correction",
+};
+
+function isWarningKind(kind: RouteWarningKind) {
+  return (
+    kind === "steep" ||
+    kind === "close-points" ||
+    kind === "spacing-shift" ||
+    kind === "rhythm-break"
+  );
+}
+
+function useGroupedWarnings(warnings: RouteWarning[]) {
+  return useMemo(() => {
     const map = new Map<RouteWarningKind, { count: number; first?: number }>();
-    for (const w of warnings) {
-      const existing = map.get(w.kind);
+    for (const warning of warnings) {
+      const existing = map.get(warning.kind);
       if (!existing) {
-        map.set(w.kind, { count: 1, first: w.waypointIndex });
+        map.set(warning.kind, { count: 1, first: warning.waypointIndex });
       } else {
         existing.count += 1;
       }
     }
     return Array.from(map.entries());
   }, [warnings]);
+}
 
+function RouteWarningSummary({ warnings }: { warnings: RouteWarning[] }) {
+  const grouped = useGroupedWarnings(warnings);
   if (grouped.length === 0) return null;
 
+  const [kind, summary] = grouped[0];
+  const extraCount = grouped.length - 1;
+  const warn = isWarningKind(kind);
+
   return (
-    <div className="mb-2 space-y-1">
-      {grouped.map(([kind, { count, first }]) => {
-        const isWarn =
-          kind === "steep" ||
-          kind === "close-points" ||
-          kind === "spacing-shift" ||
-          kind === "rhythm-break" ||
-          kind === "alignment-drift";
-        return (
-          <div
-            key={kind}
-            className={`flex items-start gap-1.5 rounded px-2 py-1 text-[11px] leading-snug ${
-              isWarn
-                ? "bg-amber-500/8 text-amber-600 dark:text-amber-400"
-                : "bg-muted/40 text-muted-foreground"
-            }`}
-          >
-            <span className="mt-px shrink-0">{isWarn ? "⚠" : "↳"}</span>
-            <span>{WARNING_LABELS[kind](count, first)}</span>
-          </div>
-        );
-      })}
+    <div
+      className={cn(
+        "mb-2 flex items-center gap-1.5 rounded px-2 py-1 text-[11px] leading-snug",
+        warn
+          ? "bg-amber-500/8 text-amber-600 dark:text-amber-400"
+          : "bg-muted/40 text-muted-foreground"
+      )}
+    >
+      <span className="shrink-0">{warn ? "⚠" : "↳"}</span>
+      <span className="min-w-0 truncate">
+        {WARNING_LABELS[kind](summary.count, summary.first)}
+      </span>
+      {extraCount > 0 && (
+        <span className="text-muted-foreground shrink-0">
+          +{extraCount} more
+        </span>
+      )}
+    </div>
+  );
+}
+
+function RouteWarningDetails({ warnings }: { warnings: RouteWarning[] }) {
+  const grouped = useGroupedWarnings(warnings);
+
+  if (grouped.length === 0) {
+    return (
+      <div className="text-muted-foreground rounded border border-dashed px-3 py-2 text-sm">
+        No route warnings for this path.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="text-muted-foreground text-[11px] font-semibold tracking-widest uppercase">
+        Route Review
+      </div>
+      <div className="space-y-1.5">
+        {grouped.map(([kind, { count, first }]) => {
+          const warn = isWarningKind(kind);
+          return (
+            <div
+              key={kind}
+              className={cn(
+                "flex items-start gap-2 rounded px-2.5 py-2 text-xs leading-snug",
+                warn
+                  ? "bg-amber-500/8 text-amber-700 dark:text-amber-300"
+                  : "bg-muted/40 text-muted-foreground"
+              )}
+            >
+              <span className="mt-px shrink-0">{warn ? "⚠" : "↳"}</span>
+              <span className="min-w-0">
+                <span className="block font-medium">
+                  {WARNING_DETAILS[kind].title}
+                </span>
+                <span className="text-muted-foreground block">
+                  {WARNING_LABELS[kind](count, first)}
+                </span>
+                <span className="text-muted-foreground mt-1 block">
+                  {WARNING_DETAILS[kind].problem}
+                </span>
+                <span className="text-muted-foreground mt-1 block">
+                  {WARNING_DETAILS[kind].fix}
+                </span>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RouteColorKey({ kinds }: { kinds: RouteWarningKind[] }) {
+  const warningKinds = kinds.filter(
+    (kind): kind is SegmentWarningKind => kind !== "flat" && kind !== "stub"
+  );
+  if (warningKinds.length === 0) return null;
+
+  const uniqueKinds = Array.from(new Set(warningKinds));
+  const items = [
+    { color: "var(--color-primary)", label: "Normal" },
+    ...uniqueKinds.map((kind) => ({
+      color: getRouteWarningSegmentColor(kind, "var(--color-primary)"),
+      label: WARNING_SHORT_LABELS[kind],
+    })),
+  ];
+
+  return (
+    <div className="text-muted-foreground mb-2 flex flex-wrap gap-x-3 gap-y-1 text-[10px] leading-tight">
+      {items.map((item) => (
+        <span key={item.label} className="inline-flex items-center gap-1.5">
+          <span
+            className="h-1.5 w-4 rounded-full"
+            style={{ backgroundColor: item.color }}
+            aria-hidden="true"
+          />
+          <span>{item.label}</span>
+        </span>
+      ))}
     </div>
   );
 }
@@ -95,16 +251,226 @@ const PLOT_H = VIEW_H - PAD_TOP - PAD_BOTTOM;
 function niceStep(range: number, targetTicks: number): number {
   const raw = range / targetTicks;
   const mag = Math.pow(10, Math.floor(Math.log10(raw)));
-  const candidates = [1, 2, 2.5, 5, 10].map((c) => c * mag);
-  return candidates.find((c) => c >= raw) ?? candidates[candidates.length - 1];
+  const candidates = [1, 2, 2.5, 5, 10].map((candidate) => candidate * mag);
+  return candidates.find((candidate) => candidate >= raw) ?? candidates.at(-1)!;
+}
+
+function ElevationSvg({
+  fillPath,
+  height,
+  minSample,
+  maxSample,
+  samples,
+  toX,
+  toY,
+  warningKindBySegment,
+  xTicks,
+  yTicks,
+}: {
+  fillPath: string;
+  height: number;
+  minSample: { d: number; z: number };
+  maxSample: { d: number; z: number };
+  samples: Array<{ d: number; z: number }>;
+  toX: (d: number) => number;
+  toY: (z: number) => number;
+  warningKindBySegment: Map<number, SegmentWarningKind>;
+  xTicks: Array<{ d: number; label: string }>;
+  yTicks: Array<{ z: number; label: string }>;
+}) {
+  const id = useId().replaceAll(":", "");
+  const fillId = `elev-fill-${id}`;
+  const clipId = `elev-clip-${id}`;
+
+  return (
+    <svg
+      viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+      width="100%"
+      height={height}
+      className="overflow-visible"
+      aria-label="Elevation profile chart"
+    >
+      <defs>
+        <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
+          <stop
+            offset="0%"
+            stopColor="var(--color-primary)"
+            stopOpacity="0.35"
+          />
+          <stop
+            offset="100%"
+            stopColor="var(--color-primary)"
+            stopOpacity="0.03"
+          />
+        </linearGradient>
+        <clipPath id={clipId}>
+          <rect x={PAD_LEFT} y={PAD_TOP} width={PLOT_W} height={PLOT_H} />
+        </clipPath>
+      </defs>
+
+      {yTicks.map(({ z }) => (
+        <line
+          key={z}
+          x1={PAD_LEFT}
+          y1={toY(z).toFixed(2)}
+          x2={PAD_LEFT + PLOT_W}
+          y2={toY(z).toFixed(2)}
+          stroke="currentColor"
+          strokeOpacity={0.2}
+          strokeWidth={0.5}
+          strokeDasharray="3 3"
+        />
+      ))}
+
+      <path d={fillPath} fill={`url(#${fillId})`} clipPath={`url(#${clipId})`} />
+      {samples.slice(1).map((sample, index) => {
+        const previous = samples[index];
+        if (!previous) return null;
+        const warningKind = warningKindBySegment.get(index);
+        const stroke = getRouteWarningSegmentColor(
+          warningKind,
+          "var(--color-primary)"
+        );
+
+        return (
+          <path
+            key={`segment-${index}`}
+            d={`M${toX(previous.d).toFixed(2)},${toY(previous.z).toFixed(2)} L${toX(sample.d).toFixed(2)},${toY(sample.z).toFixed(2)}`}
+            fill="none"
+            stroke={stroke}
+            strokeWidth="1.9"
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            clipPath={`url(#${clipId})`}
+          />
+        );
+      })}
+
+      {minSample.d !== maxSample.d && (
+        <>
+          <circle
+            cx={toX(minSample.d)}
+            cy={toY(minSample.z)}
+            r="3"
+            fill="var(--color-background)"
+            stroke="var(--color-primary)"
+            strokeWidth="1.5"
+          />
+          <text
+            x={toX(minSample.d)}
+            y={toY(minSample.z) + 10}
+            textAnchor="middle"
+            fontSize="10"
+            fill="currentColor"
+            fillOpacity={0.7}
+          >
+            {minSample.z.toFixed(1)}m
+          </text>
+        </>
+      )}
+
+      <circle
+        cx={toX(maxSample.d)}
+        cy={toY(maxSample.z)}
+        r="3"
+        fill="var(--color-primary)"
+        stroke="var(--color-background)"
+        strokeWidth="1.5"
+      />
+      <text
+        x={toX(maxSample.d)}
+        y={toY(maxSample.z) - 5}
+        textAnchor="middle"
+        fontSize="10"
+        fill="var(--color-primary)"
+        fontWeight="600"
+      >
+        {maxSample.z.toFixed(1)}m
+      </text>
+
+      <line
+        x1={PAD_LEFT}
+        y1={PAD_TOP + PLOT_H}
+        x2={PAD_LEFT + PLOT_W}
+        y2={PAD_TOP + PLOT_H}
+        stroke="currentColor"
+        strokeOpacity={0.3}
+        strokeWidth={1}
+      />
+      <line
+        x1={PAD_LEFT}
+        y1={PAD_TOP}
+        x2={PAD_LEFT}
+        y2={PAD_TOP + PLOT_H}
+        stroke="currentColor"
+        strokeOpacity={0.3}
+        strokeWidth={1}
+      />
+
+      {xTicks.map(({ d, label }) => (
+        <g key={d}>
+          <line
+            x1={toX(d)}
+            y1={PAD_TOP + PLOT_H}
+            x2={toX(d)}
+            y2={PAD_TOP + PLOT_H + 3}
+            stroke="currentColor"
+            strokeOpacity={0.3}
+            strokeWidth={1}
+          />
+          <text
+            x={toX(d)}
+            y={VIEW_H - 4}
+            textAnchor="middle"
+            fontSize="10"
+            fill="currentColor"
+            fillOpacity={0.7}
+          >
+            {label}
+          </text>
+        </g>
+      ))}
+
+      {yTicks.map(({ z, label }) => (
+        <g key={z}>
+          <line
+            x1={PAD_LEFT - 3}
+            y1={toY(z)}
+            x2={PAD_LEFT}
+            y2={toY(z)}
+            stroke="currentColor"
+            strokeOpacity={0.3}
+            strokeWidth={1}
+          />
+          <text
+            x={PAD_LEFT - 5}
+            y={toY(z) + 3}
+            textAnchor="end"
+            fontSize="10"
+            fill="currentColor"
+            fillOpacity={0.7}
+          >
+            {label}
+          </text>
+        </g>
+      ))}
+    </svg>
+  );
 }
 
 export default function ElevationChart({ className }: { className?: string }) {
   const path = useEditor(selectPrimaryPolyline);
+  const isMobile = useIsMobile();
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const portalRoot = typeof document === "undefined" ? null : document.body;
 
   const warnings = useMemo(
     () => (path ? getPolylineRouteWarnings(path) : []),
     [path]
+  );
+  const warningKinds = useMemo(
+    () => warnings.map((warning) => warning.kind),
+    [warnings]
   );
   const warningSegments = useMemo(
     () => (path ? getPolylineRouteWarningSegmentVisuals(path) : []),
@@ -124,8 +490,11 @@ export default function ElevationChart({ className }: { className?: string }) {
     if (samples.length < 2) return null;
 
     const totalDist = getPolylineTotalLength2D(path);
-    const rawMinZ = samples.reduce((a, s) => Math.min(a, s.z), Infinity);
-    const rawMaxZ = samples.reduce((a, s) => Math.max(a, s.z), -Infinity);
+    const rawMinZ = samples.reduce((a, sample) => Math.min(a, sample.z), Infinity);
+    const rawMaxZ = samples.reduce(
+      (a, sample) => Math.max(a, sample.z),
+      -Infinity
+    );
     const zRange = rawMaxZ - rawMinZ;
     const zPad = zRange < 0.5 ? 0.5 : zRange * 0.12;
     const minZ = rawMinZ - zPad;
@@ -137,8 +506,8 @@ export default function ElevationChart({ className }: { className?: string }) {
 
     const linePath = samples
       .map(
-        ({ d, z }, i) =>
-          `${i === 0 ? "M" : "L"}${toX(d).toFixed(2)},${toY(z).toFixed(2)}`
+        ({ d, z }, index) =>
+          `${index === 0 ? "M" : "L"}${toX(d).toFixed(2)},${toY(z).toFixed(2)}`
       )
       .join(" ");
 
@@ -150,23 +519,30 @@ export default function ElevationChart({ className }: { className?: string }) {
       ` L${lastX.toFixed(2)},${baselineY} L${firstX.toFixed(2)},${baselineY} Z`;
 
     const xStep = niceStep(totalDist, 5);
-    const xTicks: { d: number; label: string }[] = [];
+    const xTicks: Array<{ d: number; label: string }> = [];
     for (let d = 0; d <= totalDist + xStep * 0.01; d += xStep) {
-      const c = Math.min(d, totalDist);
-      xTicks.push({ d: c, label: c.toFixed(0) });
-      if (c >= totalDist) break;
+      const clampedDistance = Math.min(d, totalDist);
+      xTicks.push({ d: clampedDistance, label: clampedDistance.toFixed(0) });
+      if (clampedDistance >= totalDist) break;
     }
 
     const yStep = niceStep(zSpan, 4);
     const yTickStart = Math.ceil(minZ / yStep) * yStep;
-    const yTicks: { z: number; label: string }[] = [];
+    const yTicks: Array<{ z: number; label: string }> = [];
     for (let z = yTickStart; z <= maxZ + yStep * 0.01; z += yStep) {
-      if (z >= minZ - 0.001 && z <= maxZ + 0.001)
+      if (z >= minZ - 0.001 && z <= maxZ + 0.001) {
         yTicks.push({ z, label: z.toFixed(1) });
+      }
     }
 
-    const minSample = samples.reduce((a, s) => (s.z < a.z ? s : a), samples[0]);
-    const maxSample = samples.reduce((a, s) => (s.z > a.z ? s : a), samples[0]);
+    const minSample = samples.reduce(
+      (a, sample) => (sample.z < a.z ? sample : a),
+      samples[0]
+    );
+    const maxSample = samples.reduce(
+      (a, sample) => (sample.z > a.z ? sample : a),
+      samples[0]
+    );
 
     return {
       fillPath,
@@ -210,6 +586,54 @@ export default function ElevationChart({ className }: { className?: string }) {
     maxSample,
   } = chartData;
 
+  const chartProps = {
+    fillPath,
+    minSample,
+    maxSample,
+    samples,
+    toX,
+    toY,
+    warningKindBySegment,
+    xTicks,
+    yTicks,
+  };
+  const detailsContent = (
+    <div className="space-y-4">
+      <div>
+        <div className="text-muted-foreground mb-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
+          <span>{totalDist.toFixed(1)} m route</span>
+          <span>
+            {rawMinZ.toFixed(1)}-{rawMaxZ.toFixed(1)} m elevation
+          </span>
+        </div>
+        <ElevationSvg {...chartProps} height={isMobile ? 180 : 220} />
+      </div>
+      <RouteColorKey kinds={warningKinds} />
+      <RouteWarningDetails warnings={warnings} />
+    </div>
+  );
+  const detailsOverlay = isMobile ? (
+    <MobileDrawer
+      open={detailsOpen}
+      onOpenChange={setDetailsOpen}
+      title="Elevation Profile"
+      subtitle="Route height, colored warning sections, and route-review notes."
+    >
+      {detailsContent}
+    </MobileDrawer>
+  ) : (
+    <DesktopModal
+      open={detailsOpen}
+      onOpenChange={setDetailsOpen}
+      title="Elevation Profile"
+      subtitle="Route height, colored warning sections, and route-review notes."
+      maxWidth="max-w-2xl"
+      panelClassName="px-7 py-7"
+    >
+      {detailsContent}
+    </DesktopModal>
+  );
+
   return (
     <div
       className={cn(
@@ -217,189 +641,38 @@ export default function ElevationChart({ className }: { className?: string }) {
         className
       )}
     >
-      <div className="mb-2 flex items-baseline justify-between">
+      <div className="mb-2 flex items-center justify-between gap-2">
         <span className="text-muted-foreground text-[11px] font-semibold tracking-widest uppercase">
           Elevation Profile
         </span>
-        <span className="text-muted-foreground text-[11px]">
-          {totalDist.toFixed(1)} m · {rawMinZ.toFixed(1)}–{rawMaxZ.toFixed(1)} m
-        </span>
+        <div className="flex min-w-0 items-center gap-1.5">
+          <span className="text-muted-foreground truncate text-[11px]">
+            {totalDist.toFixed(1)} m · {rawMinZ.toFixed(1)}–{rawMaxZ.toFixed(1)} m
+          </span>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="text-muted-foreground hover:bg-muted/70 hover:text-foreground focus-visible:bg-muted/70 h-6 w-6 shrink-0"
+                aria-label="Open elevation details"
+                onClick={() => setDetailsOpen(true)}
+              >
+                <Info className="size-3.5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={6}>
+              Elevation details
+            </TooltipContent>
+          </Tooltip>
+        </div>
       </div>
 
-      <RouteWarnings warnings={warnings} />
-
-      <svg
-        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
-        width="100%"
-        height={VIEW_H}
-        className="overflow-visible"
-        aria-label="Elevation profile chart"
-      >
-        <defs>
-          <linearGradient id="elev-fill" x1="0" y1="0" x2="0" y2="1">
-            <stop
-              offset="0%"
-              stopColor="var(--color-primary)"
-              stopOpacity="0.35"
-            />
-            <stop
-              offset="100%"
-              stopColor="var(--color-primary)"
-              stopOpacity="0.03"
-            />
-          </linearGradient>
-          <clipPath id="elev-clip">
-            <rect x={PAD_LEFT} y={PAD_TOP} width={PLOT_W} height={PLOT_H} />
-          </clipPath>
-        </defs>
-
-        {yTicks.map(({ z }) => (
-          <line
-            key={z}
-            x1={PAD_LEFT}
-            y1={toY(z).toFixed(2)}
-            x2={PAD_LEFT + PLOT_W}
-            y2={toY(z).toFixed(2)}
-            stroke="currentColor"
-            strokeOpacity={0.2}
-            strokeWidth={0.5}
-            strokeDasharray="3 3"
-          />
-        ))}
-
-        <path d={fillPath} fill="url(#elev-fill)" clipPath="url(#elev-clip)" />
-        {samples.slice(1).map((sample, index) => {
-          const previous = samples[index];
-          if (!previous) return null;
-          const warningKind = warningKindBySegment.get(index);
-          const stroke = getRouteWarningSegmentColor(
-            warningKind,
-            "var(--color-primary)"
-          );
-
-          return (
-            <path
-              key={`segment-${index}`}
-              d={`M${toX(previous.d).toFixed(2)},${toY(previous.z).toFixed(2)} L${toX(sample.d).toFixed(2)},${toY(sample.z).toFixed(2)}`}
-              fill="none"
-              stroke={stroke}
-              strokeWidth="1.9"
-              strokeLinejoin="round"
-              strokeLinecap="round"
-              clipPath="url(#elev-clip)"
-            />
-          );
-        })}
-
-        {minSample.d !== maxSample.d && (
-          <>
-            <circle
-              cx={toX(minSample.d)}
-              cy={toY(minSample.z)}
-              r="3"
-              fill="var(--color-background)"
-              stroke="var(--color-primary)"
-              strokeWidth="1.5"
-            />
-            <text
-              x={toX(minSample.d)}
-              y={toY(minSample.z) + 10}
-              textAnchor="middle"
-              fontSize="10"
-              fill="currentColor"
-              fillOpacity={0.7}
-            >
-              {minSample.z.toFixed(1)}m
-            </text>
-          </>
-        )}
-
-        <circle
-          cx={toX(maxSample.d)}
-          cy={toY(maxSample.z)}
-          r="3"
-          fill="var(--color-primary)"
-          stroke="var(--color-background)"
-          strokeWidth="1.5"
-        />
-        <text
-          x={toX(maxSample.d)}
-          y={toY(maxSample.z) - 5}
-          textAnchor="middle"
-          fontSize="10"
-          fill="var(--color-primary)"
-          fontWeight="600"
-        >
-          {maxSample.z.toFixed(1)}m
-        </text>
-
-        <line
-          x1={PAD_LEFT}
-          y1={PAD_TOP + PLOT_H}
-          x2={PAD_LEFT + PLOT_W}
-          y2={PAD_TOP + PLOT_H}
-          stroke="currentColor"
-          strokeOpacity={0.3}
-          strokeWidth={1}
-        />
-        <line
-          x1={PAD_LEFT}
-          y1={PAD_TOP}
-          x2={PAD_LEFT}
-          y2={PAD_TOP + PLOT_H}
-          stroke="currentColor"
-          strokeOpacity={0.3}
-          strokeWidth={1}
-        />
-
-        {xTicks.map(({ d, label }) => (
-          <g key={d}>
-            <line
-              x1={toX(d)}
-              y1={PAD_TOP + PLOT_H}
-              x2={toX(d)}
-              y2={PAD_TOP + PLOT_H + 3}
-              stroke="currentColor"
-              strokeOpacity={0.3}
-              strokeWidth={1}
-            />
-            <text
-              x={toX(d)}
-              y={VIEW_H - 4}
-              textAnchor="middle"
-              fontSize="10"
-              fill="currentColor"
-              fillOpacity={0.7}
-            >
-              {label}
-            </text>
-          </g>
-        ))}
-
-        {yTicks.map(({ z, label }) => (
-          <g key={z}>
-            <line
-              x1={PAD_LEFT - 3}
-              y1={toY(z)}
-              x2={PAD_LEFT}
-              y2={toY(z)}
-              stroke="currentColor"
-              strokeOpacity={0.3}
-              strokeWidth={1}
-            />
-            <text
-              x={PAD_LEFT - 5}
-              y={toY(z) + 3}
-              textAnchor="end"
-              fontSize="10"
-              fill="currentColor"
-              fillOpacity={0.7}
-            >
-              {label}
-            </text>
-          </g>
-        ))}
-      </svg>
+      <RouteWarningSummary warnings={warnings} />
+      <RouteColorKey kinds={warningKinds} />
+      <ElevationSvg {...chartProps} height={VIEW_H} />
+      {portalRoot && detailsOpen ? createPortal(detailsOverlay, portalRoot) : null}
     </div>
   );
 }

--- a/src/lib/track/polyline-derived.ts
+++ b/src/lib/track/polyline-derived.ts
@@ -191,8 +191,7 @@ export type RouteWarningKind =
   | "hairpin"
   | "close-points"
   | "spacing-shift"
-  | "rhythm-break"
-  | "alignment-drift";
+  | "rhythm-break";
 
 export interface RouteWarning {
   kind: RouteWarningKind;
@@ -224,7 +223,6 @@ export interface RouteWarningSegmentVisual {
  * - close-points: consecutive waypoints < 0.5 m apart
  * - spacing-shift: abrupt jump from a short segment into a much longer one
  * - rhythm-break: short corrective segment between longer sections
- * - alignment-drift: a small kink breaks an otherwise straighter line
  */
 export function getPolylineRouteWarnings(path: PolylineShape): RouteWarning[] {
   const pts = path.points;
@@ -276,42 +274,6 @@ export function getPolylineRouteWarnings(path: PolylineShape): RouteWarning[] {
       if (angleDeg < 45) {
         warnings.push({ kind: "hairpin", waypointIndex: i });
       }
-    }
-  }
-
-  for (let i = 1; i < pts.length - 1; i += 1) {
-    const previous = pts[i - 1];
-    const current = pts[i];
-    const next = pts[i + 1];
-    const previousLength = segmentLengths[i - 1];
-    const nextLength = segmentLengths[i];
-    const angleDeg = turnAnglesByWaypoint.get(i);
-
-    if (
-      !previous ||
-      !current ||
-      !next ||
-      typeof previousLength !== "number" ||
-      typeof nextLength !== "number" ||
-      typeof angleDeg !== "number"
-    ) {
-      continue;
-    }
-
-    if (previousLength < 2.5 || nextLength < 2.5) continue;
-    if (angleDeg < 150 || angleDeg > 172) continue;
-
-    const baselineLength = Math.hypot(next.x - previous.x, next.y - previous.y);
-    if (baselineLength < 4) continue;
-
-    const offset =
-      Math.abs(
-        (next.x - previous.x) * (previous.y - current.y) -
-          (previous.x - current.x) * (next.y - previous.y)
-      ) / baselineLength;
-
-    if (offset >= 0.35 && offset <= 1.6) {
-      warnings.push({ kind: "alignment-drift", waypointIndex: i });
     }
   }
 
@@ -400,10 +362,9 @@ export function getPolylineRouteWarningVisuals(
 const ROUTE_WARNING_PRIORITY: Record<SegmentWarningKind, number> = {
   hairpin: 1,
   "spacing-shift": 2,
-  "alignment-drift": 3,
-  "rhythm-break": 4,
-  steep: 5,
-  "close-points": 6,
+  "rhythm-break": 3,
+  steep: 4,
+  "close-points": 5,
 };
 
 export function getRouteWarningSegmentColor(
@@ -413,7 +374,6 @@ export function getRouteWarningSegmentColor(
   if (!kind) return defaultColor;
   if (kind === "close-points") return "#ef4444";
   if (kind === "steep") return "#f97316";
-  if (kind === "alignment-drift") return "#84cc16";
   if (kind === "rhythm-break") return "#f59e0b";
   if (kind === "spacing-shift") return "#eab308";
   return "#fbbf24";
@@ -462,8 +422,7 @@ export function getPolylineRouteWarningSegmentVisuals(
 
     if (
       warning.kind === "hairpin" ||
-      warning.kind === "rhythm-break" ||
-      warning.kind === "alignment-drift"
+      warning.kind === "rhythm-break"
     ) {
       assignSegment(warning.waypointIndex - 1, warning.kind);
       assignSegment(warning.waypointIndex, warning.kind);

--- a/src/lib/track/polyline-derived.ts
+++ b/src/lib/track/polyline-derived.ts
@@ -420,10 +420,7 @@ export function getPolylineRouteWarningSegmentVisuals(
       continue;
     }
 
-    if (
-      warning.kind === "hairpin" ||
-      warning.kind === "rhythm-break"
-    ) {
+    if (warning.kind === "hairpin" || warning.kind === "rhythm-break") {
       assignSegment(warning.waypointIndex - 1, warning.kind);
       assignSegment(warning.waypointIndex, warning.kind);
     }

--- a/tests/lib/track/polyline-derived.test.ts
+++ b/tests/lib/track/polyline-derived.test.ts
@@ -147,8 +147,8 @@ describe("polyline derived helpers", () => {
     expect(getRouteWarningSegmentColor("close-points", "#123456")).toBe(
       "#ef4444"
     );
-    expect(getRouteWarningSegmentColor("alignment-drift", "#123456")).toBe(
-      "#84cc16"
+    expect(getRouteWarningSegmentColor("rhythm-break", "#123456")).toBe(
+      "#f59e0b"
     );
     expect(getRouteWarningSegmentColor("hairpin", "#123456")).toBe("#fbbf24");
   });


### PR DESCRIPTION
Improve the track editing feedback loop based on user feedback around waypoint dragging, unclear snap behavior, and route review warnings.

## Changes

- Made desktop path waypoint dragging less aggressive so points no longer jump as readily to nearby route waypoints.
- Clarified snap behavior in the desktop status bar, mobile controls, and canvas status text.
- Moved elevation profile details into a responsive modal/drawer with fuller explanations.
- Removed the alignment-drift warning because straight-line assumptions do not fit FPV race-line design.
- Reframed route review guidance around short correction segments that interrupt flow.