### PR TITLE
feat: add measurement unit system support

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -21,6 +21,8 @@ The most useful next product move is deepening the race-day workflow, keeping th
 - Race director page with pilot line, timing/start box placement, and ops notes
 - Usability and reliability pass focused on recovery states, mobile ergonomics, editor interactions, exports, sharing, and larger layouts
 - Share version history so owners can update a published track without surprising existing links
+- Regional measurement units so international users can work in familiar metric or imperial-style measurements while TrackDraw keeps meter-based geometry internally
+- Multilingual product experience built on the same locale-aware foundation, starting with explicit language choice and controlled translation scope
 - Gallery collections for curated browsing beyond the current featured bucket
 - Dashboard operator tooling for public track review, share lifecycle inspection, contextual account/project diagnostics, and API usage visibility
 
@@ -157,6 +159,63 @@ Suggested first slices:
 - Performance and large-layout stability
   - Started with bounded dense-grid rendering for SVG/PDF/PNG exports so fine grid settings do not explode export payload size
   - Added long-route obstacle-numbering coverage with bounded route-segment scans for dense gate layouts
+
+#### Regional Measurement Units
+
+International users should be able to work in familiar metric or imperial-style measurements without TrackDraw changing its internal geometry model.
+
+Why:
+
+- TrackDraw currently stores, calculates, exports, and validates geometry in meters, which remains the safest shared model for maps, simulation-adjacent outputs, and backwards-compatible project files
+- Metric should remain the natural default for most international users, including markets such as Europe, China, and Japan
+- Users in places or clubs that expect feet/inches, including US users and some mixed-measurement UK contexts, should not have to mentally convert field size, obstacle dimensions, route length, or setup/export summaries while designing
+- Unit support is a core editor usability feature and should remain available without an account
+- Browser locale can provide a useful first guess, but venue practice and club expectations can differ from country defaults, so users need an explicit override
+
+Focus:
+
+- Add a simple metric versus imperial-style unit preference with a metric default that preserves existing project behavior
+- Use browser locale signals to choose the first-run unit default when no saved preference exists, then persist the user's override locally and, where appropriate, in account/project settings
+- Centralize measurement formatting so field labels, rulers, inspectors, route/elevation summaries, gallery metadata, and export previews stop hard-coding `m`
+- Support unit-aware numeric input for common values such as meters, feet, and inches while storing normalized meter values in project data
+- Keep JSON/API geometry meter-based for compatibility, while allowing share/export presentation to use the selected measurement system
+
+Current shipped foundation:
+
+- Browser-locale-informed metric versus imperial default with local manual override
+- Shared measurement formatting for core editor chrome, rulers, inspector summaries, gallery cards, import previews, share canvas labels, and visual export labels
+- Unit-aware measurement inputs for field settings, selected object dimensions/positions, and route waypoint elevation
+- PNG/SVG/PDF/Race Pack presentation follows the selected unit system while JSON/API geometry remains meter-based
+
+Important boundary:
+
+- Do not convert stored coordinates, field dimensions, route data, or obstacle dimensions away from meters
+- Do not add account-only regional settings as the first slice; the editor needs this for logged-out international users too
+- Do not couple measurement units to UI language; translation/localization can be a later track, while this slice focuses on measurement defaults, formatting, and input
+- Avoid broad localization work in this slice unless it is required for measurement clarity
+
+#### Multilingual Product Experience
+
+Regional measurement support should be treated as the first locale-aware foundation for TrackDraw, but a multilingual product needs its own rollout plan so translation work does not destabilize the editor.
+
+Why:
+
+- International users may benefit from familiar product language in addition to familiar measurement units
+- Locale-aware defaults, preference storage, shared formatting helpers, and text boundaries created for unit support can reduce the later cost of full i18n
+- Translation touches high-risk surfaces such as editor tools, import/export recovery, share pages, Race Pack/PDF copy, dashboard moderation, and legal pages, so it needs deliberate QA rather than ad hoc string replacement
+
+Focus:
+
+- Add an i18n architecture that moves hard-coded product copy behind typed message catalogs while preserving existing route behavior and metadata quality
+- Use browser language as a first-run default only when no saved language preference exists, and keep manual language selection separate from measurement units
+- Start with a small language set chosen from actual user demand and maintenance capacity, with English as the stable fallback for incomplete translations
+- Review translated UI on desktop and mobile, including compact buttons, inspector panels, dialogs, share pages, exported PDFs/Race Packs, and legal pages where applicable
+
+Important boundary:
+
+- Do not block regional measurement support on full i18n; units can ship first as a smaller, lower-risk slice
+- Do not infer units only from language, because English users can prefer metric and non-English users can work with imperial-style venue expectations
+- Do not translate legal pages casually; any material legal translation needs a separate review standard
 
 ### 3. Account-Backed Follow-up (`Account-backed`)
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -22,7 +22,7 @@ Labels used below:
 
 ## Current Priority
 
-The completed release-sized work is archived below. The REST API, live race overlay preparation, account project lifecycle polish, UI/UX polish, and stability pass are now complete. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, account-backed project lifecycle depth beyond the shipped conflict/retry baseline, and better dashboard visibility over public and integration-sensitive surfaces.
+The completed release-sized work is archived below. The REST API, live race overlay preparation, account project lifecycle polish, UI/UX polish, and stability pass are now complete. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, regional measurement support and multilingual-readiness for international users, account-backed project lifecycle depth beyond the shipped conflict/retry baseline, and better dashboard visibility over public and integration-sensitive surfaces.
 
 ## Follow-up
 
@@ -35,6 +35,30 @@ The completed release-sized work is archived below. The REST API, live race over
 
 - [ ] Venue library and constraints (`Account-backed`)
       Support reusable venue records with boundaries, constraints, and venue-specific profiles.
+
+- [x] Regional measurement units (`No account required`)
+      Support regional metric and imperial-style display and input without changing the internal meter-based design model.
+  - [x] Unit preference model
+        Add a project-safe and user-friendly unit preference for metric or imperial-style measurements, with a metric default that fits most international users and does not break existing projects.
+  - [x] Locale-informed defaults
+        Use browser locale signals to choose an initial measurement default when no explicit preference exists, while keeping the detected value transparent and manually overrideable.
+  - [x] Editor display formatting
+        Replace direct `m` labels in field size, rulers, inspectors, route/elevation summaries, gallery metadata, and export previews with shared unit formatting.
+  - [x] Unit-aware numeric input
+        Let users enter common metric and imperial-style values such as meters, feet, and inches while storing normalized meter values in the design.
+  - [x] Export and share presentation
+        Show the selected measurement system in PDF/Race Pack/share-facing summaries while keeping JSON/API geometry compatible and meter-based.
+
+- [ ] Multilingual product experience (`Research`, `No account required`)
+      Use the regional measurement work as a first locale-aware foundation, then evaluate a full i18n layer for the public site, editor, share pages, and exported handoff copy.
+  - [ ] I18n architecture and text inventory
+        Audit hard-coded UI, export, share, legal-adjacent, dashboard, and error/recovery copy so translatable product text can move behind a stable message catalog without weakening type safety.
+  - [ ] Language detection and override
+        Use browser language as an initial default when no explicit language preference exists, but keep language selection manually overrideable and independent from measurement units.
+  - [ ] First language rollout
+        Choose the first supported languages from actual user demand and translation-maintenance capacity, with English as the stable fallback for incomplete translations.
+  - [ ] Translation QA boundary
+        Define how translated UI, mobile layouts, export PDFs/Race Packs, share pages, and legal pages are reviewed so longer translated strings do not break core workflows.
 
 - [ ] Share version history (`Account-backed`)
       Let owners update published shares while keeping clear version history, current-version state, and rollback options for account-backed projects.

--- a/src/app/share/[token]/layout.tsx
+++ b/src/app/share/[token]/layout.tsx
@@ -13,6 +13,7 @@ import {
   SITE_NAME,
   getSiteMediaUrl,
 } from "@/lib/seo";
+import { formatFieldSize } from "@/lib/track/units";
 
 type ShareTokenLayoutProps = {
   children: React.ReactNode;
@@ -35,7 +36,11 @@ function buildShareMetadataDescription(params: {
   shapeCount: number;
 }) {
   const base = params.description.trim();
-  const fieldLabel = `${params.fieldWidth} x ${params.fieldHeight} m`;
+  const fieldLabel = formatFieldSize(
+    params.fieldWidth,
+    params.fieldHeight,
+    "metric"
+  );
   const obstacleLabel =
     params.shapeCount === 1 ? "1 obstacle" : `${params.shapeCount} obstacles`;
   const detail = `FPV drone race track layout built with TrackDraw on a ${fieldLabel} field with ${obstacleLabel}.`;

--- a/src/app/share/[token]/page.tsx
+++ b/src/app/share/[token]/page.tsx
@@ -10,6 +10,7 @@ import {
   getSiteUrl,
   serializeJsonLd,
 } from "@/lib/seo";
+import { formatFieldSize } from "@/lib/track/units";
 import { parseEditorView } from "@/lib/view";
 import ShareViewer from "../ShareViewer";
 import ShareError from "../ShareError";
@@ -68,7 +69,11 @@ export default async function ShareTokenPage({
             ],
             spatialCoverage: {
               "@type": "Place",
-              name: `${resolvedShare.design.field.width} x ${resolvedShare.design.field.height} m field`,
+              name: `${formatFieldSize(
+                resolvedShare.design.field.width,
+                resolvedShare.design.field.height,
+                "metric"
+              )} field`,
             },
           }
         : null;

--- a/src/components/MeasurementUnitToggle.tsx
+++ b/src/components/MeasurementUnitToggle.tsx
@@ -21,14 +21,14 @@ export function MeasurementUnitToggle({
   const { unitSystem, setUnitSystem } = useMeasurementUnitSystem();
   const nextUnitSystem = unitSystem === "metric" ? "imperial" : "metric";
   const label = unitSystem === "metric" ? "Metric" : "Imperial";
-  const nextLabel = nextUnitSystem === "metric" ? "metric" : "imperial";
+  const nextLabel = nextUnitSystem === "metric" ? "Metric" : "Imperial";
 
   const button = (
     <button
       type="button"
       onClick={() => setUnitSystem(nextUnitSystem)}
-      aria-label={`Units: ${label}. Switch to ${nextLabel}.`}
-      title={`Units: ${label}. Switch to ${nextLabel}.`}
+      aria-label={`Measurement preset: ${label}. Switch to ${nextLabel}.`}
+      title={`Measurement preset: ${label}. Switch to ${nextLabel}.`}
       className={cn(
         "text-muted-foreground hover:bg-muted hover:text-foreground inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-xs transition-colors lg:h-7 lg:px-2",
         className
@@ -45,9 +45,9 @@ export function MeasurementUnitToggle({
     <Tooltip>
       <TooltipTrigger asChild>{button}</TooltipTrigger>
       <TooltipContent>
-        <span className="block font-medium">Units: {label}</span>
+        <span className="block font-medium">Measurement preset: {label}</span>
         <span className="mt-1 block opacity-80">
-          Switch to {nextLabel} measurements.
+          Switch displayed distances and compatible inputs.
         </span>
       </TooltipContent>
     </Tooltip>

--- a/src/components/MeasurementUnitToggle.tsx
+++ b/src/components/MeasurementUnitToggle.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Ruler } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/AppTooltip";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
+import { cn } from "@/lib/utils";
+
+export function MeasurementUnitToggle({
+  compact = false,
+  className,
+  tooltip = true,
+}: {
+  compact?: boolean;
+  className?: string;
+  tooltip?: boolean;
+}) {
+  const { unitSystem, setUnitSystem } = useMeasurementUnitSystem();
+  const nextUnitSystem = unitSystem === "metric" ? "imperial" : "metric";
+  const label = unitSystem === "metric" ? "Metric" : "Imperial";
+  const nextLabel = nextUnitSystem === "metric" ? "metric" : "imperial";
+
+  const button = (
+    <button
+      type="button"
+      onClick={() => setUnitSystem(nextUnitSystem)}
+      aria-label={`Units: ${label}. Switch to ${nextLabel}.`}
+      title={`Units: ${label}. Switch to ${nextLabel}.`}
+      className={cn(
+        "text-muted-foreground hover:bg-muted hover:text-foreground inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-xs transition-colors lg:h-7 lg:px-2",
+        className
+      )}
+    >
+      <Ruler className="size-3.5" />
+      <span className="font-mono">{compact ? label.slice(0, 3) : label}</span>
+    </button>
+  );
+
+  if (!tooltip) return button;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{button}</TooltipTrigger>
+      <TooltipContent>
+        <span className="block font-medium">Units: {label}</span>
+        <span className="mt-1 block opacity-80">
+          Switch to {nextLabel} measurements.
+        </span>
+      </TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/canvas/CanvasRuler.tsx
+++ b/src/components/canvas/CanvasRuler.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import {
+  formatMeasurement,
+  type MeasurementUnitSystem,
+} from "@/lib/track/units";
 
 export const RULER_SIZE = 24;
 
@@ -15,6 +19,7 @@ interface RulerProps {
   /** Viewport width (h) or height (v) in pixels */
   length: number;
   isDark: boolean;
+  unitSystem?: MeasurementUnitSystem;
 }
 
 export function CanvasRuler({
@@ -24,6 +29,7 @@ export function CanvasRuler({
   gridStep,
   length,
   isDark,
+  unitSystem = "metric",
 }: RulerProps) {
   const ref = useRef<HTMLCanvasElement>(null);
 
@@ -114,9 +120,9 @@ export function CanvasRuler({
       ctx.stroke();
 
       if (isMajor) {
-        const label = Number.isInteger(meters)
-          ? String(meters)
-          : meters.toFixed(1);
+        const label = formatMeasurement(meters, unitSystem, {
+          precision: Number.isInteger(meters) ? 0 : 1,
+        });
         ctx.fillStyle = isDark ? "#7aa8cc" : "#4a6a88";
 
         if (isH) {
@@ -135,7 +141,7 @@ export function CanvasRuler({
         }
       }
     }
-  }, [orientation, stageTransform, ppm, gridStep, length, isDark]);
+  }, [orientation, stageTransform, ppm, gridStep, length, isDark, unitSystem]);
 
   const isH = orientation === "h";
   return (

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -29,6 +29,7 @@ import { getShapeLocalBounds } from "@/components/canvas/renderers/shape-bounds"
 import { TrackShapeNode } from "@/components/canvas/renderers/shape-node";
 import { useTrackCanvasViewport } from "@/components/canvas/useTrackCanvasViewport";
 import { useHistorySession } from "@/hooks/useHistorySession";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
 import {
   useSessionActions,
@@ -42,7 +43,12 @@ import {
   selectPrimaryPolyline,
   selectShapeRecordMap,
 } from "@/store/selectors";
-import { m2px, px2m } from "@/lib/track/units";
+import {
+  formatCompactFieldSize,
+  formatMeasurement,
+  m2px,
+  px2m,
+} from "@/lib/track/units";
 import {
   buildSnapIndex,
   getNearbySnapCandidates as getNearbySnapCandidatesFromIndex,
@@ -334,6 +340,7 @@ const TrackCanvas = memo(
     ref
   ) {
     usePerfMetric("render:TrackCanvas");
+    const { unitSystem } = useMeasurementUnitSystem();
     const design = useEditor((state) => state.track.design);
     const designShapes = useEditor(selectDesignShapes);
     const [zmin, zmax] = useEditor(selectDesignPolylineZRange);
@@ -341,6 +348,14 @@ const TrackCanvas = memo(
     const primaryPolylineId = useEditor(
       (state) => selectPrimaryPolyline(state)?.id ?? null
     );
+    const fieldLabel = formatCompactFieldSize(
+      design.field.width,
+      design.field.height,
+      unitSystem
+    );
+    const gridLabel = formatMeasurement(design.field.gridStep, unitSystem, {
+      precision: 1,
+    });
     const selection = useEditor((state) => state.session.selection);
     const {
       setSelection,
@@ -1895,7 +1910,9 @@ const TrackCanvas = memo(
                     <>
                       <span className="text-border/80">·</span>
                       <span className="text-foreground/70 font-medium tabular-nums">
-                        {draftLengthWithCursor.toFixed(1)} m
+                        {formatMeasurement(draftLengthWithCursor, unitSystem, {
+                          precision: 1,
+                        })}
                       </span>
                     </>
                   )}
@@ -1903,10 +1920,10 @@ const TrackCanvas = memo(
               ) : (
                 <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                   <span>
-                    {design.field.width}m × {design.field.height}m
+                    {fieldLabel}
                   </span>
                   <span className="text-border">·</span>
-                  <span>Grid {design.field.gridStep}m</span>
+                  <span>Grid {gridLabel}</span>
                   <span className="text-border">·</span>
                   <span>
                     {snapEnabled
@@ -1985,7 +2002,7 @@ const TrackCanvas = memo(
                   widthPx={widthPx}
                 />
                 <StableFieldContent
-                  designField={design.field}
+                  fieldLabel={fieldLabel}
                   grid={grid}
                   heightPx={heightPx}
                   isDark={isDark}
@@ -2291,6 +2308,7 @@ const TrackCanvas = memo(
                       gridStep={design.field.gridStep}
                       length={viewportSize.width - RULER_SIZE}
                       isDark={isDark}
+                      unitSystem={unitSystem}
                     />
                   </div>
                 </div>
@@ -2315,6 +2333,7 @@ const TrackCanvas = memo(
                       gridStep={design.field.gridStep}
                       length={viewportSize.height - RULER_SIZE}
                       isDark={isDark}
+                      unitSystem={unitSystem}
                     />
                   </div>
                 </div>

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -1919,9 +1919,7 @@ const TrackCanvas = memo(
                 </div>
               ) : (
                 <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                  <span>
-                    {fieldLabel}
-                  </span>
+                  <span>{fieldLabel}</span>
                   <span className="text-border">·</span>
                   <span>Grid {gridLabel}</span>
                   <span className="text-border">·</span>

--- a/src/components/canvas/renderers/field-layer.tsx
+++ b/src/components/canvas/renderers/field-layer.tsx
@@ -8,11 +8,7 @@ import type { RectLike } from "@/lib/canvas/shared";
 // Only re-renders when design, theme, or field dimensions change.
 
 export interface StableFieldContentProps {
-  designField: {
-    width: number;
-    height: number;
-    ppm: number;
-  };
+  fieldLabel: string;
   grid: React.JSX.Element[];
   heightPx: number;
   isDark: boolean;
@@ -21,7 +17,7 @@ export interface StableFieldContentProps {
 }
 
 export const StableFieldContent = memo(function StableFieldContent({
-  designField,
+  fieldLabel,
   grid,
   heightPx,
   isDark,
@@ -121,7 +117,7 @@ export const StableFieldContent = memo(function StableFieldContent({
       <Text
         x={widthPx - 6}
         y={heightPx - 14}
-        text={`${designField.width}×${designField.height}m`}
+        text={fieldLabel}
         fontSize={9}
         fill={isDark ? "#3a5878" : "#6888a8"}
         align="right"
@@ -195,12 +191,8 @@ export function FieldOverlayContent({
 // ── Legacy combined export (kept for backwards compatibility) ─────────────────
 
 export interface FieldLayerContentProps {
-  designField: {
-    width: number;
-    height: number;
-    ppm: number;
-  };
   effectiveSelectionFrame: RectLike | null;
+  fieldLabel: string;
   grid: React.JSX.Element[];
   heightPx: number;
   hoverCell: { x: number; y: number } | null;
@@ -211,8 +203,8 @@ export interface FieldLayerContentProps {
 }
 
 export function FieldLayerContent({
-  designField,
   effectiveSelectionFrame,
+  fieldLabel,
   grid,
   heightPx,
   hoverCell,
@@ -224,7 +216,7 @@ export function FieldLayerContent({
   return (
     <>
       <StableFieldContent
-        designField={designField}
+        fieldLabel={fieldLabel}
         grid={grid}
         heightPx={heightPx}
         isDark={isDark}

--- a/src/components/canvas/share/TrackCanvas.tsx
+++ b/src/components/canvas/share/TrackCanvas.tsx
@@ -23,10 +23,15 @@ import { StableFieldContent } from "@/components/canvas/renderers/field-layer";
 import { getShapeLocalBounds } from "@/components/canvas/renderers/shape-bounds";
 import { useTrackCanvasViewport } from "@/components/canvas/useTrackCanvasViewport";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { useTheme } from "@/hooks/useTheme";
 import { getObstacleNumberMap } from "@/lib/track/obstacleNumbering";
-import { m2px } from "@/lib/track/units";
+import {
+  formatCompactFieldSize,
+  formatMeasurement,
+  m2px,
+} from "@/lib/track/units";
 import { useEditor } from "@/store/editor";
 import {
   selectDesignPolylineZRange,
@@ -46,12 +51,21 @@ const TrackCanvas = memo(
   ) {
     usePerfMetric("render:share/TrackCanvas");
 
+    const { unitSystem } = useMeasurementUnitSystem();
     const design = useEditor((state) => state.track.design);
     const designShapes = useEditor(selectDesignShapes);
     const [zmin, zmax] = useEditor(selectDesignPolylineZRange);
     const primaryPolylineId = useEditor(
       (state) => selectPrimaryPolyline(state)?.id ?? null
     );
+    const fieldLabel = formatCompactFieldSize(
+      design.field.width,
+      design.field.height,
+      unitSystem
+    );
+    const gridLabel = formatMeasurement(design.field.gridStep, unitSystem, {
+      precision: 1,
+    });
     const stageRef = useRef<KonvaStage | null>(null);
     const containerRef = useRef<HTMLDivElement | null>(null);
     const contentDragActiveRef = useRef(false);
@@ -385,10 +399,10 @@ const TrackCanvas = memo(
         >
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
             <span>
-              {design.field.width}m × {design.field.height}m
+              {fieldLabel}
             </span>
             <span className="text-border">·</span>
-            <span>Grid {design.field.gridStep}m</span>
+            <span>Grid {gridLabel}</span>
             <span className="text-border">·</span>
             <span>Drag to pan, wheel to zoom</span>
           </div>
@@ -437,7 +451,7 @@ const TrackCanvas = memo(
         >
           <Layer listening={false}>
             <StableFieldContent
-              designField={design.field}
+              fieldLabel={fieldLabel}
               grid={grid}
               heightPx={heightPx}
               isDark={isDark}
@@ -528,6 +542,7 @@ const TrackCanvas = memo(
                   gridStep={design.field.gridStep}
                   length={viewportSize.width - RULER_SIZE}
                   isDark={isDark}
+                  unitSystem={unitSystem}
                 />
               </div>
             </div>
@@ -552,6 +567,7 @@ const TrackCanvas = memo(
                   gridStep={design.field.gridStep}
                   length={viewportSize.height - RULER_SIZE}
                   isDark={isDark}
+                  unitSystem={unitSystem}
                 />
               </div>
             </div>

--- a/src/components/canvas/share/TrackCanvas.tsx
+++ b/src/components/canvas/share/TrackCanvas.tsx
@@ -398,9 +398,7 @@ const TrackCanvas = memo(
           }}
         >
           <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-            <span>
-              {fieldLabel}
-            </span>
+            <span>{fieldLabel}</span>
             <span className="text-border">·</span>
             <span>Grid {gridLabel}</span>
             <span className="text-border">·</span>

--- a/src/components/dashboard/GalleryManager.tsx
+++ b/src/components/dashboard/GalleryManager.tsx
@@ -62,6 +62,7 @@ import type {
   GalleryState,
   StoredGalleryEntry,
 } from "@/lib/server/gallery";
+import { formatFieldSize as formatMeasurementFieldSize } from "@/lib/track/units";
 
 type DashboardGalleryManagerProps = {
   currentUserRole: AccountRole;
@@ -178,7 +179,7 @@ function formatFieldSize(entry: DashboardGalleryEntry) {
     return "Not set";
   }
 
-  return `${entry.fieldWidth} x ${entry.fieldHeight} m`;
+  return formatMeasurementFieldSize(entry.fieldWidth, entry.fieldHeight, "metric");
 }
 
 function formatElementCount(entry: DashboardGalleryEntry) {

--- a/src/components/dashboard/GalleryManager.tsx
+++ b/src/components/dashboard/GalleryManager.tsx
@@ -179,7 +179,11 @@ function formatFieldSize(entry: DashboardGalleryEntry) {
     return "Not set";
   }
 
-  return formatMeasurementFieldSize(entry.fieldWidth, entry.fieldHeight, "metric");
+  return formatMeasurementFieldSize(
+    entry.fieldWidth,
+    entry.fieldHeight,
+    "metric"
+  );
 }
 
 function formatElementCount(entry: DashboardGalleryEntry) {

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { MobileDrawer } from "@/components/MobileDrawer";
 import { DesktopModal } from "@/components/DesktopModal";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import { buildStoredSharePath } from "@/lib/share";
 import { serializeDesign } from "@/lib/track/design";
 import { downloadJsonFile } from "@/lib/export/download-json";
@@ -243,6 +244,7 @@ export default function ExportDialog({
   projectId = null,
 }: ExportDialogProps) {
   const design = useEditor((s) => s.track.design);
+  const { unitSystem } = useMeasurementUnitSystem();
   const currentTheme = useTheme();
   const isMobile = useIsMobile();
   const [busy, setBusy] = useState<string | null>(null);
@@ -458,7 +460,7 @@ export default function ExportDialog({
                   `${safeName({ view: "2d", theme: exportTheme })}.png`,
                   exportTheme,
                   3,
-                  { includeObstacleNumbers }
+                  { includeObstacleNumbers, unitSystem }
                 )
               )
             }
@@ -475,7 +477,7 @@ export default function ExportDialog({
                   design,
                   `${safeName({ view: "2d", theme: exportTheme })}.svg`,
                   exportTheme,
-                  { includeObstacleNumbers }
+                  { includeObstacleNumbers, unitSystem }
                 )
               )
             }
@@ -557,6 +559,7 @@ export default function ExportDialog({
                     includeObstacleNumbers,
                     preset: "race-day",
                     shareUrl,
+                    unitSystem,
                   }
                 );
               })
@@ -691,7 +694,7 @@ export default function ExportDialog({
                   `${safeName({ view: "2d", theme: exportTheme })}.png`,
                   exportTheme,
                   3,
-                  { includeObstacleNumbers }
+                  { includeObstacleNumbers, unitSystem }
                 )
               )
             }
@@ -709,7 +712,7 @@ export default function ExportDialog({
                   design,
                   `${safeName({ view: "2d", theme: exportTheme })}.svg`,
                   exportTheme,
-                  { includeObstacleNumbers }
+                  { includeObstacleNumbers, unitSystem }
                 )
               )
             }
@@ -781,6 +784,7 @@ export default function ExportDialog({
                     includeObstacleNumbers,
                     preset: "race-day",
                     shareUrl,
+                    unitSystem,
                   }
                 );
               })

--- a/src/components/dialogs/ImportDialog.tsx
+++ b/src/components/dialogs/ImportDialog.tsx
@@ -5,8 +5,10 @@ import { MobileDrawer } from "@/components/MobileDrawer";
 import { DesktopModal } from "@/components/DesktopModal";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { parseDesign } from "@/lib/track/design";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import { useTrackActions } from "@/store/actions";
 import { cn } from "@/lib/utils";
+import { formatFieldSize } from "@/lib/track/units";
 import { Upload, FileJson, AlertCircle, CheckCircle2 } from "lucide-react";
 import { toast } from "sonner";
 import type { TrackDesign } from "@/lib/types";
@@ -31,6 +33,7 @@ export default function ImportDialog({
   onBeforeConfirm,
 }: ImportDialogProps) {
   const { replaceDesign } = useTrackActions();
+  const { unitSystem } = useMeasurementUnitSystem();
   const isMobile = useIsMobile();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [dragging, setDragging] = useState(false);
@@ -189,7 +192,11 @@ export default function ImportDialog({
                 {parsed.design.title || "Untitled project"}
               </p>
               <p className="text-muted-foreground mt-0.5 text-xs">
-                {parsed.design.field.width} × {parsed.design.field.height} m
+                {formatFieldSize(
+                  parsed.design.field.width,
+                  parsed.design.field.height,
+                  unitSystem
+                )}
                 &nbsp;·&nbsp;
                 {parsed.shapeCount}{" "}
                 {parsed.shapeCount === 1 ? "object" : "objects"}

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -34,6 +34,7 @@ import { loadProject } from "@/lib/projects";
 import { downloadJsonFile } from "@/lib/export/download-json";
 import { getLayoutPresetById } from "@/lib/planning/layout-presets";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import { useDeveloperMode } from "@/hooks/useDeveloperMode";
 import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
@@ -204,6 +205,7 @@ export default function EditorShell({
   const { undo, redo, canUndo, canRedo } = useUndoRedo();
   const { enabled: developerModeEnabled, toggle: toggleDeveloperMode } =
     useDeveloperMode();
+  const { unitSystem } = useMeasurementUnitSystem();
   const selection = useEditor((state) => state.session.selection);
   const design = useEditor((state) => state.track.design);
   const activeTool = useEditor((state) => state.ui.activeTool);
@@ -260,6 +262,7 @@ export default function EditorShell({
     segmentSelection,
     selection,
     shapeById,
+    unitSystem,
     vertexSelection,
   });
   const isMobile = useIsMobile();

--- a/src/components/editor/MobileAppMenu.tsx
+++ b/src/components/editor/MobileAppMenu.tsx
@@ -332,7 +332,6 @@ export default function MobileAppMenu({
                 </div>
                 <ThemeToggle />
               </div>
-
               {user ? (
                 <div className="border-border/60 mt-2 border-t pt-2">
                   <button

--- a/src/components/editor/StatusBar.tsx
+++ b/src/components/editor/StatusBar.tsx
@@ -89,7 +89,9 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
       {/* Grid step — desktop only */}
       <span className="hidden lg:contents">
         <span className="text-muted-foreground/45">·</span>
-        <span>{formatMeasurement(field.gridStep, unitSystem, { precision: 1 })}</span>
+        <span>
+          {formatMeasurement(field.gridStep, unitSystem, { precision: 1 })}
+        </span>
         <span className="text-muted-foreground/45">·</span>
       </span>
 
@@ -174,9 +176,7 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
 
       {/* Field size — desktop only */}
       <span className="hidden lg:contents">
-        <span>
-          {formatFieldSize(field.width, field.height, unitSystem)}
-        </span>
+        <span>{formatFieldSize(field.width, field.height, unitSystem)}</span>
         <span className="text-muted-foreground/45">·</span>
       </span>
 

--- a/src/components/editor/StatusBar.tsx
+++ b/src/components/editor/StatusBar.tsx
@@ -5,7 +5,9 @@ import { useUiActions } from "@/store/actions";
 import { selectShapeRecordMap } from "@/store/selectors";
 import VersionTag from "@/components/VersionTag";
 import { useDeveloperMode } from "@/hooks/useDeveloperMode";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import { getLayoutPresetById } from "@/lib/planning/layout-presets";
+import { formatFieldSize, formatMeasurement } from "@/lib/track/units";
 import { getShapeGroupId, getShapeGroupName } from "@/lib/track/shape-groups";
 import { Magnet } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -36,6 +38,7 @@ interface StatusBarProps {
 
 export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
   const { enabled, toggle } = useDeveloperMode();
+  const { unitSystem } = useMeasurementUnitSystem();
   const { toggleSnapEnabled } = useUiActions();
   const activeTool = useEditor((state) => state.ui.activeTool);
   const activePresetId = useEditor((state) => state.ui.activePresetId);
@@ -86,7 +89,7 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
       {/* Grid step — desktop only */}
       <span className="hidden lg:contents">
         <span className="text-muted-foreground/45">·</span>
-        <span>{field.gridStep}m</span>
+        <span>{formatMeasurement(field.gridStep, unitSystem, { precision: 1 })}</span>
         <span className="text-muted-foreground/45">·</span>
       </span>
 
@@ -94,10 +97,18 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
       <span className="hidden lg:contents">
         {cursorPos ? (
           <span>
-            {cursorPos.x.toFixed(1)}, {cursorPos.y.toFixed(1)} m
+            {formatMeasurement(cursorPos.x, unitSystem, {
+              precision: 1,
+            })}
+            ,{" "}
+            {formatMeasurement(cursorPos.y, unitSystem, {
+              precision: 1,
+            })}
           </span>
         ) : (
-          <span className="text-muted-foreground/45">— m</span>
+          <span className="text-muted-foreground/45">
+            — {unitSystem === "imperial" ? "ft" : "m"}
+          </span>
         )}
       </span>
 
@@ -164,7 +175,7 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
       {/* Field size — desktop only */}
       <span className="hidden lg:contents">
         <span>
-          {field.width}×{field.height} m
+          {formatFieldSize(field.width, field.height, unitSystem)}
         </span>
         <span className="text-muted-foreground/45">·</span>
       </span>

--- a/src/components/editor/mobile/EditorMobilePanels.tsx
+++ b/src/components/editor/mobile/EditorMobilePanels.tsx
@@ -31,8 +31,10 @@ import { PathBuilderOverlay } from "@/components/editor/mobile/PathBuilderOverla
 import { ViewControls } from "@/components/editor/mobile/ViewControls";
 import { mobileToolEntries } from "@/components/editor/tool-icons";
 import { MobileDrawer } from "@/components/MobileDrawer";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import type { EditorTool } from "@/lib/editor-tools";
 import { getEditorMobilePanelsViewModel } from "@/lib/editor/mobile/view-model";
+import { formatMeasurement } from "@/lib/track/units";
 import { cn } from "@/lib/utils";
 
 export type EditorViewportTab = "2d" | "3d";
@@ -391,6 +393,7 @@ export function EditorMobilePanels({
   onTabChange,
   studioHref = "/studio",
 }: EditorMobilePanelsProps) {
+  const { unitSystem } = useMeasurementUnitSystem();
   const mobileOverlaySurfaceClassName =
     "pointer-events-auto w-full max-w-sm rounded-[1.35rem] border border-white/10 bg-slate-950/86 p-2 text-white shadow-[0_18px_36px_rgba(15,23,42,0.32)] backdrop-blur";
   const [isLandscapeMobile, setIsLandscapeMobile] = useState(false);
@@ -624,6 +627,11 @@ export function EditorMobilePanels({
             className={mobileOverlaySurfaceClassName}
             draftPathClosed={draftPathClosed}
             draftPathLength={draftPathLength}
+            draftPathLengthLabel={formatMeasurement(
+              draftPathLength,
+              unitSystem,
+              { precision: 1 }
+            )}
             draftPathPointCount={draftPathPointCount}
             onCancelPath={onCancelPath}
             onCloseLoop={onCloseLoop}

--- a/src/components/editor/mobile/PathBuilderOverlay.tsx
+++ b/src/components/editor/mobile/PathBuilderOverlay.tsx
@@ -7,6 +7,7 @@ interface EditorMobilePathBuilderOverlayProps {
   className: string;
   draftPathClosed: boolean;
   draftPathLength: number;
+  draftPathLengthLabel?: string;
   draftPathPointCount: number;
   onCancelPath: () => void;
   onCloseLoop: () => void;
@@ -18,6 +19,7 @@ export function PathBuilderOverlay({
   className,
   draftPathClosed,
   draftPathLength,
+  draftPathLengthLabel,
   draftPathPointCount,
   onCancelPath,
   onCloseLoop,
@@ -37,9 +39,9 @@ export function PathBuilderOverlay({
           </p>
           <p className="truncate text-[11px] text-white/70">
             {draftPathClosed
-              ? `Loop connected · ${draftPathPointCount} points · ${draftPathLength.toFixed(1)} m`
+              ? `Loop connected · ${draftPathPointCount} points · ${draftPathLengthLabel ?? `${draftPathLength.toFixed(1)} m`}`
               : draftPathPointCount > 0
-                ? `${draftPathPointCount} points · ${draftPathLength.toFixed(1)} m`
+                ? `${draftPathPointCount} points · ${draftPathLengthLabel ?? `${draftPathLength.toFixed(1)} m`}`
                 : "Tap the canvas to place the first point"}
           </p>
         </div>

--- a/src/components/gallery/PublicGalleryGrid.tsx
+++ b/src/components/gallery/PublicGalleryGrid.tsx
@@ -5,8 +5,10 @@ import Image from "next/image";
 import Link from "next/link";
 import { ArrowRight, Clock3, Grid2X2, Ruler, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import type { PublicGalleryEntry } from "@/lib/server/gallery";
 import { getSiteMediaUrl } from "@/lib/seo";
+import { formatFieldSize as formatMeasurementFieldSize } from "@/lib/track/units";
 import { cn } from "@/lib/utils";
 
 type PublicGalleryGridProps = {
@@ -58,12 +60,19 @@ function formatDate(value: string | null) {
   }
 }
 
-function formatFieldSize(entry: PublicGalleryEntry) {
+function formatFieldSize(
+  entry: PublicGalleryEntry,
+  unitSystem: "metric" | "imperial"
+) {
   if (entry.fieldWidth == null || entry.fieldHeight == null) {
     return "Field size not set";
   }
 
-  return `${entry.fieldWidth} x ${entry.fieldHeight} m`;
+  return formatMeasurementFieldSize(
+    entry.fieldWidth,
+    entry.fieldHeight,
+    unitSystem
+  );
 }
 
 function getOwnerLabel(entry: PublicGalleryEntry) {
@@ -94,11 +103,13 @@ function GalleryCard({
   mediaBaseUrl,
   imageFailed,
   onImageError,
+  unitSystem,
 }: {
   entry: PublicGalleryEntry;
   mediaBaseUrl: string;
   imageFailed: boolean;
   onImageError: () => void;
+  unitSystem: "metric" | "imperial";
 }) {
   const previewUrl = getPreviewUrl(entry, mediaBaseUrl);
 
@@ -153,7 +164,7 @@ function GalleryCard({
         <div className="mt-auto flex flex-wrap gap-2">
           <span className="border-border/55 bg-muted/28 text-muted-foreground inline-flex min-w-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs">
             <Ruler className="size-3" />
-            <span className="truncate">{formatFieldSize(entry)}</span>
+            <span className="truncate">{formatFieldSize(entry, unitSystem)}</span>
           </span>
           <span className="border-border/55 bg-muted/28 text-muted-foreground inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs">
             <Grid2X2 className="size-3" />
@@ -179,6 +190,7 @@ export default function PublicGalleryGrid({
   entries,
   mediaBaseUrl = getSiteMediaUrl(""),
 }: PublicGalleryGridProps) {
+  const { unitSystem } = useMeasurementUnitSystem();
   const [visibleRecentCount, setVisibleRecentCount] =
     useState(RECENT_PAGE_SIZE);
   const [failedImages, setFailedImages] = useState<Record<string, boolean>>({});
@@ -229,6 +241,7 @@ export default function PublicGalleryGrid({
                 entry={entry}
                 mediaBaseUrl={mediaBaseUrl}
                 imageFailed={failedImages[entry.id] ?? false}
+                unitSystem={unitSystem}
                 onImageError={() =>
                   setFailedImages((current) => ({
                     ...current,
@@ -259,6 +272,7 @@ export default function PublicGalleryGrid({
                 entry={entry}
                 mediaBaseUrl={mediaBaseUrl}
                 imageFailed={failedImages[entry.id] ?? false}
+                unitSystem={unitSystem}
                 onImageError={() =>
                   setFailedImages((current) => ({
                     ...current,

--- a/src/components/gallery/PublicGalleryGrid.tsx
+++ b/src/components/gallery/PublicGalleryGrid.tsx
@@ -164,7 +164,9 @@ function GalleryCard({
         <div className="mt-auto flex flex-wrap gap-2">
           <span className="border-border/55 bg-muted/28 text-muted-foreground inline-flex min-w-0 items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs">
             <Ruler className="size-3" />
-            <span className="truncate">{formatFieldSize(entry, unitSystem)}</span>
+            <span className="truncate">
+              {formatFieldSize(entry, unitSystem)}
+            </span>
           </span>
           <span className="border-border/55 bg-muted/28 text-muted-foreground inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs">
             <Grid2X2 className="size-3" />

--- a/src/components/inspector/ElevationChart.tsx
+++ b/src/components/inspector/ElevationChart.tsx
@@ -24,6 +24,8 @@ import {
   TooltipTrigger,
 } from "@/components/AppTooltip";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
+import { formatMeasurement } from "@/lib/track/units";
 
 type SegmentWarningKind = Exclude<RouteWarningKind, "flat" | "stub">;
 
@@ -487,6 +489,7 @@ function ElevationSvg({
 }
 
 export default function ElevationChart({ className }: { className?: string }) {
+  const { unitSystem } = useMeasurementUnitSystem();
   const path = useEditor(selectPrimaryPolyline);
   const isMobile = useIsMobile();
   const [detailsOpen, setDetailsOpen] = useState(false);
@@ -632,9 +635,12 @@ export default function ElevationChart({ className }: { className?: string }) {
     <div className="space-y-4">
       <div>
         <div className="text-muted-foreground mb-2 flex flex-wrap gap-x-4 gap-y-1 text-xs">
-          <span>{totalDist.toFixed(1)} m route</span>
           <span>
-            {rawMinZ.toFixed(1)}-{rawMaxZ.toFixed(1)} m elevation
+            {formatMeasurement(totalDist, unitSystem, { precision: 1 })} route
+          </span>
+          <span>
+            {formatMeasurement(rawMinZ, unitSystem, { precision: 1 })}-
+            {formatMeasurement(rawMaxZ, unitSystem, { precision: 1 })} elevation
           </span>
         </div>
         <ElevationSvg {...chartProps} height={isMobile ? 180 : 220} />
@@ -678,8 +684,9 @@ export default function ElevationChart({ className }: { className?: string }) {
         </span>
         <div className="flex min-w-0 items-center gap-1.5">
           <span className="text-muted-foreground truncate text-[11px]">
-            {totalDist.toFixed(1)} m · {rawMinZ.toFixed(1)}–{rawMaxZ.toFixed(1)}{" "}
-            m
+            {formatMeasurement(totalDist, unitSystem, { precision: 1 })} ·{" "}
+            {formatMeasurement(rawMinZ, unitSystem, { precision: 1 })}–
+            {formatMeasurement(rawMaxZ, unitSystem, { precision: 1 })}
           </span>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/src/components/inspector/ElevationPanel.tsx
+++ b/src/components/inspector/ElevationPanel.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEditor } from "@/store/editor";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import {
   getPolylineElevationSamples,
   getPolylineTotalLength2D,
 } from "@/lib/track/polyline-derived";
+import { formatMeasurement } from "@/lib/track/units";
 import { selectPrimaryPolyline } from "@/store/selectors";
 
 const W = 260;
@@ -12,6 +14,7 @@ const H = 80;
 const PAD = { top: 8, right: 8, bottom: 20, left: 32 };
 
 export default function ElevationPanel() {
+  const { unitSystem } = useMeasurementUnitSystem();
   const path = useEditor(selectPrimaryPolyline);
 
   if (!path) {
@@ -70,7 +73,9 @@ export default function ElevationPanel() {
           Elevation Profile
         </p>
         <p className="text-muted-foreground text-[11px]">
-          {total.toFixed(1)} m · {minZ.toFixed(1)}–{maxZ.toFixed(1)} m
+          {formatMeasurement(total, unitSystem, { precision: 1 })} ·{" "}
+          {formatMeasurement(minZ, unitSystem, { precision: 1 })}–
+          {formatMeasurement(maxZ, unitSystem, { precision: 1 })}
         </p>
       </div>
 

--- a/src/components/inspector/shared.tsx
+++ b/src/components/inspector/shared.tsx
@@ -6,6 +6,11 @@ import { useHistorySession } from "@/hooks/useHistorySession";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { useSessionActions } from "@/store/actions";
+import {
+  formatMeasurementInputValue,
+  parseMeasurementInput,
+  type MeasurementUnitSystem,
+} from "@/lib/track/units";
 import { ChevronDown } from "lucide-react";
 
 export const fmt = (value: number) => Number(value.toFixed(2));
@@ -166,6 +171,61 @@ export function Num({
         }
       }}
       onChange={(event) => onChange(+event.target.value)}
+      className="bg-background border-border/50 focus-visible:border-border/80 h-8 rounded-md px-2.5 font-mono text-[11px] shadow-none focus-visible:ring-0 lg:h-7 lg:px-2"
+    />
+  );
+}
+
+export function MeasurementNum({
+  valueMeters,
+  unitSystem,
+  onChange,
+  minMeters,
+}: {
+  valueMeters: number;
+  unitSystem: MeasurementUnitSystem;
+  onChange: (valueMeters: number) => void;
+  minMeters?: number;
+}) {
+  const { startBatch, finishBatch } = useInspectorInputBatch();
+  const [draft, setDraft] = useState<string | null>(null);
+  const displayValue =
+    draft ?? formatMeasurementInputValue(valueMeters, unitSystem);
+
+  const commit = () => {
+    if (draft === null) return;
+
+    const parsed = parseMeasurementInput(draft, unitSystem);
+    if (parsed === null) {
+      setDraft(null);
+      return;
+    }
+
+    const nextValue =
+      typeof minMeters === "number" ? Math.max(minMeters, parsed) : parsed;
+    onChange(nextValue);
+    setDraft(null);
+  };
+
+  return (
+    <Input
+      type="text"
+      inputMode="decimal"
+      value={displayValue}
+      onFocus={() => {
+        setDraft(displayValue);
+        startBatch();
+      }}
+      onBlur={() => {
+        commit();
+        finishBatch();
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.currentTarget.blur();
+        }
+      }}
+      onChange={(event) => setDraft(event.target.value)}
       className="bg-background border-border/50 focus-visible:border-border/80 h-8 rounded-md px-2.5 font-mono text-[11px] shadow-none focus-visible:ring-0 lg:h-7 lg:px-2"
     />
   );

--- a/src/components/inspector/views/polyline/PolylineWaypointList.tsx
+++ b/src/components/inspector/views/polyline/PolylineWaypointList.tsx
@@ -2,10 +2,13 @@
 
 import { Plus, PlusCircle, X } from "lucide-react";
 import { ListPanel } from "@/components/inspector/views/list-panel";
+import { MeasurementNum } from "@/components/inspector/shared";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import {
   getInsertedWaypointMidpoint,
   getNextAppendedWaypoint,
 } from "@/lib/inspector/single/view-model";
+import { formatMeasurement } from "@/lib/track/units";
 import type { PolylinePoint, PolylineShape } from "@/lib/types";
 
 interface PolylineWaypointListProps {
@@ -31,14 +34,14 @@ interface PolylineWaypointListProps {
 
 export function PolylineWaypointList({
   appendPolylinePoint,
-  finishBatch,
   insertPolylinePoint,
   removePolylinePoint,
   setHoveredWaypoint,
   shape,
-  startBatch,
   updatePolylinePoint,
 }: PolylineWaypointListProps) {
+  const { unitSystem } = useMeasurementUnitSystem();
+
   return (
     <div className="mt-3">
       <ListPanel
@@ -80,29 +83,21 @@ export function PolylineWaypointList({
               </span>
               <div className="min-w-0">
                 <span className="text-foreground/85 block font-mono text-[11px] leading-none tabular-nums">
-                  {point.x.toFixed(1)}, {point.y.toFixed(1)}
+                  {formatMeasurement(point.x, unitSystem, { precision: 1 })},{" "}
+                  {formatMeasurement(point.y, unitSystem, { precision: 1 })}
                 </span>
               </div>
-              <input
-                type="number"
-                step={0.5}
-                title="Elevation (m)"
-                className="text-foreground/90 focus:bg-muted/45 focus:text-foreground hover:border-border/25 focus:border-border/60 h-7 w-14 rounded-md border border-transparent bg-transparent px-1.5 py-0.5 text-right font-mono text-[11px] transition-colors focus:outline-hidden"
-                value={point.z ?? 0}
-                disabled={shape.locked}
-                onFocus={startBatch}
-                onBlur={finishBatch}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.currentTarget.blur();
-                  }
-                }}
-                onChange={(event) => {
+              <div className={shape.locked ? "pointer-events-none opacity-50" : ""}>
+                <MeasurementNum
+                  valueMeters={point.z ?? 0}
+                  unitSystem={unitSystem}
+                  onChange={(value) => {
                   updatePolylinePoint(shape.id, index, {
-                    z: +event.target.value,
+                      z: value,
                   });
-                }}
-              />
+                  }}
+                />
+              </div>
               <div className="flex items-center justify-end gap-0.5 opacity-100 transition-opacity lg:opacity-0 lg:group-hover/row:opacity-100">
                 {index < shape.points.length - 1 && (
                   <button

--- a/src/components/inspector/views/polyline/PolylineWaypointList.tsx
+++ b/src/components/inspector/views/polyline/PolylineWaypointList.tsx
@@ -87,14 +87,16 @@ export function PolylineWaypointList({
                   {formatMeasurement(point.y, unitSystem, { precision: 1 })}
                 </span>
               </div>
-              <div className={shape.locked ? "pointer-events-none opacity-50" : ""}>
+              <div
+                className={shape.locked ? "pointer-events-none opacity-50" : ""}
+              >
                 <MeasurementNum
                   valueMeters={point.z ?? 0}
                   unitSystem={unitSystem}
                   onChange={(value) => {
-                  updatePolylinePoint(shape.id, index, {
+                    updatePolylinePoint(shape.id, index, {
                       z: value,
-                  });
+                    });
                   }}
                 />
               </div>

--- a/src/components/inspector/views/project-layout.tsx
+++ b/src/components/inspector/views/project-layout.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { Eye, EyeOff, MapPinned, Trash2 } from "lucide-react";
 import ElevationChart from "@/components/inspector/ElevationChart";
+import { MeasurementUnitToggle } from "@/components/MeasurementUnitToggle";
 import { MapReferenceDialog } from "@/components/map-reference/MapReferenceDialog";
 import { Input } from "@/components/ui/input";
 import { shapeKindLabels } from "@/lib/editor-tools";
@@ -20,11 +21,14 @@ import type {
   TrackDesign,
 } from "@/lib/types";
 import {
+  MeasurementNum,
   Num,
   Row,
   Section,
   useInspectorInputBatch,
 } from "@/components/inspector/shared";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
+import { formatFieldSize, formatMeasurement } from "@/lib/track/units";
 import {
   InspectorFooterDesktop,
   InspectorFooterMobile,
@@ -295,6 +299,8 @@ export function ProjectLayoutInspectorView({
   mobileInline = false,
 }: ProjectLayoutInspectorViewProps) {
   const { startBatch, finishBatch } = useInspectorInputBatch();
+  const { unitSystem } = useMeasurementUnitSystem();
+  const fieldUnitLabel = unitSystem === "imperial" ? "ft" : "m";
   const isDesktop = useIsDesktopInspector();
   const inventory = normalizeInventoryProfile(design.inventory);
   const inventoryComparison = getInventoryComparison(design);
@@ -400,8 +406,10 @@ export function ProjectLayoutInspectorView({
         subtitle="Tune the project title, field setup, and available obstacle stock."
         meta={[
           `${shapes.length} items`,
-          `${design.field.width}x${design.field.height} m`,
-          `grid ${design.field.gridStep} m`,
+          formatFieldSize(design.field.width, design.field.height, unitSystem),
+          `grid ${formatMeasurement(design.field.gridStep, unitSystem, {
+            precision: 1,
+          })}`,
         ]}
       />
       <div>
@@ -423,37 +431,53 @@ export function ProjectLayoutInspectorView({
         />
       </div>
       <Section title="Field">
-        <Row label="Width (m)">
-          <Num
-            value={design.field.width}
+        <Row label="Units">
+          <MeasurementUnitToggle />
+        </Row>
+        <Row label={`Width (${fieldUnitLabel})`}>
+          <MeasurementNum
+            valueMeters={design.field.width}
+            unitSystem={unitSystem}
             onChange={(value) => updateField({ width: value })}
-            step={0.5}
-            min={5}
+            minMeters={5}
           />
         </Row>
-        <Row label="Height (m)">
-          <Num
-            value={design.field.height}
+        <Row label={`Height (${fieldUnitLabel})`}>
+          <MeasurementNum
+            valueMeters={design.field.height}
+            unitSystem={unitSystem}
             onChange={(value) => updateField({ height: value })}
-            step={0.5}
-            min={5}
+            minMeters={5}
           />
         </Row>
-        <Row label="Grid (m)">
-          <Num
-            value={design.field.gridStep}
+        <Row label={`Grid (${fieldUnitLabel})`}>
+          <MeasurementNum
+            valueMeters={design.field.gridStep}
+            unitSystem={unitSystem}
             onChange={(value) => updateField({ gridStep: value })}
-            step={0.5}
-            min={0.5}
+            minMeters={0.5}
           />
         </Row>
-        <Row label="Scale (px/m)">
-          <Num
-            value={design.field.ppm}
-            onChange={(value) => updateField({ ppm: value })}
-            step={5}
-            min={5}
-          />
+        <Row label="Render scale">
+          <div
+            className="flex min-w-0 items-center gap-2"
+            title="Internal canvas density in pixels per meter"
+          >
+            <div className="min-w-0 flex-1">
+              <Num
+                value={design.field.ppm}
+                onChange={(value) => updateField({ ppm: value })}
+                step={5}
+                min={5}
+              />
+            </div>
+            <span
+              className="text-muted-foreground/65 shrink-0 text-[10px] font-medium tracking-[0.08em] uppercase"
+              aria-label="pixels per meter, internal canvas scale"
+            >
+              px/m
+            </span>
+          </div>
         </Row>
       </Section>
       {inventoryContent}

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { shapeKindLabels } from "@/lib/editor-tools";
 import { getSingleInspectorViewModel } from "@/lib/inspector/single/view-model";
+import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import {
   getShapeTimingMarker,
   getTimingMarkerMeta,
@@ -25,6 +26,7 @@ import {
 import {
   fmt,
   IconBtn,
+  MeasurementNum,
   Num,
   Row,
   Section,
@@ -88,6 +90,8 @@ export function SingleInspectorView({
   mobileInline = false,
 }: SingleInspectorViewProps) {
   const { startBatch, finishBatch } = useInspectorInputBatch();
+  const { unitSystem } = useMeasurementUnitSystem();
+  const unitLabel = unitSystem === "imperial" ? "ft" : "m";
   const [directionReversedByShape, setDirectionReversedByShape] = useState<
     Record<string, boolean>
   >({});
@@ -279,19 +283,21 @@ export function SingleInspectorView({
               <div className="grid grid-cols-2 gap-2">
                 <label className="min-w-0">
                   <span className="text-muted-foreground/65 mb-1 block text-[10px] font-semibold tracking-[0.12em] uppercase">
-                    X (m)
+                    X ({unitLabel})
                   </span>
-                  <Num
-                    value={fmt(anchorPosition.x)}
+                  <MeasurementNum
+                    valueMeters={fmt(anchorPosition.x)}
+                    unitSystem={unitSystem}
                     onChange={(value) => updateShape(shape.id, { x: value })}
                   />
                 </label>
                 <label className="min-w-0">
                   <span className="text-muted-foreground/65 mb-1 block text-[10px] font-semibold tracking-[0.12em] uppercase">
-                    Y (m)
+                    Y ({unitLabel})
                   </span>
-                  <Num
-                    value={fmt(anchorPosition.y)}
+                  <MeasurementNum
+                    valueMeters={fmt(anchorPosition.y)}
+                    unitSystem={unitSystem}
                     onChange={(value) => updateShape(shape.id, { y: value })}
                   />
                 </label>
@@ -406,28 +412,28 @@ export function SingleInspectorView({
 
           {shape.kind === "gate" && (
             <Section title="Gate" defaultOpen={secondarySectionDefaultOpen}>
-              <Row label="Width (m)">
-                <Num
-                  value={shape.width}
+              <Row label="Width">
+                <MeasurementNum
+                  valueMeters={shape.width}
+                  unitSystem={unitSystem}
                   onChange={(value) => updateShape(shape.id, { width: value })}
-                  step={0.1}
-                  min={0.5}
+                  minMeters={0.5}
                 />
               </Row>
-              <Row label="Height (m)">
-                <Num
-                  value={shape.height}
+              <Row label="Height">
+                <MeasurementNum
+                  valueMeters={shape.height}
+                  unitSystem={unitSystem}
                   onChange={(value) => updateShape(shape.id, { height: value })}
-                  step={0.1}
-                  min={0.5}
+                  minMeters={0.5}
                 />
               </Row>
-              <Row label="Thickness (m)">
-                <Num
-                  value={shape.thick ?? 0.2}
+              <Row label="Thickness">
+                <MeasurementNum
+                  valueMeters={shape.thick ?? 0.2}
+                  unitSystem={unitSystem}
                   onChange={(value) => updateShape(shape.id, { thick: value })}
-                  step={0.05}
-                  min={0.05}
+                  minMeters={0.05}
                 />
               </Row>
             </Section>
@@ -435,22 +441,22 @@ export function SingleInspectorView({
 
           {shape.kind === "flag" && (
             <Section title="Flag" defaultOpen={secondarySectionDefaultOpen}>
-              <Row label="Radius (m)">
-                <Num
-                  value={shape.radius}
+              <Row label="Radius">
+                <MeasurementNum
+                  valueMeters={shape.radius}
+                  unitSystem={unitSystem}
                   onChange={(value) => updateShape(shape.id, { radius: value })}
-                  step={0.05}
-                  min={0.05}
+                  minMeters={0.05}
                 />
               </Row>
-              <Row label="Pole height (m)">
-                <Num
-                  value={shape.poleHeight ?? 3.5}
+              <Row label="Pole height">
+                <MeasurementNum
+                  valueMeters={shape.poleHeight ?? 3.5}
+                  unitSystem={unitSystem}
                   onChange={(value) =>
                     updateShape(shape.id, { poleHeight: value })
                   }
-                  step={0.1}
-                  min={0}
+                  minMeters={0}
                 />
               </Row>
             </Section>
@@ -458,12 +464,12 @@ export function SingleInspectorView({
 
           {shape.kind === "cone" && (
             <Section title="Cone" defaultOpen={secondarySectionDefaultOpen}>
-              <Row label="Radius (m)">
-                <Num
-                  value={shape.radius}
+              <Row label="Radius">
+                <MeasurementNum
+                  valueMeters={shape.radius}
+                  unitSystem={unitSystem}
                   onChange={(value) => updateShape(shape.id, { radius: value })}
-                  step={0.05}
-                  min={0.05}
+                  minMeters={0.05}
                 />
               </Row>
             </Section>
@@ -517,12 +523,12 @@ export function SingleInspectorView({
               title="Start Pads"
               defaultOpen={secondarySectionDefaultOpen}
             >
-              <Row label="Width (m)">
-                <Num
-                  value={shape.width}
+              <Row label="Width">
+                <MeasurementNum
+                  valueMeters={shape.width}
+                  unitSystem={unitSystem}
                   onChange={(value) => updateShape(shape.id, { width: value })}
-                  step={0.1}
-                  min={0.5}
+                  minMeters={0.5}
                 />
               </Row>
             </Section>
@@ -530,32 +536,32 @@ export function SingleInspectorView({
 
           {shape.kind === "ladder" && (
             <Section title="Ladder" defaultOpen={secondarySectionDefaultOpen}>
-              <Row label="Width (m)">
-                <Num
-                  value={shape.width}
+              <Row label="Width">
+                <MeasurementNum
+                  valueMeters={shape.width}
+                  unitSystem={unitSystem}
                   onChange={(value) => updateShape(shape.id, { width: value })}
-                  step={0.1}
-                  min={0.5}
+                  minMeters={0.5}
                 />
               </Row>
-              <Row label="Height (m)">
-                <Num
-                  value={shape.height}
+              <Row label="Height">
+                <MeasurementNum
+                  valueMeters={shape.height}
+                  unitSystem={unitSystem}
                   onChange={(value) => updateShape(shape.id, { height: value })}
-                  step={0.1}
-                  min={0.5}
+                  minMeters={0.5}
                 />
               </Row>
-              <Row label="Elevation (m)">
-                <Num
-                  value={shape.elevation ?? 0}
+              <Row label="Elevation">
+                <MeasurementNum
+                  valueMeters={shape.elevation ?? 0}
+                  unitSystem={unitSystem}
                   onChange={(value) =>
                     updateShape(shape.id, {
                       elevation: Math.max(0, value),
                     })
                   }
-                  step={0.1}
-                  min={0}
+                  minMeters={0}
                 />
               </Row>
               <Row label="Gates">
@@ -582,30 +588,30 @@ export function SingleInspectorView({
               title="Dive Gate"
               defaultOpen={secondarySectionDefaultOpen}
             >
-              <Row label="Size (m)">
-                <Num
-                  value={shape.size}
+              <Row label="Size">
+                <MeasurementNum
+                  valueMeters={shape.size}
+                  unitSystem={unitSystem}
                   onChange={(value) => updateShape(shape.id, { size: value })}
-                  step={0.1}
-                  min={0.5}
+                  minMeters={0.5}
                 />
               </Row>
-              <Row label="Elevation (m)">
-                <Num
-                  value={shape.elevation ?? 3}
+              <Row label="Elevation">
+                <MeasurementNum
+                  valueMeters={shape.elevation ?? 3}
+                  unitSystem={unitSystem}
                   onChange={(value) =>
                     updateShape(shape.id, { elevation: value })
                   }
-                  step={0.1}
-                  min={0.1}
+                  minMeters={0.1}
                 />
               </Row>
-              <Row label="Thickness (m)">
-                <Num
-                  value={shape.thick ?? 0.2}
+              <Row label="Thickness">
+                <MeasurementNum
+                  valueMeters={shape.thick ?? 0.2}
+                  unitSystem={unitSystem}
                   onChange={(value) => updateShape(shape.id, { thick: value })}
-                  step={0.05}
-                  min={0.05}
+                  minMeters={0.05}
                 />
               </Row>
               <Row label="Tilt (deg)">
@@ -628,14 +634,14 @@ export function SingleInspectorView({
               title="Race Line"
               defaultOpen={secondarySectionDefaultOpen}
             >
-              <Row label="Stroke width (m)">
-                <Num
-                  value={shape.strokeWidth ?? 0.26}
+              <Row label="Stroke width">
+                <MeasurementNum
+                  valueMeters={shape.strokeWidth ?? 0.26}
+                  unitSystem={unitSystem}
                   onChange={(value) =>
                     updateShape(shape.id, { strokeWidth: value })
                   }
-                  step={0.05}
-                  min={0.05}
+                  minMeters={0.05}
                 />
               </Row>
               <Row label="Flow">
@@ -673,16 +679,16 @@ export function SingleInspectorView({
                 </Row>
               )}
               {shape.showArrows && (
-                <Row label="Arrow spacing (m)">
-                  <Num
-                    value={shape.arrowSpacing ?? 15}
+                <Row label="Arrow spacing">
+                  <MeasurementNum
+                    valueMeters={shape.arrowSpacing ?? 15}
+                    unitSystem={unitSystem}
                     onChange={(value) =>
                       updateShape(shape.id, {
                         arrowSpacing: Math.max(1, Math.round(value * 2) / 2),
                       })
                     }
-                    step={0.5}
-                    min={1}
+                    minMeters={1}
                   />
                 </Row>
               )}

--- a/src/hooks/useMeasurementUnitSystem.ts
+++ b/src/hooks/useMeasurementUnitSystem.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/track/units";
 
 const EVENT = "trackdraw-measurement-unit-system";
+let memoryUnitSystem: MeasurementUnitSystem | null = null;
 
 function getBrowserDefault(): MeasurementUnitSystem {
   if (typeof navigator === "undefined") return "metric";
@@ -22,9 +23,9 @@ function getSnapshot(): MeasurementUnitSystem {
     const stored = normalizeMeasurementUnitSystem(
       window.localStorage.getItem(MEASUREMENT_STORAGE_KEY)
     );
-    return stored ?? getBrowserDefault();
+    return stored ?? memoryUnitSystem ?? getBrowserDefault();
   } catch {
-    return getBrowserDefault();
+    return memoryUnitSystem ?? getBrowserDefault();
   }
 }
 
@@ -46,6 +47,8 @@ function subscribe(callback: () => void) {
 
 export function setMeasurementUnitSystem(unitSystem: MeasurementUnitSystem) {
   if (typeof window === "undefined") return;
+
+  memoryUnitSystem = unitSystem;
 
   try {
     window.localStorage.setItem(MEASUREMENT_STORAGE_KEY, unitSystem);

--- a/src/hooks/useMeasurementUnitSystem.ts
+++ b/src/hooks/useMeasurementUnitSystem.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import {
+  getMeasurementUnitSystemFromLocales,
+  MEASUREMENT_STORAGE_KEY,
+  normalizeMeasurementUnitSystem,
+  type MeasurementUnitSystem,
+} from "@/lib/track/units";
+
+const EVENT = "trackdraw-measurement-unit-system";
+
+function getBrowserDefault(): MeasurementUnitSystem {
+  if (typeof navigator === "undefined") return "metric";
+  return getMeasurementUnitSystemFromLocales(navigator.languages);
+}
+
+function getSnapshot(): MeasurementUnitSystem {
+  if (typeof window === "undefined") return "metric";
+
+  try {
+    const stored = normalizeMeasurementUnitSystem(
+      window.localStorage.getItem(MEASUREMENT_STORAGE_KEY)
+    );
+    return stored ?? getBrowserDefault();
+  } catch {
+    return getBrowserDefault();
+  }
+}
+
+function subscribe(callback: () => void) {
+  if (typeof window === "undefined") return () => {};
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === MEASUREMENT_STORAGE_KEY) callback();
+  };
+
+  window.addEventListener(EVENT, callback);
+  window.addEventListener("storage", handleStorage);
+
+  return () => {
+    window.removeEventListener(EVENT, callback);
+    window.removeEventListener("storage", handleStorage);
+  };
+}
+
+export function setMeasurementUnitSystem(unitSystem: MeasurementUnitSystem) {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(MEASUREMENT_STORAGE_KEY, unitSystem);
+  } catch {
+    // Keep the in-memory UI responsive even when storage is unavailable.
+  }
+
+  window.dispatchEvent(new Event(EVENT));
+}
+
+export function useMeasurementUnitSystem() {
+  const unitSystem = useSyncExternalStore<MeasurementUnitSystem>(
+    subscribe,
+    getSnapshot,
+    () => "metric"
+  );
+
+  return {
+    unitSystem,
+    setUnitSystem: setMeasurementUnitSystem,
+  };
+}

--- a/src/lib/editor/shell-view-model.ts
+++ b/src/lib/editor/shell-view-model.ts
@@ -4,6 +4,10 @@ import {
   getShapeGroupName,
   selectionHasGroupedShapes,
 } from "@/lib/track/shape-groups";
+import {
+  formatMeasurement,
+  type MeasurementUnitSystem,
+} from "@/lib/track/units";
 import type { Shape } from "@/lib/types";
 
 export function getEditorShellSelectionState(options: {
@@ -16,6 +20,7 @@ export function getEditorShellSelectionState(options: {
   } | null;
   selection: string[];
   shapeById: Record<string, Shape>;
+  unitSystem?: MeasurementUnitSystem;
   vertexSelection: { shapeId: string; idx: number } | null;
 }) {
   const {
@@ -24,6 +29,7 @@ export function getEditorShellSelectionState(options: {
     segmentSelection,
     selection,
     shapeById,
+    unitSystem = "metric",
     vertexSelection,
   } = options;
 
@@ -62,9 +68,11 @@ export function getEditorShellSelectionState(options: {
       ? vertexSelection
       : null;
   const mobilePrecisionStep = Math.min(designGridStep, 0.1);
-  const mobilePrecisionStepLabel = `${mobilePrecisionStep.toFixed(
-    mobilePrecisionStep < 0.1 ? 2 : 1
-  )} m`;
+  const mobilePrecisionStepLabel = formatMeasurement(
+    mobilePrecisionStep,
+    unitSystem,
+    { precision: mobilePrecisionStep < 0.1 ? 2 : 1 }
+  );
   const singleSelectionCanRotate = Boolean(
     singleSelectedShape &&
     singleSelectedShape.kind !== "polyline" &&

--- a/src/lib/export/exportPdf.ts
+++ b/src/lib/export/exportPdf.ts
@@ -7,6 +7,7 @@ import {
 import { buildSetupPlan } from "@/lib/planning/setup-estimate";
 import { createQrCode } from "@/lib/qr-code";
 import { getDesignTimingMarkers, timingRoleLabels } from "@/lib/track/timing";
+import { formatFieldSize, formatMeasurement } from "@/lib/track/units";
 import type { TrackDesign } from "../types";
 import {
   designToSvg,
@@ -294,6 +295,7 @@ function buildRacePackContext(design: TrackDesign, options?: Export2DOptions) {
   return {
     inventoryComparison,
     numberingEnabled,
+    unitSystem: options?.unitSystem ?? "metric",
     setupSequence: setupPlan.steps,
     shortages,
     estimatedSetupRange: setupPlan.estimatedElapsedRange,
@@ -341,7 +343,7 @@ function drawRacePackCover(
   pdf.setFontSize(10);
   pdf.setTextColor(...MUTED);
   pdf.text(
-    `${design.field.width} × ${design.field.height} m  ·  ${dateText}  ·  ${context.numberingEnabled ? "numbering included" : "numbering hidden"}`,
+    `${formatFieldSize(design.field.width, design.field.height, options?.unitSystem ?? "metric")}  ·  ${dateText}  ·  ${context.numberingEnabled ? "numbering included" : "numbering hidden"}`,
     margin,
     y
   );
@@ -472,10 +474,20 @@ function drawRacePackMapPage(
   pdf.setFont("helvetica", "normal");
   pdf.setFontSize(8.2);
   pdf.setTextColor(...MUTED);
-  pdf.text(`${design.field.width} m`, imgX + imgW / 2, imgY + imgH + 7, {
+  const racePackWidthLabel = formatMeasurement(
+    design.field.width,
+    context.unitSystem,
+    { precision: 1 }
+  );
+  const racePackHeightLabel = formatMeasurement(
+    design.field.height,
+    context.unitSystem,
+    { precision: 1 }
+  );
+  pdf.text(racePackWidthLabel, imgX + imgW / 2, imgY + imgH + 7, {
     align: "center",
   });
-  pdf.text(`${design.field.height} m`, imgX - 6, imgY + imgH / 2, {
+  pdf.text(racePackHeightLabel, imgX - 6, imgY + imgH / 2, {
     angle: 90,
     align: "center",
   });
@@ -575,7 +587,7 @@ function drawRacePackBuildSheet(
       const title = item.marker.timingId
         ? `${item.title} (${item.marker.timingId})`
         : item.title;
-      const detail = `${timingRoleLabels[item.marker.role]} · ${item.shape.name?.trim() || item.shape.kind} · ${item.shape.x.toFixed(1)}, ${item.shape.y.toFixed(1)} m`;
+      const detail = `${timingRoleLabels[item.marker.role]} · ${item.shape.name?.trim() || item.shape.kind} · ${formatMeasurement(item.shape.x, context.unitSystem, { precision: 1 })}, ${formatMeasurement(item.shape.y, context.unitSystem, { precision: 1 })}`;
       ensurePageSpace(12, "Timing points");
       pdf.setTextColor(...INK);
       pdf.setFont("helvetica", "bold");
@@ -756,8 +768,20 @@ async function exportStandardPdf(
   pdf.setFont("helvetica", "normal");
   pdf.setFontSize(7.5);
   pdf.setTextColor(...MUTED);
-  pdf.text(`${width} m`, imgX + imgW / 2, imgY + imgH + 7, { align: "center" });
-  pdf.text(`${height} m`, imgX - 6, imgY + imgH / 2, {
+  const standardWidthLabel = formatMeasurement(
+    width,
+    options?.unitSystem ?? "metric",
+    { precision: 1 }
+  );
+  const standardHeightLabel = formatMeasurement(
+    height,
+    options?.unitSystem ?? "metric",
+    { precision: 1 }
+  );
+  pdf.text(standardWidthLabel, imgX + imgW / 2, imgY + imgH + 7, {
+    align: "center",
+  });
+  pdf.text(standardHeightLabel, imgX - 6, imgY + imgH / 2, {
     angle: 90,
     align: "center",
   });
@@ -778,7 +802,12 @@ async function exportStandardPdf(
   pdf.text(design.title.trim() || "Untitled Track", margin + 5, midY);
   pdf.setFont("helvetica", "normal");
   pdf.setFontSize(7);
-  pdf.text(`${width} × ${height} m`, pageW / 2, midY, { align: "center" });
+  pdf.text(
+    formatFieldSize(width, height, options?.unitSystem ?? "metric"),
+    pageW / 2,
+    midY,
+    { align: "center" }
+  );
   pdf.text(dateText, pageW - margin - 5, midY, { align: "right" });
 
   pdf.save(filename);

--- a/src/lib/export/exportSvg.ts
+++ b/src/lib/export/exportSvg.ts
@@ -15,6 +15,10 @@ import {
   getObstacleNumberMap,
   isNumberedObstacle,
 } from "../track/obstacleNumbering";
+import {
+  formatCompactFieldSize,
+  type MeasurementUnitSystem,
+} from "../track/units";
 import { getShapeTimingMarker, getTimingMarkerColor } from "../track/timing";
 import {
   getPolyline2DDerived,
@@ -301,6 +305,7 @@ export type ExportTheme = "dark" | "light";
 export interface Export2DOptions {
   includeObstacleNumbers?: boolean;
   preset?: "standard" | "race-day";
+  unitSystem?: MeasurementUnitSystem;
 }
 
 export function designToSvg(
@@ -374,7 +379,11 @@ export function designToSvg(
       ? ""
       : obstacleNumbersToSvg(design, ppm, theme);
   const titleText = design.title.trim() || "Untitled Track";
-  const sizeText = `${width}×${height} m`;
+  const sizeText = formatCompactFieldSize(
+    width,
+    height,
+    options?.unitSystem ?? "metric"
+  );
   const dateText = new Date().toLocaleDateString("en-GB", {
     day: "2-digit",
     month: "short",

--- a/src/lib/track/units.ts
+++ b/src/lib/track/units.ts
@@ -120,20 +120,10 @@ export function parseMeasurementInput(
   if (unit === "m" || unit === "meter" || unit === "meters") {
     return amount;
   }
-  if (
-    unit === "ft" ||
-    unit === "foot" ||
-    unit === "feet" ||
-    unit === "'"
-  ) {
+  if (unit === "ft" || unit === "foot" || unit === "feet" || unit === "'") {
     return feetToMeters(amount);
   }
-  if (
-    unit === "in" ||
-    unit === "inch" ||
-    unit === "inches" ||
-    unit === '"'
-  ) {
+  if (unit === "in" || unit === "inch" || unit === "inches" || unit === '"') {
     return inchesToMeters(amount);
   }
 

--- a/src/lib/track/units.ts
+++ b/src/lib/track/units.ts
@@ -56,7 +56,7 @@ function trimNumber(value: number, digits: number) {
 export function formatMeasurement(
   meters: number,
   unitSystem: MeasurementUnitSystem = "metric",
-  options: { precision?: number; compact?: boolean } = {}
+  options: { precision?: number } = {}
 ) {
   const precision = options.precision ?? (Math.abs(meters) < 10 ? 1 : 0);
 
@@ -102,7 +102,7 @@ export function formatMeasurementInputValue(
   unitSystem: MeasurementUnitSystem
 ) {
   const value = unitSystem === "imperial" ? metersToFeet(meters) : meters;
-  return trimNumber(value, value < 10 ? 2 : 1);
+  return trimNumber(value, Math.abs(value) < 10 ? 2 : 1);
 }
 
 export function parseMeasurementInput(

--- a/src/lib/track/units.ts
+++ b/src/lib/track/units.ts
@@ -1,2 +1,143 @@
 export const m2px = (m: number, ppm: number) => m * ppm;
 export const px2m = (px: number, ppm: number) => px / ppm;
+
+export type MeasurementUnitSystem = "metric" | "imperial";
+
+export const MEASUREMENT_STORAGE_KEY = "trackdraw.measurementUnitSystem";
+
+const FEET_PER_METER = 3.280839895;
+const METERS_PER_FOOT = 1 / FEET_PER_METER;
+const METERS_PER_INCH = METERS_PER_FOOT / 12;
+
+const IMPERIAL_LOCALES = new Set(["US", "LR", "MM"]);
+
+export function normalizeMeasurementUnitSystem(
+  value: unknown
+): MeasurementUnitSystem | null {
+  return value === "metric" || value === "imperial" ? value : null;
+}
+
+export function getMeasurementUnitSystemFromLocales(
+  locales: readonly string[] | undefined
+): MeasurementUnitSystem {
+  const firstRegion = locales
+    ?.map((locale) => {
+      try {
+        return new Intl.Locale(locale).region?.toUpperCase() ?? null;
+      } catch {
+        const match = locale.match(/[-_]([A-Za-z]{2})\b/);
+        return match?.[1]?.toUpperCase() ?? null;
+      }
+    })
+    .find((region): region is string => Boolean(region));
+
+  return firstRegion && IMPERIAL_LOCALES.has(firstRegion)
+    ? "imperial"
+    : "metric";
+}
+
+export function metersToFeet(meters: number) {
+  return meters * FEET_PER_METER;
+}
+
+export function feetToMeters(feet: number) {
+  return feet * METERS_PER_FOOT;
+}
+
+export function inchesToMeters(inches: number) {
+  return inches * METERS_PER_INCH;
+}
+
+function trimNumber(value: number, digits: number) {
+  if (!Number.isFinite(value)) return "0";
+  return Number(value.toFixed(digits)).toString();
+}
+
+export function formatMeasurement(
+  meters: number,
+  unitSystem: MeasurementUnitSystem = "metric",
+  options: { precision?: number; compact?: boolean } = {}
+) {
+  const precision = options.precision ?? (Math.abs(meters) < 10 ? 1 : 0);
+
+  if (unitSystem === "imperial") {
+    return `${trimNumber(metersToFeet(meters), precision)} ft`;
+  }
+
+  return `${trimNumber(meters, precision)} m`;
+}
+
+export function formatFieldSize(
+  widthMeters: number,
+  heightMeters: number,
+  unitSystem: MeasurementUnitSystem = "metric"
+) {
+  if (unitSystem === "imperial") {
+    return `${trimNumber(metersToFeet(widthMeters), 0)} x ${trimNumber(
+      metersToFeet(heightMeters),
+      0
+    )} ft`;
+  }
+
+  return `${trimNumber(widthMeters, 1)} x ${trimNumber(heightMeters, 1)} m`;
+}
+
+export function formatCompactFieldSize(
+  widthMeters: number,
+  heightMeters: number,
+  unitSystem: MeasurementUnitSystem = "metric"
+) {
+  if (unitSystem === "imperial") {
+    return `${trimNumber(metersToFeet(widthMeters), 0)}×${trimNumber(
+      metersToFeet(heightMeters),
+      0
+    )} ft`;
+  }
+
+  return `${trimNumber(widthMeters, 1)}×${trimNumber(heightMeters, 1)} m`;
+}
+
+export function formatMeasurementInputValue(
+  meters: number,
+  unitSystem: MeasurementUnitSystem
+) {
+  const value = unitSystem === "imperial" ? metersToFeet(meters) : meters;
+  return trimNumber(value, value < 10 ? 2 : 1);
+}
+
+export function parseMeasurementInput(
+  value: string,
+  fallbackUnitSystem: MeasurementUnitSystem = "metric"
+) {
+  const trimmed = value.trim().toLowerCase();
+  const match = trimmed.match(/^(-?\d+(?:[.,]\d+)?)\s*([a-z"']*)$/);
+  if (!match) return null;
+
+  const amount = Number(match[1].replace(",", "."));
+  if (!Number.isFinite(amount)) return null;
+
+  const unit = match[2];
+  if (unit === "m" || unit === "meter" || unit === "meters") {
+    return amount;
+  }
+  if (
+    unit === "ft" ||
+    unit === "foot" ||
+    unit === "feet" ||
+    unit === "'"
+  ) {
+    return feetToMeters(amount);
+  }
+  if (
+    unit === "in" ||
+    unit === "inch" ||
+    unit === "inches" ||
+    unit === '"'
+  ) {
+    return inchesToMeters(amount);
+  }
+
+  if (unit) return null;
+
+  return fallbackUnitSystem === "imperial" ? feetToMeters(amount) : amount;
+}

--- a/tests/hooks/useMeasurementUnitSystem.test.tsx
+++ b/tests/hooks/useMeasurementUnitSystem.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "localStorage"
+);
+
+function createThrowingStorage(): Storage {
+  return {
+    get length() {
+      return 0;
+    },
+    clear: vi.fn(),
+    getItem: vi.fn(() => {
+      throw new DOMException("Storage unavailable", "SecurityError");
+    }),
+    key: vi.fn(() => null),
+    removeItem: vi.fn(),
+    setItem: vi.fn(() => {
+      throw new DOMException("Storage unavailable", "SecurityError");
+    }),
+  };
+}
+
+describe("useMeasurementUnitSystem", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: createThrowingStorage(),
+    });
+    Object.defineProperty(window.navigator, "languages", {
+      configurable: true,
+      value: ["nl-NL"],
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (originalLocalStorageDescriptor) {
+      Object.defineProperty(
+        window,
+        "localStorage",
+        originalLocalStorageDescriptor
+      );
+    }
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps unit changes responsive when localStorage is unavailable", async () => {
+    const { useMeasurementUnitSystem } = await import(
+      "@/hooks/useMeasurementUnitSystem"
+    );
+    const { result } = renderHook(() => useMeasurementUnitSystem());
+
+    expect(result.current.unitSystem).toBe("metric");
+
+    act(() => {
+      result.current.setUnitSystem("imperial");
+    });
+
+    expect(result.current.unitSystem).toBe("imperial");
+  });
+});

--- a/tests/hooks/useMeasurementUnitSystem.test.tsx
+++ b/tests/hooks/useMeasurementUnitSystem.test.tsx
@@ -52,9 +52,8 @@ describe("useMeasurementUnitSystem", () => {
   });
 
   it("keeps unit changes responsive when localStorage is unavailable", async () => {
-    const { useMeasurementUnitSystem } = await import(
-      "@/hooks/useMeasurementUnitSystem"
-    );
+    const { useMeasurementUnitSystem } =
+      await import("@/hooks/useMeasurementUnitSystem");
     const { result } = renderHook(() => useMeasurementUnitSystem());
 
     expect(result.current.unitSystem).toBe("metric");

--- a/tests/lib/export/exportPdf.test.ts
+++ b/tests/lib/export/exportPdf.test.ts
@@ -192,7 +192,7 @@ describe("exportPdf", () => {
     expect(
       pdf.textCalls.some((call) => call.includes("Standard PDF Smoke"))
     ).toBe(true);
-    expect(pdf.textCalls.some((call) => call.includes("60 × 40 m"))).toBe(true);
+    expect(pdf.textCalls.some((call) => call.includes("60 x 40 m"))).toBe(true);
   });
 
   it("passes dense practical layouts through Race Pack PDF rendering", async () => {

--- a/tests/lib/track/units.test.ts
+++ b/tests/lib/track/units.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { m2px, px2m } from "@/lib/track/units";
+import {
+  feetToMeters,
+  formatFieldSize,
+  formatMeasurement,
+  getMeasurementUnitSystemFromLocales,
+  m2px,
+  parseMeasurementInput,
+  px2m,
+} from "@/lib/track/units";
 
 describe("track unit helpers", () => {
   it("converts meters to pixels", () => {
@@ -14,5 +22,33 @@ describe("track unit helpers", () => {
     const meters = 7.25;
     const ppm = 18;
     expect(px2m(m2px(meters, ppm), ppm)).toBe(meters);
+  });
+
+  it("derives first-run unit defaults from browser locales", () => {
+    expect(getMeasurementUnitSystemFromLocales(["en-US"])).toBe("imperial");
+    expect(getMeasurementUnitSystemFromLocales(["en-GB"])).toBe("metric");
+    expect(getMeasurementUnitSystemFromLocales(["ja-JP"])).toBe("metric");
+    expect(getMeasurementUnitSystemFromLocales(["nl-NL"])).toBe("metric");
+  });
+
+  it("formats metric and imperial measurements", () => {
+    expect(formatMeasurement(10, "metric")).toBe("10 m");
+    expect(formatMeasurement(10, "imperial")).toBe("33 ft");
+    expect(formatFieldSize(60, 40, "metric")).toBe("60 x 40 m");
+    expect(formatFieldSize(60, 40, "imperial")).toBe("197 x 131 ft");
+  });
+
+  it("parses metric and imperial measurement input into meters", () => {
+    expect(parseMeasurementInput("10", "metric")).toBe(10);
+    expect(parseMeasurementInput("10", "imperial")).toBeCloseTo(
+      feetToMeters(10)
+    );
+    expect(parseMeasurementInput("10 ft", "metric")).toBeCloseTo(
+      feetToMeters(10)
+    );
+    expect(parseMeasurementInput("12 in", "metric")).toBeCloseTo(
+      feetToMeters(1)
+    );
+    expect(parseMeasurementInput("3 m", "imperial")).toBe(3);
   });
 });

--- a/tests/lib/track/units.test.ts
+++ b/tests/lib/track/units.test.ts
@@ -3,6 +3,7 @@ import {
   feetToMeters,
   formatFieldSize,
   formatMeasurement,
+  formatMeasurementInputValue,
   getMeasurementUnitSystemFromLocales,
   m2px,
   parseMeasurementInput,
@@ -36,6 +37,12 @@ describe("track unit helpers", () => {
     expect(formatMeasurement(10, "imperial")).toBe("33 ft");
     expect(formatFieldSize(60, 40, "metric")).toBe("60 x 40 m");
     expect(formatFieldSize(60, 40, "imperial")).toBe("197 x 131 ft");
+  });
+
+  it("formats negative measurement input values using absolute precision", () => {
+    expect(formatMeasurementInputValue(-100, "metric")).toBe("-100");
+    expect(formatMeasurementInputValue(-2, "metric")).toBe("-2");
+    expect(formatMeasurementInputValue(-100, "imperial")).toBe("-328.1");
   });
 
   it("parses metric and imperial measurement input into meters", () => {


### PR DESCRIPTION
- Introduced a new hook `useMeasurementUnitSystem` to manage measurement unit preferences (metric/imperial) based on browser locale and local storage.
- Updated various components (e.g., `ElevationChart`, `ElevationPanel`, `PolylineWaypointList`, etc.) to utilize the new measurement unit system for displaying dimensions and distances.
- Refactored measurement formatting functions in `units.ts` to handle both metric and imperial units, including `formatMeasurement`, `formatFieldSize`, and `parseMeasurementInput`.
- Enhanced the UI to allow users to toggle between metric and imperial units, ensuring consistent display across the application.
- Updated tests to cover new functionality and ensure correct measurement conversions and formatting.