### PR TITLE
fix: Harden Worker request guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ Update `README.md`, `CONTRIBUTING.md`, or files in `docs/` when behavior, routes
 - Keep `README.md` product-facing and lightweight.
 - Keep contributor setup, commands, runtime notes, and validation guidance in `CONTRIBUTING.md`.
 - Keep longer planning, deployment, and research material in `docs/`.
+- Check `docs/deployment/deployment-setup.md` whenever adding or changing routes, deployed runtime behavior, Cloudflare bindings, Worker guards, scheduled jobs, public media handling, or WAF/rate-limit assumptions. New public pages or route families may need deployment documentation updates even when the code change is otherwise self-contained.
 - Do not include machine-specific absolute filesystem paths in committed docs or repo files. Use repo-relative paths, route names, package names, or external repository names so GitHub documentation remains portable.
 - Do not update completed roadmap archive sections just to reflect newly shipped work elsewhere. Treat archived release sections as closed snapshots unless a factual correction is genuinely necessary.
 - For larger refactors, architecture passes, or foundation work documented in `docs/research`, describe the work in explicit phases with a clear start and done state for each phase, plus a short top-level checklist that can be ticked off in order.

--- a/custom-worker.ts
+++ b/custom-worker.ts
@@ -1,6 +1,7 @@
 // @ts-ignore `.open-next/worker.js` is generated at build time
 import { default as handler } from "./.open-next/worker.js";
 import { cleanupExpiredApiKeys } from "./src/lib/server/api-key-retention";
+import { getEarlyWorkerResponse } from "./src/lib/server/request-guards";
 import { cleanupExpiredShares } from "./src/lib/server/share-retention";
 
 type D1PreparedStatement = {
@@ -27,6 +28,13 @@ type WorkerExecutionContext = {
 
 const worker = {
   ...handler,
+
+  fetch(request: Request, env: WorkerEnv, ctx: WorkerExecutionContext) {
+    const earlyResponse = getEarlyWorkerResponse(request);
+    if (earlyResponse) return earlyResponse;
+
+    return handler.fetch(request, env, ctx);
+  },
 
   async scheduled(
     _controller: ScheduledController,

--- a/docs/deployment/deployment-setup.md
+++ b/docs/deployment/deployment-setup.md
@@ -146,42 +146,40 @@ Create a second WAF custom rule for obvious Server Action probes:
 
 ### Rate-limit CPU-sensitive pages
 
-Create this as a WAF rate limiting rule after reviewing recent traffic volume.
+Create this as a WAF rate limiting rule for public routes that can create meaningful Worker rendering load.
 
 Where to create it:
 
 - New Cloudflare dashboard: select the `trackdraw.app` zone, open `Security` → `Security rules`, then choose `Create rule` → `Rate limiting rules`.
 
-Use route families instead of a hand-maintained list of public pages. The default rule should target page rendering by excluding stable non-page namespaces such as API and asset routes.
+Use route families instead of a hand-maintained list of individual pages. Keep API writes and account/dashboard pages out of this rule; they need endpoint-specific protection.
 
-Suggested broad rule:
+Rule settings:
 
-- Rule name: `Limit public page render bursts`
+- Rule name: `Limit CPU-sensitive public routes`
 - Field/expression mode: use `Edit expression`
 - Expression:
   ```text
-  http.request.method in {"GET" "HEAD"}
-  and not (
-    http.request.uri.path eq "/api"
-    or starts_with(http.request.uri.path, "/api/")
+  not cf.client.bot
+  and (
+    http.request.uri.path eq "/studio"
+    or http.request.uri.path eq "/gallery"
+    or http.request.uri.path eq "/sitemap.xml"
+    or starts_with(http.request.uri.path, "/share/")
+    or starts_with(http.request.uri.path, "/embed/")
   )
-  and not starts_with(http.request.uri.path, "/_next/")
-  and not starts_with(http.request.uri.path, "/assets/")
-  and not starts_with(http.request.uri.path, "/favicon")
-  and http.request.uri.path ne "/robots.txt"
-  and not cf.client.bot
   ```
-- Scope: covers `/`, `/studio`, `/gallery`, `/share/*`, `/sitemap.xml`, legal pages, guides, and future public pages without editing the rule.
-- Cache status: disable `Also apply rate limiting to cached assets` so the counter focuses on requests reaching the Worker.
-- Characteristics: use `IP` and `User-Agent`.
-- Threshold: start from Cloudflare Security Analytics for the real traffic pattern, then choose a conservative threshold above normal user and crawler traffic.
-- Action: `Managed Challenge`.
+- Scope: covers Studio, gallery, sitemap generation, shared tracks, and embeds. Add new route families here only when they render user/content-heavy pages.
+- Characteristics: use `IP`.
+- Threshold: `120 requests` per `1 minute`.
+- Action: `Block`.
+- Duration: `10 seconds`.
 
 Additional guidance:
 
-- Do not add every new public route to Cloudflare manually. Prefer broad page-render rules with stable exclusions.
+- Do not add every new public route to Cloudflare manually. Add only route families that are proven to create meaningful Worker rendering load.
 - Keep API rate limits separate and endpoint-specific. `/api/*` has different write semantics, authentication behavior, and user-impact risks than public page rendering.
-- Keep verified bots allowed for public gallery/share discovery, but rate-limit generic or unverified crawlers that repeatedly hit share pages or Studio.
+- Keep verified bots allowed for public gallery/share discovery. The rate limiting expression excludes them through `not cf.client.bot`.
 - When investigating `Worker exceeded CPU time limit`, group events by `http.request.uri.path`, method, user agent, and timestamp. If the spike aligns with the daily cron in [`wrangler.jsonc`](../../wrangler.jsonc), inspect retention cleanup. Otherwise prioritize public SSR/API traffic.
 
 Cloudflare references:

--- a/docs/deployment/deployment-setup.md
+++ b/docs/deployment/deployment-setup.md
@@ -98,6 +98,88 @@ openssl rand -base64 32
 Add deployed auth and mail secrets to Cloudflare Worker secrets for the matching environment, not to the repository.
 Keep non-secret mail configuration in [`wrangler.jsonc`](../../wrangler.jsonc) so GitHub-driven deploys do not drift from dashboard-only vars.
 
+## Production protection
+
+TrackDraw should protect the Worker both in code and at Cloudflare's edge.
+
+The repository-level guard in [`custom-worker.ts`](../../custom-worker.ts) rejects unsafe non-API page methods before requests reach OpenNext. This specifically protects against invalid Server Action probes such as `POST /studio` with a bogus `next-action` header. TrackDraw does not use Server Actions, and page routes are expected to be `GET`, `HEAD`, or `OPTIONS` only. Legitimate writes should go through `/api/*`.
+
+Recommended Cloudflare dashboard setup:
+
+### Block invalid page writes
+
+Create this as a WAF custom rule.
+
+Where to create it:
+
+- New Cloudflare dashboard: select the `trackdraw.app` zone, open `Security` → `Security rules`, then choose `Create rule` → `Custom rule`.
+
+Rule settings:
+
+- Rule name: `Block unsafe methods on page routes`
+- Field/expression mode: use `Edit expression`
+- Expression:
+  ```text
+  not starts_with(http.request.uri.path, "/api/")
+  and http.request.method in {"POST" "PUT" "PATCH" "DELETE"}
+  ```
+- Action: `Block`
+- Deploy after saving.
+
+Create a second WAF custom rule for obvious Server Action probes:
+
+- Rule name: `Block invalid Server Action probes`
+- Field/expression mode: use `Edit expression`
+- Expression:
+  ```text
+  http.request.headers["next-action"][0] ne ""
+  and not starts_with(http.request.uri.path, "/api/")
+  ```
+- Action: `Block`
+- Deploy after saving.
+
+### Rate-limit CPU-sensitive pages
+
+Create this as a WAF rate limiting rule after reviewing recent traffic volume.
+
+Where to create it:
+
+- New Cloudflare dashboard: select the `trackdraw.app` zone, open `Security` → `Security rules`, then choose `Create rule` → `Rate limiting rules`.
+- Older Cloudflare dashboard/docs path: select the zone, open `Security` → `WAF` → `Rate limiting rules`, then choose `Create rule`.
+
+Suggested first rule:
+
+- Rule name: `Limit public page bursts`
+- Field/expression mode: use `Edit expression`
+- Expression:
+  ```text
+  (
+    http.request.uri.path eq "/studio"
+    or http.request.uri.path eq "/gallery"
+    or http.request.uri.path eq "/sitemap.xml"
+    or starts_with(http.request.uri.path, "/share/")
+  )
+  and http.request.method in {"GET" "HEAD"}
+  ```
+- Cache status: if available, disable `Also apply rate limiting to cached assets` so the counter focuses on requests reaching the Worker.
+- Characteristics: use at least `IP` and `User-Agent`. Keep Cloudflare's default data-center characteristic if the dashboard includes it.
+- Threshold: start from Cloudflare Security Analytics for the real traffic pattern. If there is no baseline yet, start in a conservative log/simulate mode or with a high threshold and reduce after observing false positives.
+- Action: start with `Log`/`Simulate` if available on the plan. Otherwise use `Managed Challenge` before moving to `Block`.
+
+Additional guidance:
+
+- Keep verified bots allowed for public gallery/share discovery, but rate-limit generic or unverified crawlers that repeatedly hit share pages or Studio.
+- When investigating `Worker exceeded CPU time limit`, group events by `http.request.uri.path`, method, user agent, and timestamp. If the spike aligns with the daily cron in [`wrangler.jsonc`](../../wrangler.jsonc), inspect retention cleanup. Otherwise prioritize public SSR/API traffic.
+
+Cloudflare references:
+
+- Workers CPU limits: <https://developers.cloudflare.com/workers/platform/limits/>
+- Workers error observability: <https://developers.cloudflare.com/workers/observability/errors/>
+- WAF custom rules in the dashboard: <https://developers.cloudflare.com/waf/custom-rules/create-dashboard/>
+- WAF rate limiting rules: <https://developers.cloudflare.com/waf/rate-limiting-rules/>
+- Create rate limiting rules in the dashboard: <https://developers.cloudflare.com/waf/rate-limiting-rules/create-zone-dashboard/>
+- Rate limiting best practices: <https://developers.cloudflare.com/waf/rate-limiting-rules/best-practices/>
+
 ### R2-backed public site media
 
 If a landing-page or other public site asset is too large for `public/`, store it in a public R2 bucket and expose it through the fixed site media host `https://media.trackdraw.app`.

--- a/docs/deployment/deployment-setup.md
+++ b/docs/deployment/deployment-setup.md
@@ -120,7 +120,10 @@ Rule settings:
 - Field/expression mode: use `Edit expression`
 - Expression:
   ```text
-  not starts_with(http.request.uri.path, "/api/")
+  not (
+    http.request.uri.path eq "/api"
+    or starts_with(http.request.uri.path, "/api/")
+  )
   and http.request.method in {"POST" "PUT" "PATCH" "DELETE"}
   ```
 - Action: `Block`
@@ -133,7 +136,10 @@ Create a second WAF custom rule for obvious Server Action probes:
 - Expression:
   ```text
   http.request.headers["next-action"][0] ne ""
-  and not starts_with(http.request.uri.path, "/api/")
+  and not (
+    http.request.uri.path eq "/api"
+    or starts_with(http.request.uri.path, "/api/")
+  )
   ```
 - Action: `Block`
 - Deploy after saving.
@@ -145,29 +151,36 @@ Create this as a WAF rate limiting rule after reviewing recent traffic volume.
 Where to create it:
 
 - New Cloudflare dashboard: select the `trackdraw.app` zone, open `Security` → `Security rules`, then choose `Create rule` → `Rate limiting rules`.
-- Older Cloudflare dashboard/docs path: select the zone, open `Security` → `WAF` → `Rate limiting rules`, then choose `Create rule`.
 
-Suggested first rule:
+Use route families instead of a hand-maintained list of public pages. The default rule should target page rendering by excluding stable non-page namespaces such as API and asset routes.
 
-- Rule name: `Limit public page bursts`
+Suggested broad rule:
+
+- Rule name: `Limit public page render bursts`
 - Field/expression mode: use `Edit expression`
 - Expression:
   ```text
-  (
-    http.request.uri.path eq "/studio"
-    or http.request.uri.path eq "/gallery"
-    or http.request.uri.path eq "/sitemap.xml"
-    or starts_with(http.request.uri.path, "/share/")
+  http.request.method in {"GET" "HEAD"}
+  and not (
+    http.request.uri.path eq "/api"
+    or starts_with(http.request.uri.path, "/api/")
   )
-  and http.request.method in {"GET" "HEAD"}
+  and not starts_with(http.request.uri.path, "/_next/")
+  and not starts_with(http.request.uri.path, "/assets/")
+  and not starts_with(http.request.uri.path, "/favicon")
+  and http.request.uri.path ne "/robots.txt"
+  and not cf.client.bot
   ```
-- Cache status: if available, disable `Also apply rate limiting to cached assets` so the counter focuses on requests reaching the Worker.
-- Characteristics: use at least `IP` and `User-Agent`. Keep Cloudflare's default data-center characteristic if the dashboard includes it.
-- Threshold: start from Cloudflare Security Analytics for the real traffic pattern. If there is no baseline yet, start in a conservative log/simulate mode or with a high threshold and reduce after observing false positives.
-- Action: start with `Log`/`Simulate` if available on the plan. Otherwise use `Managed Challenge` before moving to `Block`.
+- Scope: covers `/`, `/studio`, `/gallery`, `/share/*`, `/sitemap.xml`, legal pages, guides, and future public pages without editing the rule.
+- Cache status: disable `Also apply rate limiting to cached assets` so the counter focuses on requests reaching the Worker.
+- Characteristics: use `IP` and `User-Agent`.
+- Threshold: start from Cloudflare Security Analytics for the real traffic pattern, then choose a conservative threshold above normal user and crawler traffic.
+- Action: `Managed Challenge`.
 
 Additional guidance:
 
+- Do not add every new public route to Cloudflare manually. Prefer broad page-render rules with stable exclusions.
+- Keep API rate limits separate and endpoint-specific. `/api/*` has different write semantics, authentication behavior, and user-impact risks than public page rendering.
 - Keep verified bots allowed for public gallery/share discovery, but rate-limit generic or unverified crawlers that repeatedly hit share pages or Studio.
 - When investigating `Worker exceeded CPU time limit`, group events by `http.request.uri.path`, method, user agent, and timestamp. If the spike aligns with the daily cron in [`wrangler.jsonc`](../../wrangler.jsonc), inspect retention cleanup. Otherwise prioritize public SSR/API traffic.
 

--- a/docs/deployment/deployment-setup.md
+++ b/docs/deployment/deployment-setup.md
@@ -129,13 +129,14 @@ Rule settings:
 - Action: `Block`
 - Deploy after saving.
 
-Create a second WAF custom rule for obvious Server Action probes:
+Create a second WAF custom rule for obvious POST Server Action probes:
 
 - Rule name: `Block invalid Server Action probes`
 - Field/expression mode: use `Edit expression`
 - Expression:
   ```text
-  http.request.headers["next-action"][0] ne ""
+  http.request.method eq "POST"
+  and http.request.headers["next-action"][0] ne ""
   and not (
     http.request.uri.path eq "/api"
     or starts_with(http.request.uri.path, "/api/")
@@ -143,6 +144,7 @@ Create a second WAF custom rule for obvious Server Action probes:
   ```
 - Action: `Block`
 - Deploy after saving.
+- Keep this rule `POST`-only. Do not block `GET` or `HEAD` requests just because a crawler or proxy sends an unexpected `next-action` header; discovery paths such as `/robots.txt`, `/robot.txt`, and `/sitemap.xml` should remain crawlable.
 
 ### Rate-limit CPU-sensitive pages
 
@@ -164,14 +166,13 @@ Rule settings:
   and (
     http.request.uri.path eq "/studio"
     or http.request.uri.path eq "/gallery"
-    or http.request.uri.path eq "/sitemap.xml"
     or starts_with(http.request.uri.path, "/share/")
     or starts_with(http.request.uri.path, "/embed/")
   )
   ```
-- Scope: covers Studio, gallery, sitemap generation, shared tracks, and embeds. Add new route families here only when they render user/content-heavy pages.
+- Scope: covers Studio, gallery, shared tracks, and embeds. Add new route families here only when they render user/content-heavy pages.
 - Characteristics: use `IP`.
-- Threshold: `120 requests` per `1 minute`.
+- Threshold: `120 requests` per `10 seconds`.
 - Action: `Block`.
 - Duration: `10 seconds`.
 
@@ -180,6 +181,7 @@ Additional guidance:
 - Do not add every new public route to Cloudflare manually. Add only route families that are proven to create meaningful Worker rendering load.
 - Keep API rate limits separate and endpoint-specific. `/api/*` has different write semantics, authentication behavior, and user-impact risks than public page rendering.
 - Keep verified bots allowed for public gallery/share discovery. The rate limiting expression excludes them through `not cf.client.bot`.
+- Keep `/robots.txt`, common typo probes such as `/robot.txt`, and `/sitemap.xml` out of this rate limit. These requests are crawler-driven by design, and not every useful crawler is guaranteed to match Cloudflare's verified bot field.
 - When investigating `Worker exceeded CPU time limit`, group events by `http.request.uri.path`, method, user agent, and timestamp. If the spike aligns with the daily cron in [`wrangler.jsonc`](../../wrangler.jsonc), inspect retention cleanup. Otherwise prioritize public SSR/API traffic.
 
 Cloudflare references:

--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -20,10 +20,8 @@ export function Footer() {
   return (
     <footer className="border-border bg-muted/20 border-t">
       <div className="mx-auto max-w-6xl px-6 py-10 md:py-14">
-        {/* Top grid — mobile: brand full width + 2 cols, md: 5 cols */}
-        <div className="mb-10 grid grid-cols-2 gap-x-6 gap-y-8 md:grid-cols-5">
-          {/* Brand — spans 2 cols on mobile */}
-          <div className="col-span-2 space-y-3 md:col-span-1">
+        <div className="mb-10 grid gap-x-8 gap-y-8 md:grid-cols-[minmax(0,1.25fr)_minmax(0,3fr)] lg:gap-x-12">
+          <div className="space-y-3">
             <div className="flex items-center gap-2.5">
               <span className="inline-flex">
                 <span className="relative block h-8 w-35 dark:hidden">
@@ -54,131 +52,129 @@ export function Footer() {
             </p>
           </div>
 
-          {/* Product */}
-          <div className="space-y-3">
-            <h3 className="text-foreground/50 text-xs font-semibold tracking-widest uppercase">
-              Product
-            </h3>
-            <ul className="space-y-2.5 text-sm">
-              <li>
-                <Link
-                  href="/studio"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  Open Studio
-                </Link>
-              </li>
-              <li>
-                <a
-                  href="https://github.com/dutchdronesquad/trackdraw/releases"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                >
-                  Release notes
-                </a>
-              </li>
-            </ul>
-          </div>
+          <div className="grid grid-cols-2 gap-x-6 gap-y-8 md:grid-cols-4 md:gap-x-8">
+            <div className="space-y-3">
+              <h3 className="text-foreground/50 text-xs font-semibold tracking-widest uppercase">
+                Product
+              </h3>
+              <ul className="space-y-2.5 text-sm">
+                <li>
+                  <Link
+                    href="/studio"
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    Open Studio
+                  </Link>
+                </li>
+                <li>
+                  <a
+                    href="https://github.com/dutchdronesquad/trackdraw/releases"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    Release notes
+                  </a>
+                </li>
+              </ul>
+            </div>
 
-          {/* Legal */}
-          <div className="space-y-3">
-            <h3 className="text-foreground/50 text-xs font-semibold tracking-widest uppercase">
-              Legal
-            </h3>
-            <ul className="space-y-2.5 text-sm">
-              <li>
-                <Link
-                  href="/privacy"
-                  className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
-                >
-                  <ShieldCheck className="size-4 shrink-0" />
-                  Privacy Policy
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="/terms"
-                  className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
-                >
-                  <FileText className="size-4 shrink-0" />
-                  Terms of Service
-                </Link>
-              </li>
-            </ul>
-          </div>
+            <div className="space-y-3">
+              <h3 className="text-foreground/50 text-xs font-semibold tracking-widest uppercase">
+                Legal
+              </h3>
+              <ul className="space-y-2.5 text-sm">
+                <li>
+                  <Link
+                    href="/privacy"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+                  >
+                    <ShieldCheck className="size-4 shrink-0" />
+                    Privacy Policy
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    href="/terms"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+                  >
+                    <FileText className="size-4 shrink-0" />
+                    Terms of Service
+                  </Link>
+                </li>
+              </ul>
+            </div>
 
-          {/* Community */}
-          <div className="space-y-3">
-            <h3 className="text-foreground/50 text-xs font-semibold tracking-widest uppercase">
-              Community
-            </h3>
-            <ul className="space-y-2.5 text-sm">
-              <li>
-                <a
-                  href="https://github.com/dutchdronesquad/trackdraw"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
-                >
-                  <GithubIcon className="size-4 shrink-0" />
-                  GitHub
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://dutchdronesquad.nl"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
-                >
-                  <Flag className="size-4 shrink-0" />
-                  Dutch Drone Squad
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://github.com/dutchdronesquad/trackdraw/issues"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
-                >
-                  <Bug className="size-4 shrink-0" />
-                  Report an issue
-                </a>
-              </li>
-            </ul>
-          </div>
+            <div className="space-y-3">
+              <h3 className="text-foreground/50 text-xs font-semibold tracking-widest uppercase">
+                Community
+              </h3>
+              <ul className="space-y-2.5 text-sm">
+                <li>
+                  <a
+                    href="https://github.com/dutchdronesquad/trackdraw"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+                  >
+                    <GithubIcon className="size-4 shrink-0" />
+                    GitHub
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://dutchdronesquad.nl"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+                  >
+                    <Flag className="size-4 shrink-0" />
+                    Dutch Drone Squad
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://github.com/dutchdronesquad/trackdraw/issues"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+                  >
+                    <Bug className="size-4 shrink-0" />
+                    Report an issue
+                  </a>
+                </li>
+              </ul>
+            </div>
 
-          {/* Support */}
-          <div className="space-y-3">
-            <h3 className="text-foreground/50 text-xs font-semibold tracking-widest uppercase">
-              Support
-            </h3>
-            <ul className="space-y-2.5 text-sm">
-              <li>
-                <a
-                  href="https://github.com/sponsors/klaasnicolaas"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
-                >
-                  <Heart className="size-4 shrink-0" />
-                  GitHub Sponsors
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://ko-fi.com/klaasnicolaas"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
-                >
-                  <Coffee className="size-4 shrink-0" />
-                  Ko-fi
-                </a>
-              </li>
-            </ul>
+            <div className="space-y-3">
+              <h3 className="text-foreground/50 text-xs font-semibold tracking-widest uppercase">
+                Support
+              </h3>
+              <ul className="space-y-2.5 text-sm">
+                <li>
+                  <a
+                    href="https://github.com/sponsors/klaasnicolaas"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+                  >
+                    <Heart className="size-4 shrink-0" />
+                    GitHub Sponsors
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://ko-fi.com/klaasnicolaas"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+                  >
+                    <Coffee className="size-4 shrink-0" />
+                    Ko-fi
+                  </a>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
 

--- a/src/lib/server/request-guards.ts
+++ b/src/lib/server/request-guards.ts
@@ -1,5 +1,7 @@
 const SAFE_PAGE_METHODS = "GET, HEAD, OPTIONS";
-const SAFE_PAGE_METHOD_SET = new Set(["GET", "HEAD", "OPTIONS"]);
+const SAFE_PAGE_METHOD_SET = new Set(
+  SAFE_PAGE_METHODS.split(",").map((method) => method.trim())
+);
 
 function isApiPath(pathname: string) {
   return pathname === "/api" || pathname.startsWith("/api/");

--- a/src/lib/server/request-guards.ts
+++ b/src/lib/server/request-guards.ts
@@ -1,0 +1,35 @@
+const SAFE_PAGE_METHODS = "GET, HEAD, OPTIONS";
+const SAFE_PAGE_METHOD_SET = new Set(["GET", "HEAD", "OPTIONS"]);
+
+function isApiPath(pathname: string) {
+  return pathname === "/api" || pathname.startsWith("/api/");
+}
+
+function noStoreHeaders(extra?: HeadersInit) {
+  return {
+    "cache-control": "no-store",
+    ...extra,
+  };
+}
+
+export function getEarlyWorkerResponse(request: Request): Response | null {
+  const url = new URL(request.url);
+  const method = request.method.toUpperCase();
+  const isApiRequest = isApiPath(url.pathname);
+
+  if (method === "POST" && request.headers.has("next-action") && !isApiRequest) {
+    return new Response("Not found", {
+      status: 404,
+      headers: noStoreHeaders(),
+    });
+  }
+
+  if (!isApiRequest && !SAFE_PAGE_METHOD_SET.has(method)) {
+    return new Response("Method not allowed", {
+      status: 405,
+      headers: noStoreHeaders({ allow: SAFE_PAGE_METHODS }),
+    });
+  }
+
+  return null;
+}

--- a/src/lib/server/request-guards.ts
+++ b/src/lib/server/request-guards.ts
@@ -17,7 +17,11 @@ export function getEarlyWorkerResponse(request: Request): Response | null {
   const method = request.method.toUpperCase();
   const isApiRequest = isApiPath(url.pathname);
 
-  if (method === "POST" && request.headers.has("next-action") && !isApiRequest) {
+  if (
+    method === "POST" &&
+    request.headers.has("next-action") &&
+    !isApiRequest
+  ) {
     return new Response("Not found", {
       status: 404,
       headers: noStoreHeaders(),

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -75,11 +75,13 @@ export function decodeDesignWithReason(
   token: string
 ): { ok: true; design: TrackDesign } | { ok: false; reason: ShareDecodeError } {
   const normalized = normalizeShareToken(token);
+  if (normalized.length > MAX_SAFE_TOKEN_LENGTH) {
+    return { ok: false, reason: "too-large" };
+  }
+
   const design = decodeDesign(token);
   if (design) return { ok: true, design };
-  const reason: ShareDecodeError =
-    normalized.length > MAX_SAFE_TOKEN_LENGTH ? "too-large" : "invalid";
-  return { ok: false, reason };
+  return { ok: false, reason: "invalid" };
 }
 
 export function getShareTitle(design: TrackDesign) {

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -68,8 +68,9 @@ export type ShareDecodeError = "too-large" | "invalid";
 /**
  * Like decodeDesign, but distinguishes between a token that is too long for
  * browsers/apps to pass intact ("too-large") and one that is simply corrupt or
- * miscopied ("invalid"). The heuristic is: if the token itself exceeds
- * MAX_SAFE_TOKEN_LENGTH the decode failure is most likely due to truncation.
+ * miscopied ("invalid"). Tokens over MAX_SAFE_TOKEN_LENGTH are rejected before
+ * decompression, so callers should not expect a best-effort decode for
+ * long-but-valid tokens.
  */
 export function decodeDesignWithReason(
   token: string

--- a/tests/lib/server/request-guards.test.ts
+++ b/tests/lib/server/request-guards.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { getEarlyWorkerResponse } from "@/lib/server/request-guards";
+
+describe("getEarlyWorkerResponse", () => {
+  it("blocks unsupported server action POSTs before they reach Next", async () => {
+    const response = getEarlyWorkerResponse(
+      new Request("https://trackdraw.app/studio", {
+        method: "POST",
+        headers: {
+          "next-action": "0000000000000000000000000000000000000",
+        },
+      })
+    );
+
+    expect(response?.status).toBe(404);
+    expect(await response?.text()).toBe("Not found");
+  });
+
+  it("blocks regular POSTs to the client-only studio page", () => {
+    const response = getEarlyWorkerResponse(
+      new Request("https://trackdraw.app/studio", { method: "POST" })
+    );
+
+    expect(response?.status).toBe(405);
+    expect(response?.headers.get("allow")).toBe("GET, HEAD, OPTIONS");
+  });
+
+  it("blocks unsafe methods to non-API page routes", () => {
+    const response = getEarlyWorkerResponse(
+      new Request("https://trackdraw.app/share/example-token", {
+        method: "PUT",
+      })
+    );
+
+    expect(response?.status).toBe(405);
+  });
+
+  it("does not block normal studio page requests", () => {
+    const response = getEarlyWorkerResponse(
+      new Request("https://trackdraw.app/studio", { method: "GET" })
+    );
+
+    expect(response).toBeNull();
+  });
+
+  it("does not block page OPTIONS requests", () => {
+    const response = getEarlyWorkerResponse(
+      new Request("https://trackdraw.app/studio", { method: "OPTIONS" })
+    );
+
+    expect(response).toBeNull();
+  });
+
+  it("does not block API POST requests", () => {
+    const response = getEarlyWorkerResponse(
+      new Request("https://trackdraw.app/api/shares", {
+        method: "POST",
+        headers: {
+          "next-action": "0000000000000000000000000000000000000",
+        },
+      })
+    );
+
+    expect(response).toBeNull();
+  });
+});

--- a/tests/lib/share.test.ts
+++ b/tests/lib/share.test.ts
@@ -89,7 +89,10 @@ describe("share helpers", () => {
   });
 
   it("reports decode reasons for invalid and oversized tokens", () => {
-    const decompressSpy = vi.spyOn(LZString, "decompressFromEncodedURIComponent");
+    const decompressSpy = vi.spyOn(
+      LZString,
+      "decompressFromEncodedURIComponent"
+    );
 
     expect(decodeDesignWithReason("%%%")).toEqual({
       ok: false,

--- a/tests/lib/share.test.ts
+++ b/tests/lib/share.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@/lib/share";
 import { createDefaultDesign, normalizeDesign } from "@/lib/track/design";
 import { parseEditorView } from "@/lib/view";
+import LZString from "lz-string";
 
 describe("share helpers", () => {
   afterEach(() => {
@@ -88,6 +89,8 @@ describe("share helpers", () => {
   });
 
   it("reports decode reasons for invalid and oversized tokens", () => {
+    const decompressSpy = vi.spyOn(LZString, "decompressFromEncodedURIComponent");
+
     expect(decodeDesignWithReason("%%%")).toEqual({
       ok: false,
       reason: "invalid",
@@ -96,6 +99,7 @@ describe("share helpers", () => {
       ok: false,
       reason: "too-large",
     });
+    expect(decompressSpy).toHaveBeenCalledTimes(1);
   });
 
   it("returns sensible share title and description fallbacks", () => {


### PR DESCRIPTION
Adds early Worker-level request guards for invalid page writes, including bogus Server Action probes against Studio, before requests reach the OpenNext renderer. Also skips legacy share-token decompression for oversized tokens to reduce CPU exposure from malformed share URLs.

Updates deployment docs with current Cloudflare Security Rules setup guidance for WAF custom rules and rate limiting.