### PR TITLE
refactor: collapsible inspector panel and EditorShell decomposition

### DIFF
--- a/docs/research/track-element-catalog.md
+++ b/docs/research/track-element-catalog.md
@@ -1,0 +1,106 @@
+# Track Element Catalog
+
+TrackDraw currently has generic editor primitives such as gate, flag, cone, ladder, dive gate, start pads, label, and race line. One useful next step is a catalog layer that knows about real track elements, official names, dimensions, 2D behavior, 3D presentation, and export/integration compatibility.
+
+The catalog should start local and typed, not as a database. A database becomes useful later for club inventory, venue-specific kits, custom saved elements, and account-backed libraries.
+
+## Top-Level Checklist
+
+- [ ] Define a typed local element catalog for official and TrackDraw-provided elements.
+- [ ] Move default placement for generic tools and presets onto catalog entries.
+- [ ] Add official race-gate entries, including a MultiGP-style 5 ft x 5 ft standard gate, without changing existing saved designs.
+
+## Reference Observations
+
+TrackForge presents a useful comparison point for product shape, not something TrackDraw should clone wholesale. Its public app exposes a named track-element list with items such as Champs Gate (10x8), Standard Gate (7x6), Panel Flag, Feather Flag, Launch Block, Dive Gate (7x6), SGDC Dive Gate (3x3), Hurdle (10x5), and Waypoint. It also exposes grouping, saved elements, and an inventory surface.
+
+TrackDraw already has stronger 2D editing, sharing, export handoff, account/gallery/API direction, and mobile-supported product boundaries. The opportunity is to make TrackDraw's element model feel more like real FPV planning while keeping the core editor predictable.
+
+External references to retain while designing this:
+
+- TrackForge public app: `https://trackforge.racing/`
+- MultiGP Standard 5 ft x 5 ft gate reference: `https://shop.multigp.com/product/standard-multigp-gate-5x5/`
+- MultiGP Global Qualifier diagram example with 5 ft x 5 ft gates: `https://www.multigp.com/wp-content/uploads/2022/03/2022-MultiGP-GQ-track-official-diagram-imperial.pdf`
+
+## Phase 1: Local Element Catalog Foundation
+
+Start state:
+
+- Shape defaults are spread across generic editor tools and layout/starter preset helpers.
+- A gate is generic and currently has no official product identity.
+- 2D and 3D rendering mostly infer behavior from `ShapeKind` rather than a richer element definition.
+
+Scope:
+
+- Add a catalog module such as `src/lib/track/elements/catalog.ts`.
+- Model catalog entries separately from saved shape instances.
+- Keep saved shapes meter-based and backwards compatible.
+- Add official metadata fields without making them required on existing shapes.
+
+Candidate catalog entry fields:
+
+- `id`: stable internal identifier, such as `multigp-standard-gate-5x5`
+- `name`: user-facing name, such as `MultiGP Standard Gate 5x5`
+- `organization`: optional source, such as `MultiGP`
+- `kind`: existing TrackDraw shape kind
+- `dimensions`: meter-based canonical dimensions plus display dimensions
+- `defaultShape`: current TrackDraw shape draft defaults
+- `tags`: `official`, `race`, `practice`, `timing-compatible`, `sim-export`
+- `sources`: optional public URLs or documentation references
+- `render2d`: optional icon/render hints
+- `render3d`: optional model/render hints
+- `exportHints`: optional simulator/export compatibility metadata
+
+Done state:
+
+- New generic gate placement can be powered by a catalog entry without changing existing project files.
+- Tests verify catalog dimensions and shape defaults.
+- Layout and starter presets can opt into catalog entries instead of duplicating dimensions.
+- Existing imports/exports remain compatible.
+
+## Phase 2: Official Element Entries
+
+Start state:
+
+- The catalog exists, but only replaces existing generic defaults.
+
+Scope:
+
+- Add the first official gate entries after validating exact sizing and source language:
+  - MultiGP Standard Gate 5x5
+  - MultiGP Champ Gate 7x6 or 10x8 only after confirming the correct naming/dimensions for the intended race context
+  - Dive gate variants only after deciding whether they should remain one `divegate` shape or become catalog-driven variants
+- Keep "Custom Gate" available so users are not boxed into official-only dimensions.
+- Expose the official name in inspector/export summaries only when the shape was created from a catalog entry or explicitly assigned one.
+
+Done state:
+
+- Users can place at least one official named race gate.
+- The inspector can show the official identity and dimensions without hiding editable width/height controls.
+- Export and Race Pack copy can reference official names where helpful.
+
+## Phase 3: Element Library UI
+
+Start state:
+
+- Catalog entries exist, but the toolbar may still look like generic shape tools.
+
+Scope:
+
+- Add a compact element picker behind existing tool groups instead of expanding the primary toolbar.
+- Keep quick placement fast: one-click Gate still places the default gate.
+- Add a secondary way to choose variants such as official gates, flags, launch blocks, hurdles, and custom saved elements.
+- Avoid card-in-card layouts and keep mobile picker behavior deliberate.
+
+Done state:
+
+- Users can choose official or generic variants without slowing down the common workflow.
+- Mobile users can still place common items without opening a dense desktop-style library.
+- The current starter layouts continue to work.
+
+## Boundaries
+
+- Do not change stored shape dimensions globally just because an official catalog entry exists.
+- Do not migrate existing projects to new official gate sizes automatically.
+- Do not couple element catalog work to accounts in the first slice.
+- Do not copy a competitor's UI wholesale; borrow validated product patterns and fit them into TrackDraw's existing editor model.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -16,17 +16,18 @@ TrackDraw is now strong in these areas:
 - Portable outputs through PNG, SVG, PDF, 3D render capture, and JSON project files
 - Account-backed REST API with API key management and a live race overlay data endpoint
 
-The most useful next product move is deepening the race-day workflow, keeping the editor dependable, refining the account-backed project model, and giving operators better dashboard visibility over public and integration-sensitive surfaces:
+The most useful next product move is deepening the race-day workflow, keeping the editor dependable, refining the account-backed project model, and improving catalog-backed official elements, 3D review, and workspace ergonomics:
 
 - Race director page with pilot line, timing/start box placement, and ops notes
 - Usability and reliability pass focused on recovery states, mobile ergonomics, editor interactions, exports, sharing, and larger layouts
-- Share version history so owners can update a published track without surprising existing links
-- Regional measurement units so international users can work in familiar metric or imperial-style measurements while TrackDraw keeps meter-based geometry internally
+- Catalog-backed official track elements
+- More realistic 3D review and focused 3D item controls
+- Generated flightpath research as a separate route-authoring assist
+- Editor workspace ergonomics for larger layouts, including collapsible side panels where they preserve selection context
+- Regional measurement units so international users can work with familiar Metric or Imperial presets while TrackDraw keeps meter-based geometry internally
 - Multilingual product experience built on the same locale-aware foundation, starting with explicit language choice and controlled translation scope
-- Gallery collections for curated browsing beyond the current featured bucket
-- Dashboard operator tooling for public track review, share lifecycle inspection, contextual account/project diagnostics, and API usage visibility
 
-Larger product ideas such as venue libraries, AR, and build mode should stay parked until there is clearer need.
+Lower-priority follow-up such as share version history, gallery collections, dashboard operator tooling, Velocidrone export stabilization, AR, and build mode should stay parked until there is clearer need.
 
 ## Product Principles
 
@@ -162,7 +163,7 @@ Suggested first slices:
 
 #### Regional Measurement Units
 
-International users should be able to work in familiar metric or imperial-style measurements without TrackDraw changing its internal geometry model.
+International users should be able to work in familiar Metric or Imperial measurement presets without TrackDraw changing its internal geometry model.
 
 Why:
 
@@ -174,18 +175,18 @@ Why:
 
 Focus:
 
-- Add a simple metric versus imperial-style unit preference with a metric default that preserves existing project behavior
+- Add a simple Metric versus Imperial unit preference with a Metric default that preserves existing project behavior
 - Use browser locale signals to choose the first-run unit default when no saved preference exists, then persist the user's override locally and, where appropriate, in account/project settings
 - Centralize measurement formatting so field labels, rulers, inspectors, route/elevation summaries, gallery metadata, and export previews stop hard-coding `m`
 - Support unit-aware numeric input for common values such as meters, feet, and inches while storing normalized meter values in project data
-- Keep JSON/API geometry meter-based for compatibility, while allowing share/export presentation to use the selected measurement system
+- Keep JSON/API geometry and speed values meter-based/SI for compatibility, while allowing share/export presentation to use the selected measurement preset
 
 Current shipped foundation:
 
-- Browser-locale-informed metric versus imperial default with local manual override
+- Browser-locale-informed Metric versus Imperial default with local manual override
 - Shared measurement formatting for core editor chrome, rulers, inspector summaries, gallery cards, import previews, share canvas labels, and visual export labels
 - Unit-aware measurement inputs for field settings, selected object dimensions/positions, and route waypoint elevation
-- PNG/SVG/PDF/Race Pack presentation follows the selected unit system while JSON/API geometry remains meter-based
+- PNG/SVG/PDF/Race Pack presentation follows the selected measurement preset while JSON/API geometry remains meter-based
 
 Important boundary:
 
@@ -214,8 +215,99 @@ Focus:
 Important boundary:
 
 - Do not block regional measurement support on full i18n; units can ship first as a smaller, lower-risk slice
-- Do not infer units only from language, because English users can prefer metric and non-English users can work with imperial-style venue expectations
+- Do not infer units only from language, because English users can prefer Metric and non-English users can work with Imperial venue expectations
 - Do not translate legal pages casually; any material legal translation needs a separate review standard
+
+#### Track Element Catalog
+
+TrackDraw should move from generic element defaults toward a clearer equipment model with official names, dimensions, source references, and reusable placement defaults.
+
+Supporting research document:
+
+- `docs/research/track-element-catalog.md`
+
+Why:
+
+- Real race directors think in named equipment such as standard gates, champ gates, flags, launch blocks, hurdles, and club-specific kits, not just generic shape primitives
+- Official names and dimensions should be introduced through a durable catalog so TrackDraw can support MultiGP-style gates and other known objects without silently changing old projects
+- A catalog can feed 2D placement, 3D rendering, export metadata, inventory/setup counts, and future account-backed club libraries from one source of truth
+
+Feature tracks:
+
+- Track element catalog: define typed local catalog entries with official names, meter-based dimensions, display dimensions, source references, shape defaults, 2D hints, 3D hints, and export compatibility metadata
+- Official equipment entries: reintroduce any default race-gate size changes through catalog entries rather than hard-coded generic defaults, while preserving custom gate editing and saved-project compatibility
+- Element library UI: expose official and custom variants without slowing down the current quick-placement toolbar flow
+
+Important boundary:
+
+- Do not automatically migrate existing projects to official gate dimensions
+- Do not make the first element catalog account-backed or database-backed; start local and typed so it is testable and versioned
+- Do not copy competitor UI patterns wholesale; adapt useful patterns to TrackDraw's existing editor and handoff workflows
+
+#### 3D Preview And Direct Manipulation
+
+TrackDraw should improve 3D review and focused 3D editing as separate editor capabilities, not as part of the track element catalog.
+
+Why:
+
+- 3D review can become more useful with better lighting, contrast, sun/directional-light treatment, shadows, and more realistic gates/flags
+- Direct 3D controls can speed up selected item edits when they stay narrow and respect lock state, undo/redo, and mobile constraints
+
+Feature tracks:
+
+- 3D preview realism and lighting: improve scene readability with sun/directional lighting, shadows, contrast, and more realistic gate/flag presentation before adding heavy asset workflows
+- Focused 3D item controls: add direct controls for common edits such as elevation, rotation, scaling, and orientation only where undo/redo, lock state, and mobile behavior remain safe
+
+Important boundary:
+
+- Do not make 3D controls broad enough to destabilize the existing 2D-first editor
+- Do not bury 3D preview or direct manipulation work under the element catalog; they should remain standalone editor features
+
+#### Generated Flightpath Assistance
+
+TrackDraw should research generated flightpaths as route-authoring assistance, separate from the element catalog and separate from 3D preview rendering.
+
+Why:
+
+- TrackDraw already has explicit route authoring, elevation, obstacle numbering, and overlay preparation
+- Generated flightpaths may help with first-pass drafting, route review, flythrough preparation, and ambiguous gate-order warnings
+- The useful product boundary is whether users can accept and edit a suggested route, not whether TrackDraw can fully simulate an optimal racing line
+
+Feature tracks:
+
+- Generated flightpath research: prototype route generation from ordered elements as an optional starting point that users can accept and edit
+- Route ambiguity warnings: explore lightweight feedback for unclear order, direction, or corkscrew-like layouts before adding simulation-heavy path optimization
+
+Important boundary:
+
+- Do not treat generated flightpaths as authoritative until they are validated against real layouts
+- Do not replace explicit race-line authoring; generated routes should remain assistive and editable
+- Do not bury generated flightpath work under the element catalog or 3D preview work; it should remain a standalone route-authoring feature
+
+#### Editor Workspace Ergonomics
+
+TrackDraw should keep improving dense editor layouts without mixing those usability changes into the track element catalog work.
+
+Why:
+
+- Dense desktop editing benefits from collapsible side panels so users can reclaim canvas space without losing selection context
+- Mobile already relies on drawer-style surfaces, so desktop/tablet workspace density should be improved without regressing mobile editor flows
+- Workspace preferences are local UI state and should stay separate from saved track geometry and catalog definitions
+
+Feature tracks:
+
+- Collapsible inspector workspace: continue refining the shipped desktop collapse rail only if real usage shows friction around selection context or repeated resizing
+- Persistent sidebar density: keep local-only collapse preferences for editor chrome where that improves repeated editing
+
+Important boundary:
+
+- Do not bury workspace improvements under the element catalog; inspector collapse should remain a standalone usability feature
+- Do not store workspace density in project files unless it becomes an explicit share/review requirement
+
+Current shipped foundation:
+
+- Desktop users can collapse the inspector from the inspector header into a narrow right-side rail, then reopen it from that rail while preserving the current selection and leaving mobile drawer behavior unchanged
+- The left editor toolbar and right inspector collapsed states are persisted locally so repeated desktop editing keeps the chosen workspace density after refresh
 
 ### 3. Account-Backed Follow-up (`Account-backed`)
 
@@ -243,7 +335,7 @@ Focus:
 - Keep local-first publish flows simple for unauthenticated use
 - Improve operator visibility for temporary, published, revoked, gallery-linked, and embedded share states before adding deeper share administration
 
-#### Share Version History
+#### Share Version History (`Lower priority`)
 
 Account-backed shares should support deliberate publish history so owners can update a published track without making existing links feel mysterious or losing the last known-good public version.
 
@@ -286,7 +378,7 @@ Important boundary:
 - Do not add branching, named release channels, collaborative approval, or public version browsing in the first pass
 - Do not expose private project history through public gallery, embeds, or share metadata
 
-#### Gallery Featured Collections
+#### Gallery Featured Collections (`Lower priority`)
 
 The gallery can become more useful through curated collections without becoming a social feed.
 
@@ -303,7 +395,7 @@ Focus:
 - Surface selected collections on `/gallery` while keeping every card destination on `/share/[token]`
 - Keep collection pages or deep collection routing out of the first slice unless the gallery needs it later
 
-#### Dashboard Operator Tooling
+#### Dashboard Operator Tooling (`Lower priority`)
 
 The dashboard should become the control surface for public, account-backed, and integration-sensitive behavior without turning TrackDraw into a social platform or support console that can casually mutate user work.
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -22,32 +22,49 @@ Labels used below:
 
 ## Current Priority
 
-The completed release-sized work is archived below. The REST API, live race overlay preparation, account project lifecycle polish, UI/UX polish, and stability pass are now complete. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, regional measurement support and multilingual-readiness for international users, account-backed project lifecycle depth beyond the shipped conflict/retry baseline, and better dashboard visibility over public and integration-sensitive surfaces.
+The completed release-sized work is archived below. The REST API, live race overlay preparation, account project lifecycle polish, UI/UX polish, and stability pass are now complete. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, catalog-backed official track elements, 3D preview improvements, generated flightpath assistance, regional measurement support and multilingual-readiness for international users, and account-backed project lifecycle depth beyond the shipped conflict/retry baseline.
 
 ## Follow-up
 
-- [ ] Velocidrone experimental export stabilization (`No account required`)
-      The first experimental `.trk` export is already shipped. Keep this parked until there is appetite to validate more real layouts and tighten prefab mapping and orientation edge cases.
-  - [ ] Validate the current `.trk` export on more layouts
-        Test the shipped export across a wider range of real track layouts so the current best-effort mapping is grounded in repeatable validation instead of one-off success cases.
-  - [ ] Resolve remaining mapping and orientation edge cases
-        Tighten the current export where prefab substitutions, facing direction, or rotation assumptions still produce avoidable cleanup work after import.
+- [ ] Track element catalog (`Research`, `No account required`)
+      Build a catalog-backed element model for official gates, richer placement defaults, and future equipment/library expansion before changing default race-gate sizing.
+  - [ ] Local element catalog foundation
+        Define typed catalog entries for official names, dimensions, source references, 2D defaults, 3D render hints, and export compatibility while keeping saved project geometry meter-based.
+  - [ ] Official gate and obstacle entries
+        Add entries such as a MultiGP-style standard gate only through the catalog, with custom gate editing preserved and no automatic migration of existing projects.
 
-- [ ] Venue library and constraints (`Account-backed`)
-      Support reusable venue records with boundaries, constraints, and venue-specific profiles.
+- [ ] 3D preview realism and lighting (`Research`, `No account required`)
+      Improve the 3D preview's readability and realism with stronger contrast, sun/directional lighting, shadows, and more recognizable gates/flags while keeping mobile performance safe.
+  - [ ] 3D readability and realism pass
+        Evaluate sun/directional lighting, stronger contrast, more realistic gates/flags, and shadow treatment without making the scene visually noisy.
+
+- [ ] Focused 3D item controls (`No account required`)
+      Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.
+  - [ ] 3D transform handles
+        Prototype selected-item controls for elevation, rotation, scale, and orientation only where the behavior is predictable across 2D and 3D.
+
+- [ ] Generated flightpath assistance (`Research`, `No account required`)
+      Research generated flightpaths from placed elements as an optional drafting/review aid that users can accept and edit.
+  - [ ] Generated flightpath research
+        Prototype flightpath generation from placed elements as an assistive review/drafting feature that can be accepted or edited, not as a replacement for explicit race-line authoring.
+
+- [x] Collapsible inspector workspace (`No account required`)
+      Let desktop/tablet users collapse the inspector sidebar to reclaim canvas space during dense editing while preserving selection context.
+  - [x] Collapsible inspector workspace
+        Add the collapse control to the inspector header, keep a reopen control in the collapsed rail, persist desktop workspace density locally, and verify it does not regress mobile drawer behavior.
 
 - [x] Regional measurement units (`No account required`)
-      Support regional metric and imperial-style display and input without changing the internal meter-based design model.
+      Support regional Metric and Imperial display/input presets without changing the internal meter-based design model.
   - [x] Unit preference model
-        Add a project-safe and user-friendly unit preference for metric or imperial-style measurements, with a metric default that fits most international users and does not break existing projects.
+        Add a project-safe and user-friendly Metric/Imperial preference, with a Metric default that fits most international users and does not break existing projects.
   - [x] Locale-informed defaults
         Use browser locale signals to choose an initial measurement default when no explicit preference exists, while keeping the detected value transparent and manually overrideable.
   - [x] Editor display formatting
         Replace direct `m` labels in field size, rulers, inspectors, route/elevation summaries, gallery metadata, and export previews with shared unit formatting.
   - [x] Unit-aware numeric input
-        Let users enter common metric and imperial-style values such as meters, feet, and inches while storing normalized meter values in the design.
+        Let users enter common Metric and Imperial values such as meters, feet, and inches while storing normalized meter values in the design.
   - [x] Export and share presentation
-        Show the selected measurement system in PDF/Race Pack/share-facing summaries while keeping JSON/API geometry compatible and meter-based.
+        Show the selected measurement preset in PDF/Race Pack/share-facing summaries while keeping JSON/API geometry and speed values compatible and meter-based/SI.
 
 - [ ] Multilingual product experience (`Research`, `No account required`)
       Use the regional measurement work as a first locale-aware foundation, then evaluate a full i18n layer for the public site, editor, share pages, and exported handoff copy.
@@ -60,48 +77,19 @@ The completed release-sized work is archived below. The REST API, live race over
   - [ ] Translation QA boundary
         Define how translated UI, mobile layouts, export PDFs/Race Packs, share pages, and legal pages are reviewed so longer translated strings do not break core workflows.
 
-- [ ] Share version history (`Account-backed`)
-      Let owners update published shares while keeping clear version history, current-version state, and rollback options for account-backed projects.
-  - [ ] Published version data model
-        Store each deliberate publish/update as an immutable published-version record linked to the account-backed share and project, while keeping the existing share token as the stable public address.
-  - [ ] Owner publish/update flow
-        Make updating an already-published share an explicit action that creates a new version and shows the current published timestamp plus unpublished editor changes.
-  - [ ] Version review and restore
-        Let owners inspect recent versions with timestamp, gallery metadata, field size, and obstacle count, then restore a previous snapshot by publishing it as a new latest version.
-  - [ ] Dashboard lifecycle visibility
-        Surface current version, latest update time, version count, gallery state, and embed availability in the dashboard share lifecycle inspector.
-
-- [ ] Gallery featured collections (`Account-backed`)
-      Let admins curate small gallery collections such as indoor practice, beginner friendly, technical layouts, and race-day examples without adding social feeds or voting.
-  - [ ] Collection management
-        Add dashboard controls for creating, ordering, and publishing curated gallery collections.
-  - [ ] Public collection sections
-        Surface curated collections on `/gallery` while keeping individual gallery cards pointed at `/share/[token]`.
-
-- [ ] Dashboard operator tooling (`Account-backed`)
-      Improve dashboard visibility for public gallery tracks, published shares, contextual diagnostics, and API usage without turning TrackDraw into a social platform or broad support console.
-  - [ ] Gallery collections management
-        Add dashboard controls for creating, ordering, publishing, and assigning curated gallery collections.
-  - [ ] Public track quality review
-        Give moderators a review list with preview, title, description, field size, obstacle count, public indexing status, owner context, and feature/hide/restore/open actions.
-  - [ ] Share lifecycle inspector
-        Show share owner, project, token state, expiry/revocation, gallery listing, embed availability, and latest publish/update metadata in one operator view.
-  - [ ] Contextual account/project diagnostics
-        Add inspect affordances inside existing Users, Gallery, Share, API, and Audit surfaces instead of a standalone diagnostics page.
-    - [x] Gallery/share inspect drawer
-          Started with a read-only Inspect action on dashboard gallery rows that shows owner, share token, share lifecycle, gallery state, description, share title, field size, element count, preview media state, publish/update dates, and copy/open share actions.
-    - [ ] User context panel
-          Show role, created/updated dates, account-backed project count, active share count, gallery entry count, API key count, and recent account audit events from the Users table.
-    - [ ] Project context panel
-          Show project owner, title, updated timestamp, active share state, gallery state, API project ID, overlay readiness, field size, obstacle count, route presence, and timing-marker readiness.
-    - [ ] Entity timeline links
-          Link users, gallery entries, share tokens, projects, and API keys into filtered audit context when audit events already exist.
-    - [ ] Diagnostics boundary
-          Keep diagnostics contextual and read-focused: no standalone diagnostics page, project impersonation, private project editing, API key secrets, local-only browser projects, raw project JSON, or account takeover/session controls in the first slice.
-  - [ ] API usage dashboard
-        Show API key activity, last-used timestamps, rate-limit hits, endpoint error patterns, and overlay readiness/API usage signals for account projects.
-
 ## Later Product Follow-up
+
+- [ ] Velocidrone experimental export stabilization (`Lower priority`, `No account required`)
+      Keep this parked until there is appetite to validate more real layouts and tighten prefab mapping/orientation edge cases.
+
+- [ ] Share version history (`Lower priority`, `Account-backed`)
+      Let owners update published shares with clear version history, current-version state, and rollback options once share lifecycle work becomes a priority again.
+
+- [ ] Gallery featured collections (`Lower priority`, `Account-backed`)
+      Let admins curate small gallery collections such as indoor practice, beginner friendly, technical layouts, and race-day examples when gallery growth warrants it.
+
+- [ ] Dashboard operator tooling (`Lower priority`, `Account-backed`)
+      Improve dashboard visibility for public gallery tracks, published shares, contextual diagnostics, and API usage after higher-priority editor and catalog work settles.
 
 - [ ] Race-day communication and briefing (`No account required`)
       The first Race Pack release is shipped, and the immediate QR/timing-marker slice is archived with v1.6.0. The remaining work here is larger race-day operations follow-up.

--- a/src/components/editor/DesktopInspectorPanel.tsx
+++ b/src/components/editor/DesktopInspectorPanel.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { PanelRightClose, PanelRightOpen } from "lucide-react";
+import type { InspectorProps } from "@/components/inspector/Inspector";
+import { usePersistentBoolean } from "@/hooks/usePersistentBoolean";
+import { cn } from "@/lib/utils";
+
+const Inspector = dynamic<InspectorProps>(
+  () => import("@/components/inspector/Inspector"),
+  { ssr: false }
+);
+
+const INSPECTOR_COLLAPSED_STORAGE_KEY = "trackdraw.inspectorCollapsed";
+
+export function DesktopInspectorPanel({
+  onResumeSelectedPath,
+}: {
+  onResumeSelectedPath?: (shapeId: string) => void;
+}) {
+  const [collapsed, setCollapsed] = usePersistentBoolean(
+    INSPECTOR_COLLAPSED_STORAGE_KEY
+  );
+
+  return (
+    <aside
+      aria-label="Inspector"
+      className={cn(
+        "border-border/80 bg-card/95 hidden min-h-0 shrink-0 flex-col overflow-hidden border-l backdrop-blur transition-[width] duration-200 ease-out lg:flex",
+        collapsed ? "w-12" : "w-85"
+      )}
+    >
+      {collapsed ? (
+        <>
+          <div className="border-border/60 flex h-11 shrink-0 items-center justify-center border-b px-2">
+            <button
+              type="button"
+              aria-controls="desktop-inspector-panel"
+              aria-expanded={false}
+              aria-label="Expand inspector"
+              title="Expand inspector"
+              onClick={() => setCollapsed(false)}
+              className="text-muted-foreground hover:bg-muted hover:text-foreground inline-flex size-8 items-center justify-center rounded-md transition-colors"
+            >
+              <PanelRightOpen className="size-4" />
+            </button>
+          </div>
+          <div className="flex min-h-0 flex-1 items-start justify-center overflow-hidden px-2 py-4">
+            <span className="text-muted-foreground font-mono text-[10px] tracking-[0.18em] uppercase [writing-mode:vertical-rl]">
+              Inspector
+            </span>
+          </div>
+        </>
+      ) : (
+        <div
+          id="desktop-inspector-panel"
+          className="min-h-0 flex-1 overflow-hidden"
+        >
+          <Inspector
+            headerAction={
+              <button
+                type="button"
+                aria-controls="desktop-inspector-panel"
+                aria-expanded
+                aria-label="Collapse inspector"
+                title="Collapse inspector"
+                onClick={() => setCollapsed(true)}
+                className="text-muted-foreground hover:bg-muted hover:text-foreground inline-flex size-8 items-center justify-center rounded-md transition-colors"
+              >
+                <PanelRightClose className="size-4" />
+              </button>
+            }
+            onResumeSelectedPath={onResumeSelectedPath}
+          />
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/components/editor/DesktopInspectorPanel.tsx
+++ b/src/components/editor/DesktopInspectorPanel.tsx
@@ -24,6 +24,7 @@ export function DesktopInspectorPanel({
 
   return (
     <aside
+      id="desktop-inspector-panel"
       aria-label="Inspector"
       className={cn(
         "border-border/80 bg-card/95 hidden min-h-0 shrink-0 flex-col overflow-hidden border-l backdrop-blur transition-[width] duration-200 ease-out lg:flex",
@@ -52,10 +53,7 @@ export function DesktopInspectorPanel({
           </div>
         </>
       ) : (
-        <div
-          id="desktop-inspector-panel"
-          className="min-h-0 flex-1 overflow-hidden"
-        >
+        <div className="min-h-0 flex-1 overflow-hidden">
           <Inspector
             headerAction={
               <button

--- a/src/components/editor/EditorDialogsHost.tsx
+++ b/src/components/editor/EditorDialogsHost.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { RefObject } from "react";
+import type {
+  TrackCanvasHandle,
+} from "@/components/canvas/editor/TrackCanvas";
+import type {
+  TrackPreview3DHandle,
+} from "@/components/canvas/editor/TrackPreview3D";
+import type { ExportDialogProps } from "@/components/dialogs/ExportDialog";
+import type { ProjectMeta, RestorePointMeta } from "@/lib/projects";
+import type { EditorView } from "@/lib/view";
+import type {
+  AccountShareItem,
+  ProjectSyncMeta,
+  ProjectVersionConflict,
+} from "./useAccountProjectSync";
+import type { AuthUser } from "@/lib/auth-client";
+
+const ShareDialog = dynamic(() => import("@/components/dialogs/ShareDialog"), {
+  ssr: false,
+});
+
+const ImportDialog = dynamic(
+  () => import("@/components/dialogs/ImportDialog"),
+  { ssr: false }
+);
+
+const ExportDialog = dynamic<ExportDialogProps>(
+  () => import("@/components/dialogs/ExportDialog"),
+  { ssr: false }
+);
+
+const KeyboardShortcutsDialog = dynamic(
+  () => import("@/components/dialogs/KeyboardShortcutsDialog"),
+  { ssr: false }
+);
+
+const CompleteProfileDialog = dynamic(
+  () => import("@/components/dialogs/CompleteProfileDialog"),
+  { ssr: false }
+);
+
+const ProjectVersionConflictDialog = dynamic(
+  () => import("@/components/dialogs/ProjectVersionConflictDialog"),
+  { ssr: false }
+);
+
+const ProjectManagerDialog = dynamic(
+  () => import("@/components/dialogs/ProjectManager"),
+  { ssr: false }
+);
+
+const NewProjectDialog = dynamic(
+  () => import("@/components/dialogs/NewProjectDialog"),
+  { ssr: false }
+);
+
+const LayoutPresetPicker = dynamic(
+  () =>
+    import("@/components/editor/LayoutPresetPicker").then((mod) => ({
+      default: mod.LayoutPresetPicker,
+    })),
+  { ssr: false }
+);
+
+export interface EditorDialogsHostProps {
+  isMobile: boolean;
+  activeDesignId: string;
+
+  // Share
+  shareOpen: boolean;
+  onShareOpenChange: (open: boolean) => void;
+  hasPath: boolean;
+  shareProjectId: string | null;
+  existingShareMode: boolean;
+  onRefreshAccountShares: (force: boolean) => void;
+  onShareExportJson: () => void;
+
+  // Import
+  importOpen: boolean;
+  onImportOpenChange: (open: boolean) => void;
+  onImportBeforeConfirm: () => void;
+  onImportBackupCurrent: () => void;
+
+  // Export
+  exportOpen: boolean;
+  onExportOpenChange: (open: boolean) => void;
+  canvasRef: RefObject<TrackCanvasHandle | null>;
+  preview3DRef: RefObject<TrackPreview3DHandle | null>;
+  activeTab: EditorView;
+  exportProjectId: string | null;
+  onExportRequest3DView: () => void;
+
+  // Shortcuts
+  shortcutsOpen: boolean;
+  onShortcutsOpenChange: (open: boolean) => void;
+
+  // New project
+  newProjectOpen: boolean;
+  onNewProjectOpenChange: (open: boolean) => void;
+  newProjectHasContent: boolean;
+  onNewProject: () => void;
+  onNewProjectBackup: () => void;
+  onNewProjectStarterLayout: (layoutId: string) => void;
+
+  // Project manager
+  projectManagerOpen: boolean;
+  onProjectManagerOpenChange: (open: boolean) => void;
+  onProjectManagerOpenNewProject: () => void;
+  onOpenProject?: (id: string) => void;
+  onOpenAccountProject?: (id: string) => void;
+  onSyncProject?: (id: string) => void;
+  onDeleteProject?: (id: string) => void;
+  onDeleteProjects?: (ids: string[]) => void;
+  onRenameProject?: (id: string, title: string) => void;
+  onExportProject?: (id: string) => void;
+  onRestorePoint?: (id: string) => void;
+  onDeleteRestorePoint?: (id: string) => void;
+  onRevokeShare?: (token: string) => void;
+  projects?: ProjectMeta[];
+  accountProjects?: Array<{
+    id: string;
+    title: string;
+    updatedAt: string;
+    shapeCount: number;
+  }>;
+  accountProjectsLoading?: boolean;
+  accountProjectsError?: string | null;
+  accountShares?: AccountShareItem[];
+  accountSharesLoading?: boolean;
+  projectSyncMetaById?: Record<string, ProjectSyncMeta>;
+  syncingProjectId?: string | null;
+  restorePoints?: RestorePointMeta[];
+  activeRestorePointId?: string;
+
+  // Preset picker
+  presetPickerOpen: boolean;
+  onPresetPickerOpenChange: (open: boolean) => void;
+  activePresetId: string | null;
+  onSelectPreset: (id: string) => void;
+
+  // Complete profile
+  completeProfileOpen: boolean;
+  onCompleteProfileOpenChange: (open: boolean) => void;
+  authUser: AuthUser | null;
+  onCompleteProfileSave: (name: string) => Promise<void>;
+
+  // Version conflict
+  projectVersionConflict: ProjectVersionConflict | null;
+  onOpenCloudConflictVersion: () => void;
+  onKeepLocalConflictCopy: () => void;
+}
+
+export function EditorDialogsHost({
+  isMobile,
+  activeDesignId,
+
+  shareOpen,
+  onShareOpenChange,
+  hasPath,
+  shareProjectId,
+  existingShareMode,
+  onRefreshAccountShares,
+  onShareExportJson,
+
+  importOpen,
+  onImportOpenChange,
+  onImportBeforeConfirm,
+  onImportBackupCurrent,
+
+  exportOpen,
+  onExportOpenChange,
+  canvasRef,
+  preview3DRef,
+  activeTab,
+  exportProjectId,
+  onExportRequest3DView,
+
+  shortcutsOpen,
+  onShortcutsOpenChange,
+
+  newProjectOpen,
+  onNewProjectOpenChange,
+  newProjectHasContent,
+  onNewProject,
+  onNewProjectBackup,
+  onNewProjectStarterLayout,
+
+  projectManagerOpen,
+  onProjectManagerOpenChange,
+  onProjectManagerOpenNewProject,
+  onOpenProject,
+  onOpenAccountProject,
+  onSyncProject,
+  onDeleteProject,
+  onDeleteProjects,
+  onRenameProject,
+  onExportProject,
+  onRestorePoint,
+  onDeleteRestorePoint,
+  onRevokeShare,
+  projects,
+  accountProjects,
+  accountProjectsLoading,
+  accountProjectsError,
+  accountShares,
+  accountSharesLoading,
+  projectSyncMetaById,
+  syncingProjectId,
+  restorePoints,
+  activeRestorePointId,
+
+  presetPickerOpen,
+  onPresetPickerOpenChange,
+  activePresetId,
+  onSelectPreset,
+
+  completeProfileOpen,
+  onCompleteProfileOpenChange,
+  authUser,
+  onCompleteProfileSave,
+
+  projectVersionConflict,
+  onOpenCloudConflictVersion,
+  onKeepLocalConflictCopy,
+}: EditorDialogsHostProps) {
+  return (
+    <>
+      {shareOpen ? (
+        <ShareDialog
+          open={shareOpen}
+          onOpenChange={onShareOpenChange}
+          hasPath={hasPath}
+          projectId={shareProjectId}
+          onSharePublished={() => void onRefreshAccountShares(true)}
+          existingShareMode={existingShareMode}
+          onExportJson={onShareExportJson}
+        />
+      ) : null}
+
+      {importOpen ? (
+        <ImportDialog
+          open={importOpen}
+          onOpenChange={onImportOpenChange}
+          onBeforeConfirm={onImportBeforeConfirm}
+          onBackupCurrent={onImportBackupCurrent}
+        />
+      ) : null}
+
+      {exportOpen ? (
+        <ExportDialog
+          open={exportOpen}
+          onOpenChange={onExportOpenChange}
+          canvasRef={canvasRef}
+          preview3DRef={preview3DRef}
+          activeTab={activeTab}
+          onRequest3DView={onExportRequest3DView}
+          projectId={exportProjectId}
+        />
+      ) : null}
+
+      {shortcutsOpen ? (
+        <KeyboardShortcutsDialog
+          open={shortcutsOpen}
+          onOpenChange={onShortcutsOpenChange}
+        />
+      ) : null}
+
+      {newProjectOpen ? (
+        <NewProjectDialog
+          open={newProjectOpen}
+          onOpenChange={onNewProjectOpenChange}
+          hasContent={newProjectHasContent}
+          onNewProject={onNewProject}
+          onBackupProject={onNewProjectBackup}
+          onStartStarterLayout={onNewProjectStarterLayout}
+        />
+      ) : null}
+
+      {projectManagerOpen ? (
+        <ProjectManagerDialog
+          open={projectManagerOpen}
+          onOpenChange={onProjectManagerOpenChange}
+          onOpenNewProject={onProjectManagerOpenNewProject}
+          onOpenProject={onOpenProject}
+          onOpenAccountProject={onOpenAccountProject}
+          onSyncProject={onSyncProject}
+          onDeleteProject={onDeleteProject}
+          onDeleteProjects={onDeleteProjects}
+          onRenameProject={onRenameProject}
+          onExportProject={onExportProject}
+          onRestorePoint={onRestorePoint}
+          onDeleteRestorePoint={onDeleteRestorePoint}
+          projects={projects}
+          accountProjects={accountProjects}
+          accountProjectsLoading={accountProjectsLoading}
+          accountProjectsError={accountProjectsError}
+          accountShares={accountShares}
+          accountSharesLoading={accountSharesLoading}
+          onRevokeShare={onRevokeShare}
+          projectSyncMetaById={projectSyncMetaById}
+          syncingProjectId={syncingProjectId}
+          restorePoints={restorePoints}
+          activeDesignId={activeDesignId}
+          activeRestorePointId={activeRestorePointId}
+          onResolveConflict={() => onProjectManagerOpenChange(false)}
+        />
+      ) : null}
+
+      {presetPickerOpen ? (
+        <LayoutPresetPicker
+          mobile={isMobile}
+          open={presetPickerOpen}
+          onOpenChange={onPresetPickerOpenChange}
+          selectedPresetId={activePresetId}
+          onSelectPreset={onSelectPreset}
+        />
+      ) : null}
+
+      {completeProfileOpen ? (
+        <CompleteProfileDialog
+          open={completeProfileOpen}
+          onOpenChange={onCompleteProfileOpenChange}
+          email={authUser?.email ?? null}
+          currentName={authUser?.name ?? ""}
+          onSave={onCompleteProfileSave}
+        />
+      ) : null}
+
+      {projectVersionConflict ? (
+        <ProjectVersionConflictDialog
+          open={Boolean(projectVersionConflict)}
+          mobile={isMobile}
+          title={projectVersionConflict.title ?? "Untitled"}
+          localUpdatedAt={projectVersionConflict.localUpdatedAt}
+          cloudUpdatedAt={projectVersionConflict.cloudUpdatedAt}
+          onOpenCloudVersion={onOpenCloudConflictVersion}
+          onKeepLocalCopy={onKeepLocalConflictCopy}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/src/components/editor/EditorDialogsHost.tsx
+++ b/src/components/editor/EditorDialogsHost.tsx
@@ -2,12 +2,8 @@
 
 import dynamic from "next/dynamic";
 import type { RefObject } from "react";
-import type {
-  TrackCanvasHandle,
-} from "@/components/canvas/editor/TrackCanvas";
-import type {
-  TrackPreview3DHandle,
-} from "@/components/canvas/editor/TrackPreview3D";
+import type { TrackCanvasHandle } from "@/components/canvas/editor/TrackCanvas";
+import type { TrackPreview3DHandle } from "@/components/canvas/editor/TrackPreview3D";
 import type { ExportDialogProps } from "@/components/dialogs/ExportDialog";
 import type { ProjectMeta, RestorePointMeta } from "@/lib/projects";
 import type { EditorView } from "@/lib/view";

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -7,26 +7,19 @@ import {
   useEffect,
   useRef,
   useState,
-  type ForwardRefExoticComponent,
-  type RefAttributes,
 } from "react";
-import StatusBar from "./StatusBar";
-import { ContextOverlayCard } from "./ContextOverlayCard";
 import { useAccountProjectSync } from "./useAccountProjectSync";
 import { useEditorDialogs } from "./useEditorDialogs";
 import { useManualProjectSave } from "./useManualProjectSave";
 import { useStarterExperience } from "./useStarterExperience";
-import { DesktopInspectorPanel } from "./DesktopInspectorPanel";
-import { Button } from "@/components/ui/button";
-import { MobileDrawer } from "@/components/MobileDrawer";
+import { EditorWorkspace } from "./EditorWorkspace";
+import { EditorStarterOverlay } from "./EditorStarterOverlay";
+import { EditorDialogsHost } from "./EditorDialogsHost";
 import type {
   TrackCanvasHandle,
-  TrackCanvasProps,
 } from "@/components/canvas/editor/TrackCanvas";
-import type { ExportDialogProps } from "@/components/dialogs/ExportDialog";
 import type {
   TrackPreview3DHandle,
-  TrackPreview3DProps,
 } from "@/components/canvas/editor/TrackPreview3D";
 import { getEditorShellSelectionState } from "@/lib/editor/shell-view-model";
 import { createDefaultDesign, serializeDesign } from "@/lib/track/design";
@@ -36,10 +29,11 @@ import { downloadJsonFile } from "@/lib/export/download-json";
 import { getLayoutPresetById } from "@/lib/planning/layout-presets";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
-import { useDeveloperMode } from "@/hooks/useDeveloperMode";
+import { useDeveloperMode, useDeveloperModeShortcut } from "@/hooks/useDeveloperMode";
 import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { useEditorProjects } from "@/hooks/useEditorProjects";
+import { useCompleteProfile } from "@/hooks/useCompleteProfile";
 import { usePersistentBoolean } from "@/hooks/usePersistentBoolean";
 import type { EditorView } from "@/lib/view";
 import {
@@ -55,47 +49,16 @@ import {
   selectShapeRecordMap,
 } from "@/store/selectors";
 import { authClient } from "@/lib/auth-client";
-import { Box, Route, X } from "lucide-react";
 import { toast } from "sonner";
 import {
   hasLockedSelection,
   showLockedSelectionActionBlockedToast,
 } from "@/components/canvas/editor/useTrackCanvasShortcuts";
 
-function createFirstUseBlankDesign() {
-  const design = createDefaultDesign();
-  return {
-    ...design,
-    title: "",
-    description: "",
-  };
-}
-
-const TrackPreview3D = dynamic<TrackPreview3DProps>(
-  () => import("@/components/canvas/editor/TrackPreview3D"),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="text-muted-foreground/40 flex h-full items-center justify-center text-xs">
-        Loading 3D…
-      </div>
-    ),
-  }
-) as ForwardRefExoticComponent<
-  TrackPreview3DProps & RefAttributes<TrackPreview3DHandle>
->;
-
-const Toolbar = dynamic(() => import("./Toolbar"), {
-  ssr: false,
-});
-
-const Header = dynamic(() => import("./Header"), {
-  ssr: false,
-});
-
-const SharedHeader = dynamic(() => import("./shared/Header"), {
-  ssr: false,
-});
+const Header = dynamic(() => import("./Header"), { ssr: false });
+const SharedHeader = dynamic(() => import("./shared/Header"), { ssr: false });
+const Toolbar = dynamic(() => import("./Toolbar"), { ssr: false });
+const PerformanceHud = dynamic(() => import("./PerformanceHud"), { ssr: false });
 
 const EditorMobilePanels = dynamic(
   () =>
@@ -110,83 +73,16 @@ const SharedMobilePanels = dynamic(
   { ssr: false }
 );
 
-const LayoutPresetPicker = dynamic(
-  () =>
-    import("@/components/editor/LayoutPresetPicker").then((mod) => ({
-      default: mod.LayoutPresetPicker,
-    })),
-  { ssr: false }
-);
-
-const PerformanceHud = dynamic(() => import("./PerformanceHud"), {
-  ssr: false,
-});
-
-const StarterSteps = dynamic(
-  () =>
-    import("@/components/editor/StarterFlow").then((mod) => ({
-      default: mod.StarterSteps,
-    })),
-  { ssr: false }
-);
-
-const StarterActions = dynamic(
-  () =>
-    import("@/components/editor/StarterFlow").then((mod) => ({
-      default: mod.StarterActions,
-    })),
-  { ssr: false }
-);
-
-const TrackCanvas = dynamic<TrackCanvasProps>(
-  () => import("@/components/canvas/editor/TrackCanvas"),
-  { ssr: false }
-) as ForwardRefExoticComponent<
-  TrackCanvasProps & RefAttributes<TrackCanvasHandle>
->;
-
-const ExportDialog = dynamic<ExportDialogProps>(
-  () => import("@/components/dialogs/ExportDialog"),
-  { ssr: false }
-);
-
-const ShareDialog = dynamic(() => import("@/components/dialogs/ShareDialog"), {
-  ssr: false,
-});
-
-const ImportDialog = dynamic(
-  () => import("@/components/dialogs/ImportDialog"),
-  {
-    ssr: false,
-  }
-);
-
-const KeyboardShortcutsDialog = dynamic(
-  () => import("@/components/dialogs/KeyboardShortcutsDialog"),
-  { ssr: false }
-);
-
-const CompleteProfileDialog = dynamic(
-  () => import("@/components/dialogs/CompleteProfileDialog"),
-  { ssr: false }
-);
-
-const ProjectVersionConflictDialog = dynamic(
-  () => import("@/components/dialogs/ProjectVersionConflictDialog"),
-  { ssr: false }
-);
-
-const ProjectManagerDialog = dynamic(
-  () => import("@/components/dialogs/ProjectManager"),
-  { ssr: false }
-);
-
-const NewProjectDialog = dynamic(
-  () => import("@/components/dialogs/NewProjectDialog"),
-  { ssr: false }
-);
-
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "trackdraw.sidebarCollapsed";
+
+function createFirstUseBlankDesign() {
+  const design = createDefaultDesign();
+  return {
+    ...design,
+    title: "",
+    description: "",
+  };
+}
 
 export default function EditorShell({
   readOnly = false,
@@ -202,9 +98,10 @@ export default function EditorShell({
   existingShareMode?: boolean;
 }) {
   usePerfMetric("render:EditorShell");
+  useDeveloperModeShortcut();
+
   const { undo, redo, canUndo, canRedo } = useUndoRedo();
-  const { enabled: developerModeEnabled, toggle: toggleDeveloperMode } =
-    useDeveloperMode();
+  const { enabled: developerModeEnabled } = useDeveloperMode();
   const { unitSystem } = useMeasurementUnitSystem();
   const selection = useEditor((state) => state.session.selection);
   const design = useEditor((state) => state.track.design);
@@ -273,7 +170,7 @@ export default function EditorShell({
   const searchParams = useSearchParams();
   const canvasRef = useRef<TrackCanvasHandle>(null);
   const preview3DRef = useRef<TrackPreview3DHandle>(null);
-  const [tab, setTab] = useState<"2d" | "3d">(initialTab);
+  const [tab, setTab] = useState<EditorView>(initialTab);
   const [hasVisited3D, setHasVisited3D] = useState(initialTab === "3d");
   const [cursorPos, setCursorPos] = useState<{ x: number; y: number } | null>(
     null
@@ -300,11 +197,9 @@ export default function EditorShell({
   const [sidebarCollapsed, setSidebarCollapsed] = usePersistentBoolean(
     SIDEBAR_COLLAPSED_STORAGE_KEY
   );
-  const [completeProfileOpen, setCompleteProfileOpen] = useState(false);
-  const [completeProfileDismissed, setCompleteProfileDismissed] =
-    useState(false);
   const [pendingFlyThroughStart, setPendingFlyThroughStart] = useState(false);
   const [mobileFlyModeActive, setMobileFlyModeActive] = useState(false);
+
   const {
     shareOpen,
     setShareOpen,
@@ -369,39 +264,6 @@ export default function EditorShell({
     setTab(initialTab);
   }, [initialTab]);
 
-  useEffect(() => {
-    if (readOnly || !authUser?.id) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setCompleteProfileOpen(false);
-      setCompleteProfileDismissed(false);
-      return;
-    }
-
-    if (authUser.name?.trim()) {
-      setCompleteProfileOpen(false);
-      setCompleteProfileDismissed(false);
-      return;
-    }
-
-    if (!completeProfileDismissed) {
-      setCompleteProfileOpen(true);
-    }
-  }, [authUser?.id, authUser?.name, completeProfileDismissed, readOnly]);
-
-  const handleCompleteProfileOpenChange = useCallback(
-    (open: boolean) => {
-      setCompleteProfileOpen(open);
-      if (!open && authUser && !authUser.name?.trim()) {
-        setCompleteProfileDismissed(true);
-      }
-    },
-    [authUser]
-  );
-
-  const handleCompleteProfileSave = useCallback(async (name: string) => {
-    await authClient.updateProfileName(name);
-    setCompleteProfileDismissed(false);
-  }, []);
   const {
     accountProjects,
     accountProjectsLoading,
@@ -436,6 +298,7 @@ export default function EditorShell({
     setActiveRestorePointId,
     setSaveStatusLabel,
   });
+
   const currentProjectSyncMeta = projectSyncMetaById[design.id];
   const { handleManualSave } = useManualProjectSave({
     readOnly,
@@ -447,6 +310,12 @@ export default function EditorShell({
     markProjectSyncFailed,
     setSaveStatusLabel,
   });
+
+  const {
+    completeProfileOpen,
+    handleCompleteProfileOpenChange,
+    handleCompleteProfileSave,
+  } = useCompleteProfile({ readOnly, authUser });
 
   const handleOpenAccountProjectFromDialog = useCallback(
     async (projectId: string) => {
@@ -562,28 +431,6 @@ export default function EditorShell({
     }
   }, [tab]);
 
-  useEffect(() => {
-    if (process.env.NODE_ENV === "production") return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || !event.shiftKey) return;
-      if (event.key !== ".") return;
-
-      const target = event.target as HTMLElement | null;
-      const isInput =
-        target?.tagName === "INPUT" ||
-        target?.tagName === "TEXTAREA" ||
-        target?.isContentEditable;
-      if (isInput) return;
-
-      event.preventDefault();
-      toggleDeveloperMode();
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [toggleDeveloperMode]);
-
   const handleMobileMultiSelectStart = useCallback(
     (shapeId: string) => {
       setMobileMultiSelectEnabled(true);
@@ -622,6 +469,36 @@ export default function EditorShell({
     [setActivePresetId, setActiveTool, setPresetPickerOpen, setSelection]
   );
 
+  const handleExportProject = useCallback(
+    (projectId: string) => {
+      try {
+        const exportDesign =
+          projectId === design.id ? design : loadProject(projectId);
+        if (!exportDesign) {
+          toast.error("Export failed", {
+            description:
+              "TrackDraw could not load this local project. Open it first or choose another saved project.",
+          });
+          return;
+        }
+
+        const serialized = serializeDesign(exportDesign);
+        const baseName = (exportDesign.title.trim() || "track").replace(
+          /[^a-z0-9-_]+/gi,
+          "_"
+        );
+
+        downloadJsonFile(`${baseName}.json`, serialized);
+        toast.success("Project JSON exported");
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Export failed";
+        toast.error("Export failed", { description: message });
+      }
+    },
+    [design]
+  );
+
   return (
     <>
       <div className="bg-background text-foreground relative flex h-dvh overflow-hidden">
@@ -638,7 +515,6 @@ export default function EditorShell({
 
         {/* ── Main column ────────────────────────────────────── */}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          {/* Header */}
           {readOnly ? (
             <SharedHeader
               tab={tab}
@@ -687,252 +563,66 @@ export default function EditorShell({
             />
           )}
 
-          {/* ── Body ─────────────────────────────────────────── */}
-          <div className="relative flex min-h-0 flex-1 overflow-hidden">
-            {/* Canvas area */}
-            <div className="flex min-h-0 flex-1 flex-col">
-              <div className="bg-canvas relative min-h-0 flex-1 overflow-hidden">
-                {/* 2D: always mounted so export always works; hidden visually when not active */}
-                <div
-                  className="absolute inset-0"
-                  style={{
-                    visibility: tab === "2d" ? "visible" : "hidden",
-                    pointerEvents: tab === "2d" ? "auto" : "none",
-                  }}
-                >
-                  <TrackCanvas
-                    ref={canvasRef}
-                    onCursorChange={setCursorPos}
-                    onDraftPathStateChange={setMobileDraftPathState}
-                    onSnapChange={setSnapActive}
-                    onMobileMultiSelectStart={handleMobileMultiSelectStart}
-                    mobileRulersEnabled={mobileRulersEnabled}
-                    mobileMultiSelectEnabled={mobileMultiSelectEnabled}
-                    readOnly={readOnly}
-                    showObstacleNumbers={showObstacleNumbers}
-                  />
-                </div>
-                {hasVisited3D ? (
-                  <div
-                    className="absolute inset-0"
-                    style={{ display: tab === "3d" ? "block" : "none" }}
-                  >
-                    <TrackPreview3D
-                      ref={preview3DRef}
-                      showGizmo={mobileGizmoEnabled}
-                      onFlyModeChange={setMobileFlyModeActive}
-                      readOnly={readOnly}
-                    />
-                  </div>
-                ) : null}
-                {shouldShowStarter && isMobile ? (
-                  <MobileDrawer
-                    open={shouldShowStarter}
-                    onOpenChange={(open) => {
-                      if (!open) setStarterDismissed(true);
-                    }}
-                    title="Welcome to TrackDraw"
-                    subtitle="Place a few gates, draw the route, check 3D, then share when the track is ready."
-                    contentClassName="max-h-[96dvh]"
-                    bodyClassName="space-y-5 pt-3 pb-4"
-                  >
-                    <StarterSteps mobile />
-                    <StarterActions
-                      mobile
-                      onPath={() => applyStarterDesign("gate")}
-                      onBlank={() => applyStarterDesign("blank")}
-                      onStarterLayout={applyStarterLayout}
-                    />
-                  </MobileDrawer>
-                ) : null}
-                {shouldShowStarter && !isMobile ? (
-                  <div className="absolute inset-0 z-20 hidden items-center justify-center bg-slate-950/10 px-5 backdrop-blur-sm lg:flex">
-                    <div className="border-border/50 bg-card/97 pointer-events-auto w-full max-w-xl rounded-4xl border px-8 py-8 shadow-[0_24px_80px_rgba(15,23,42,0.10)] backdrop-blur">
-                      <div className="relative">
-                        <div className="pr-10">
-                          <p className="text-muted-foreground text-[11px] font-medium tracking-[0.12em] uppercase">
-                            Studio
-                          </p>
-                          <p className="text-foreground mt-2 text-[1.25rem] font-semibold tracking-[-0.02em]">
-                            Welcome to TrackDraw
-                          </p>
-                          <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-                            Design the layout in 2D, review elevation in 3D, and
-                            share a read-only link when the track is ready.
-                          </p>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => setStarterDismissed(true)}
-                          className="text-muted-foreground/75 hover:text-foreground hover:bg-muted absolute top-0 right-0 cursor-pointer rounded-full p-1.5 transition-colors"
-                          aria-label="Dismiss starter dialog"
-                        >
-                          <X className="size-4" />
-                        </button>
-                      </div>
-
-                      <div className="mt-6">
-                        <StarterSteps />
-                        <StarterActions
-                          onPath={() => applyStarterDesign("gate")}
-                          onBlank={() => applyStarterDesign("blank")}
-                          onStarterLayout={applyStarterLayout}
-                        />
-                      </div>
-                    </div>
-                  </div>
-                ) : null}
-                {!readOnly &&
-                starterMode === "guided" &&
-                tab === "2d" &&
-                designShapes.length === 0 &&
-                activeTool === "gate" &&
-                !gateHintDismissed ? (
-                  <div className="pointer-events-none absolute inset-x-0 top-4 z-20 flex justify-center px-4 lg:justify-start lg:px-0">
-                    <div className="max-w-sm lg:absolute lg:top-0 lg:left-4">
-                      <ContextOverlayCard
-                        icon={<Box className="size-4" />}
-                        title="Place your first gate"
-                        badge="Guided"
-                        description="Tap or click on the canvas to drop the first gate. Add a few gates before switching to Path."
-                        action={
-                          <Button size="sm" onClick={dismissGateHint}>
-                            Got it
-                          </Button>
-                        }
-                        dismissLabel="Dismiss gate placement hint"
-                        onDismiss={dismissGateHint}
-                      />
-                    </div>
-                  </div>
-                ) : null}
-                {!readOnly &&
-                starterMode === "guided" &&
-                tab === "2d" &&
-                !shouldShowStarter &&
-                designShapes.length > 0 &&
-                !hasPath &&
-                !desktopPathHintDismissed ? (
-                  <div className="pointer-events-none absolute inset-x-0 top-4 z-20 flex justify-center px-4 lg:justify-start lg:px-0">
-                    <div className="max-w-sm lg:absolute lg:top-0 lg:left-4">
-                      <ContextOverlayCard
-                        icon={<Route className="size-4" />}
-                        title="Next, draw the route"
-                        badge="Guided"
-                        description="Place a few gates first, then switch to Path and trace the lap through them. Finish the route before checking 3D."
-                        action={
-                          <Button
-                            size="sm"
-                            onClick={() => setActiveTool("polyline")}
-                          >
-                            Start path
-                          </Button>
-                        }
-                        dismissLabel="Dismiss path onboarding hint"
-                        onDismiss={dismissDesktopPathHint}
-                      />
-                    </div>
-                  </div>
-                ) : null}
-                {!readOnly &&
-                starterMode === "guided" &&
-                tab === "3d" &&
-                !hasPath &&
-                !desktopPreviewHintDismissed ? (
-                  <div className="pointer-events-none absolute inset-x-0 top-4 z-20 flex justify-center px-4 lg:justify-start lg:px-0">
-                    <div className="max-w-sm lg:absolute lg:top-0 lg:left-4">
-                      <ContextOverlayCard
-                        icon={<Box className="size-4" />}
-                        title="3D works best after the route"
-                        badge="Preview"
-                        description="Obstacle placement already previews here, but the route is what makes elevation and fly-through review useful."
-                        action={
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            onClick={() => {
-                              handleTabChange("2d");
-                              setActiveTool("polyline");
-                            }}
-                          >
-                            Draw path in 2D
-                          </Button>
-                        }
-                        dismissLabel="Dismiss 3D preview onboarding hint"
-                        onDismiss={dismissDesktopPreviewHint}
-                      />
-                    </div>
-                  </div>
-                ) : null}
-                {!readOnly &&
-                starterMode === "guided" &&
-                tab === "3d" &&
-                hasPath &&
-                !review3DHintDismissed ? (
-                  <div className="pointer-events-none absolute inset-x-0 top-4 z-20 flex justify-center px-4 lg:justify-start lg:px-0">
-                    <div className="max-w-sm lg:absolute lg:top-0 lg:left-4">
-                      <ContextOverlayCard
-                        icon={<Box className="size-4" />}
-                        title="Now review it in 3D"
-                        badge="Guided"
-                        description="Orbit around the route, check elevation and spacing, then share or export once the layout feels right."
-                        action={
-                          <Button
-                            size="sm"
-                            onClick={() => {
-                              setShareOpen(true);
-                              dismissReview3DHint();
-                            }}
-                          >
-                            Share or export next
-                          </Button>
-                        }
-                        dismissLabel="Dismiss 3D review hint"
-                        onDismiss={dismissReview3DHint}
-                      />
-                    </div>
-                  </div>
-                ) : null}
-                {!readOnly &&
-                starterMode === "guided" &&
-                tab === "2d" &&
-                showPostPathNudge &&
-                !postPathNudgeDismissed ? (
-                  <div className="pointer-events-none absolute inset-x-0 top-4 z-20 flex justify-center px-4 lg:justify-start lg:px-0">
-                    <div className="max-w-sm lg:absolute lg:top-0 lg:left-4">
-                      <ContextOverlayCard
-                        icon={<Box className="size-4" />}
-                        title="Route ready — check it in 3D"
-                        badge="Next step"
-                        description="Switch to the 3D tab now to review the route before refining more obstacle placement."
-                        action={
-                          <Button
-                            size="sm"
-                            onClick={() => {
-                              handleTabChange("3d");
-                              dismissPostPathNudge();
-                            }}
-                          >
-                            Switch to 3D
-                          </Button>
-                        }
-                        dismissLabel="Dismiss post-path 3D nudge"
-                        onDismiss={dismissPostPathNudge}
-                      />
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-              <StatusBar cursorPos={cursorPos} snapActive={snapActive} />
-            </div>
-
-            {/* Desktop Inspector */}
-            {!readOnly && !isMobile && (
-              <DesktopInspectorPanel
-                onResumeSelectedPath={handleResumeSelectedPath}
+          {/* ── Workspace (canvas + inspector) ───────────────── */}
+          <EditorWorkspace
+            tab={tab}
+            readOnly={readOnly}
+            isMobile={isMobile}
+            canvasRef={canvasRef}
+            preview3DRef={preview3DRef}
+            hasVisited3D={hasVisited3D}
+            mobileRulersEnabled={mobileRulersEnabled}
+            mobileMultiSelectEnabled={mobileMultiSelectEnabled}
+            showObstacleNumbers={showObstacleNumbers}
+            mobileGizmoEnabled={mobileGizmoEnabled}
+            cursorPos={cursorPos}
+            snapActive={snapActive}
+            onCursorChange={setCursorPos}
+            onDraftPathStateChange={setMobileDraftPathState}
+            onSnapChange={setSnapActive}
+            onMobileMultiSelectStart={handleMobileMultiSelectStart}
+            onFlyModeChange={setMobileFlyModeActive}
+            onResumeSelectedPath={handleResumeSelectedPath}
+            overlay={
+              <EditorStarterOverlay
+                readOnly={readOnly}
+                isMobile={isMobile}
+                shouldShowStarter={shouldShowStarter}
+                onDismissStarter={() => setStarterDismissed(true)}
+                starterMode={starterMode}
+                tab={tab}
+                designShapeCount={designShapes.length}
+                activeTool={activeTool}
+                hasPath={hasPath}
+                gateHintDismissed={gateHintDismissed}
+                onDismissGateHint={dismissGateHint}
+                desktopPathHintDismissed={desktopPathHintDismissed}
+                onDismissDesktopPathHint={dismissDesktopPathHint}
+                desktopPreviewHintDismissed={desktopPreviewHintDismissed}
+                onDismissDesktopPreviewHint={dismissDesktopPreviewHint}
+                review3DHintDismissed={review3DHintDismissed}
+                onDismissReview3DHint={dismissReview3DHint}
+                showPostPathNudge={showPostPathNudge}
+                postPathNudgeDismissed={postPathNudgeDismissed}
+                onDismissPostPathNudge={dismissPostPathNudge}
+                onApplyStarterDesign={applyStarterDesign}
+                onApplyStarterLayout={applyStarterLayout}
+                onStartPathTool={() => setActiveTool("polyline")}
+                onGoTo2DAndStartPath={() => {
+                  handleTabChange("2d");
+                  setActiveTool("polyline");
+                }}
+                onShareAndDismissReview={() => {
+                  setShareOpen(true);
+                  dismissReview3DHint();
+                }}
+                onGoTo3DAndDismissNudge={() => {
+                  handleTabChange("3d");
+                  dismissPostPathNudge();
+                }}
               />
-            )}
-          </div>
+            }
+          />
         </div>
 
         {isMobile && !readOnly ? (
@@ -1168,166 +858,96 @@ export default function EditorShell({
           />
         ) : null}
 
-        {shareOpen ? (
-          <ShareDialog
-            open={shareOpen}
-            onOpenChange={setShareOpen}
-            hasPath={hasPath}
-            projectId={isAccountProject ? design.id : null}
-            onSharePublished={() => void refreshAccountShares(true)}
-            existingShareMode={existingShareMode}
-            onExportJson={() => {
-              setShareOpen(false);
-              setExportOpen(true);
-            }}
-          />
-        ) : null}
-        {importOpen ? (
-          <ImportDialog
-            open={importOpen}
-            onOpenChange={setImportOpen}
-            onBeforeConfirm={() => {
-              snapshotCurrentDesign();
-            }}
-            onBackupCurrent={() => {
-              setImportOpen(false);
-              setExportOpen(true);
-            }}
-          />
-        ) : null}
-        {exportOpen ? (
-          <ExportDialog
-            open={exportOpen}
-            onOpenChange={setExportOpen}
-            canvasRef={canvasRef}
-            preview3DRef={preview3DRef}
-            activeTab={tab}
-            onRequest3DView={() => handleTabChange("3d")}
-            projectId={isAccountProject ? design.id : null}
-          />
-        ) : null}
-        {shortcutsOpen ? (
-          <KeyboardShortcutsDialog
-            open={shortcutsOpen}
-            onOpenChange={setShortcutsOpen}
-          />
-        ) : null}
-        {newProjectOpen ? (
-          <NewProjectDialog
-            open={newProjectOpen}
-            onOpenChange={setNewProjectOpen}
-            hasContent={Boolean(design.title.trim() || designShapes.length)}
-            onNewProject={() => {
-              snapshotCurrentDesign();
-              applyStarterDesign("blank");
-              setNewProjectOpen(false);
-              setMobileToolsOpen(false);
-            }}
-            onBackupProject={() => {
-              setNewProjectOpen(false);
-              setExportOpen(true);
-            }}
-            onStartStarterLayout={(layoutId) => {
-              applyStarterLayout(layoutId);
-              setNewProjectOpen(false);
-            }}
-          />
-        ) : null}
-        {projectManagerOpen ? (
-          <ProjectManagerDialog
-            open={projectManagerOpen}
-            onOpenChange={setProjectManagerOpen}
-            onOpenNewProject={openNewProjectDialog}
-            onOpenProject={handleOpenProject}
-            onOpenAccountProject={
-              authUser && cloudProjectsAvailable
-                ? handleOpenAccountProjectFromDialog
-                : undefined
-            }
-            onSyncProject={
-              authUser && cloudProjectsAvailable ? handleSyncProject : undefined
-            }
-            onDeleteProject={handleDeleteProject}
-            onDeleteProjects={handleDeleteProjects}
-            onRenameProject={handleRenameProject}
-            onExportProject={(projectId) => {
-              try {
-                const exportDesign =
-                  projectId === design.id ? design : loadProject(projectId);
-                if (!exportDesign) {
-                  toast.error("Export failed", {
-                    description:
-                      "TrackDraw could not load this local project. Open it first or choose another saved project.",
-                  });
-                  return;
-                }
+        <EditorDialogsHost
+          isMobile={isMobile}
+          activeDesignId={design.id}
+          shareOpen={shareOpen}
+          onShareOpenChange={setShareOpen}
+          hasPath={hasPath}
+          shareProjectId={isAccountProject ? design.id : null}
+          existingShareMode={existingShareMode}
+          onRefreshAccountShares={refreshAccountShares}
+          onShareExportJson={() => {
+            setShareOpen(false);
+            setExportOpen(true);
+          }}
+          importOpen={importOpen}
+          onImportOpenChange={setImportOpen}
+          onImportBeforeConfirm={snapshotCurrentDesign}
+          onImportBackupCurrent={() => {
+            setImportOpen(false);
+            setExportOpen(true);
+          }}
+          exportOpen={exportOpen}
+          onExportOpenChange={setExportOpen}
+          canvasRef={canvasRef}
+          preview3DRef={preview3DRef}
+          activeTab={tab}
+          exportProjectId={isAccountProject ? design.id : null}
+          onExportRequest3DView={() => handleTabChange("3d")}
+          shortcutsOpen={shortcutsOpen}
+          onShortcutsOpenChange={setShortcutsOpen}
+          newProjectOpen={newProjectOpen}
+          onNewProjectOpenChange={setNewProjectOpen}
+          newProjectHasContent={Boolean(
+            design.title.trim() || designShapes.length
+          )}
+          onNewProject={() => {
+            snapshotCurrentDesign();
+            applyStarterDesign("blank");
+            setNewProjectOpen(false);
+            setMobileToolsOpen(false);
+          }}
+          onNewProjectBackup={() => {
+            setNewProjectOpen(false);
+            setExportOpen(true);
+          }}
+          onNewProjectStarterLayout={(layoutId) => {
+            applyStarterLayout(layoutId);
+            setNewProjectOpen(false);
+          }}
+          projectManagerOpen={projectManagerOpen}
+          onProjectManagerOpenChange={setProjectManagerOpen}
+          onProjectManagerOpenNewProject={openNewProjectDialog}
+          onOpenProject={handleOpenProject}
+          onOpenAccountProject={
+            authUser && cloudProjectsAvailable
+              ? handleOpenAccountProjectFromDialog
+              : undefined
+          }
+          onSyncProject={
+            authUser && cloudProjectsAvailable ? handleSyncProject : undefined
+          }
+          onDeleteProject={handleDeleteProject}
+          onDeleteProjects={handleDeleteProjects}
+          onRenameProject={handleRenameProject}
+          onExportProject={handleExportProject}
+          onRestorePoint={handleRestorePoint}
+          onDeleteRestorePoint={handleDeleteRestorePoint}
+          projects={projects}
+          accountProjects={accountProjects}
+          accountProjectsLoading={accountProjectsLoading}
+          accountProjectsError={accountProjectsError}
+          accountShares={accountShares}
+          accountSharesLoading={accountSharesLoading}
+          onRevokeShare={handleRevokeShare}
+          projectSyncMetaById={projectSyncMetaById}
+          syncingProjectId={syncingProjectId}
+          restorePoints={restorePoints}
+          activeRestorePointId={activeRestorePointId ?? undefined}
+          presetPickerOpen={presetPickerOpen}
+          onPresetPickerOpenChange={setPresetPickerOpen}
+          activePresetId={activePresetId}
+          onSelectPreset={handlePresetSelect}
+          completeProfileOpen={completeProfileOpen}
+          onCompleteProfileOpenChange={handleCompleteProfileOpenChange}
+          authUser={authUser}
+          onCompleteProfileSave={handleCompleteProfileSave}
+          projectVersionConflict={projectVersionConflict}
+          onOpenCloudConflictVersion={handleOpenCloudConflictVersion}
+          onKeepLocalConflictCopy={handleKeepLocalConflictCopy}
+        />
 
-                const serialized = serializeDesign(exportDesign);
-                const baseName = (exportDesign.title.trim() || "track").replace(
-                  /[^a-z0-9-_]+/gi,
-                  "_"
-                );
-
-                downloadJsonFile(`${baseName}.json`, serialized);
-                toast.success("Project JSON exported");
-              } catch (error) {
-                const message =
-                  error instanceof Error ? error.message : "Export failed";
-                toast.error("Export failed", {
-                  description: message,
-                });
-              }
-            }}
-            onRestorePoint={handleRestorePoint}
-            onDeleteRestorePoint={handleDeleteRestorePoint}
-            projects={projects}
-            accountProjects={accountProjects}
-            accountProjectsLoading={accountProjectsLoading}
-            accountProjectsError={accountProjectsError}
-            accountShares={accountShares}
-            accountSharesLoading={accountSharesLoading}
-            onRevokeShare={handleRevokeShare}
-            projectSyncMetaById={projectSyncMetaById}
-            syncingProjectId={syncingProjectId}
-            restorePoints={restorePoints}
-            activeDesignId={design.id}
-            activeRestorePointId={activeRestorePointId ?? undefined}
-            onResolveConflict={() => setProjectManagerOpen(false)}
-          />
-        ) : null}
-        {presetPickerOpen ? (
-          <LayoutPresetPicker
-            mobile={isMobile}
-            open={presetPickerOpen}
-            onOpenChange={setPresetPickerOpen}
-            selectedPresetId={activePresetId}
-            onSelectPreset={handlePresetSelect}
-          />
-        ) : null}
-        {completeProfileOpen ? (
-          <CompleteProfileDialog
-            open={completeProfileOpen}
-            onOpenChange={handleCompleteProfileOpenChange}
-            email={authUser?.email ?? null}
-            currentName={authUser?.name ?? ""}
-            onSave={handleCompleteProfileSave}
-          />
-        ) : null}
-        {projectVersionConflict ? (
-          <ProjectVersionConflictDialog
-            open={Boolean(projectVersionConflict)}
-            mobile={isMobile}
-            title={projectVersionConflict.title ?? "Untitled"}
-            localUpdatedAt={
-              projectVersionConflict.localUpdatedAt ?? design.updatedAt
-            }
-            cloudUpdatedAt={
-              projectVersionConflict.cloudUpdatedAt ?? design.updatedAt
-            }
-            onOpenCloudVersion={handleOpenCloudConflictVersion}
-            onKeepLocalCopy={handleKeepLocalConflictCopy}
-          />
-        ) : null}
         {developerModeEnabled ? <PerformanceHud /> : null}
       </div>
     </>

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -2,12 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAccountProjectSync } from "./useAccountProjectSync";
 import { useEditorDialogs } from "./useEditorDialogs";
 import { useManualProjectSave } from "./useManualProjectSave";
@@ -15,12 +10,8 @@ import { useStarterExperience } from "./useStarterExperience";
 import { EditorWorkspace } from "./EditorWorkspace";
 import { EditorStarterOverlay } from "./EditorStarterOverlay";
 import { EditorDialogsHost } from "./EditorDialogsHost";
-import type {
-  TrackCanvasHandle,
-} from "@/components/canvas/editor/TrackCanvas";
-import type {
-  TrackPreview3DHandle,
-} from "@/components/canvas/editor/TrackPreview3D";
+import type { TrackCanvasHandle } from "@/components/canvas/editor/TrackCanvas";
+import type { TrackPreview3DHandle } from "@/components/canvas/editor/TrackPreview3D";
 import { getEditorShellSelectionState } from "@/lib/editor/shell-view-model";
 import { createDefaultDesign, serializeDesign } from "@/lib/track/design";
 import { type EditorTool } from "@/lib/editor-tools";
@@ -29,7 +20,10 @@ import { downloadJsonFile } from "@/lib/export/download-json";
 import { getLayoutPresetById } from "@/lib/planning/layout-presets";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
-import { useDeveloperMode, useDeveloperModeShortcut } from "@/hooks/useDeveloperMode";
+import {
+  useDeveloperMode,
+  useDeveloperModeShortcut,
+} from "@/hooks/useDeveloperMode";
 import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { useEditorProjects } from "@/hooks/useEditorProjects";
@@ -58,7 +52,9 @@ import {
 const Header = dynamic(() => import("./Header"), { ssr: false });
 const SharedHeader = dynamic(() => import("./shared/Header"), { ssr: false });
 const Toolbar = dynamic(() => import("./Toolbar"), { ssr: false });
-const PerformanceHud = dynamic(() => import("./PerformanceHud"), { ssr: false });
+const PerformanceHud = dynamic(() => import("./PerformanceHud"), {
+  ssr: false,
+});
 
 const EditorMobilePanels = dynamic(
   () =>

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -16,6 +16,7 @@ import { useAccountProjectSync } from "./useAccountProjectSync";
 import { useEditorDialogs } from "./useEditorDialogs";
 import { useManualProjectSave } from "./useManualProjectSave";
 import { useStarterExperience } from "./useStarterExperience";
+import { DesktopInspectorPanel } from "./DesktopInspectorPanel";
 import { Button } from "@/components/ui/button";
 import { MobileDrawer } from "@/components/MobileDrawer";
 import type {
@@ -39,6 +40,7 @@ import { useDeveloperMode } from "@/hooks/useDeveloperMode";
 import { useUndoRedo } from "@/hooks/useUndoRedo";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { useEditorProjects } from "@/hooks/useEditorProjects";
+import { usePersistentBoolean } from "@/hooks/usePersistentBoolean";
 import type { EditorView } from "@/lib/view";
 import {
   useSessionActions,
@@ -92,10 +94,6 @@ const Header = dynamic(() => import("./Header"), {
 });
 
 const SharedHeader = dynamic(() => import("./shared/Header"), {
-  ssr: false,
-});
-
-const Inspector = dynamic(() => import("@/components/inspector/Inspector"), {
   ssr: false,
 });
 
@@ -187,6 +185,8 @@ const NewProjectDialog = dynamic(
   () => import("@/components/dialogs/NewProjectDialog"),
   { ssr: false }
 );
+
+const SIDEBAR_COLLAPSED_STORAGE_KEY = "trackdraw.sidebarCollapsed";
 
 export default function EditorShell({
   readOnly = false,
@@ -297,7 +297,9 @@ export default function EditorShell({
   });
   const [mobilePathBuilderPinnedOpen, setMobilePathBuilderPinnedOpen] =
     useState(false);
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = usePersistentBoolean(
+    SIDEBAR_COLLAPSED_STORAGE_KEY
+  );
   const [completeProfileOpen, setCompleteProfileOpen] = useState(false);
   const [completeProfileDismissed, setCompleteProfileDismissed] =
     useState(false);
@@ -926,9 +928,9 @@ export default function EditorShell({
 
             {/* Desktop Inspector */}
             {!readOnly && !isMobile && (
-              <aside className="border-border/80 bg-card/95 hidden min-h-0 w-85 shrink-0 flex-col overflow-hidden border-l backdrop-blur lg:flex">
-                <Inspector onResumeSelectedPath={handleResumeSelectedPath} />
-              </aside>
+              <DesktopInspectorPanel
+                onResumeSelectedPath={handleResumeSelectedPath}
+              />
             )}
           </div>
         </div>

--- a/src/components/editor/EditorStarterOverlay.tsx
+++ b/src/components/editor/EditorStarterOverlay.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { Box, Route, X } from "lucide-react";
+import { MobileDrawer } from "@/components/MobileDrawer";
+import { ContextOverlayCard } from "./ContextOverlayCard";
+import { Button } from "@/components/ui/button";
+import type { EditorTool } from "@/lib/editor-tools";
+import type { EditorView } from "@/lib/view";
+
+const StarterSteps = dynamic(
+  () =>
+    import("@/components/editor/StarterFlow").then((mod) => ({
+      default: mod.StarterSteps,
+    })),
+  { ssr: false }
+);
+
+const StarterActions = dynamic(
+  () =>
+    import("@/components/editor/StarterFlow").then((mod) => ({
+      default: mod.StarterActions,
+    })),
+  { ssr: false }
+);
+
+interface EditorStarterOverlayProps {
+  readOnly: boolean;
+  isMobile: boolean;
+  shouldShowStarter: boolean;
+  onDismissStarter: () => void;
+  starterMode: "guided" | "blank" | null;
+  tab: EditorView;
+  designShapeCount: number;
+  activeTool: EditorTool;
+  hasPath: boolean;
+  gateHintDismissed: boolean;
+  onDismissGateHint: () => void;
+  desktopPathHintDismissed: boolean;
+  onDismissDesktopPathHint: () => void;
+  desktopPreviewHintDismissed: boolean;
+  onDismissDesktopPreviewHint: () => void;
+  review3DHintDismissed: boolean;
+  onDismissReview3DHint: () => void;
+  showPostPathNudge: boolean;
+  postPathNudgeDismissed: boolean;
+  onDismissPostPathNudge: () => void;
+  onApplyStarterDesign: (type: "gate" | "blank") => void;
+  onApplyStarterLayout: (layoutId: string) => void;
+  onStartPathTool: () => void;
+  onGoTo2DAndStartPath: () => void;
+  onShareAndDismissReview: () => void;
+  onGoTo3DAndDismissNudge: () => void;
+}
+
+export function EditorStarterOverlay({
+  readOnly,
+  isMobile,
+  shouldShowStarter,
+  onDismissStarter,
+  starterMode,
+  tab,
+  designShapeCount,
+  activeTool,
+  hasPath,
+  gateHintDismissed,
+  onDismissGateHint,
+  desktopPathHintDismissed,
+  onDismissDesktopPathHint,
+  desktopPreviewHintDismissed,
+  onDismissDesktopPreviewHint,
+  review3DHintDismissed,
+  onDismissReview3DHint,
+  showPostPathNudge,
+  postPathNudgeDismissed,
+  onDismissPostPathNudge,
+  onApplyStarterDesign,
+  onApplyStarterLayout,
+  onStartPathTool,
+  onGoTo2DAndStartPath,
+  onShareAndDismissReview,
+  onGoTo3DAndDismissNudge,
+}: EditorStarterOverlayProps) {
+  return (
+    <>
+      {shouldShowStarter && isMobile ? (
+        <MobileDrawer
+          open={shouldShowStarter}
+          onOpenChange={(open) => {
+            if (!open) onDismissStarter();
+          }}
+          title="Welcome to TrackDraw"
+          subtitle="Place a few gates, draw the route, check 3D, then share when the track is ready."
+          contentClassName="max-h-[96dvh]"
+          bodyClassName="space-y-5 pt-3 pb-4"
+        >
+          <StarterSteps mobile />
+          <StarterActions
+            mobile
+            onPath={() => onApplyStarterDesign("gate")}
+            onBlank={() => onApplyStarterDesign("blank")}
+            onStarterLayout={onApplyStarterLayout}
+          />
+        </MobileDrawer>
+      ) : null}
+
+      {shouldShowStarter && !isMobile ? (
+        <div className="absolute inset-0 z-20 hidden items-center justify-center bg-slate-950/10 px-5 backdrop-blur-sm lg:flex">
+          <div className="border-border/50 bg-card/97 pointer-events-auto w-full max-w-xl rounded-4xl border px-8 py-8 shadow-[0_24px_80px_rgba(15,23,42,0.10)] backdrop-blur">
+            <div className="relative">
+              <div className="pr-10">
+                <p className="text-muted-foreground text-[11px] font-medium tracking-[0.12em] uppercase">
+                  Studio
+                </p>
+                <p className="text-foreground mt-2 text-[1.25rem] font-semibold tracking-[-0.02em]">
+                  Welcome to TrackDraw
+                </p>
+                <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
+                  Design the layout in 2D, review elevation in 3D, and share a
+                  read-only link when the track is ready.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={onDismissStarter}
+                className="text-muted-foreground/75 hover:text-foreground hover:bg-muted absolute top-0 right-0 cursor-pointer rounded-full p-1.5 transition-colors"
+                aria-label="Dismiss starter dialog"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+
+            <div className="mt-6">
+              <StarterSteps />
+              <StarterActions
+                onPath={() => onApplyStarterDesign("gate")}
+                onBlank={() => onApplyStarterDesign("blank")}
+                onStarterLayout={onApplyStarterLayout}
+              />
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {!readOnly &&
+      starterMode === "guided" &&
+      tab === "2d" &&
+      designShapeCount === 0 &&
+      activeTool === "gate" &&
+      !gateHintDismissed ? (
+        <div className="pointer-events-none absolute inset-x-0 top-4 z-20 flex justify-center px-4 lg:justify-start lg:px-0">
+          <div className="max-w-sm lg:absolute lg:top-0 lg:left-4">
+            <ContextOverlayCard
+              icon={<Box className="size-4" />}
+              title="Place your first gate"
+              badge="Guided"
+              description="Tap or click on the canvas to drop the first gate. Add a few gates before switching to Path."
+              action={
+                <Button size="sm" onClick={onDismissGateHint}>
+                  Got it
+                </Button>
+              }
+              dismissLabel="Dismiss gate placement hint"
+              onDismiss={onDismissGateHint}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {!readOnly &&
+      starterMode === "guided" &&
+      tab === "2d" &&
+      !shouldShowStarter &&
+      designShapeCount > 0 &&
+      !hasPath &&
+      !desktopPathHintDismissed ? (
+        <div className="pointer-events-none absolute inset-x-0 top-4 z-20 flex justify-center px-4 lg:justify-start lg:px-0">
+          <div className="max-w-sm lg:absolute lg:top-0 lg:left-4">
+            <ContextOverlayCard
+              icon={<Route className="size-4" />}
+              title="Next, draw the route"
+              badge="Guided"
+              description="Place a few gates first, then switch to Path and trace the lap through them. Finish the route before checking 3D."
+              action={
+                <Button size="sm" onClick={onStartPathTool}>
+                  Start path
+                </Button>
+              }
+              dismissLabel="Dismiss path onboarding hint"
+              onDismiss={onDismissDesktopPathHint}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {!readOnly &&
+      starterMode === "guided" &&
+      tab === "3d" &&
+      !hasPath &&
+      !desktopPreviewHintDismissed ? (
+        <div className="pointer-events-none absolute inset-x-0 top-4 z-20 flex justify-center px-4 lg:justify-start lg:px-0">
+          <div className="max-w-sm lg:absolute lg:top-0 lg:left-4">
+            <ContextOverlayCard
+              icon={<Box className="size-4" />}
+              title="3D works best after the route"
+              badge="Preview"
+              description="Obstacle placement already previews here, but the route is what makes elevation and fly-through review useful."
+              action={
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={onGoTo2DAndStartPath}
+                >
+                  Draw path in 2D
+                </Button>
+              }
+              dismissLabel="Dismiss 3D preview onboarding hint"
+              onDismiss={onDismissDesktopPreviewHint}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {!readOnly &&
+      starterMode === "guided" &&
+      tab === "3d" &&
+      hasPath &&
+      !review3DHintDismissed ? (
+        <div className="pointer-events-none absolute inset-x-0 top-4 z-20 flex justify-center px-4 lg:justify-start lg:px-0">
+          <div className="max-w-sm lg:absolute lg:top-0 lg:left-4">
+            <ContextOverlayCard
+              icon={<Box className="size-4" />}
+              title="Now review it in 3D"
+              badge="Guided"
+              description="Orbit around the route, check elevation and spacing, then share or export once the layout feels right."
+              action={
+                <Button size="sm" onClick={onShareAndDismissReview}>
+                  Share or export next
+                </Button>
+              }
+              dismissLabel="Dismiss 3D review hint"
+              onDismiss={onDismissReview3DHint}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {!readOnly &&
+      starterMode === "guided" &&
+      tab === "2d" &&
+      showPostPathNudge &&
+      !postPathNudgeDismissed ? (
+        <div className="pointer-events-none absolute inset-x-0 top-4 z-20 flex justify-center px-4 lg:justify-start lg:px-0">
+          <div className="max-w-sm lg:absolute lg:top-0 lg:left-4">
+            <ContextOverlayCard
+              icon={<Box className="size-4" />}
+              title="Route ready — check it in 3D"
+              badge="Next step"
+              description="Switch to the 3D tab now to review the route before refining more obstacle placement."
+              action={
+                <Button size="sm" onClick={onGoTo3DAndDismissNudge}>
+                  Switch to 3D
+                </Button>
+              }
+              dismissLabel="Dismiss post-path 3D nudge"
+              onDismiss={onDismissPostPathNudge}
+            />
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/editor/EditorWorkspace.tsx
+++ b/src/components/editor/EditorWorkspace.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { type ReactNode, type ForwardRefExoticComponent, type RefAttributes } from "react";
+import { DesktopInspectorPanel } from "./DesktopInspectorPanel";
+import StatusBar from "./StatusBar";
+import type {
+  TrackCanvasHandle,
+  TrackCanvasProps,
+} from "@/components/canvas/editor/TrackCanvas";
+import type {
+  TrackPreview3DHandle,
+  TrackPreview3DProps,
+} from "@/components/canvas/editor/TrackPreview3D";
+import type { EditorView } from "@/lib/view";
+import type { RefObject } from "react";
+
+const TrackCanvas = dynamic<TrackCanvasProps>(
+  () => import("@/components/canvas/editor/TrackCanvas"),
+  { ssr: false }
+) as ForwardRefExoticComponent<
+  TrackCanvasProps & RefAttributes<TrackCanvasHandle>
+>;
+
+const TrackPreview3D = dynamic<TrackPreview3DProps>(
+  () => import("@/components/canvas/editor/TrackPreview3D"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="text-muted-foreground/40 flex h-full items-center justify-center text-xs">
+        Loading 3D…
+      </div>
+    ),
+  }
+) as ForwardRefExoticComponent<
+  TrackPreview3DProps & RefAttributes<TrackPreview3DHandle>
+>;
+
+interface EditorWorkspaceProps {
+  tab: EditorView;
+  readOnly: boolean;
+  isMobile: boolean;
+  canvasRef: RefObject<TrackCanvasHandle | null>;
+  preview3DRef: RefObject<TrackPreview3DHandle | null>;
+  hasVisited3D: boolean;
+  mobileRulersEnabled: boolean;
+  mobileMultiSelectEnabled: boolean;
+  showObstacleNumbers: boolean;
+  mobileGizmoEnabled: boolean;
+  cursorPos: { x: number; y: number } | null;
+  snapActive: boolean;
+  onCursorChange: (pos: { x: number; y: number } | null) => void;
+  onDraftPathStateChange: (state: {
+    active: boolean;
+    canClose: boolean;
+    closed: boolean;
+    length: number;
+    pointCount: number;
+  }) => void;
+  onSnapChange: (active: boolean) => void;
+  onMobileMultiSelectStart: (shapeId: string) => void;
+  onFlyModeChange: (active: boolean) => void;
+  onResumeSelectedPath: (shapeId: string) => void;
+  overlay?: ReactNode;
+}
+
+export function EditorWorkspace({
+  tab,
+  readOnly,
+  isMobile,
+  canvasRef,
+  preview3DRef,
+  hasVisited3D,
+  mobileRulersEnabled,
+  mobileMultiSelectEnabled,
+  showObstacleNumbers,
+  mobileGizmoEnabled,
+  cursorPos,
+  snapActive,
+  onCursorChange,
+  onDraftPathStateChange,
+  onSnapChange,
+  onMobileMultiSelectStart,
+  onFlyModeChange,
+  onResumeSelectedPath,
+  overlay,
+}: EditorWorkspaceProps) {
+  return (
+    <div className="relative flex min-h-0 flex-1 overflow-hidden">
+      {/* Canvas area */}
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="bg-canvas relative min-h-0 flex-1 overflow-hidden">
+          {/* 2D: always mounted so export always works; hidden visually when not active */}
+          <div
+            className="absolute inset-0"
+            style={{
+              visibility: tab === "2d" ? "visible" : "hidden",
+              pointerEvents: tab === "2d" ? "auto" : "none",
+            }}
+          >
+            <TrackCanvas
+              ref={canvasRef}
+              onCursorChange={onCursorChange}
+              onDraftPathStateChange={onDraftPathStateChange}
+              onSnapChange={onSnapChange}
+              onMobileMultiSelectStart={onMobileMultiSelectStart}
+              mobileRulersEnabled={mobileRulersEnabled}
+              mobileMultiSelectEnabled={mobileMultiSelectEnabled}
+              readOnly={readOnly}
+              showObstacleNumbers={showObstacleNumbers}
+            />
+          </div>
+          {hasVisited3D ? (
+            <div
+              className="absolute inset-0"
+              style={{ display: tab === "3d" ? "block" : "none" }}
+            >
+              <TrackPreview3D
+                ref={preview3DRef}
+                showGizmo={mobileGizmoEnabled}
+                onFlyModeChange={onFlyModeChange}
+                readOnly={readOnly}
+              />
+            </div>
+          ) : null}
+          {overlay}
+        </div>
+        <StatusBar cursorPos={cursorPos} snapActive={snapActive} />
+      </div>
+
+      {/* Desktop Inspector */}
+      {!readOnly && !isMobile && (
+        <DesktopInspectorPanel onResumeSelectedPath={onResumeSelectedPath} />
+      )}
+    </div>
+  );
+}

--- a/src/components/editor/EditorWorkspace.tsx
+++ b/src/components/editor/EditorWorkspace.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { type ReactNode, type ForwardRefExoticComponent, type RefAttributes } from "react";
+import {
+  type ReactNode,
+  type ForwardRefExoticComponent,
+  type RefAttributes,
+} from "react";
 import { DesktopInspectorPanel } from "./DesktopInspectorPanel";
 import StatusBar from "./StatusBar";
 import type {

--- a/src/components/inspector/Inspector.tsx
+++ b/src/components/inspector/Inspector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState } from "react";
+import { memo, useState, type ReactNode } from "react";
 import { motion } from "framer-motion";
 import {
   MultiInspectorView,
@@ -17,13 +17,17 @@ import {
 import { useEditor } from "@/store/editor";
 import { selectDesignShapes, selectSelectedShapes } from "@/store/selectors";
 
-function Inspector({
-  onResumeSelectedPath,
-  mobileInline = false,
-}: {
+export interface InspectorProps {
+  headerAction?: ReactNode;
   onResumeSelectedPath?: (shapeId: string) => void;
   mobileInline?: boolean;
-}) {
+}
+
+function Inspector({
+  headerAction,
+  onResumeSelectedPath,
+  mobileInline = false,
+}: InspectorProps) {
   usePerfMetric("render:Inspector");
   const design = useEditor((state) => state.track.design);
   const selection = useEditor((state) => state.session.selection);
@@ -138,50 +142,57 @@ function Inspector({
       )}
     >
       <div className="border-border/60 bg-card/96 px-4 py-3 lg:px-3 lg:py-2.5">
-        <div
-          role="tablist"
-          aria-label="Inspector panels"
-          className="border-border/60 flex items-center gap-5 border-b"
-        >
-          {[
-            { id: "project" as const, label: "Project" },
-            { id: "layout" as const, label: "Layout" },
-            { id: "selection" as const, label: "Selection" },
-          ].map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              role="tab"
-              aria-selected={panel === item.id}
-              aria-controls={`inspector-panel-${item.id}`}
-              id={`inspector-tab-${item.id}`}
-              disabled={item.id === "selection" && selectionDisabled}
-              onClick={() => setPanelOverride(item.id)}
-              className={cn(
-                "group relative -mb-px min-h-11 px-1 py-2.5 text-sm font-semibold transition-colors",
-                panel === item.id
-                  ? "text-foreground"
-                  : "text-muted-foreground hover:text-foreground active:text-foreground",
-                item.id === "selection" && selectionDisabled
-                  ? "cursor-not-allowed opacity-45"
-                  : ""
-              )}
-            >
-              {panel === item.id ? (
-                <motion.span
-                  layoutId={activeTabIndicatorLayoutId}
-                  className="bg-foreground absolute inset-x-0 bottom-[-1px] h-0.5 rounded-full"
-                  transition={{
-                    type: "spring",
-                    stiffness: 420,
-                    damping: 34,
-                  }}
-                />
-              ) : null}
-              {item.label}
-              <span className="group-hover:bg-border pointer-events-none absolute inset-x-0 -bottom-px h-px bg-transparent transition-colors" />
-            </button>
-          ))}
+        <div className="border-border/60 flex items-center justify-between gap-3 border-b">
+          <div
+            role="tablist"
+            aria-label="Inspector panels"
+            className="flex min-w-0 items-center gap-5"
+          >
+            {[
+              { id: "project" as const, label: "Project" },
+              { id: "layout" as const, label: "Layout" },
+              { id: "selection" as const, label: "Selection" },
+            ].map((item) => (
+              <button
+                key={item.id}
+                type="button"
+                role="tab"
+                aria-selected={panel === item.id}
+                aria-controls={`inspector-panel-${item.id}`}
+                id={`inspector-tab-${item.id}`}
+                disabled={item.id === "selection" && selectionDisabled}
+                onClick={() => setPanelOverride(item.id)}
+                className={cn(
+                  "group relative -mb-px min-h-11 px-1 py-2.5 text-sm font-semibold transition-colors",
+                  panel === item.id
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground active:text-foreground",
+                  item.id === "selection" && selectionDisabled
+                    ? "cursor-not-allowed opacity-45"
+                    : ""
+                )}
+              >
+                {panel === item.id ? (
+                  <motion.span
+                    layoutId={activeTabIndicatorLayoutId}
+                    className="bg-foreground absolute inset-x-0 bottom-[-1px] h-0.5 rounded-full"
+                    transition={{
+                      type: "spring",
+                      stiffness: 420,
+                      damping: 34,
+                    }}
+                  />
+                ) : null}
+                {item.label}
+                <span className="group-hover:bg-border pointer-events-none absolute inset-x-0 -bottom-px h-px bg-transparent transition-colors" />
+              </button>
+            ))}
+          </div>
+          {headerAction ? (
+            <div className="-mb-px flex min-h-11 shrink-0 items-center py-1">
+              {headerAction}
+            </div>
+          ) : null}
         </div>
       </div>
 

--- a/src/hooks/useCompleteProfile.ts
+++ b/src/hooks/useCompleteProfile.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { authClient, type AuthUser } from "@/lib/auth-client";
+
+export function useCompleteProfile({
+  readOnly,
+  authUser,
+}: {
+  readOnly: boolean;
+  authUser: AuthUser | null;
+}) {
+  const [completeProfileOpen, setCompleteProfileOpen] = useState(false);
+  const [completeProfileDismissed, setCompleteProfileDismissed] =
+    useState(false);
+
+  useEffect(() => {
+    if (readOnly || !authUser?.id) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setCompleteProfileOpen(false);
+      setCompleteProfileDismissed(false);
+      return;
+    }
+
+    if (authUser.name?.trim()) {
+      setCompleteProfileOpen(false);
+      setCompleteProfileDismissed(false);
+      return;
+    }
+
+    if (!completeProfileDismissed) {
+      setCompleteProfileOpen(true);
+    }
+  }, [authUser?.id, authUser?.name, completeProfileDismissed, readOnly]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      setCompleteProfileOpen(open);
+      if (!open && authUser && !authUser.name?.trim()) {
+        setCompleteProfileDismissed(true);
+      }
+    },
+    [authUser]
+  );
+
+  const handleSave = useCallback(async (name: string) => {
+    await authClient.updateProfileName(name);
+    setCompleteProfileDismissed(false);
+  }, []);
+
+  return {
+    completeProfileOpen,
+    handleCompleteProfileOpenChange: handleOpenChange,
+    handleCompleteProfileSave: handleSave,
+  };
+}

--- a/src/hooks/useDeveloperMode.ts
+++ b/src/hooks/useDeveloperMode.ts
@@ -67,3 +67,27 @@ export function useDeveloperMode() {
     toggle,
   };
 }
+
+export function useDeveloperModeShortcut() {
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || !event.shiftKey) return;
+      if (event.key !== ".") return;
+
+      const target = event.target as HTMLElement | null;
+      const isInput =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable;
+      if (isInput) return;
+
+      event.preventDefault();
+      setDeveloperModeEnabled(!developerModeEnabled);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+}

--- a/src/hooks/usePersistentBoolean.ts
+++ b/src/hooks/usePersistentBoolean.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function usePersistentBoolean(key: string, defaultValue = false) {
+  const [value, setValue] = useState(() => {
+    if (typeof window === "undefined") return defaultValue;
+
+    try {
+      const stored = window.localStorage.getItem(key);
+      if (stored === "true") return true;
+      if (stored === "false") return false;
+    } catch {
+      // Keep the UI responsive when storage is blocked.
+    }
+
+    return defaultValue;
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(key, value ? "true" : "false");
+    } catch {
+      // Ignore blocked or full storage; the in-memory state still updates.
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -6,7 +6,7 @@ import { createAuthClient } from "better-auth/react";
 import { magicLinkClient } from "better-auth/client/plugins";
 import { parseAccountRole, type AccountRole } from "@/lib/account-roles";
 
-type AuthUser = {
+export type AuthUser = {
   id: string;
   email: string | null;
   name: string | null;


### PR DESCRIPTION
- Adds a collapsible desktop inspector panel with persistent collapse state (localStorage-backed via new `usePersistentBoolean` hook)
- Decomposes EditorShell (~1337 → ~570 lines) into focused components: `EditorWorkspace`, `EditorStarterOverlay`, `EditorDialogsHost`, and `DesktopInspectorPanel`
- Extracts `useCompleteProfile` hook and moves the dev-mode keyboard shortcut (`Cmd+Shift+.`) into `useDeveloperModeShortcut`
- Exports `AuthUser` type from `auth-client` for shared use
- Updates roadmap to reflect catalog-backed elements, 3D review, and workspace ergonomics as next product direction; adds track-element catalog research doc
