### PR TITLE
feat: Track element catalog foundation with catalog-backed gate placement

### DIFF
--- a/docs/research/track-element-catalog.md
+++ b/docs/research/track-element-catalog.md
@@ -6,9 +6,9 @@ The catalog should start local and typed, not as a database. A database becomes 
 
 ## Top-Level Checklist
 
-- [ ] Define a typed local element catalog for official and TrackDraw-provided elements.
-- [ ] Move default placement for generic tools and presets onto catalog entries.
-- [ ] Add official race-gate entries, including a MultiGP-style 5 ft x 5 ft standard gate, without changing existing saved designs.
+- [x] Define a typed local element catalog for official and TrackDraw-provided elements.
+- [x] Move default placement for generic tools and presets onto catalog entries.
+- [x] Add an initial official race-gate entry, including a MultiGP-style 5 ft x 5 ft standard gate, without changing existing saved designs.
 
 ## Reference Observations
 
@@ -58,11 +58,16 @@ Done state:
 - Layout and starter presets can opt into catalog entries instead of duplicating dimensions.
 - Existing imports/exports remain compatible.
 
+Status:
+
+- Shipped a typed local catalog module with TrackDraw-provided element entries, a source-backed MultiGP Standard Gate 5x5 entry, shared catalog placement helpers for toolbar tools, layout presets, and starter layouts, and tests for default dimensions and optional catalog metadata.
+
 ## Phase 2: Official Element Entries
 
 Start state:
 
-- The catalog exists, but only replaces existing generic defaults.
+- The catalog exists and powers existing generic defaults.
+- The first official MultiGP Standard Gate 5x5 entry exists in code, but it is not yet exposed through a user-facing element library.
 
 Scope:
 

--- a/docs/research/track-element-catalog.md
+++ b/docs/research/track-element-catalog.md
@@ -8,7 +8,8 @@ The catalog should start local and typed, not as a database. A database becomes 
 
 - [x] Define a typed local element catalog for official and TrackDraw-provided elements.
 - [x] Move default placement for generic tools and presets onto catalog entries.
-- [x] Add an initial official race-gate entry, including a MultiGP-style 5 ft x 5 ft standard gate, without changing existing saved designs.
+- [x] Add initial official race-gate entries, including MultiGP-style 5x5 and 7x6 variants, without changing existing saved designs.
+- [x] Show catalog identity, official size status, and fixed official dimensions for placed catalog-backed gates.
 
 ## Reference Observations
 
@@ -73,16 +74,24 @@ Scope:
 
 - Add the first official gate entries after validating exact sizing and source language:
   - MultiGP Standard Gate 5x5
-  - MultiGP Champ Gate 7x6 or 10x8 only after confirming the correct naming/dimensions for the intended race context
+  - MultiGP Championship Gate 7x6
+  - Hurdles only after deciding whether they should remain `gate`-like catalog variants or become their own obstacle category
   - Dive gate variants only after deciding whether they should remain one `divegate` shape or become catalog-driven variants
-- Keep "Custom Gate" available so users are not boxed into official-only dimensions.
+- Keep "Custom Gate" available through the standard TrackDraw Gate so users are not boxed into official-only dimensions.
 - Expose the official name in inspector/export summaries only when the shape was created from a catalog entry or explicitly assigned one.
+- Keep official gate width and height fixed after placement. Custom sizing belongs to the standard TrackDraw Gate instead of modifying an official catalog item.
 
 Done state:
 
 - Users can place at least one official named race gate.
 - The inspector can show the official identity and dimensions without hiding editable width/height controls.
 - Export and Race Pack copy can reference official names where helpful.
+
+Status:
+
+- Users can now place catalog-backed MultiGP-style gate variants through the normal Gate placement flow: Standard Gate 5x5 and Championship Gate 7x6. Desktop keeps the active gate type in a compact canvas placement control with a dropdown for additional variants, while mobile keeps one Gate entry in the tools drawer with a compact type picker for variants.
+- Newly placed official gates remain normal `gate` shapes, with their source identity stored under `meta.catalog`. The inspector shows the catalog type, source, official size, and official dimension status.
+- Official gate width and height are fixed in normal editing. Custom sizing belongs to the standard TrackDraw Gate.
 
 ## Phase 3: Element Library UI
 
@@ -95,6 +104,7 @@ Scope:
 - Add a compact element picker behind existing tool groups instead of expanding the primary toolbar.
 - Keep quick placement fast: one-click Gate still places the default gate.
 - Add a secondary way to choose variants such as official gates, flags, launch blocks, hurdles, and custom saved elements.
+- Keep official gates in the Gate/element placement flow rather than adding a separate top-level catalog placement mode that competes with the normal Gate tool.
 - Avoid card-in-card layouts and keep mobile picker behavior deliberate.
 
 Done state:
@@ -103,9 +113,14 @@ Done state:
 - Mobile users can still place common items without opening a dense desktop-style library.
 - The current starter layouts continue to work.
 
+Status:
+
+- The first UI slice keeps Gate as the primary placement tool and avoids a separate catalog dialog. This deliberately favors an active-element dropdown that can scale from two gate variants to a longer curated list without expanding the toolbar.
+
 ## Boundaries
 
 - Do not change stored shape dimensions globally just because an official catalog entry exists.
 - Do not migrate existing projects to new official gate sizes automatically.
 - Do not couple element catalog work to accounts in the first slice.
+- Do not make realistic 3D model fidelity part of the catalog phase. The catalog should expose identity, dimensions, source metadata, and render hints; the 3D preview work should consume those hints for official visual variants.
 - Do not copy a competitor's UI wholesale; borrow validated product patterns and fit them into TrackDraw's existing editor model.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -235,7 +235,7 @@ Why:
 Feature tracks:
 
 - Track element catalog: define typed local catalog entries with official names, meter-based dimensions, display dimensions, source references, shape defaults, 2D hints, 3D hints, and export compatibility metadata
-- Official equipment entries: reintroduce any default race-gate size changes through catalog entries rather than hard-coded generic defaults, while preserving custom gate editing and saved-project compatibility
+- Official equipment entries: expose cataloged official entries such as the MultiGP Standard Gate 5x5 through deliberate placement/library UI rather than hard-coded generic defaults, while preserving custom gate editing and saved-project compatibility
 - Element library UI: expose official and custom variants without slowing down the current quick-placement toolbar flow
 
 Important boundary:
@@ -243,6 +243,11 @@ Important boundary:
 - Do not automatically migrate existing projects to official gate dimensions
 - Do not make the first element catalog account-backed or database-backed; start local and typed so it is testable and versioned
 - Do not copy competitor UI patterns wholesale; adapt useful patterns to TrackDraw's existing editor and handoff workflows
+
+Current shipped foundation:
+
+- A typed local catalog module now holds TrackDraw-provided element entries and a source-backed MultiGP Standard Gate 5x5 entry without changing the existing generic gate default
+- Toolbar placement, layout presets, and starter layouts now use shared catalog placement helpers for generic elements, keeping saved geometry meter-based and backwards compatible
 
 #### 3D Preview And Direct Manipulation
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -235,7 +235,7 @@ Why:
 Feature tracks:
 
 - Track element catalog: define typed local catalog entries with official names, meter-based dimensions, display dimensions, source references, shape defaults, 2D hints, 3D hints, and export compatibility metadata
-- Official equipment entries: expose cataloged official entries such as the MultiGP Standard Gate 5x5 through deliberate placement/library UI rather than hard-coded generic defaults, while preserving custom gate editing and saved-project compatibility
+- Official equipment entries: expose cataloged official entries such as the MultiGP Standard Gate 5x5 through deliberate placement/library UI rather than hard-coded generic defaults, while keeping custom sizing on the standard TrackDraw Gate and preserving saved-project compatibility
 - Element library UI: expose official and custom variants without slowing down the current quick-placement toolbar flow
 
 Important boundary:
@@ -246,8 +246,10 @@ Important boundary:
 
 Current shipped foundation:
 
-- A typed local catalog module now holds TrackDraw-provided element entries and a source-backed MultiGP Standard Gate 5x5 entry without changing the existing generic gate default
+- A typed local catalog module now holds TrackDraw-provided element entries and source-backed MultiGP-style 5x5 and 7x6 gate entries without changing the existing generic gate default
 - Toolbar placement, layout presets, and starter layouts now use shared catalog placement helpers for generic elements, keeping saved geometry meter-based and backwards compatible
+- Gate placement can now switch between the generic TrackDraw gate and catalog-backed MultiGP-style 5x5 and 7x6 gate variants through a compact desktop placement dropdown and a compact mobile Gate type picker
+- The inspector shows catalog type, source, official size, and dimension status while keeping official gate width and height fixed in normal editing
 
 #### 3D Preview And Direct Manipulation
 
@@ -256,17 +258,20 @@ TrackDraw should improve 3D review and focused 3D editing as separate editor cap
 Why:
 
 - 3D review can become more useful with better lighting, contrast, sun/directional-light treatment, shadows, and more realistic gates/flags
+- Catalog metadata can tell 3D rendering which official object was placed, but the visual fidelity work itself belongs here rather than in the catalog model
 - Direct 3D controls can speed up selected item edits when they stay narrow and respect lock state, undo/redo, and mobile constraints
 
 Feature tracks:
 
 - 3D preview realism and lighting: improve scene readability with sun/directional lighting, shadows, contrast, and more realistic gate/flag presentation before adding heavy asset workflows
+- Catalog-aware 3D element rendering: use catalog identity such as `MultiGP Standard Gate 5x5` to render official elements with more recognizable shapes/materials while keeping generic gates lightweight
 - Focused 3D item controls: add direct controls for common edits such as elevation, rotation, scaling, and orientation only where undo/redo, lock state, and mobile behavior remain safe
 
 Important boundary:
 
 - Do not make 3D controls broad enough to destabilize the existing 2D-first editor
 - Do not bury 3D preview or direct manipulation work under the element catalog; they should remain standalone editor features
+- Do not duplicate catalog source/dimension decisions in the 3D renderer; consume catalog metadata and render hints instead
 
 #### Generated Flightpath Assistance
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -28,10 +28,10 @@ The completed release-sized work is archived below. The REST API, live race over
 
 - [ ] Track element catalog (`Research`, `No account required`)
       Build a catalog-backed element model for official gates, richer placement defaults, and future equipment/library expansion before changing default race-gate sizing.
-  - [ ] Local element catalog foundation
+  - [x] Local element catalog foundation
         Define typed catalog entries for official names, dimensions, source references, 2D defaults, 3D render hints, and export compatibility while keeping saved project geometry meter-based.
   - [ ] Official gate and obstacle entries
-        Add entries such as a MultiGP-style standard gate only through the catalog, with custom gate editing preserved and no automatic migration of existing projects.
+        Expose entries such as the cataloged MultiGP-style standard gate through deliberate placement/library UI, with custom gate editing preserved and no automatic migration of existing projects.
 
 - [ ] 3D preview realism and lighting (`Research`, `No account required`)
       Improve the 3D preview's readability and realism with stronger contrast, sun/directional lighting, shadows, and more recognizable gates/flags while keeping mobile performance safe.

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -27,16 +27,22 @@ The completed release-sized work is archived below. The REST API, live race over
 ## Follow-up
 
 - [ ] Track element catalog (`Research`, `No account required`)
-      Build a catalog-backed element model for official gates, richer placement defaults, and future equipment/library expansion before changing default race-gate sizing.
+      Build a catalog-backed element model for official gates, richer placement defaults, and future equipment/library expansion before changing default race-gate sizing. This track owns element identity, source metadata, dimensions, and placement selection, not high-fidelity 3D rendering.
   - [x] Local element catalog foundation
         Define typed catalog entries for official names, dimensions, source references, 2D defaults, 3D render hints, and export compatibility while keeping saved project geometry meter-based.
   - [ ] Official gate and obstacle entries
-        Expose entries such as the cataloged MultiGP-style standard gate through deliberate placement/library UI, with custom gate editing preserved and no automatic migration of existing projects.
+        Expose entries such as the cataloged MultiGP-style standard gate through deliberate placement/library UI, with custom sizing kept on the standard TrackDraw Gate and no automatic migration of existing projects.
+  - [x] MultiGP gate placement selector
+        Keep Gate as the primary placement tool while letting users switch the active gate type between the generic TrackDraw gate and catalog-backed MultiGP-style 5x5 and 7x6 variants through compact desktop and mobile type pickers.
+  - [x] Catalog identity in inspector
+        Show placed catalog-backed elements with their official type, source, official size, and dimension status while keeping official gate width and height fixed in normal editing.
 
 - [ ] 3D preview realism and lighting (`Research`, `No account required`)
-      Improve the 3D preview's readability and realism with stronger contrast, sun/directional lighting, shadows, and more recognizable gates/flags while keeping mobile performance safe.
+      Improve the 3D preview's readability and realism with stronger contrast, sun/directional lighting, shadows, and more recognizable gates/flags while keeping mobile performance safe. Use catalog metadata to render official variants differently where helpful, such as a more realistic MultiGP Standard Gate 5x5.
   - [ ] 3D readability and realism pass
         Evaluate sun/directional lighting, stronger contrast, more realistic gates/flags, and shadow treatment without making the scene visually noisy.
+  - [ ] Catalog-aware 3D element rendering
+        Use `meta.catalog` and catalog render hints to choose more realistic 3D treatments for official elements, starting with the MultiGP Standard Gate 5x5, while keeping generic gates lightweight.
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -385,6 +385,9 @@ const TrackCanvas = memo(
     } = useTrackActions();
     const activeTool = useEditor((state) => state.ui.activeTool);
     const activePresetId = useEditor((state) => state.ui.activePresetId);
+    const activeGateElementId = useEditor(
+      (state) => state.ui.activeGateElementId
+    );
     const snapEnabled = useEditor((state) => state.ui.snapEnabled);
     const segmentSel = useEditor((state) => state.ui.segmentSelection);
     const vertexSel = useEditor((state) => state.ui.vertexSelection);
@@ -1168,6 +1171,7 @@ const TrackCanvas = memo(
     } = useTrackCanvasInteractions({
       activeTool,
       activePresetId,
+      activeGateElementId,
       addShape,
       addShapes,
       contentDragActiveRef,

--- a/src/components/canvas/useTrackCanvasInteractions.ts
+++ b/src/components/canvas/useTrackCanvasInteractions.ts
@@ -24,6 +24,7 @@ import {
 } from "@/lib/canvas/interaction-helpers";
 import { findNearestSnapTargetWithRoutes } from "@/lib/canvas/snap";
 import { createShapeForTool, type EditorTool } from "@/lib/editor-tools";
+import type { TrackElementCatalogId } from "@/lib/track/elements/catalog";
 import {
   getLayoutPresetById,
   placeLayoutPreset,
@@ -39,6 +40,7 @@ import type { PolylineShape, Shape, ShapeDraft } from "@/lib/types";
 interface TrackCanvasInteractionsParams {
   activeTool: EditorTool;
   activePresetId: string | null;
+  activeGateElementId: TrackElementCatalogId | null;
   addShape: (shape: ShapeDraft) => string;
   addShapes: (shapes: ShapeDraft[]) => string[];
   contentDragActiveRef: React.RefObject<boolean>;
@@ -101,6 +103,7 @@ interface TrackCanvasInteractionsParams {
 export function useTrackCanvasInteractions({
   activeTool,
   activePresetId,
+  activeGateElementId,
   addShape,
   addShapes,
   contentDragActiveRef,
@@ -613,7 +616,9 @@ export function useTrackCanvasInteractions({
           touchInteractionModeRef.current = "none";
           return;
         }
-        const shape = createShapeForTool(activeTool, meters);
+        const shape = createShapeForTool(activeTool, meters, {
+          gateElementId: activeGateElementId,
+        });
         if (!shape) return;
         const id = addShape(shape);
         setSelection([id]);
@@ -634,6 +639,7 @@ export function useTrackCanvasInteractions({
     [
       activeTool,
       activePresetId,
+      activeGateElementId,
       addShape,
       addShapes,
       finalizePath,
@@ -841,7 +847,9 @@ export function useTrackCanvasInteractions({
           suppressTapRef.current = true;
           return;
         }
-        const shape = createShapeForTool(activeTool, meters);
+        const shape = createShapeForTool(activeTool, meters, {
+          gateElementId: activeGateElementId,
+        });
         if (!shape) return;
         const id = addShape(shape);
         setSelection([id]);
@@ -875,6 +883,7 @@ export function useTrackCanvasInteractions({
     [
       activeTool,
       activePresetId,
+      activeGateElementId,
       addShape,
       addShapes,
       marqueeAdditiveRef,

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -416,7 +416,14 @@ export default function EditorShell({
       setActiveTool("gate");
       setMobileToolsOpen(false);
     },
-    [setActiveGateElementId, setActiveTool, setSelection]
+    [
+      setActiveGateElementId,
+      setActiveTool,
+      setMobileMultiSelectEnabled,
+      setMobilePathBuilderPinnedOpen,
+      setMobileToolsOpen,
+      setSelection,
+    ]
   );
 
   useEffect(() => {

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -18,6 +18,7 @@ import { type EditorTool } from "@/lib/editor-tools";
 import { loadProject } from "@/lib/projects";
 import { downloadJsonFile } from "@/lib/export/download-json";
 import { getLayoutPresetById } from "@/lib/planning/layout-presets";
+import type { TrackElementCatalogId } from "@/lib/track/elements/catalog";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import {
@@ -103,6 +104,9 @@ export default function EditorShell({
   const design = useEditor((state) => state.track.design);
   const activeTool = useEditor((state) => state.ui.activeTool);
   const activePresetId = useEditor((state) => state.ui.activePresetId);
+  const activeGateElementId = useEditor(
+    (state) => state.ui.activeGateElementId
+  );
   const snapEnabled = useEditor((state) => state.ui.snapEnabled);
   const {
     duplicateShapes,
@@ -119,6 +123,7 @@ export default function EditorShell({
   } = useTrackActions();
   const {
     setActiveTool,
+    setActiveGateElementId,
     setActivePresetId,
     setSegmentSelection,
     toggleSnapEnabled,
@@ -402,6 +407,18 @@ export default function EditorShell({
     setMobilePathBuilderPinnedOpen(false);
   }, [activeTool, mobileDraftPathState.active]);
 
+  const handleGateElementSelect = useCallback(
+    (entryId: TrackElementCatalogId) => {
+      setSelection([]);
+      setMobileMultiSelectEnabled(false);
+      setMobilePathBuilderPinnedOpen(false);
+      setActiveGateElementId(entryId);
+      setActiveTool("gate");
+      setMobileToolsOpen(false);
+    },
+    [setActiveGateElementId, setActiveTool, setSelection]
+  );
+
   useEffect(() => {
     if (!pendingFlyThroughStart || tab !== "3d") return;
 
@@ -624,6 +641,7 @@ export default function EditorShell({
         {isMobile && !readOnly ? (
           <EditorMobilePanels
             activeTool={activeTool}
+            activeGateElementId={activeGateElementId}
             activePresetLabel={activePresetLabel}
             draftPathActive={mobileDraftPathState.active}
             draftPathClosed={mobileDraftPathState.closed}
@@ -778,6 +796,7 @@ export default function EditorShell({
               setMobileMultiSelectEnabled(false);
               setSelection([]);
             }}
+            onSelectGateElement={handleGateElementSelect}
             onSelectTool={(tool) => {
               setSelection([]);
               setMobileMultiSelectEnabled(false);

--- a/src/components/editor/EditorWorkspace.tsx
+++ b/src/components/editor/EditorWorkspace.tsx
@@ -7,6 +7,7 @@ import {
   type RefAttributes,
 } from "react";
 import { DesktopInspectorPanel } from "./DesktopInspectorPanel";
+import { ElementPlacementControl } from "./ElementPlacementControl";
 import StatusBar from "./StatusBar";
 import type {
   TrackCanvasHandle,
@@ -126,6 +127,9 @@ export function EditorWorkspace({
                 readOnly={readOnly}
               />
             </div>
+          ) : null}
+          {tab === "2d" && !readOnly && !isMobile ? (
+            <ElementPlacementControl />
           ) : null}
           {overlay}
         </div>

--- a/src/components/editor/ElementPlacementControl.tsx
+++ b/src/components/editor/ElementPlacementControl.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { type CSSProperties, useState } from "react";
+import { Check, ChevronDown } from "lucide-react";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  getGateTrackElementCatalogEntries,
+  TRACKDRAW_GATE_ELEMENT_ID,
+} from "@/lib/track/elements/catalog";
+import { cn } from "@/lib/utils";
+import { useSessionActions, useUiActions } from "@/store/actions";
+import { useEditor } from "@/store/editor";
+
+const gateCatalogEntries = getGateTrackElementCatalogEntries();
+const placementControlWidthCh = Math.max(
+  22,
+  Math.min(
+    32,
+    Math.max(...gateCatalogEntries.map((entry) => entry.name.length)) + 5
+  )
+);
+
+export function ElementPlacementControl() {
+  const [open, setOpen] = useState(false);
+  const activeTool = useEditor((state) => state.ui.activeTool);
+  const activeGateElementId =
+    useEditor((state) => state.ui.activeGateElementId) ??
+    TRACKDRAW_GATE_ELEMENT_ID;
+  const { setActiveGateElementId } = useUiActions();
+  const { setSelection } = useSessionActions();
+  const activeEntry =
+    gateCatalogEntries.find((entry) => entry.id === activeGateElementId) ??
+    gateCatalogEntries[0];
+  const controlWidthStyle = {
+    width: `min(${placementControlWidthCh}ch, calc(100vw - 2rem))`,
+  } satisfies CSSProperties;
+
+  if (activeTool !== "gate" || !activeEntry) return null;
+
+  return (
+    <div className="pointer-events-auto absolute bottom-3 left-1/2 z-20 hidden -translate-x-1/2 lg:block">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          style={controlWidthStyle}
+          className="group grid h-11 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md border border-border/65 bg-sidebar/94 px-2.5 text-left shadow-[0_10px_30px_rgba(15,23,42,0.16)] backdrop-blur-md transition-colors hover:border-border hover:bg-sidebar"
+        >
+          <span className="rounded-sm bg-muted px-1.5 py-1 font-mono text-[9px] leading-none font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+            Gate
+          </span>
+          <span className="min-w-0">
+            <span className="block truncate text-xs leading-none font-medium text-foreground">
+              {activeEntry.name}
+            </span>
+            <span className="mt-1 flex min-w-0 items-center gap-1.5">
+              <span className="truncate text-[11px] leading-none text-muted-foreground">
+                {activeEntry.dimensions.display.label}
+              </span>
+              {activeEntry.official ? (
+                <span className="shrink-0 rounded-[3px] bg-brand-primary/12 px-1 py-0.5 text-[9px] leading-none font-semibold tracking-[0.08em] text-brand-primary uppercase">
+                  Official
+                </span>
+              ) : null}
+            </span>
+          </span>
+          <span className="flex shrink-0 items-center">
+            <ChevronDown
+              className={cn(
+                "size-3.5 text-muted-foreground transition-transform",
+                open && "rotate-180"
+              )}
+            />
+          </span>
+        </PopoverTrigger>
+        <PopoverContent
+          align="center"
+          side="top"
+          sideOffset={8}
+          style={controlWidthStyle}
+          className="overflow-hidden p-0"
+        >
+          <div className="border-border/70 border-b px-3 py-2">
+            <p className="text-[11px] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+              Choose gate type
+            </p>
+          </div>
+          <div className="max-h-72 space-y-1 overflow-y-auto p-1.5">
+            {gateCatalogEntries.map((entry) => {
+              const active = activeGateElementId === entry.id;
+              return (
+                <button
+                  key={entry.id}
+                  type="button"
+                  onClick={() => {
+                    setSelection([]);
+                    setActiveGateElementId(entry.id);
+                    setOpen(false);
+                  }}
+                  className={cn(
+                    "flex w-full items-center gap-3 rounded-md px-2.5 py-2 text-left transition-colors",
+                    active
+                      ? "bg-brand-primary/10 text-foreground"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                  )}
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm leading-tight font-medium">
+                      {entry.name}
+                    </span>
+                    <span className="mt-1 flex min-w-0 items-center gap-1.5 text-xs opacity-75">
+                      <span className="truncate">
+                        {entry.dimensions.display.label}
+                      </span>
+                      {entry.official ? (
+                        <span className="rounded-[3px] bg-muted px-1 py-0.5 text-[9px] leading-none font-semibold tracking-[0.08em] uppercase">
+                          Official
+                        </span>
+                      ) : null}
+                    </span>
+                  </span>
+                  <Check
+                    className={cn(
+                      "size-4 shrink-0 text-brand-primary transition-opacity",
+                      active ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                </button>
+              );
+            })}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/editor/ElementPlacementControl.tsx
+++ b/src/components/editor/ElementPlacementControl.tsx
@@ -46,21 +46,21 @@ export function ElementPlacementControl() {
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger
           style={controlWidthStyle}
-          className="group grid h-11 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md border border-border/65 bg-sidebar/94 px-2.5 text-left shadow-[0_10px_30px_rgba(15,23,42,0.16)] backdrop-blur-md transition-colors hover:border-border hover:bg-sidebar"
+          className="group border-border/65 bg-sidebar/94 hover:border-border hover:bg-sidebar grid h-11 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md border px-2.5 text-left shadow-[0_10px_30px_rgba(15,23,42,0.16)] backdrop-blur-md transition-colors"
         >
-          <span className="rounded-sm bg-muted px-1.5 py-1 font-mono text-[9px] leading-none font-semibold tracking-[0.12em] text-muted-foreground uppercase">
+          <span className="bg-muted text-muted-foreground rounded-sm px-1.5 py-1 font-mono text-[9px] leading-none font-semibold tracking-[0.12em] uppercase">
             Gate
           </span>
           <span className="min-w-0">
-            <span className="block truncate text-xs leading-none font-medium text-foreground">
+            <span className="text-foreground block truncate text-xs leading-none font-medium">
               {activeEntry.name}
             </span>
             <span className="mt-1 flex min-w-0 items-center gap-1.5">
-              <span className="truncate text-[11px] leading-none text-muted-foreground">
+              <span className="text-muted-foreground truncate text-[11px] leading-none">
                 {activeEntry.dimensions.display.label}
               </span>
               {activeEntry.official ? (
-                <span className="shrink-0 rounded-[3px] bg-brand-primary/12 px-1 py-0.5 text-[9px] leading-none font-semibold tracking-[0.08em] text-brand-primary uppercase">
+                <span className="bg-brand-primary/12 text-brand-primary shrink-0 rounded-[3px] px-1 py-0.5 text-[9px] leading-none font-semibold tracking-[0.08em] uppercase">
                   Official
                 </span>
               ) : null}
@@ -69,7 +69,7 @@ export function ElementPlacementControl() {
           <span className="flex shrink-0 items-center">
             <ChevronDown
               className={cn(
-                "size-3.5 text-muted-foreground transition-transform",
+                "text-muted-foreground size-3.5 transition-transform",
                 open && "rotate-180"
               )}
             />
@@ -83,7 +83,7 @@ export function ElementPlacementControl() {
           className="overflow-hidden p-0"
         >
           <div className="border-border/70 border-b px-3 py-2">
-            <p className="text-[11px] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+            <p className="text-muted-foreground text-[11px] font-semibold tracking-[0.08em] uppercase">
               Choose gate type
             </p>
           </div>
@@ -115,7 +115,7 @@ export function ElementPlacementControl() {
                         {entry.dimensions.display.label}
                       </span>
                       {entry.official ? (
-                        <span className="rounded-[3px] bg-muted px-1 py-0.5 text-[9px] leading-none font-semibold tracking-[0.08em] uppercase">
+                        <span className="bg-muted rounded-[3px] px-1 py-0.5 text-[9px] leading-none font-semibold tracking-[0.08em] uppercase">
                           Official
                         </span>
                       ) : null}
@@ -123,7 +123,7 @@ export function ElementPlacementControl() {
                   </span>
                   <Check
                     className={cn(
-                      "size-4 shrink-0 text-brand-primary transition-opacity",
+                      "text-brand-primary size-4 shrink-0 transition-opacity",
                       active ? "opacity-100" : "opacity-0"
                     )}
                   />

--- a/src/components/editor/mobile/EditorMobilePanels.tsx
+++ b/src/components/editor/mobile/EditorMobilePanels.tsx
@@ -13,8 +13,6 @@ import {
   Lock,
   PencilLine,
   Plus,
-  Magnet,
-  Redo2,
   RotateCcw,
   RotateCw,
   Scan,
@@ -23,17 +21,17 @@ import {
   SquareMousePointer,
   Trash2,
   Unlock,
-  Undo2,
 } from "lucide-react";
 import Inspector from "@/components/inspector/Inspector";
 import { MultiSelectOverlay } from "@/components/editor/mobile/MultiSelectOverlay";
 import { PathBuilderOverlay } from "@/components/editor/mobile/PathBuilderOverlay";
+import { ToolsControls } from "@/components/editor/mobile/ToolsControls";
 import { ViewControls } from "@/components/editor/mobile/ViewControls";
-import { mobileToolEntries } from "@/components/editor/tool-icons";
 import { MobileDrawer } from "@/components/MobileDrawer";
 import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import type { EditorTool } from "@/lib/editor-tools";
 import { getEditorMobilePanelsViewModel } from "@/lib/editor/mobile/view-model";
+import type { TrackElementCatalogId } from "@/lib/track/elements/catalog";
 import { formatMeasurement } from "@/lib/track/units";
 import { cn } from "@/lib/utils";
 
@@ -41,6 +39,7 @@ export type EditorViewportTab = "2d" | "3d";
 
 interface EditorMobilePanelsProps {
   activeTool: EditorTool;
+  activeGateElementId: TrackElementCatalogId | null;
   activePresetLabel?: string | null;
   draftPathActive: boolean;
   draftPathClosed: boolean;
@@ -98,6 +97,7 @@ interface EditorMobilePanelsProps {
   onSetMobileGizmoEnabled: (enabled: boolean) => void;
   onSetMobileObstacleNumbersEnabled: (enabled: boolean) => void;
   onToggleSnapEnabled: () => void;
+  onSelectGateElement: (entryId: TrackElementCatalogId) => void;
   onSelectTool: (tool: EditorTool) => void;
   onSetMobileToolsOpen: (open: boolean) => void;
   onSetMobileViewOpen: (open: boolean) => void;
@@ -320,6 +320,7 @@ function MobileQuickActionsOverlay({
 
 export function EditorMobilePanels({
   activeTool,
+  activeGateElementId,
   activePresetLabel,
   canAddWaypoint = false,
   canDeleteWaypoint = false,
@@ -380,6 +381,7 @@ export function EditorMobilePanels({
   onSetMobileGizmoEnabled,
   onSetMobileObstacleNumbersEnabled,
   onToggleSnapEnabled,
+  onSelectGateElement,
   onSelectTool,
   onSetMobileToolsOpen,
   onSetMobileViewOpen,
@@ -425,11 +427,6 @@ export function EditorMobilePanels({
     onOpenView();
   };
 
-  const runMobileAction = (action: () => void) => {
-    blurActiveControl();
-    action();
-  };
-
   useEffect(() => {
     const mediaQuery = window.matchMedia(
       "(max-width: 1023px) and (orientation: landscape)"
@@ -472,7 +469,6 @@ export function EditorMobilePanels({
   };
   const showQuickAdjustOverlayVisible =
     showQuickAdjustOverlay && singleSelectionCanQuickAdjust;
-
   return (
     <>
       {!readOnly && !mobileFlyModeActive && (
@@ -700,133 +696,21 @@ export function EditorMobilePanels({
           subtitle={
             tab === "3d"
               ? "Project actions for the current 3D session"
-              : "Drawing and project actions"
+              : "Drawing and editing tools"
           }
-          bodyClassName="space-y-5 pt-3 pb-4"
+          bodyClassName="space-y-4 pt-3 pb-4"
         >
-          <>
-            <div>
-              <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-                History
-              </p>
-              <div className="grid grid-cols-2 gap-2">
-                <button
-                  onClick={() => runMobileAction(onUndo)}
-                  disabled={!canUndo}
-                  className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex items-center justify-center gap-1.5 rounded-2xl border px-3 py-3 transition-all disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  <Undo2 className="size-4" />
-                  <span className="text-[11px] leading-none font-medium">
-                    Undo
-                  </span>
-                </button>
-                <button
-                  onClick={() => runMobileAction(onRedo)}
-                  disabled={!canRedo}
-                  className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex items-center justify-center gap-1.5 rounded-2xl border px-3 py-3 transition-all disabled:cursor-not-allowed disabled:opacity-40"
-                >
-                  <Redo2 className="size-4" />
-                  <span className="text-[11px] leading-none font-medium">
-                    Redo
-                  </span>
-                </button>
-              </div>
-            </div>
-            {tab === "2d" && (
-              <div>
-                <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-                  Snap
-                </p>
-                <button
-                  onClick={() => runMobileAction(onToggleSnapEnabled)}
-                  className={cn(
-                    "border-border/50 flex w-full items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left transition-all",
-                    snapEnabled
-                      ? "text-foreground border-emerald-500/30 bg-emerald-500/8"
-                      : "bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground"
-                  )}
-                >
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm font-medium">
-                      {snapEnabled ? "Snap on" : "Snap off"}
-                    </p>
-                    <p className="pt-1 text-[11px] leading-relaxed opacity-80">
-                      {snapEnabled
-                        ? "Points and drags lock to nearby grid positions, objects, and route points."
-                        : "Place and drag freely until you turn snap back on."}
-                    </p>
-                  </div>
-                  <Magnet
-                    className={cn(
-                      "size-4 shrink-0",
-                      snapEnabled ? "text-emerald-500" : "text-muted-foreground"
-                    )}
-                  />
-                </button>
-              </div>
-            )}
-            {tab === "2d" && (
-              <div>
-                <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-                  Presets
-                </p>
-                <button
-                  onClick={() => runMobileAction(() => onSelectTool("preset"))}
-                  className={cn(
-                    "border-border/50 flex w-full items-center justify-between gap-3 rounded-2xl border px-4 py-3 text-left transition-all",
-                    activeTool === "preset"
-                      ? "border-border/80 bg-muted/55 text-foreground"
-                      : "bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground"
-                  )}
-                >
-                  <div className="min-w-0 flex-1">
-                    <p className="text-sm font-medium">Layout presets</p>
-                    <p className="pt-1 text-[11px] leading-relaxed opacity-80">
-                      {activePresetLabel
-                        ? `Current preset: ${activePresetLabel}`
-                        : "Place a curated multi-shape section in one tap."}
-                    </p>
-                  </div>
-                  <LayoutGrid className="size-4 shrink-0" />
-                </button>
-              </div>
-            )}
-            {tab === "2d" && (
-              <div>
-                <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-                  Drawing tools
-                </p>
-                <div className="grid grid-cols-3 gap-2">
-                  {mobileToolEntries
-                    .filter(
-                      (tool) => tool.id !== "grab" && tool.id !== "preset"
-                    )
-                    .map((tool) => {
-                      const active = activeTool === tool.id;
-                      return (
-                        <button
-                          key={tool.id}
-                          onClick={() =>
-                            runMobileAction(() => onSelectTool(tool.id))
-                          }
-                          className={cn(
-                            "flex flex-col items-center gap-1.5 rounded-2xl border px-2 py-3 transition-all",
-                            active
-                              ? "border-border/80 bg-muted/55 text-foreground"
-                              : "border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground"
-                          )}
-                        >
-                          {tool.icon}
-                          <span className="text-[11px] leading-none font-medium">
-                            {tool.label}
-                          </span>
-                        </button>
-                      );
-                    })}
-                </div>
-              </div>
-            )}
-          </>
+          <ToolsControls
+            activeTool={activeTool}
+            activeGateElementId={activeGateElementId}
+            canRedo={canRedo}
+            canUndo={canUndo}
+            tab={tab}
+            onRedo={onRedo}
+            onSelectGateElement={onSelectGateElement}
+            onSelectTool={onSelectTool}
+            onUndo={onUndo}
+          />
         </MobileDrawer>
       )}
 
@@ -853,6 +737,8 @@ export function EditorMobilePanels({
             onStartFlyThrough={onStartFlyThrough}
             onTabChange={onTabChange}
             saveStatusLabel={saveStatusLabel}
+            snapEnabled={snapEnabled}
+            onToggleSnapEnabled={onToggleSnapEnabled}
             closePanel={() => onSetMobileViewOpen(false)}
             tab={tab}
           />

--- a/src/components/editor/mobile/ToolsControls.tsx
+++ b/src/components/editor/mobile/ToolsControls.tsx
@@ -78,7 +78,7 @@ export function ToolsControls({
           </p>
 
           {/* Gate — full-width card with inline type picker */}
-          <div className="mb-2 overflow-hidden rounded-2xl border border-border/50 bg-muted/14">
+          <div className="border-border/50 bg-muted/14 mb-2 overflow-hidden rounded-2xl border">
             <button
               type="button"
               onClick={() => runAction(() => onSelectTool("gate"))}
@@ -90,7 +90,7 @@ export function ToolsControls({
               )}
             >
               <div className="flex min-w-0 items-center gap-3">
-                <span className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-border/45 bg-background/50">
+                <span className="border-border/45 bg-background/50 flex size-10 shrink-0 items-center justify-center rounded-xl border">
                   {mobileGateToolEntry?.icon}
                 </span>
                 <div className="min-w-0">
@@ -103,7 +103,7 @@ export function ToolsControls({
                 </div>
               </div>
               {activeGateEntry?.official ? (
-                <span className="shrink-0 rounded-md bg-brand-primary/12 px-1.5 py-1 text-[9px] leading-none font-semibold tracking-[0.08em] text-brand-primary uppercase">
+                <span className="bg-brand-primary/12 text-brand-primary shrink-0 rounded-md px-1.5 py-1 text-[9px] leading-none font-semibold tracking-[0.08em] uppercase">
                   Official
                 </span>
               ) : null}
@@ -123,7 +123,7 @@ export function ToolsControls({
               />
             </button>
             {gateTypesOpen ? (
-              <div className="space-y-1 border-t border-border/25 p-1.5">
+              <div className="border-border/25 space-y-1 border-t p-1.5">
                 {gateCatalogEntries.map((entry) => {
                   const active = activeGateEntry?.id === entry.id;
                   return (
@@ -151,7 +151,7 @@ export function ToolsControls({
                       </span>
                       <Check
                         className={cn(
-                          "size-3.5 shrink-0 text-brand-primary transition-opacity",
+                          "text-brand-primary size-3.5 shrink-0 transition-opacity",
                           active ? "opacity-100" : "opacity-0"
                         )}
                       />
@@ -192,7 +192,6 @@ export function ToolsControls({
                 );
               })}
           </div>
-
         </div>
       )}
     </>

--- a/src/components/editor/mobile/ToolsControls.tsx
+++ b/src/components/editor/mobile/ToolsControls.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ChevronDown, Redo2, Undo2 } from "lucide-react";
+import { mobileToolEntries } from "@/components/editor/tool-icons";
+import {
+  getGateTrackElementCatalogEntries,
+  type TrackElementCatalogId,
+} from "@/lib/track/elements/catalog";
+import type { EditorTool } from "@/lib/editor-tools";
+import { cn } from "@/lib/utils";
+import type { EditorViewportTab } from "./Panels";
+
+const gateCatalogEntries = getGateTrackElementCatalogEntries();
+const mobileGateToolEntry = mobileToolEntries.find((t) => t.id === "gate");
+
+interface ToolsControlsProps {
+  activeTool: EditorTool;
+  activeGateElementId: TrackElementCatalogId | null;
+  canRedo: boolean;
+  canUndo: boolean;
+  tab: EditorViewportTab;
+  onRedo: () => void;
+  onSelectGateElement: (id: TrackElementCatalogId) => void;
+  onSelectTool: (tool: EditorTool) => void;
+  onUndo: () => void;
+}
+
+function runAction(action: () => void) {
+  const el = document.activeElement;
+  if (el instanceof HTMLElement) el.blur();
+  action();
+}
+
+export function ToolsControls({
+  activeTool,
+  activeGateElementId,
+  canRedo,
+  canUndo,
+  tab,
+  onRedo,
+  onSelectGateElement,
+  onSelectTool,
+  onUndo,
+}: ToolsControlsProps) {
+  const [gateTypesOpen, setGateTypesOpen] = useState(false);
+
+  const activeGateEntry =
+    gateCatalogEntries.find((e) => e.id === activeGateElementId) ??
+    gateCatalogEntries[0];
+
+  return (
+    <>
+      {/* Compact undo / redo — no section header */}
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          onClick={() => runAction(onUndo)}
+          disabled={!canUndo}
+          className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex items-center justify-center gap-1.5 rounded-2xl border px-3 py-2.5 text-[11px] font-medium transition-all disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <Undo2 className="size-3.5" />
+          Undo
+        </button>
+        <button
+          onClick={() => runAction(onRedo)}
+          disabled={!canRedo}
+          className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex items-center justify-center gap-1.5 rounded-2xl border px-3 py-2.5 text-[11px] font-medium transition-all disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          <Redo2 className="size-3.5" />
+          Redo
+        </button>
+      </div>
+
+      {tab === "2d" && (
+        <div>
+          <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
+            Tools
+          </p>
+
+          {/* Gate — full-width card with inline type picker */}
+          <div className="mb-2 overflow-hidden rounded-2xl border border-border/50 bg-muted/14">
+            <button
+              type="button"
+              onClick={() => runAction(() => onSelectTool("gate"))}
+              className={cn(
+                "flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-all",
+                activeTool === "gate"
+                  ? "bg-muted/55 text-foreground"
+                  : "text-muted-foreground hover:bg-muted/28 hover:text-foreground"
+              )}
+            >
+              <div className="flex min-w-0 items-center gap-3">
+                <span className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-border/45 bg-background/50">
+                  {mobileGateToolEntry?.icon}
+                </span>
+                <div className="min-w-0">
+                  <p className="text-sm font-medium">Gate</p>
+                  <p className="truncate pt-0.5 text-[11px] opacity-70">
+                    {activeGateEntry
+                      ? `${activeGateEntry.name} · ${activeGateEntry.dimensions.display.label}`
+                      : "Place a gate"}
+                  </p>
+                </div>
+              </div>
+              {activeGateEntry?.official ? (
+                <span className="shrink-0 rounded-md bg-brand-primary/12 px-1.5 py-1 text-[9px] leading-none font-semibold tracking-[0.08em] text-brand-primary uppercase">
+                  Official
+                </span>
+              ) : null}
+            </button>
+            <button
+              type="button"
+              onClick={() => setGateTypesOpen((c) => !c)}
+              className="border-border/25 text-muted-foreground hover:bg-muted/22 hover:text-foreground flex min-h-9 w-full items-center justify-between gap-2 border-t px-4 text-left text-[11px] font-medium transition-colors"
+              aria-expanded={gateTypesOpen}
+            >
+              <span>Change gate type</span>
+              <ChevronDown
+                className={cn(
+                  "size-3.5 transition-transform",
+                  gateTypesOpen && "rotate-180"
+                )}
+              />
+            </button>
+            {gateTypesOpen ? (
+              <div className="space-y-1 border-t border-border/25 p-1.5">
+                {gateCatalogEntries.map((entry) => {
+                  const active = activeGateEntry?.id === entry.id;
+                  return (
+                    <button
+                      key={entry.id}
+                      type="button"
+                      onClick={() =>
+                        runAction(() => onSelectGateElement(entry.id))
+                      }
+                      className={cn(
+                        "flex min-h-11 w-full items-center gap-2 rounded-xl px-2.5 py-2 text-left transition-colors",
+                        active
+                          ? "bg-muted/60 text-foreground"
+                          : "text-muted-foreground hover:bg-muted/28 hover:text-foreground"
+                      )}
+                    >
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-[12px] font-medium">
+                          {entry.name}
+                        </span>
+                        <span className="mt-0.5 block truncate text-[10px] opacity-75">
+                          {entry.dimensions.display.label}
+                          {entry.official ? " · Official" : ""}
+                        </span>
+                      </span>
+                      <Check
+                        className={cn(
+                          "size-3.5 shrink-0 text-brand-primary transition-opacity",
+                          active ? "opacity-100" : "opacity-0"
+                        )}
+                      />
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
+          </div>
+
+          {/* Drawing tools grid — preset excluded */}
+          <div className="grid grid-cols-3 gap-2">
+            {mobileToolEntries
+              .filter(
+                (tool) =>
+                  tool.id !== "grab" &&
+                  tool.id !== "gate" &&
+                  tool.id !== "preset"
+              )
+              .map((tool) => {
+                const active = activeTool === tool.id;
+                return (
+                  <button
+                    key={tool.id}
+                    onClick={() => runAction(() => onSelectTool(tool.id))}
+                    className={cn(
+                      "flex flex-col items-center gap-1.5 rounded-2xl border px-2 py-3 transition-all",
+                      active
+                        ? "border-border/80 bg-muted/55 text-foreground"
+                        : "border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground"
+                    )}
+                  >
+                    {tool.icon}
+                    <span className="text-[11px] leading-none font-medium">
+                      {tool.label}
+                    </span>
+                  </button>
+                );
+              })}
+          </div>
+
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/editor/mobile/ViewControls.tsx
+++ b/src/components/editor/mobile/ViewControls.tsx
@@ -18,6 +18,8 @@ interface EditorMobileViewControlsProps {
   onSetMobileRulersEnabled: (enabled: boolean) => void;
   onShare?: () => void;
   onStartFlyThrough: () => void;
+  snapEnabled?: boolean;
+  onToggleSnapEnabled?: () => void;
   onTabChange: (tab: EditorViewportTab) => void;
   saveStatusLabel: string;
   showShareActions?: boolean;
@@ -82,9 +84,11 @@ export function ViewControls({
   onShare,
   onStartFlyThrough,
   onTabChange,
+  onToggleSnapEnabled,
   readOnly = false,
   saveStatusLabel,
   showShareActions = true,
+  snapEnabled = false,
   studioHref = "/studio",
   tab,
 }: EditorMobileViewControlsProps) {
@@ -139,6 +143,34 @@ export function ViewControls({
         </button>
         {tab === "2d" ? (
           <>
+            {onToggleSnapEnabled && (
+              <button
+                onClick={onToggleSnapEnabled}
+                className={cn(
+                  "border-border/50 bg-muted/18 mt-2.5 flex w-full items-center justify-between rounded-2xl border px-3 py-2.5 text-left transition-colors",
+                  snapEnabled
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                <div>
+                  <p className="text-[11px] font-medium">Snap</p>
+                  <p className="text-muted-foreground/75 pt-0.5 text-[11px]">
+                    Lock to nearby grid positions and objects
+                  </p>
+                </div>
+                <div
+                  className={cn(
+                    "flex h-6 w-10 items-center rounded-full p-0.5 transition-colors",
+                    snapEnabled
+                      ? "bg-foreground/90 justify-end"
+                      : "bg-border/80 justify-start"
+                  )}
+                >
+                  <span className="bg-background block size-5 rounded-full shadow-xs" />
+                </div>
+              </button>
+            )}
             <ToggleRow
               title="Rulers"
               description="Show top and left guides on mobile"

--- a/src/components/inspector/views/multi.tsx
+++ b/src/components/inspector/views/multi.tsx
@@ -170,7 +170,10 @@ export function MultiInspectorView({
                     setGroupName(selection, event.target.value)
                   }
                   placeholder="Optional group name"
-                  className="bg-muted/50 border-border/70 focus-visible:border-border/80 focus-visible:ring-ring/20 h-8 rounded-md px-2.5 text-[11px] focus-visible:ring-1 lg:h-7 lg:px-2"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  className="bg-background border-border/50 focus-visible:border-border/80 h-8 rounded-md px-2.5 text-[11px] shadow-none focus-visible:ring-0 lg:h-7 lg:px-2"
                 />
               </Row>
             </Section>

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -487,8 +487,8 @@ export function SingleInspectorView({
             {shape.kind === "gate" && (
               <>
                 <Row label="Width">
-                  {isOfficialCatalogGate ? (
-                    renderOfficialMeasurement(shape.width)
+                  {isOfficialCatalogGate && catalogGateDimensions ? (
+                    renderOfficialMeasurement(catalogGateDimensions.width)
                   ) : (
                     <MeasurementNum
                       valueMeters={shape.width}
@@ -501,8 +501,8 @@ export function SingleInspectorView({
                   )}
                 </Row>
                 <Row label="Height">
-                  {isOfficialCatalogGate ? (
-                    renderOfficialMeasurement(shape.height)
+                  {isOfficialCatalogGate && catalogGateDimensions ? (
+                    renderOfficialMeasurement(catalogGateDimensions.height)
                   ) : (
                     <MeasurementNum
                       valueMeters={shape.height}

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -298,23 +298,23 @@ export function SingleInspectorView({
             <Section title="Catalog" defaultOpen>
               <Row label="Type">
                 <div className="min-w-0">
-                  <p className="truncate text-[12px] font-medium text-foreground">
+                  <p className="text-foreground truncate text-[12px] font-medium">
                     {catalogIdentity.snapshot.name}
                   </p>
-                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                  <p className="text-muted-foreground mt-0.5 text-[11px]">
                     {shapeKindLabels[catalogIdentity.assignedKind]}
                   </p>
                 </div>
               </Row>
               {catalogIdentity.snapshot.organization ? (
                 <Row label="Source">
-                  <span className="text-[12px] text-foreground">
+                  <span className="text-foreground text-[12px]">
                     {catalogIdentity.snapshot.organization}
                   </span>
                 </Row>
               ) : null}
               <Row label="Official size">
-                <span className="text-[12px] text-foreground">
+                <span className="text-foreground text-[12px]">
                   {catalogIdentity.snapshot.dimensionsLabel}
                 </span>
               </Row>
@@ -624,9 +624,7 @@ export function SingleInspectorView({
                   <MeasurementNum
                     valueMeters={shape.size}
                     unitSystem={unitSystem}
-                    onChange={(value) =>
-                      updateShape(shape.id, { size: value })
-                    }
+                    onChange={(value) => updateShape(shape.id, { size: value })}
                     minMeters={0.5}
                   />
                 </Row>

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -8,6 +8,11 @@ import { shapeKindLabels } from "@/lib/editor-tools";
 import { getSingleInspectorViewModel } from "@/lib/inspector/single/view-model";
 import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import {
+  getTrackElementCatalogEntry,
+  getTrackElementCatalogIdentity,
+} from "@/lib/track/elements/catalog";
+import { formatMeasurement } from "@/lib/track/units";
+import {
   getShapeTimingMarker,
   getTimingMarkerMeta,
   isTimingMarkerShape,
@@ -111,9 +116,24 @@ export function SingleInspectorView({
     shape.kind === "polyline" &&
     (Boolean(onResumeSelectedPath) || showDefaultPathActions);
   const timingMarker = getShapeTimingMarker(shape);
+  const catalogIdentity = getTrackElementCatalogIdentity(shape.meta);
+  const catalogEntry = getTrackElementCatalogEntry(catalogIdentity?.elementId);
+  const selectedGateShape = shape.kind === "gate" ? shape : null;
+  const catalogGateDimensions =
+    selectedGateShape &&
+    catalogEntry?.kind === "gate" &&
+    typeof catalogEntry.dimensions.widthMeters === "number" &&
+    typeof catalogEntry.dimensions.heightMeters === "number"
+      ? {
+          width: catalogEntry.dimensions.widthMeters,
+          height: catalogEntry.dimensions.heightMeters,
+        }
+      : null;
+  const isOfficialCatalogGate =
+    catalogIdentity?.official === true && catalogGateDimensions !== null;
   const canSetTimingMarker = isTimingMarkerShape(shape);
   const secondarySectionDefaultOpen = !mobileInline;
-  const timingSectionDefaultOpen = !mobileInline || Boolean(timingMarker);
+  const timingSectionDefaultOpen = !mobileInline || canSetTimingMarker;
   const timingRoleOptions: Array<{
     label: string;
     role: TimingRole | "none";
@@ -132,6 +152,16 @@ export function SingleInspectorView({
       meta: getTimingMarkerMeta(shape.meta, marker),
     } as Partial<Shape>);
   };
+  const renderOfficialMeasurement = (valueMeters: number) => (
+    <div className="border-border/50 bg-muted/25 text-foreground/82 flex h-8 min-w-0 items-center justify-between gap-2 rounded-md border px-2.5 text-[11px] shadow-none lg:h-7 lg:px-2">
+      <span className="min-w-0 truncate font-mono">
+        {formatMeasurement(valueMeters, unitSystem, { precision: 2 })}
+      </span>
+      <span className="text-muted-foreground/70 shrink-0 text-[10px] font-medium">
+        Official
+      </span>
+    </div>
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -247,7 +277,10 @@ export function SingleInspectorView({
                     setGroupName([shape.id], event.target.value)
                   }
                   placeholder="Optional group name"
-                  className="bg-muted/50 border-border/70 focus-visible:border-border/80 focus-visible:ring-ring/20 h-8 rounded-md px-2.5 text-[11px] focus-visible:ring-1 lg:h-7 lg:px-2"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  className="bg-background border-border/50 focus-visible:border-border/80 h-8 rounded-md px-2.5 text-[11px] shadow-none focus-visible:ring-0 lg:h-7 lg:px-2"
                 />
               </Row>
               <div className="pt-1">
@@ -261,87 +294,45 @@ export function SingleInspectorView({
               </div>
             </Section>
           )}
-          <Section title="Transform">
-            <Row label="Name">
-              <Input
-                value={shape.name ?? ""}
-                onFocus={startBatch}
-                onBlur={finishBatch}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.currentTarget.blur();
-                  }
-                }}
-                onChange={(event) =>
-                  updateShape(shape.id, { name: event.target.value })
-                }
-                placeholder={`${shapeKindLabels[shape.kind]} name`}
-                className="bg-muted/50 border-border/70 focus-visible:border-border/80 focus-visible:ring-ring/20 h-8 rounded-md px-2.5 text-[11px] focus-visible:ring-1 lg:h-7 lg:px-2"
-              />
-            </Row>
-            <Row label="Position">
-              <div className="grid grid-cols-2 gap-2">
-                <label className="min-w-0">
-                  <span className="text-muted-foreground/65 mb-1 block text-[10px] font-semibold tracking-[0.12em] uppercase">
-                    X ({unitLabel})
-                  </span>
-                  <MeasurementNum
-                    valueMeters={fmt(anchorPosition.x)}
-                    unitSystem={unitSystem}
-                    onChange={(value) => updateShape(shape.id, { x: value })}
-                  />
-                </label>
-                <label className="min-w-0">
-                  <span className="text-muted-foreground/65 mb-1 block text-[10px] font-semibold tracking-[0.12em] uppercase">
-                    Y ({unitLabel})
-                  </span>
-                  <MeasurementNum
-                    valueMeters={fmt(anchorPosition.y)}
-                    unitSystem={unitSystem}
-                    onChange={(value) => updateShape(shape.id, { y: value })}
-                  />
-                </label>
-              </div>
-            </Row>
-            {shape.kind !== "cone" && (
-              <Row label="Rotation (deg)">
-                <Num
-                  value={shape.rotation}
-                  onChange={(value) =>
-                    updateShape(shape.id, { rotation: value })
-                  }
-                  step={1}
-                />
+          {catalogIdentity ? (
+            <Section title="Catalog" defaultOpen>
+              <Row label="Type">
+                <div className="min-w-0">
+                  <p className="truncate text-[12px] font-medium text-foreground">
+                    {catalogIdentity.snapshot.name}
+                  </p>
+                  <p className="mt-0.5 text-[11px] text-muted-foreground">
+                    {shapeKindLabels[catalogIdentity.assignedKind]}
+                  </p>
+                </div>
               </Row>
-            )}
-            <Row label="Color">
-              <div className="flex items-center gap-2">
-                <label className="group relative block cursor-pointer">
-                  <span
-                    className="border-border/45 block size-9 rounded-lg border shadow-xs transition-transform group-hover:scale-[1.03] lg:size-7"
-                    style={{
-                      background: `linear-gradient(135deg, ${defaultColor} 0%, color-mix(in oklab, ${defaultColor} 72%, black) 100%)`,
-                    }}
-                  />
-                  <span className="absolute inset-0 rounded-lg ring-1 ring-white/18 ring-inset" />
-                  <input
-                    type="color"
-                    className="absolute inset-0 cursor-pointer opacity-0"
-                    value={defaultColor}
-                    onFocus={startBatch}
-                    onBlur={finishBatch}
-                    onChange={(event) =>
-                      updateShape(shape.id, { color: event.target.value })
-                    }
-                    aria-label="Pick color"
-                  />
-                </label>
-                <span className="border-border/45 bg-muted/35 text-foreground/78 inline-flex h-8 items-center rounded-lg border px-2.5 font-mono text-[11px] lg:h-7">
-                  {defaultColor}
+              {catalogIdentity.snapshot.organization ? (
+                <Row label="Source">
+                  <span className="text-[12px] text-foreground">
+                    {catalogIdentity.snapshot.organization}
+                  </span>
+                </Row>
+              ) : null}
+              <Row label="Official size">
+                <span className="text-[12px] text-foreground">
+                  {catalogIdentity.snapshot.dimensionsLabel}
                 </span>
-              </div>
-            </Row>
-          </Section>
+              </Row>
+              <Row label="Status">
+                <span
+                  className={`inline-flex min-h-6 items-center rounded-md border px-2 py-1 text-[11px] font-medium ${
+                    catalogIdentity.official
+                      ? "border-emerald-500/25 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300"
+                      : "border-border/60 bg-muted/40 text-muted-foreground"
+                  }`}
+                >
+                  {catalogIdentity.official
+                    ? "Official dimensions"
+                    : "Catalog item"}
+                </span>
+              </Row>
+            </Section>
+          ) : null}
 
           {canSetTimingMarker && (
             <Section title="Race timing" defaultOpen={timingSectionDefaultOpen}>
@@ -410,8 +401,178 @@ export function SingleInspectorView({
             </Section>
           )}
 
-          {shape.kind === "gate" && (
-            <Section title="Gate" defaultOpen={secondarySectionDefaultOpen}>
+          <Section title="Transform">
+            <Row label="Name">
+              <Input
+                value={shape.name ?? ""}
+                onFocus={startBatch}
+                onBlur={finishBatch}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    event.currentTarget.blur();
+                  }
+                }}
+                onChange={(event) =>
+                  updateShape(shape.id, { name: event.target.value })
+                }
+                placeholder={`${shapeKindLabels[shape.kind]} name`}
+                autoComplete="off"
+                autoCorrect="off"
+                spellCheck={false}
+                className="bg-background border-border/50 focus-visible:border-border/80 h-8 rounded-md px-2.5 text-[11px] shadow-none focus-visible:ring-0 lg:h-7 lg:px-2"
+              />
+            </Row>
+            <Row label="Position">
+              <div className="grid grid-cols-2 gap-2">
+                <label className="min-w-0">
+                  <span className="text-muted-foreground/65 mb-1 block text-[10px] font-semibold tracking-[0.12em] uppercase">
+                    X ({unitLabel})
+                  </span>
+                  <MeasurementNum
+                    valueMeters={fmt(anchorPosition.x)}
+                    unitSystem={unitSystem}
+                    onChange={(value) => updateShape(shape.id, { x: value })}
+                  />
+                </label>
+                <label className="min-w-0">
+                  <span className="text-muted-foreground/65 mb-1 block text-[10px] font-semibold tracking-[0.12em] uppercase">
+                    Y ({unitLabel})
+                  </span>
+                  <MeasurementNum
+                    valueMeters={fmt(anchorPosition.y)}
+                    unitSystem={unitSystem}
+                    onChange={(value) => updateShape(shape.id, { y: value })}
+                  />
+                </label>
+              </div>
+            </Row>
+            {shape.kind !== "cone" && (
+              <Row label="Rotation (deg)">
+                <Num
+                  value={shape.rotation}
+                  onChange={(value) =>
+                    updateShape(shape.id, { rotation: value })
+                  }
+                  step={1}
+                />
+              </Row>
+            )}
+            <Row label="Color">
+              <div className="flex items-center gap-2">
+                <label className="group relative block cursor-pointer">
+                  <span
+                    className="border-border/45 block size-9 rounded-lg border shadow-xs transition-transform group-hover:scale-[1.03] lg:size-7"
+                    style={{
+                      background: `linear-gradient(135deg, ${defaultColor} 0%, color-mix(in oklab, ${defaultColor} 72%, black) 100%)`,
+                    }}
+                  />
+                  <span className="absolute inset-0 rounded-lg ring-1 ring-white/18 ring-inset" />
+                  <input
+                    type="color"
+                    className="absolute inset-0 cursor-pointer opacity-0"
+                    value={defaultColor}
+                    onFocus={startBatch}
+                    onBlur={finishBatch}
+                    onChange={(event) =>
+                      updateShape(shape.id, { color: event.target.value })
+                    }
+                    aria-label="Pick color"
+                  />
+                </label>
+                <span className="border-border/45 bg-muted/35 text-foreground/78 inline-flex h-8 items-center rounded-lg border px-2.5 font-mono text-[11px] lg:h-7">
+                  {defaultColor}
+                </span>
+              </div>
+            </Row>
+            {shape.kind === "gate" && (
+              <>
+                <Row label="Width">
+                  {isOfficialCatalogGate ? (
+                    renderOfficialMeasurement(shape.width)
+                  ) : (
+                    <MeasurementNum
+                      valueMeters={shape.width}
+                      unitSystem={unitSystem}
+                      onChange={(value) =>
+                        updateShape(shape.id, { width: value })
+                      }
+                      minMeters={0.5}
+                    />
+                  )}
+                </Row>
+                <Row label="Height">
+                  {isOfficialCatalogGate ? (
+                    renderOfficialMeasurement(shape.height)
+                  ) : (
+                    <MeasurementNum
+                      valueMeters={shape.height}
+                      unitSystem={unitSystem}
+                      onChange={(value) =>
+                        updateShape(shape.id, { height: value })
+                      }
+                      minMeters={0.5}
+                    />
+                  )}
+                </Row>
+                <Row label="Thickness">
+                  <MeasurementNum
+                    valueMeters={shape.thick ?? 0.2}
+                    unitSystem={unitSystem}
+                    onChange={(value) =>
+                      updateShape(shape.id, { thick: value })
+                    }
+                    minMeters={0.05}
+                  />
+                </Row>
+              </>
+            )}
+            {shape.kind === "flag" && (
+              <>
+                <Row label="Radius">
+                  <MeasurementNum
+                    valueMeters={shape.radius}
+                    unitSystem={unitSystem}
+                    onChange={(value) =>
+                      updateShape(shape.id, { radius: value })
+                    }
+                    minMeters={0.05}
+                  />
+                </Row>
+                <Row label="Pole height">
+                  <MeasurementNum
+                    valueMeters={shape.poleHeight ?? 3.5}
+                    unitSystem={unitSystem}
+                    onChange={(value) =>
+                      updateShape(shape.id, { poleHeight: value })
+                    }
+                    minMeters={0}
+                  />
+                </Row>
+              </>
+            )}
+            {shape.kind === "cone" && (
+              <Row label="Radius">
+                <MeasurementNum
+                  valueMeters={shape.radius}
+                  unitSystem={unitSystem}
+                  onChange={(value) => updateShape(shape.id, { radius: value })}
+                  minMeters={0.05}
+                />
+              </Row>
+            )}
+            {shape.kind === "label" && (
+              <Row label="Font size (px)">
+                <Num
+                  value={shape.fontSize ?? 18}
+                  onChange={(value) =>
+                    updateShape(shape.id, { fontSize: value })
+                  }
+                  step={1}
+                  min={8}
+                />
+              </Row>
+            )}
+            {shape.kind === "startfinish" && (
               <Row label="Width">
                 <MeasurementNum
                   valueMeters={shape.width}
@@ -420,60 +581,90 @@ export function SingleInspectorView({
                   minMeters={0.5}
                 />
               </Row>
-              <Row label="Height">
-                <MeasurementNum
-                  valueMeters={shape.height}
-                  unitSystem={unitSystem}
-                  onChange={(value) => updateShape(shape.id, { height: value })}
-                  minMeters={0.5}
-                />
-              </Row>
-              <Row label="Thickness">
-                <MeasurementNum
-                  valueMeters={shape.thick ?? 0.2}
-                  unitSystem={unitSystem}
-                  onChange={(value) => updateShape(shape.id, { thick: value })}
-                  minMeters={0.05}
-                />
-              </Row>
-            </Section>
-          )}
-
-          {shape.kind === "flag" && (
-            <Section title="Flag" defaultOpen={secondarySectionDefaultOpen}>
-              <Row label="Radius">
-                <MeasurementNum
-                  valueMeters={shape.radius}
-                  unitSystem={unitSystem}
-                  onChange={(value) => updateShape(shape.id, { radius: value })}
-                  minMeters={0.05}
-                />
-              </Row>
-              <Row label="Pole height">
-                <MeasurementNum
-                  valueMeters={shape.poleHeight ?? 3.5}
-                  unitSystem={unitSystem}
-                  onChange={(value) =>
-                    updateShape(shape.id, { poleHeight: value })
-                  }
-                  minMeters={0}
-                />
-              </Row>
-            </Section>
-          )}
-
-          {shape.kind === "cone" && (
-            <Section title="Cone" defaultOpen={secondarySectionDefaultOpen}>
-              <Row label="Radius">
-                <MeasurementNum
-                  valueMeters={shape.radius}
-                  unitSystem={unitSystem}
-                  onChange={(value) => updateShape(shape.id, { radius: value })}
-                  minMeters={0.05}
-                />
-              </Row>
-            </Section>
-          )}
+            )}
+            {shape.kind === "ladder" && (
+              <>
+                <Row label="Width">
+                  <MeasurementNum
+                    valueMeters={shape.width}
+                    unitSystem={unitSystem}
+                    onChange={(value) =>
+                      updateShape(shape.id, { width: value })
+                    }
+                    minMeters={0.5}
+                  />
+                </Row>
+                <Row label="Height">
+                  <MeasurementNum
+                    valueMeters={shape.height}
+                    unitSystem={unitSystem}
+                    onChange={(value) =>
+                      updateShape(shape.id, { height: value })
+                    }
+                    minMeters={0.5}
+                  />
+                </Row>
+                <Row label="Elevation">
+                  <MeasurementNum
+                    valueMeters={shape.elevation ?? 0}
+                    unitSystem={unitSystem}
+                    onChange={(value) =>
+                      updateShape(shape.id, {
+                        elevation: Math.max(0, value),
+                      })
+                    }
+                    minMeters={0}
+                  />
+                </Row>
+              </>
+            )}
+            {shape.kind === "divegate" && (
+              <>
+                <Row label="Size">
+                  <MeasurementNum
+                    valueMeters={shape.size}
+                    unitSystem={unitSystem}
+                    onChange={(value) =>
+                      updateShape(shape.id, { size: value })
+                    }
+                    minMeters={0.5}
+                  />
+                </Row>
+                <Row label="Elevation">
+                  <MeasurementNum
+                    valueMeters={shape.elevation ?? 3}
+                    unitSystem={unitSystem}
+                    onChange={(value) =>
+                      updateShape(shape.id, { elevation: value })
+                    }
+                    minMeters={0.1}
+                  />
+                </Row>
+                <Row label="Thickness">
+                  <MeasurementNum
+                    valueMeters={shape.thick ?? 0.2}
+                    unitSystem={unitSystem}
+                    onChange={(value) =>
+                      updateShape(shape.id, { thick: value })
+                    }
+                    minMeters={0.05}
+                  />
+                </Row>
+                <Row label="Tilt (deg)">
+                  <Num
+                    value={shape.tilt ?? 0}
+                    onChange={(value) =>
+                      updateShape(shape.id, {
+                        tilt: Math.round(Math.max(0, Math.min(90, value))),
+                      })
+                    }
+                    step={5}
+                    min={0}
+                  />
+                </Row>
+              </>
+            )}
+          </Section>
 
           {shape.kind === "label" && (
             <Section title="Label" defaultOpen={secondarySectionDefaultOpen}>
@@ -487,16 +678,6 @@ export function SingleInspectorView({
                   onChange={(event) =>
                     updateShape(shape.id, { text: event.target.value })
                   }
-                />
-              </Row>
-              <Row label="Font size (px)">
-                <Num
-                  value={shape.fontSize ?? 18}
-                  onChange={(value) =>
-                    updateShape(shape.id, { fontSize: value })
-                  }
-                  step={1}
-                  min={8}
                 />
               </Row>
               <Row label="3D mode">
@@ -518,52 +699,8 @@ export function SingleInspectorView({
             </Section>
           )}
 
-          {shape.kind === "startfinish" && (
-            <Section
-              title="Start Pads"
-              defaultOpen={secondarySectionDefaultOpen}
-            >
-              <Row label="Width">
-                <MeasurementNum
-                  valueMeters={shape.width}
-                  unitSystem={unitSystem}
-                  onChange={(value) => updateShape(shape.id, { width: value })}
-                  minMeters={0.5}
-                />
-              </Row>
-            </Section>
-          )}
-
           {shape.kind === "ladder" && (
             <Section title="Ladder" defaultOpen={secondarySectionDefaultOpen}>
-              <Row label="Width">
-                <MeasurementNum
-                  valueMeters={shape.width}
-                  unitSystem={unitSystem}
-                  onChange={(value) => updateShape(shape.id, { width: value })}
-                  minMeters={0.5}
-                />
-              </Row>
-              <Row label="Height">
-                <MeasurementNum
-                  valueMeters={shape.height}
-                  unitSystem={unitSystem}
-                  onChange={(value) => updateShape(shape.id, { height: value })}
-                  minMeters={0.5}
-                />
-              </Row>
-              <Row label="Elevation">
-                <MeasurementNum
-                  valueMeters={shape.elevation ?? 0}
-                  unitSystem={unitSystem}
-                  onChange={(value) =>
-                    updateShape(shape.id, {
-                      elevation: Math.max(0, value),
-                    })
-                  }
-                  minMeters={0}
-                />
-              </Row>
               <Row label="Gates">
                 <Num
                   value={shape.rungs}
@@ -578,52 +715,6 @@ export function SingleInspectorView({
                   }}
                   step={1}
                   min={1}
-                />
-              </Row>
-            </Section>
-          )}
-
-          {shape.kind === "divegate" && (
-            <Section
-              title="Dive Gate"
-              defaultOpen={secondarySectionDefaultOpen}
-            >
-              <Row label="Size">
-                <MeasurementNum
-                  valueMeters={shape.size}
-                  unitSystem={unitSystem}
-                  onChange={(value) => updateShape(shape.id, { size: value })}
-                  minMeters={0.5}
-                />
-              </Row>
-              <Row label="Elevation">
-                <MeasurementNum
-                  valueMeters={shape.elevation ?? 3}
-                  unitSystem={unitSystem}
-                  onChange={(value) =>
-                    updateShape(shape.id, { elevation: value })
-                  }
-                  minMeters={0.1}
-                />
-              </Row>
-              <Row label="Thickness">
-                <MeasurementNum
-                  valueMeters={shape.thick ?? 0.2}
-                  unitSystem={unitSystem}
-                  onChange={(value) => updateShape(shape.id, { thick: value })}
-                  minMeters={0.05}
-                />
-              </Row>
-              <Row label="Tilt (deg)">
-                <Num
-                  value={shape.tilt ?? 0}
-                  onChange={(value) =>
-                    updateShape(shape.id, {
-                      tilt: Math.round(Math.max(0, Math.min(90, value))),
-                    })
-                  }
-                  step={5}
-                  min={0}
                 />
               </Row>
             </Section>

--- a/src/lib/editor-tools.ts
+++ b/src/lib/editor-tools.ts
@@ -1,14 +1,15 @@
-import type {
-  ConeShape,
-  DiveGateShape,
-  FlagShape,
-  GateShape,
-  LabelShape,
-  LadderShape,
-  ShapeDraft,
-  ShapeKind,
-  StartFinishShape,
-} from "@/lib/types";
+import {
+  createCatalogShapeDraft,
+  TRACKDRAW_CONE_ELEMENT_ID,
+  TRACKDRAW_DIVE_GATE_ELEMENT_ID,
+  TRACKDRAW_FLAG_ELEMENT_ID,
+  TRACKDRAW_GATE_ELEMENT_ID,
+  TRACKDRAW_LABEL_ELEMENT_ID,
+  TRACKDRAW_LADDER_ELEMENT_ID,
+  TRACKDRAW_START_FINISH_ELEMENT_ID,
+  type TrackElementCatalogId,
+} from "@/lib/track/elements/catalog";
+import type { ShapeDraft, ShapeKind } from "@/lib/types";
 
 export type EditorTool =
   | "select"
@@ -22,22 +23,6 @@ export type EditorTool =
   | "startfinish"
   | "ladder"
   | "divegate";
-
-type ToolShapeDefaults = {
-  gate: Pick<GateShape, "width" | "height" | "thick" | "color">;
-  flag: Pick<FlagShape, "radius" | "poleHeight" | "color">;
-  cone: Pick<ConeShape, "radius" | "color">;
-  label: Pick<LabelShape, "text" | "fontSize" | "color">;
-  startfinish: Pick<StartFinishShape, "width" | "color">;
-  ladder: Pick<
-    LadderShape,
-    "width" | "height" | "rungs" | "elevation" | "color"
-  >;
-  divegate: Pick<
-    DiveGateShape,
-    "size" | "thick" | "tilt" | "elevation" | "color"
-  >;
-};
 
 export const shapeKindLabels: Record<ShapeKind, string> = {
   gate: "Gate",
@@ -77,87 +62,27 @@ export const toolShortcuts: Partial<Record<EditorTool, string>> = {
   divegate: "D",
 };
 
-const toolShapeDefaults: ToolShapeDefaults = {
-  gate: { width: 2, height: 2, thick: 0.2, color: "#3b82f6" },
-  flag: { radius: 0.25, poleHeight: 3.5, color: "#a855f7" },
-  cone: { radius: 0.2, color: "#f97316" },
-  label: { text: "Gate A", fontSize: 18, color: "#e2e8f0" },
-  startfinish: { width: 3, color: "#f59e0b" },
-  ladder: { width: 2, height: 6, rungs: 3, elevation: 0, color: "#14b8a6" },
-  divegate: {
-    size: 2.8,
-    thick: 0.2,
-    tilt: 0,
-    elevation: 3,
-    color: "#f97316",
-  },
-};
+const toolCatalogEntryIds: Partial<Record<EditorTool, TrackElementCatalogId>> =
+  {
+    gate: TRACKDRAW_GATE_ELEMENT_ID,
+    flag: TRACKDRAW_FLAG_ELEMENT_ID,
+    cone: TRACKDRAW_CONE_ELEMENT_ID,
+    label: TRACKDRAW_LABEL_ELEMENT_ID,
+    startfinish: TRACKDRAW_START_FINISH_ELEMENT_ID,
+    ladder: TRACKDRAW_LADDER_ELEMENT_ID,
+    divegate: TRACKDRAW_DIVE_GATE_ELEMENT_ID,
+  };
 
 export function createShapeForTool(
   tool: EditorTool,
   point: { x: number; y: number }
 ): ShapeDraft | null {
-  switch (tool) {
-    case "gate":
-      return {
-        kind: "gate",
-        x: point.x,
-        y: point.y,
-        rotation: 0,
-        ...toolShapeDefaults.gate,
-      };
-    case "flag":
-      return {
-        kind: "flag",
-        x: point.x,
-        y: point.y,
-        rotation: 0,
-        ...toolShapeDefaults.flag,
-      };
-    case "cone":
-      return {
-        kind: "cone",
-        x: point.x,
-        y: point.y,
-        rotation: 0,
-        ...toolShapeDefaults.cone,
-      };
-    case "label":
-      return {
-        kind: "label",
-        x: point.x,
-        y: point.y,
-        rotation: 0,
-        ...toolShapeDefaults.label,
-      };
-    case "startfinish":
-      return {
-        kind: "startfinish",
-        x: point.x,
-        y: point.y,
-        rotation: 0,
-        ...toolShapeDefaults.startfinish,
-      };
-    case "ladder":
-      return {
-        kind: "ladder",
-        x: point.x,
-        y: point.y,
-        rotation: 0,
-        ...toolShapeDefaults.ladder,
-      };
-    case "divegate":
-      return {
-        kind: "divegate",
-        x: point.x,
-        y: point.y,
-        rotation: 0,
-        ...toolShapeDefaults.divegate,
-      };
-    case "select":
-    case "grab":
-    case "preset":
-    case "polyline":
-      return null;
-  }
+  const entryId = toolCatalogEntryIds[tool];
+  if (!entryId) return null;
+
+  return createCatalogShapeDraft(entryId, {
+    x: point.x,
+    y: point.y,
+    rotation: 0,
+  });
 }

--- a/src/lib/editor-tools.ts
+++ b/src/lib/editor-tools.ts
@@ -1,5 +1,6 @@
 import {
   createCatalogShapeDraft,
+  getTrackElementCatalogEntry,
   TRACKDRAW_CONE_ELEMENT_ID,
   TRACKDRAW_DIVE_GATE_ELEMENT_ID,
   TRACKDRAW_FLAG_ELEMENT_ID,
@@ -75,14 +76,26 @@ const toolCatalogEntryIds: Partial<Record<EditorTool, TrackElementCatalogId>> =
 
 export function createShapeForTool(
   tool: EditorTool,
-  point: { x: number; y: number }
+  point: { x: number; y: number },
+  options: { gateElementId?: TrackElementCatalogId | null } = {}
 ): ShapeDraft | null {
-  const entryId = toolCatalogEntryIds[tool];
+  const entryId =
+    tool === "gate"
+      ? options.gateElementId || TRACKDRAW_GATE_ELEMENT_ID
+      : toolCatalogEntryIds[tool];
   if (!entryId) return null;
 
-  return createCatalogShapeDraft(entryId, {
+  const entry = getTrackElementCatalogEntry(entryId);
+  const resolvedEntryId =
+    tool === "gate" && entry?.kind !== "gate"
+      ? TRACKDRAW_GATE_ELEMENT_ID
+      : entryId;
+  const resolvedEntry = getTrackElementCatalogEntry(resolvedEntryId);
+
+  return createCatalogShapeDraft(resolvedEntryId, {
     x: point.x,
     y: point.y,
     rotation: 0,
+    includeCatalogMetadata: resolvedEntry?.official === true,
   });
 }

--- a/src/lib/editor/store-state.ts
+++ b/src/lib/editor/store-state.ts
@@ -1,5 +1,9 @@
 import { DEFAULT_LAYOUT_PRESET_ID } from "@/lib/planning/layout-presets";
 import { createDefaultDesign } from "@/lib/track/design";
+import {
+  TRACKDRAW_GATE_ELEMENT_ID,
+  type TrackElementCatalogId,
+} from "@/lib/track/elements/catalog";
 import type {
   EditorSessionState,
   EditorTrackState,
@@ -8,6 +12,7 @@ import type {
 
 interface EditorUiResetOptions {
   activePresetId?: string | null;
+  activeGateElementId?: TrackElementCatalogId | null;
   zoom?: number;
   panOffset?: { x: number; y: number };
 }
@@ -24,6 +29,8 @@ export function createDefaultEditorUiState(
   return {
     activeTool: "select",
     activePresetId: options.activePresetId ?? DEFAULT_LAYOUT_PRESET_ID,
+    activeGateElementId:
+      options.activeGateElementId ?? TRACKDRAW_GATE_ELEMENT_ID,
     snapEnabled: true,
     zoom: options.zoom ?? 1,
     panOffset: options.panOffset ?? { x: 0, y: 0 },
@@ -47,6 +54,8 @@ export function resetEditorUiState(
 ): EditorUiState {
   return createDefaultEditorUiState({
     activePresetId: options.activePresetId ?? current.activePresetId,
+    activeGateElementId:
+      options.activeGateElementId ?? current.activeGateElementId,
     zoom: options.zoom ?? current.zoom,
     panOffset: options.panOffset ?? current.panOffset,
   });

--- a/src/lib/editor/store-types.ts
+++ b/src/lib/editor/store-types.ts
@@ -9,6 +9,7 @@ import type {
 } from "@/lib/types";
 import type { EditorTool } from "@/lib/editor-tools";
 import type { DraftPoint, RectLike } from "@/lib/canvas/shared";
+import type { TrackElementCatalogId } from "@/lib/track/elements/catalog";
 
 export interface EditorTrackState {
   design: TrackDesign;
@@ -17,6 +18,7 @@ export interface EditorTrackState {
 export interface EditorUiState {
   activeTool: EditorTool;
   activePresetId: string | null;
+  activeGateElementId: TrackElementCatalogId | null;
   snapEnabled: boolean;
   zoom: number;
   panOffset: { x: number; y: number };
@@ -123,6 +125,7 @@ export interface EditorSessionActions {
 export interface EditorUiActions {
   setActiveTool: (tool: EditorTool) => void;
   setActivePresetId: (presetId: string | null) => void;
+  setActiveGateElementId: (entryId: TrackElementCatalogId | null) => void;
   setSnapEnabled: (enabled: boolean) => void;
   toggleSnapEnabled: () => void;
   setZoom: (zoom: number) => void;
@@ -244,6 +247,7 @@ export const editorStateOwnership = {
   ui: [
     "activeTool",
     "activePresetId",
+    "activeGateElementId",
     "snapEnabled",
     "zoom",
     "panOffset",
@@ -302,6 +306,7 @@ export const editorActionOwnership = {
   ui: [
     "setActiveTool",
     "setActivePresetId",
+    "setActiveGateElementId",
     "setSnapEnabled",
     "toggleSnapEnabled",
     "setZoom",

--- a/src/lib/planning/layout-presets.ts
+++ b/src/lib/planning/layout-presets.ts
@@ -1,3 +1,10 @@
+import {
+  createCatalogShapeDraft,
+  TRACKDRAW_FLAG_ELEMENT_ID,
+  TRACKDRAW_GATE_ELEMENT_ID,
+  TRACKDRAW_LADDER_ELEMENT_ID,
+  TRACKDRAW_START_FINISH_ELEMENT_ID,
+} from "@/lib/track/elements/catalog";
 import type { PolylineShape, Shape, ShapeDraft, ShapeKind } from "@/lib/types";
 
 type PlaceablePresetShape = Exclude<Shape, PolylineShape>;
@@ -25,14 +32,12 @@ const gate = (
   rotation = 0,
   color = "#3b82f6"
 ): LayoutPresetShapeDraft => ({
-  kind: "gate",
-  x,
-  y,
-  rotation,
-  width: 2,
-  height: 2,
-  thick: 0.2,
-  color,
+  ...createCatalogShapeDraft(TRACKDRAW_GATE_ELEMENT_ID, {
+    x,
+    y,
+    rotation,
+    color,
+  }),
 });
 
 const ladder = (
@@ -41,14 +46,12 @@ const ladder = (
   rotation = 0,
   color = "#14b8a6"
 ): LayoutPresetShapeDraft => ({
-  kind: "ladder",
-  x,
-  y,
-  rotation,
-  width: 2,
-  height: 6,
-  rungs: 3,
-  color,
+  ...createCatalogShapeDraft(TRACKDRAW_LADDER_ELEMENT_ID, {
+    x,
+    y,
+    rotation,
+    color,
+  }),
 });
 
 const startFinish = (
@@ -57,12 +60,12 @@ const startFinish = (
   rotation = 0,
   color = "#f59e0b"
 ): LayoutPresetShapeDraft => ({
-  kind: "startfinish",
-  x,
-  y,
-  rotation,
-  width: 3,
-  color,
+  ...createCatalogShapeDraft(TRACKDRAW_START_FINISH_ELEMENT_ID, {
+    x,
+    y,
+    rotation,
+    color,
+  }),
 });
 
 const flag = (
@@ -71,13 +74,12 @@ const flag = (
   rotation = 0,
   color = "#a855f7"
 ): LayoutPresetShapeDraft => ({
-  kind: "flag",
-  x,
-  y,
-  rotation,
-  radius: 0.25,
-  poleHeight: 3.5,
-  color,
+  ...createCatalogShapeDraft(TRACKDRAW_FLAG_ELEMENT_ID, {
+    x,
+    y,
+    rotation,
+    color,
+  }),
 });
 
 export const layoutPresets: LayoutPreset[] = [

--- a/src/lib/planning/starter-layouts.ts
+++ b/src/lib/planning/starter-layouts.ts
@@ -1,4 +1,11 @@
 import { nanoid } from "nanoid";
+import {
+  createCatalogShapeDraft,
+  TRACKDRAW_FLAG_ELEMENT_ID,
+  TRACKDRAW_GATE_ELEMENT_ID,
+  TRACKDRAW_LADDER_ELEMENT_ID,
+  TRACKDRAW_START_FINISH_ELEMENT_ID,
+} from "@/lib/track/elements/catalog";
 import { createDefaultDesign, nowIso } from "@/lib/track/design";
 import type { ShapeDraft, TrackDesign } from "@/lib/types";
 
@@ -11,25 +18,21 @@ export interface StarterLayout {
 }
 
 const gate = (x: number, y: number, rotation = 0, color = "#3b82f6") => ({
-  kind: "gate" as const,
-  x,
-  y,
-  rotation,
-  width: 2,
-  height: 2,
-  thick: 0.2,
-  color,
+  ...createCatalogShapeDraft(TRACKDRAW_GATE_ELEMENT_ID, {
+    x,
+    y,
+    rotation,
+    color,
+  }),
 });
 
 const ladder = (x: number, y: number, rotation = 0, color = "#14b8a6") => ({
-  kind: "ladder" as const,
-  x,
-  y,
-  rotation,
-  width: 2,
-  height: 6,
-  rungs: 3,
-  color,
+  ...createCatalogShapeDraft(TRACKDRAW_LADDER_ELEMENT_ID, {
+    x,
+    y,
+    rotation,
+    color,
+  }),
 });
 
 const startFinish = (
@@ -38,22 +41,21 @@ const startFinish = (
   rotation = 0,
   color = "#f59e0b"
 ) => ({
-  kind: "startfinish" as const,
-  x,
-  y,
-  rotation,
-  width: 3,
-  color,
+  ...createCatalogShapeDraft(TRACKDRAW_START_FINISH_ELEMENT_ID, {
+    x,
+    y,
+    rotation,
+    color,
+  }),
 });
 
 const flag = (x: number, y: number, rotation = 0, color = "#a855f7") => ({
-  kind: "flag" as const,
-  x,
-  y,
-  rotation,
-  radius: 0.25,
-  poleHeight: 3.5,
-  color,
+  ...createCatalogShapeDraft(TRACKDRAW_FLAG_ELEMENT_ID, {
+    x,
+    y,
+    rotation,
+    color,
+  }),
 });
 
 export const starterLayouts: StarterLayout[] = [

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -1,0 +1,307 @@
+import { feetToMeters, type MeasurementUnitSystem } from "@/lib/track/units";
+import type { PolylineShape, Shape, ShapeDraft } from "@/lib/types";
+
+export const TRACKDRAW_GATE_ELEMENT_ID = "trackdraw-generic-gate";
+export const TRACKDRAW_FLAG_ELEMENT_ID = "trackdraw-generic-flag";
+export const TRACKDRAW_CONE_ELEMENT_ID = "trackdraw-generic-cone";
+export const TRACKDRAW_LABEL_ELEMENT_ID = "trackdraw-generic-label";
+export const TRACKDRAW_START_FINISH_ELEMENT_ID =
+  "trackdraw-generic-start-finish";
+export const TRACKDRAW_LADDER_ELEMENT_ID = "trackdraw-generic-ladder";
+export const TRACKDRAW_DIVE_GATE_ELEMENT_ID = "trackdraw-generic-dive-gate";
+export const MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID = "multigp-standard-gate-5x5";
+
+export type TrackElementCatalogId =
+  | typeof TRACKDRAW_GATE_ELEMENT_ID
+  | typeof TRACKDRAW_FLAG_ELEMENT_ID
+  | typeof TRACKDRAW_CONE_ELEMENT_ID
+  | typeof TRACKDRAW_LABEL_ELEMENT_ID
+  | typeof TRACKDRAW_START_FINISH_ELEMENT_ID
+  | typeof TRACKDRAW_LADDER_ELEMENT_ID
+  | typeof TRACKDRAW_DIVE_GATE_ELEMENT_ID
+  | typeof MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID;
+
+type PlaceableCatalogShape = Exclude<Shape, PolylineShape>;
+export type TrackElementShapeDraft = ShapeDraft<PlaceableCatalogShape>;
+
+export interface TrackElementDimensions {
+  widthMeters?: number;
+  heightMeters?: number;
+  radiusMeters?: number;
+  sizeMeters?: number;
+  display: {
+    unitSystem: MeasurementUnitSystem;
+    label: string;
+  };
+}
+
+export interface TrackElementSource {
+  label: string;
+  url: string;
+}
+
+export interface TrackElementCatalogEntry {
+  id: TrackElementCatalogId;
+  name: string;
+  organization?: string;
+  kind: PlaceableCatalogShape["kind"];
+  official?: boolean;
+  dimensions: TrackElementDimensions;
+  defaultShape: TrackElementShapeDraft;
+  tags: string[];
+  sources?: TrackElementSource[];
+  render2d?: {
+    icon?: string;
+  };
+  render3d?: {
+    modelHint?: string;
+  };
+  exportHints?: {
+    simulatorFriendly?: boolean;
+  };
+}
+
+const trackdrawGateDefaults = {
+  kind: "gate",
+  x: 0,
+  y: 0,
+  rotation: 0,
+  width: 2,
+  height: 2,
+  thick: 0.2,
+  color: "#3b82f6",
+} satisfies TrackElementShapeDraft;
+
+const trackdrawFlagDefaults = {
+  kind: "flag",
+  x: 0,
+  y: 0,
+  rotation: 0,
+  radius: 0.25,
+  poleHeight: 3.5,
+  color: "#a855f7",
+} satisfies TrackElementShapeDraft;
+
+export const trackElementCatalog = [
+  {
+    id: TRACKDRAW_GATE_ELEMENT_ID,
+    name: "TrackDraw Gate",
+    organization: "TrackDraw",
+    kind: "gate",
+    dimensions: {
+      widthMeters: trackdrawGateDefaults.width,
+      heightMeters: trackdrawGateDefaults.height,
+      display: { unitSystem: "metric", label: "2 x 2 m" },
+    },
+    defaultShape: trackdrawGateDefaults,
+    tags: ["generic", "race", "practice"],
+    render2d: { icon: "gate" },
+    render3d: { modelHint: "gate-frame" },
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+    name: "MultiGP Standard Gate 5x5",
+    organization: "MultiGP",
+    kind: "gate",
+    official: true,
+    dimensions: {
+      widthMeters: feetToMeters(5),
+      heightMeters: feetToMeters(5),
+      display: { unitSystem: "imperial", label: "5 ft x 5 ft" },
+    },
+    defaultShape: {
+      ...trackdrawGateDefaults,
+      width: feetToMeters(5),
+      height: feetToMeters(5),
+    },
+    tags: ["official", "race", "practice", "multigp"],
+    sources: [
+      {
+        label: "MultiGP Standard Gate 5x5",
+        url: "https://shop.multigp.com/product/standard-multigp-gate-5x5/",
+      },
+    ],
+    render2d: { icon: "gate" },
+    render3d: { modelHint: "gate-frame" },
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: TRACKDRAW_FLAG_ELEMENT_ID,
+    name: "TrackDraw Flag",
+    organization: "TrackDraw",
+    kind: "flag",
+    dimensions: {
+      radiusMeters: trackdrawFlagDefaults.radius,
+      heightMeters: trackdrawFlagDefaults.poleHeight,
+      display: { unitSystem: "metric", label: "0.25 m radius, 3.5 m pole" },
+    },
+    defaultShape: trackdrawFlagDefaults,
+    tags: ["generic", "race", "practice"],
+    render2d: { icon: "flag" },
+    render3d: { modelHint: "flag-pole" },
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: TRACKDRAW_CONE_ELEMENT_ID,
+    name: "TrackDraw Cone",
+    organization: "TrackDraw",
+    kind: "cone",
+    dimensions: {
+      radiusMeters: 0.2,
+      display: { unitSystem: "metric", label: "0.2 m radius" },
+    },
+    defaultShape: {
+      kind: "cone",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      radius: 0.2,
+      color: "#f97316",
+    },
+    tags: ["generic", "practice"],
+    render2d: { icon: "cone" },
+    render3d: { modelHint: "cone" },
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: TRACKDRAW_LABEL_ELEMENT_ID,
+    name: "TrackDraw Label",
+    organization: "TrackDraw",
+    kind: "label",
+    dimensions: {
+      display: { unitSystem: "metric", label: "Text label" },
+    },
+    defaultShape: {
+      kind: "label",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      text: "Gate A",
+      fontSize: 18,
+      color: "#e2e8f0",
+    },
+    tags: ["generic", "annotation"],
+    render2d: { icon: "label" },
+  },
+  {
+    id: TRACKDRAW_START_FINISH_ELEMENT_ID,
+    name: "TrackDraw Start / Finish",
+    organization: "TrackDraw",
+    kind: "startfinish",
+    dimensions: {
+      widthMeters: 3,
+      display: { unitSystem: "metric", label: "3 m wide" },
+    },
+    defaultShape: {
+      kind: "startfinish",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: 3,
+      color: "#f59e0b",
+    },
+    tags: ["generic", "race", "timing-compatible"],
+    render2d: { icon: "startfinish" },
+    render3d: { modelHint: "start-pads" },
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: TRACKDRAW_LADDER_ELEMENT_ID,
+    name: "TrackDraw Ladder",
+    organization: "TrackDraw",
+    kind: "ladder",
+    dimensions: {
+      widthMeters: 2,
+      heightMeters: 6,
+      display: { unitSystem: "metric", label: "2 x 6 m, 3 rungs" },
+    },
+    defaultShape: {
+      kind: "ladder",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: 2,
+      height: 6,
+      rungs: 3,
+      elevation: 0,
+      color: "#14b8a6",
+    },
+    tags: ["generic", "technical", "practice"],
+    render2d: { icon: "ladder" },
+    render3d: { modelHint: "ladder-gate" },
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: TRACKDRAW_DIVE_GATE_ELEMENT_ID,
+    name: "TrackDraw Dive Gate",
+    organization: "TrackDraw",
+    kind: "divegate",
+    dimensions: {
+      sizeMeters: 2.8,
+      display: { unitSystem: "metric", label: "2.8 m square" },
+    },
+    defaultShape: {
+      kind: "divegate",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      size: 2.8,
+      thick: 0.2,
+      tilt: 0,
+      elevation: 3,
+      color: "#f97316",
+    },
+    tags: ["generic", "technical", "practice"],
+    render2d: { icon: "divegate" },
+    render3d: { modelHint: "dive-gate" },
+    exportHints: { simulatorFriendly: true },
+  },
+] satisfies TrackElementCatalogEntry[];
+
+const trackElementCatalogMap = new Map(
+  trackElementCatalog.map((entry) => [entry.id, entry])
+);
+
+export function getTrackElementCatalogEntry(
+  id: string | null | undefined
+): TrackElementCatalogEntry | null {
+  if (!id) return null;
+  return trackElementCatalogMap.get(id as TrackElementCatalogId) ?? null;
+}
+
+export function createCatalogShapeDraft(
+  entryId: TrackElementCatalogId,
+  placement: {
+    x: number;
+    y: number;
+    rotation?: number;
+    color?: string;
+    includeCatalogMetadata?: boolean;
+  }
+): TrackElementShapeDraft {
+  const entry = getTrackElementCatalogEntry(entryId);
+  if (!entry) {
+    throw new Error(`Unknown track element catalog entry: ${entryId}`);
+  }
+
+  const { includeCatalogMetadata, ...placementOverrides } = placement;
+  const draft = {
+    ...entry.defaultShape,
+    ...placementOverrides,
+    rotation: placement.rotation ?? entry.defaultShape.rotation,
+  } satisfies TrackElementShapeDraft;
+
+  if (!includeCatalogMetadata) return draft;
+
+  return {
+    ...draft,
+    meta: {
+      ...draft.meta,
+      catalogElementId: entry.id,
+      catalogElementName: entry.name,
+      catalogOrganization: entry.organization,
+      officialCatalogElement: entry.official === true,
+    },
+  } satisfies TrackElementShapeDraft;
+}

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -10,6 +10,8 @@ export const TRACKDRAW_START_FINISH_ELEMENT_ID =
 export const TRACKDRAW_LADDER_ELEMENT_ID = "trackdraw-generic-ladder";
 export const TRACKDRAW_DIVE_GATE_ELEMENT_ID = "trackdraw-generic-dive-gate";
 export const MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID = "multigp-standard-gate-5x5";
+export const MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID =
+  "multigp-championship-gate-7x6";
 
 export type TrackElementCatalogId =
   | typeof TRACKDRAW_GATE_ELEMENT_ID
@@ -19,10 +21,14 @@ export type TrackElementCatalogId =
   | typeof TRACKDRAW_START_FINISH_ELEMENT_ID
   | typeof TRACKDRAW_LADDER_ELEMENT_ID
   | typeof TRACKDRAW_DIVE_GATE_ELEMENT_ID
-  | typeof MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID;
+  | typeof MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
+  | typeof MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID;
 
 type PlaceableCatalogShape = Exclude<Shape, PolylineShape>;
 export type TrackElementShapeDraft = ShapeDraft<PlaceableCatalogShape>;
+export type GateTrackElementCatalogEntry = TrackElementCatalogEntry & {
+  kind: "gate";
+};
 
 export interface TrackElementDimensions {
   widthMeters?: number;
@@ -59,6 +65,55 @@ export interface TrackElementCatalogEntry {
   exportHints?: {
     simulatorFriendly?: boolean;
   };
+}
+
+export interface TrackElementCatalogIdentity {
+  version: 1;
+  elementId: TrackElementCatalogId;
+  assignedKind: PlaceableCatalogShape["kind"];
+  official: boolean;
+  snapshot: {
+    name: string;
+    organization?: string;
+    dimensionsLabel: string;
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isPlaceableCatalogShapeKind(
+  value: unknown
+): value is PlaceableCatalogShape["kind"] {
+  return (
+    value === "gate" ||
+    value === "flag" ||
+    value === "cone" ||
+    value === "label" ||
+    value === "startfinish" ||
+    value === "ladder" ||
+    value === "divegate"
+  );
+}
+
+function isTrackElementCatalogIdentity(
+  value: unknown
+): value is TrackElementCatalogIdentity {
+  if (!isRecord(value)) return false;
+  if (value.version !== 1) return false;
+  if (typeof value.elementId !== "string") return false;
+  if (!isPlaceableCatalogShapeKind(value.assignedKind)) return false;
+  if (typeof value.official !== "boolean") return false;
+  if (!isRecord(value.snapshot)) return false;
+  if (typeof value.snapshot.name !== "string") return false;
+  if (
+    "organization" in value.snapshot &&
+    typeof value.snapshot.organization !== "string"
+  ) {
+    return false;
+  }
+  return typeof value.snapshot.dimensionsLabel === "string";
 }
 
 const trackdrawGateDefaults = {
@@ -120,6 +175,33 @@ export const trackElementCatalog = [
       {
         label: "MultiGP Standard Gate 5x5",
         url: "https://shop.multigp.com/product/standard-multigp-gate-5x5/",
+      },
+    ],
+    render2d: { icon: "gate" },
+    render3d: { modelHint: "gate-frame" },
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+    name: "MultiGP Championship Gate 7x6",
+    organization: "MultiGP",
+    kind: "gate",
+    official: true,
+    dimensions: {
+      widthMeters: feetToMeters(7),
+      heightMeters: feetToMeters(6),
+      display: { unitSystem: "imperial", label: "7 ft x 6 ft" },
+    },
+    defaultShape: {
+      ...trackdrawGateDefaults,
+      width: feetToMeters(7),
+      height: feetToMeters(6),
+    },
+    tags: ["official", "championship", "race", "multigp"],
+    sources: [
+      {
+        label: "MultiGP Drone Race Course Obstacles",
+        url: "https://www.multigp.com/multigp-drone-race-course-obstacles/",
       },
     ],
     render2d: { icon: "gate" },
@@ -270,6 +352,36 @@ export function getTrackElementCatalogEntry(
   return trackElementCatalogMap.get(id as TrackElementCatalogId) ?? null;
 }
 
+export function getGateTrackElementCatalogEntries(): GateTrackElementCatalogEntry[] {
+  return (trackElementCatalog as readonly TrackElementCatalogEntry[]).filter(
+    (entry): entry is GateTrackElementCatalogEntry => entry.kind === "gate"
+  );
+}
+
+export function createTrackElementCatalogIdentity(
+  entry: TrackElementCatalogEntry
+): TrackElementCatalogIdentity {
+  return {
+    version: 1,
+    elementId: entry.id,
+    assignedKind: entry.kind,
+    official: entry.official === true,
+    snapshot: {
+      name: entry.name,
+      organization: entry.organization,
+      dimensionsLabel: entry.dimensions.display.label,
+    },
+  };
+}
+
+export function getTrackElementCatalogIdentity(
+  meta: Record<string, unknown> | null | undefined
+): TrackElementCatalogIdentity | null {
+  if (!isRecord(meta)) return null;
+  const catalog = meta.catalog;
+  return isTrackElementCatalogIdentity(catalog) ? catalog : null;
+}
+
 export function createCatalogShapeDraft(
   entryId: TrackElementCatalogId,
   placement: {
@@ -298,10 +410,7 @@ export function createCatalogShapeDraft(
     ...draft,
     meta: {
       ...draft.meta,
-      catalogElementId: entry.id,
-      catalogElementName: entry.name,
-      catalogOrganization: entry.organization,
-      officialCatalogElement: entry.official === true,
+      catalog: createTrackElementCatalogIdentity(entry),
     },
   } satisfies TrackElementShapeDraft;
 }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -99,6 +99,9 @@ export function useSessionActions() {
 export function useUiActions() {
   const setActiveTool = useEditor((state) => state.setActiveTool);
   const setActivePresetId = useEditor((state) => state.setActivePresetId);
+  const setActiveGateElementId = useEditor(
+    (state) => state.setActiveGateElementId
+  );
   const setSnapEnabled = useEditor((state) => state.setSnapEnabled);
   const toggleSnapEnabled = useEditor((state) => state.toggleSnapEnabled);
   const setZoom = useEditor((state) => state.setZoom);
@@ -121,6 +124,7 @@ export function useUiActions() {
   return {
     setActiveTool,
     setActivePresetId,
+    setActiveGateElementId,
     setSnapEnabled,
     toggleSnapEnabled,
     setZoom,

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -94,6 +94,7 @@ interface EditorState {
   sanitizeHistoryState: EditorSessionActions["sanitizeHistoryState"];
   setActiveTool: EditorUiActions["setActiveTool"];
   setActivePresetId: EditorUiActions["setActivePresetId"];
+  setActiveGateElementId: EditorUiActions["setActiveGateElementId"];
   setSnapEnabled: EditorUiActions["setSnapEnabled"];
   toggleSnapEnabled: EditorUiActions["toggleSnapEnabled"];
   setZoom: EditorUiActions["setZoom"];
@@ -478,6 +479,11 @@ export const useEditor = create<EditorState>()(
       setActivePresetId: (presetId) =>
         set((draft) => {
           draft.ui.activePresetId = presetId;
+        }),
+
+      setActiveGateElementId: (entryId) =>
+        set((draft) => {
+          draft.ui.activeGateElementId = entryId;
         }),
 
       setSnapEnabled: (enabled) =>

--- a/tests/components/inspector/SingleInspectorView.test.tsx
+++ b/tests/components/inspector/SingleInspectorView.test.tsx
@@ -101,7 +101,7 @@ describe("SingleInspectorView race timing controls", () => {
     expect(screen.queryByRole("button", { name: "Split" })).toBeNull();
   });
 
-  it("keeps mobile secondary sections collapsed while transform stays open", () => {
+  it("keeps mobile secondary sections collapsed while transform and race timing stay open", () => {
     renderSingleInspector(gate, { mobileInline: true });
 
     expect(
@@ -115,14 +115,13 @@ describe("SingleInspectorView race timing controls", () => {
         .getByRole("button", { name: "Transform" })
         .getAttribute("aria-expanded")
     ).toBe("true");
+    // Race timing stays open on mobile for any shape that supports it,
+    // so clearing the role mid-interaction does not collapse the section.
     expect(
       screen
         .getByRole("button", { name: "Race timing" })
         .getAttribute("aria-expanded")
-    ).toBe("false");
-    expect(
-      screen.getByRole("button", { name: "Gate" }).getAttribute("aria-expanded")
-    ).toBe("false");
+    ).toBe("true");
   });
 
   it("keeps grouped shape details collapsed on mobile", () => {
@@ -164,6 +163,45 @@ describe("SingleInspectorView race timing controls", () => {
       screen
         .getByRole("button", { name: "Race timing" })
         .getAttribute("aria-expanded")
+    ).toBe("true");
+  });
+
+  it("keeps race timing section open on mobile after clearing the timing role", async () => {
+    const shapeWithMarker: GateShape = {
+      ...gate,
+      meta: { timing: { role: "start_finish" } },
+    };
+    const props: React.ComponentProps<typeof SingleInspectorView> = {
+      appendPolylinePoint: vi.fn(),
+      closePolyline: vi.fn(),
+      duplicateShapes: vi.fn(),
+      insertPolylinePoint: vi.fn(),
+      removePolylinePoint: vi.fn(),
+      removeShapes: vi.fn(),
+      reversePolylinePoints: vi.fn(),
+      setGroupName: vi.fn(),
+      setHoveredWaypoint: vi.fn(),
+      setSelection: vi.fn(),
+      setShapesLocked: vi.fn(),
+      shape: shapeWithMarker,
+      ungroupSelection: vi.fn(),
+      updatePolylinePoint: vi.fn(),
+      updateShape: vi.fn(),
+      mobileInline: true,
+    };
+
+    const { rerender } = render(<SingleInspectorView {...props} />);
+
+    expect(
+      screen.getByRole("button", { name: "Race timing" }).getAttribute("aria-expanded")
+    ).toBe("true");
+
+    // Simulate the store updating after the user sets role to "Off"
+    rerender(<SingleInspectorView {...props} shape={gate} />);
+
+    // The section must stay open — closing mid-interaction was the bug
+    expect(
+      screen.getByRole("button", { name: "Race timing" }).getAttribute("aria-expanded")
     ).toBe("true");
   });
 

--- a/tests/components/inspector/SingleInspectorView.test.tsx
+++ b/tests/components/inspector/SingleInspectorView.test.tsx
@@ -193,7 +193,9 @@ describe("SingleInspectorView race timing controls", () => {
     const { rerender } = render(<SingleInspectorView {...props} />);
 
     expect(
-      screen.getByRole("button", { name: "Race timing" }).getAttribute("aria-expanded")
+      screen
+        .getByRole("button", { name: "Race timing" })
+        .getAttribute("aria-expanded")
     ).toBe("true");
 
     // Simulate the store updating after the user sets role to "Off"
@@ -201,7 +203,9 @@ describe("SingleInspectorView race timing controls", () => {
 
     // The section must stay open — closing mid-interaction was the bug
     expect(
-      screen.getByRole("button", { name: "Race timing" }).getAttribute("aria-expanded")
+      screen
+        .getByRole("button", { name: "Race timing" })
+        .getAttribute("aria-expanded")
     ).toBe("true");
   });
 

--- a/tests/hooks/usePersistentBoolean.test.tsx
+++ b/tests/hooks/usePersistentBoolean.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "localStorage"
+);
+
+function createMapStorage(initial: Record<string, string> = {}): Storage {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    get length() {
+      return store.size;
+    },
+    clear: () => store.clear(),
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => [...store.keys()][index] ?? null,
+    removeItem: (key: string) => void store.delete(key),
+    setItem: (key: string, value: string) => void store.set(key, value),
+  };
+}
+
+function createThrowingStorage(): Storage {
+  return {
+    get length() {
+      return 0;
+    },
+    clear: vi.fn(),
+    getItem: vi.fn(() => {
+      throw new DOMException("Storage unavailable", "SecurityError");
+    }),
+    key: vi.fn(() => null),
+    removeItem: vi.fn(),
+    setItem: vi.fn(() => {
+      throw new DOMException("Storage unavailable", "SecurityError");
+    }),
+  };
+}
+
+function setStorage(impl: Storage) {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: impl,
+  });
+}
+
+function restoreStorage() {
+  if (originalLocalStorageDescriptor) {
+    Object.defineProperty(window, "localStorage", originalLocalStorageDescriptor);
+  }
+}
+
+const KEY = "test.persistentBoolean";
+
+describe("usePersistentBoolean", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    restoreStorage();
+    vi.restoreAllMocks();
+  });
+
+  it("initialises to false by default when nothing stored", async () => {
+    setStorage(createMapStorage());
+    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { result } = renderHook(() => usePersistentBoolean(KEY));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("initialises to the provided defaultValue", async () => {
+    setStorage(createMapStorage());
+    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { result } = renderHook(() => usePersistentBoolean(KEY, true));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("reads a stored 'true' value from localStorage", async () => {
+    setStorage(createMapStorage({ [KEY]: "true" }));
+    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { result } = renderHook(() => usePersistentBoolean(KEY));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("reads a stored 'false' value, overriding a true defaultValue", async () => {
+    setStorage(createMapStorage({ [KEY]: "false" }));
+    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { result } = renderHook(() => usePersistentBoolean(KEY, true));
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("ignores unrecognised stored strings and falls back to defaultValue", async () => {
+    setStorage(createMapStorage({ [KEY]: "yes" }));
+    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { result } = renderHook(() => usePersistentBoolean(KEY, true));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("persists a true value to localStorage when state changes", async () => {
+    const storage = createMapStorage();
+    setStorage(storage);
+    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { result } = renderHook(() => usePersistentBoolean(KEY));
+
+    await act(async () => {
+      result.current[1](true);
+    });
+
+    expect(result.current[0]).toBe(true);
+    expect(storage.getItem(KEY)).toBe("true");
+  });
+
+  it("persists a false value to localStorage when state changes", async () => {
+    const storage = createMapStorage({ [KEY]: "true" });
+    setStorage(storage);
+    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { result } = renderHook(() => usePersistentBoolean(KEY));
+
+    await act(async () => {
+      result.current[1](false);
+    });
+
+    expect(result.current[0]).toBe(false);
+    expect(storage.getItem(KEY)).toBe("false");
+  });
+
+  it("keeps in-memory state working when localStorage.setItem throws", async () => {
+    const storage = createMapStorage();
+    vi.spyOn(storage, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage full", "QuotaExceededError");
+    });
+    setStorage(storage);
+    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { result } = renderHook(() => usePersistentBoolean(KEY));
+
+    await act(async () => {
+      result.current[1](true);
+    });
+
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("returns the defaultValue when localStorage.getItem throws", async () => {
+    setStorage(createThrowingStorage());
+    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { result } = renderHook(() => usePersistentBoolean(KEY, true));
+    expect(result.current[0]).toBe(true);
+  });
+});

--- a/tests/hooks/usePersistentBoolean.test.tsx
+++ b/tests/hooks/usePersistentBoolean.test.tsx
@@ -48,7 +48,11 @@ function setStorage(impl: Storage) {
 
 function restoreStorage() {
   if (originalLocalStorageDescriptor) {
-    Object.defineProperty(window, "localStorage", originalLocalStorageDescriptor);
+    Object.defineProperty(
+      window,
+      "localStorage",
+      originalLocalStorageDescriptor
+    );
   }
 }
 
@@ -66,35 +70,40 @@ describe("usePersistentBoolean", () => {
 
   it("initialises to false by default when nothing stored", async () => {
     setStorage(createMapStorage());
-    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { usePersistentBoolean } =
+      await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY));
     expect(result.current[0]).toBe(false);
   });
 
   it("initialises to the provided defaultValue", async () => {
     setStorage(createMapStorage());
-    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { usePersistentBoolean } =
+      await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY, true));
     expect(result.current[0]).toBe(true);
   });
 
   it("reads a stored 'true' value from localStorage", async () => {
     setStorage(createMapStorage({ [KEY]: "true" }));
-    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { usePersistentBoolean } =
+      await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY));
     expect(result.current[0]).toBe(true);
   });
 
   it("reads a stored 'false' value, overriding a true defaultValue", async () => {
     setStorage(createMapStorage({ [KEY]: "false" }));
-    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { usePersistentBoolean } =
+      await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY, true));
     expect(result.current[0]).toBe(false);
   });
 
   it("ignores unrecognised stored strings and falls back to defaultValue", async () => {
     setStorage(createMapStorage({ [KEY]: "yes" }));
-    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { usePersistentBoolean } =
+      await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY, true));
     expect(result.current[0]).toBe(true);
   });
@@ -102,7 +111,8 @@ describe("usePersistentBoolean", () => {
   it("persists a true value to localStorage when state changes", async () => {
     const storage = createMapStorage();
     setStorage(storage);
-    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { usePersistentBoolean } =
+      await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY));
 
     await act(async () => {
@@ -116,7 +126,8 @@ describe("usePersistentBoolean", () => {
   it("persists a false value to localStorage when state changes", async () => {
     const storage = createMapStorage({ [KEY]: "true" });
     setStorage(storage);
-    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { usePersistentBoolean } =
+      await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY));
 
     await act(async () => {
@@ -133,7 +144,8 @@ describe("usePersistentBoolean", () => {
       throw new DOMException("Storage full", "QuotaExceededError");
     });
     setStorage(storage);
-    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { usePersistentBoolean } =
+      await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY));
 
     await act(async () => {
@@ -145,7 +157,8 @@ describe("usePersistentBoolean", () => {
 
   it("returns the defaultValue when localStorage.getItem throws", async () => {
     setStorage(createThrowingStorage());
-    const { usePersistentBoolean } = await import("@/hooks/usePersistentBoolean");
+    const { usePersistentBoolean } =
+      await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY, true));
     expect(result.current[0]).toBe(true);
   });

--- a/tests/lib/editor-tools.test.ts
+++ b/tests/lib/editor-tools.test.ts
@@ -5,6 +5,12 @@ import {
   toolLabels,
   toolShortcuts,
 } from "@/lib/editor-tools";
+import {
+  MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+  MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+  TRACKDRAW_FLAG_ELEMENT_ID,
+} from "@/lib/track/elements/catalog";
+import { feetToMeters } from "@/lib/track/units";
 
 describe("editor tool helpers", () => {
   it("exposes stable labels and shortcuts", () => {
@@ -46,6 +52,58 @@ describe("editor tool helpers", () => {
       thick: 0.2,
       tilt: 0,
       elevation: 3,
+    });
+  });
+
+  it("creates the selected official gate variant through the gate tool", () => {
+    const shape = createShapeForTool("gate", { x: 3, y: 4 }, {
+      gateElementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+    });
+
+    expect(shape).toMatchObject({
+      kind: "gate",
+      x: 3,
+      y: 4,
+      width: feetToMeters(5),
+      height: feetToMeters(5),
+      meta: {
+        catalog: {
+          elementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+          assignedKind: "gate",
+          official: true,
+        },
+      },
+    });
+  });
+
+  it("creates larger official gate variants through the same gate tool", () => {
+    const shape = createShapeForTool("gate", { x: 6, y: 8 }, {
+      gateElementId: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+    });
+
+    expect(shape).toMatchObject({
+      kind: "gate",
+      width: feetToMeters(7),
+      height: feetToMeters(6),
+      meta: {
+        catalog: {
+          elementId: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+          assignedKind: "gate",
+          official: true,
+        },
+      },
+    });
+  });
+
+  it("falls back to the generic gate when a non-gate catalog id is passed", () => {
+    expect(
+      createShapeForTool("gate", { x: 1, y: 2 }, {
+        gateElementId: TRACKDRAW_FLAG_ELEMENT_ID,
+      })
+    ).toMatchObject({
+      kind: "gate",
+      width: 2,
+      height: 2,
     });
   });
 

--- a/tests/lib/editor-tools.test.ts
+++ b/tests/lib/editor-tools.test.ts
@@ -56,9 +56,13 @@ describe("editor tool helpers", () => {
   });
 
   it("creates the selected official gate variant through the gate tool", () => {
-    const shape = createShapeForTool("gate", { x: 3, y: 4 }, {
-      gateElementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
-    });
+    const shape = createShapeForTool(
+      "gate",
+      { x: 3, y: 4 },
+      {
+        gateElementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+      }
+    );
 
     expect(shape).toMatchObject({
       kind: "gate",
@@ -77,9 +81,13 @@ describe("editor tool helpers", () => {
   });
 
   it("creates larger official gate variants through the same gate tool", () => {
-    const shape = createShapeForTool("gate", { x: 6, y: 8 }, {
-      gateElementId: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
-    });
+    const shape = createShapeForTool(
+      "gate",
+      { x: 6, y: 8 },
+      {
+        gateElementId: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+      }
+    );
 
     expect(shape).toMatchObject({
       kind: "gate",
@@ -97,9 +105,13 @@ describe("editor tool helpers", () => {
 
   it("falls back to the generic gate when a non-gate catalog id is passed", () => {
     expect(
-      createShapeForTool("gate", { x: 1, y: 2 }, {
-        gateElementId: TRACKDRAW_FLAG_ELEMENT_ID,
-      })
+      createShapeForTool(
+        "gate",
+        { x: 1, y: 2 },
+        {
+          gateElementId: TRACKDRAW_FLAG_ELEMENT_ID,
+        }
+      )
     ).toMatchObject({
       kind: "gate",
       width: 2,

--- a/tests/lib/editor/store-state.test.ts
+++ b/tests/lib/editor/store-state.test.ts
@@ -5,12 +5,18 @@ import {
   resetEditorUiState,
   sanitizeEditorUiState,
 } from "@/lib/editor/store-state";
+import type { EditorUiState } from "@/lib/editor/store-types";
+import {
+  MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+  TRACKDRAW_GATE_ELEMENT_ID,
+} from "@/lib/track/elements/catalog";
 
 describe("editor store state helpers", () => {
   it("resetEditorUiState preserves preset and resets zoom/pan when requested", () => {
-    const current = {
+    const current: EditorUiState = {
       ...createDefaultEditorUiState(),
       activePresetId: "straight-gate-run",
+      activeGateElementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
       zoom: 2.25,
       panOffset: { x: 120, y: 75 },
       hoveredShapeId: "shape-1",
@@ -30,10 +36,17 @@ describe("editor store state helpers", () => {
     });
 
     expect(next.activePresetId).toBe("straight-gate-run");
+    expect(next.activeGateElementId).toBe(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
     expect(next.zoom).toBe(1);
     expect(next.panOffset).toEqual({ x: 0, y: 0 });
     expect(next.hoveredShapeId).toBeNull();
     expect(next.rotationSession).toBeNull();
+  });
+
+  it("defaults to the generic TrackDraw gate variant", () => {
+    expect(createDefaultEditorUiState().activeGateElementId).toBe(
+      TRACKDRAW_GATE_ELEMENT_ID
+    );
   });
 
   it("sanitizeEditorUiState clears transient hover and drag state", () => {

--- a/tests/lib/track/elements/catalog.test.ts
+++ b/tests/lib/track/elements/catalog.test.ts
@@ -23,13 +23,13 @@ describe("track element catalog", () => {
   });
 
   it("exposes gate entries for placement controls", () => {
-    expect(getGateTrackElementCatalogEntries().map((entry) => entry.id)).toEqual(
-      [
-        TRACKDRAW_GATE_ELEMENT_ID,
-        MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
-        MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
-      ]
-    );
+    expect(
+      getGateTrackElementCatalogEntries().map((entry) => entry.id)
+    ).toEqual([
+      TRACKDRAW_GATE_ELEMENT_ID,
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+      MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+    ]);
   });
 
   it("keeps the generic TrackDraw gate defaults unchanged", () => {

--- a/tests/lib/track/elements/catalog.test.ts
+++ b/tests/lib/track/elements/catalog.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { feetToMeters } from "@/lib/track/units";
+import {
+  createCatalogShapeDraft,
+  getTrackElementCatalogEntry,
+  MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+  TRACKDRAW_GATE_ELEMENT_ID,
+  trackElementCatalog,
+} from "@/lib/track/elements/catalog";
+
+describe("track element catalog", () => {
+  it("exposes unique catalog entries", () => {
+    const ids = trackElementCatalog.map((entry) => entry.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(getTrackElementCatalogEntry(TRACKDRAW_GATE_ELEMENT_ID)?.kind).toBe(
+      "gate"
+    );
+    expect(getTrackElementCatalogEntry("missing")).toBeNull();
+  });
+
+  it("keeps the generic TrackDraw gate defaults unchanged", () => {
+    const shape = createCatalogShapeDraft(TRACKDRAW_GATE_ELEMENT_ID, {
+      x: 12,
+      y: 8,
+      rotation: 15,
+    });
+
+    expect(shape).toMatchObject({
+      kind: "gate",
+      x: 12,
+      y: 8,
+      rotation: 15,
+      width: 2,
+      height: 2,
+      thick: 0.2,
+      color: "#3b82f6",
+    });
+    expect(shape.meta).toBeUndefined();
+  });
+
+  it("documents the official MultiGP 5x5 gate without changing generic placement", () => {
+    const entry = getTrackElementCatalogEntry(
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
+    );
+
+    expect(entry).toMatchObject({
+      name: "MultiGP Standard Gate 5x5",
+      organization: "MultiGP",
+      kind: "gate",
+      official: true,
+      dimensions: {
+        display: { unitSystem: "imperial", label: "5 ft x 5 ft" },
+      },
+    });
+    expect(entry?.dimensions.widthMeters).toBeCloseTo(feetToMeters(5));
+    expect(entry?.dimensions.heightMeters).toBeCloseTo(feetToMeters(5));
+  });
+
+  it("can stamp catalog identity metadata when a placement flow asks for it", () => {
+    const shape = createCatalogShapeDraft(
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+      {
+        x: 4,
+        y: 6,
+        includeCatalogMetadata: true,
+      }
+    );
+
+    expect(shape).toMatchObject({
+      kind: "gate",
+      width: feetToMeters(5),
+      height: feetToMeters(5),
+      meta: {
+        catalogElementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+        catalogElementName: "MultiGP Standard Gate 5x5",
+        catalogOrganization: "MultiGP",
+        officialCatalogElement: true,
+      },
+    });
+  });
+});

--- a/tests/lib/track/elements/catalog.test.ts
+++ b/tests/lib/track/elements/catalog.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import { feetToMeters } from "@/lib/track/units";
 import {
   createCatalogShapeDraft,
+  getGateTrackElementCatalogEntries,
   getTrackElementCatalogEntry,
+  getTrackElementCatalogIdentity,
+  MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
   MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
   TRACKDRAW_GATE_ELEMENT_ID,
   trackElementCatalog,
@@ -17,6 +20,16 @@ describe("track element catalog", () => {
       "gate"
     );
     expect(getTrackElementCatalogEntry("missing")).toBeNull();
+  });
+
+  it("exposes gate entries for placement controls", () => {
+    expect(getGateTrackElementCatalogEntries().map((entry) => entry.id)).toEqual(
+      [
+        TRACKDRAW_GATE_ELEMENT_ID,
+        MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+        MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+      ]
+    );
   });
 
   it("keeps the generic TrackDraw gate defaults unchanged", () => {
@@ -57,6 +70,28 @@ describe("track element catalog", () => {
     expect(entry?.dimensions.heightMeters).toBeCloseTo(feetToMeters(5));
   });
 
+  it("documents additional common MultiGP gate variants", () => {
+    const championshipGate = getTrackElementCatalogEntry(
+      MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID
+    );
+
+    expect(championshipGate).toMatchObject({
+      name: "MultiGP Championship Gate 7x6",
+      organization: "MultiGP",
+      kind: "gate",
+      official: true,
+      dimensions: {
+        display: { unitSystem: "imperial", label: "7 ft x 6 ft" },
+      },
+    });
+    expect(championshipGate?.dimensions.widthMeters).toBeCloseTo(
+      feetToMeters(7)
+    );
+    expect(championshipGate?.dimensions.heightMeters).toBeCloseTo(
+      feetToMeters(6)
+    );
+  });
+
   it("can stamp catalog identity metadata when a placement flow asks for it", () => {
     const shape = createCatalogShapeDraft(
       MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
@@ -72,11 +107,40 @@ describe("track element catalog", () => {
       width: feetToMeters(5),
       height: feetToMeters(5),
       meta: {
-        catalogElementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
-        catalogElementName: "MultiGP Standard Gate 5x5",
-        catalogOrganization: "MultiGP",
-        officialCatalogElement: true,
+        catalog: {
+          version: 1,
+          elementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+          assignedKind: "gate",
+          official: true,
+          snapshot: {
+            name: "MultiGP Standard Gate 5x5",
+            organization: "MultiGP",
+            dimensionsLabel: "5 ft x 5 ft",
+          },
+        },
       },
     });
+    expect(getTrackElementCatalogIdentity(shape.meta)).toMatchObject({
+      elementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+      assignedKind: "gate",
+      official: true,
+      snapshot: {
+        name: "MultiGP Standard Gate 5x5",
+        organization: "MultiGP",
+        dimensionsLabel: "5 ft x 5 ft",
+      },
+    });
+  });
+
+  it("ignores invalid catalog identity metadata", () => {
+    expect(getTrackElementCatalogIdentity(undefined)).toBeNull();
+    expect(
+      getTrackElementCatalogIdentity({
+        catalog: {
+          version: 1,
+          elementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+        },
+      })
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
Introduces a typed local track element catalog with official gate dimensions (MultiGP standard 5×5, championship 7×6) and wires it into the gate tool so placed shapes carry catalog identity. The inspector shows locked official dimensions for catalog gates and stamps catalog metadata on export.

On the editor side, EditorShell drops from ~1337 to ~570 lines through extraction of `EditorWorkspace`, `EditorStarterOverlay`, `EditorDialogsHost`, and `DesktopInspectorPanel`. The desktop inspector panel gains a persistent collapse toggle. The mobile tools drawer is restructured into a dedicated ToolsControls component with snap moved to View and a unified tool grid. A bug is fixed where the Race timing inspector section on mobile collapsed automatically when the gate role was cleared.
