### PR TITLE
feat: Catalog-aware gate visual rendering

### DIFF
--- a/docs/research/track-element-catalog.md
+++ b/docs/research/track-element-catalog.md
@@ -45,6 +45,7 @@ Candidate catalog entry fields:
 - `organization`: optional source, such as `MultiGP`
 - `kind`: existing TrackDraw shape kind
 - `dimensions`: meter-based canonical dimensions plus display dimensions
+- `editable`: optional editability flags for catalog-owned properties such as fixed official sizing or color
 - `defaultShape`: current TrackDraw shape draft defaults
 - `tags`: `official`, `race`, `practice`, `timing-compatible`, `sim-export`
 - `sources`: optional public URLs or documentation references
@@ -79,19 +80,20 @@ Scope:
   - Dive gate variants only after deciding whether they should remain one `divegate` shape or become catalog-driven variants
 - Keep "Custom Gate" available through the standard TrackDraw Gate so users are not boxed into official-only dimensions.
 - Expose the official name in inspector/export summaries only when the shape was created from a catalog entry or explicitly assigned one.
-- Keep official gate width and height fixed after placement. Custom sizing belongs to the standard TrackDraw Gate instead of modifying an official catalog item.
+- Keep official gate sizing and color fixed after placement when the catalog entry owns those values. Custom sizing and coloring belong to the standard TrackDraw Gate instead of modifying an official catalog item.
 
 Done state:
 
 - Users can place at least one official named race gate.
-- The inspector can show the official identity and dimensions without hiding editable width/height controls.
+- The inspector can show the official identity and dimensions while hiding controls for catalog-fixed sizing or color.
 - Export and Race Pack copy can reference official names where helpful.
 
 Status:
 
 - Users can now place catalog-backed MultiGP-style gate variants through the normal Gate placement flow: Standard Gate 5x5 and Championship Gate 7x6. Desktop keeps the active gate type in a compact canvas placement control with a dropdown for additional variants, while mobile keeps one Gate entry in the tools drawer with a compact type picker for variants.
-- Newly placed official gates remain normal `gate` shapes, with their source identity stored under `meta.catalog`. The inspector shows the catalog type, source, official size, and official dimension status.
-- Official gate width and height are fixed in normal editing. Custom sizing belongs to the standard TrackDraw Gate.
+- Newly placed official gates remain normal `gate` shapes, with their source identity stored under `meta.catalog`. The inspector shows the catalog type, source, official size, and fixed official status.
+- Official gate sizing and color are fixed in normal editing. Custom sizing and coloring belong to the standard TrackDraw Gate.
+- Newly placed gates default with their front facing downward on the canvas so the default gate orientation matches the editor's front/back guide expectation.
 
 ## Phase 3: Element Library UI
 
@@ -123,4 +125,5 @@ Status:
 - Do not migrate existing projects to new official gate sizes automatically.
 - Do not couple element catalog work to accounts in the first slice.
 - Do not make realistic 3D model fidelity part of the catalog phase. The catalog should expose identity, dimensions, source metadata, and render hints; the 3D preview work should consume those hints for official visual variants.
+- Do not let catalog-backed visuals introduce per-element asset generation for repeated official items in dense tracks; share reusable textures/material inputs and keep dense-layout render/export regression coverage in place.
 - Do not copy a competitor's UI wholesale; borrow validated product patterns and fit them into TrackDraw's existing editor model.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -264,14 +264,18 @@ Why:
 Feature tracks:
 
 - 3D preview realism and lighting: improve scene readability with sun/directional lighting, shadows, contrast, and more realistic gate/flag presentation before adding heavy asset workflows
-- Catalog-aware 3D element rendering: use catalog identity such as `MultiGP Standard Gate 5x5` to render official elements with more recognizable shapes/materials while keeping generic gates lightweight
+- Catalog-aware element rendering: use catalog visual metadata such as panel sizes, PVC frame placement, colors, and branding treatment to render official elements consistently across 2D, 3D, and export paths while keeping generic elements lightweight
 - Focused 3D item controls: add direct controls for common edits such as elevation, rotation, scaling, and orientation only where undo/redo, lock state, and mobile behavior remain safe
+
+Current shipped foundation:
+
+- Catalog-backed MultiGP-style 5x5 and 7x6 gates now carry visual metadata for panel sizes, PVC frame placement, colors, and branding treatment; the 2D canvas/SVG output, live 3D preview, and flythrough export consume that metadata while the generic TrackDraw Gate stays lightweight
 
 Important boundary:
 
 - Do not make 3D controls broad enough to destabilize the existing 2D-first editor
 - Do not bury 3D preview or direct manipulation work under the element catalog; they should remain standalone editor features
-- Do not duplicate catalog source/dimension decisions in the 3D renderer; consume catalog metadata and render hints instead
+- Do not duplicate catalog source, dimension, or visual decisions in renderers; consume catalog visual metadata and shared helpers instead
 
 #### Generated Flightpath Assistance
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -36,13 +36,15 @@ The completed release-sized work is archived below. The REST API, live race over
         Keep Gate as the primary placement tool while letting users switch the active gate type between the generic TrackDraw gate and catalog-backed MultiGP-style 5x5 and 7x6 variants through compact desktop and mobile type pickers.
   - [x] Catalog identity in inspector
         Show placed catalog-backed elements with their official type, source, official size, and dimension status while keeping official gate width and height fixed in normal editing.
+  - [ ] In-place catalog type switching (`No account required`)
+        Let users change the catalog type of an already-placed gate directly from the inspector — for example switching a frame-only TrackDraw gate to a MultiGP Standard Gate 5x5 or back — without needing to delete and re-place the element. The switch should apply the new catalog entry's visual spec, locked dimensions, and identity while preserving position, rotation, and route connections.
 
 - [ ] 3D preview realism and lighting (`Research`, `No account required`)
       Improve the 3D preview's readability and realism with stronger contrast, sun/directional lighting, shadows, and more recognizable gates/flags while keeping mobile performance safe. Use catalog metadata to render official variants differently where helpful, such as a more realistic MultiGP Standard Gate 5x5.
   - [ ] 3D readability and realism pass
         Evaluate sun/directional lighting, stronger contrast, more realistic gates/flags, and shadow treatment without making the scene visually noisy.
-  - [ ] Catalog-aware 3D element rendering
-        Use `meta.catalog` and catalog render hints to choose more realistic 3D treatments for official elements, starting with the MultiGP Standard Gate 5x5, while keeping generic gates lightweight.
+  - [x] Catalog-aware 3D element rendering
+        Use catalog-owned visual metadata to render catalog-backed MultiGP-style 5x5 and 7x6 gates with recognizable panel sizes, PVC frame placement, colors, and branding treatment across 2D canvas/SVG output, the live preview, and flythrough export while keeping generic gates lightweight.
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.

--- a/src/components/canvas/renderers/shape-renderers.tsx
+++ b/src/components/canvas/renderers/shape-renderers.tsx
@@ -119,14 +119,82 @@ export function renderGate(shape: GateShape, selected: boolean, ppm: number) {
   const color = marker ? getTimingMarkerColor(marker) : base.color;
   const { radius, width } = base;
   const barHeight = Math.max(base.depth, 6);
+  const selectionPad = m2px(0.3, ppm);
+
+  if (base.variant === "panel-frame") {
+    const centerWidth = base.openingWidth;
+    const leftX = -width / 2;
+    const centerX = -centerWidth / 2;
+    const rightX = width / 2 - base.panels.rightWidth;
+    const strokeColor = marker ? color : base.frame.color;
+
+    return (
+      <>
+        {selected && (
+          <Rect
+            width={width + selectionPad}
+            height={barHeight + selectionPad}
+            offsetX={(width + selectionPad) / 2}
+            offsetY={(barHeight + selectionPad) / 2}
+            stroke="#60a5fa"
+            strokeWidth={1}
+            opacity={0.85}
+            cornerRadius={2}
+            listening={false}
+          />
+        )}
+        <Rect
+          x={leftX}
+          y={-barHeight / 2}
+          width={base.panels.leftWidth}
+          height={barHeight}
+          fill={base.panels.leftColor}
+          opacity={0.94}
+          cornerRadius={[radius, 0, 0, radius]}
+          strokeEnabled={false}
+        />
+        <Rect
+          x={centerX}
+          y={-barHeight / 2}
+          width={centerWidth}
+          height={barHeight}
+          fill={base.panels.topColor}
+          opacity={0.9}
+          strokeEnabled={false}
+        />
+        <Rect
+          x={rightX}
+          y={-barHeight / 2}
+          width={base.panels.rightWidth}
+          height={barHeight}
+          fill={base.panels.rightColor}
+          opacity={0.94}
+          cornerRadius={[0, radius, radius, 0]}
+          strokeEnabled={false}
+        />
+        <Rect
+          width={width}
+          height={barHeight}
+          offsetX={width / 2}
+          offsetY={barHeight / 2}
+          fillEnabled={false}
+          stroke={strokeColor}
+          strokeWidth={marker ? 2 : 1}
+          opacity={0.88}
+          cornerRadius={radius}
+        />
+      </>
+    );
+  }
+
   return (
     <>
       {selected && (
         <Rect
-          width={width + m2px(0.3, ppm)}
-          height={barHeight + m2px(0.3, ppm)}
-          offsetX={(width + m2px(0.3, ppm)) / 2}
-          offsetY={(barHeight + m2px(0.3, ppm)) / 2}
+          width={width + selectionPad}
+          height={barHeight + selectionPad}
+          offsetX={(width + selectionPad) / 2}
+          offsetY={(barHeight + selectionPad) / 2}
           stroke="#60a5fa"
           strokeWidth={1}
           opacity={0.85}

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -22,7 +22,9 @@ import {
   getPolylineCurve3Derived,
   getPolylinePreview3DPoints,
 } from "@/lib/track/polyline-derived-3d";
+import { getGateVisualSpec } from "@/lib/track/elements/visual";
 import { getShapeTimingMarker, getTimingMarkerColor } from "@/lib/track/timing";
+import type { PanelFrameGateVisualSpec } from "@/lib/track/elements/catalog";
 import type {
   ConeShape,
   DiveGateShape,
@@ -285,34 +287,376 @@ export function WheelBridge({
   return null;
 }
 
-function useTextTexture(
+interface TextTextureOptions {
+  fontFamily?: string;
+  fontStyle?: "normal" | "italic";
+  fontWeight?: number;
+  letterSpacing?: number;
+}
+
+interface TextTextureCacheEntry {
+  refs: number;
+  texture: THREE.CanvasTexture;
+}
+
+const textTextureCache = new Map<string, TextTextureCacheEntry>();
+
+function getTextTextureCacheKey(
   text: string,
   color: string,
-  fontSize: number
+  fontSize: number,
+  options: Required<TextTextureOptions>
+) {
+  return [
+    text,
+    color,
+    fontSize,
+    options.fontFamily,
+    options.fontStyle,
+    options.fontWeight,
+    options.letterSpacing,
+  ].join("\u0001");
+}
+
+function createTextTexture(
+  text: string,
+  color: string,
+  fontSize: number,
+  options: Required<TextTextureOptions>
 ): THREE.CanvasTexture {
-  const texture = useMemo(() => {
-    const scale = 4;
-    const measW = Math.max(256, text.length * fontSize * scale * 0.62 + 40);
-    const measH = fontSize * scale * 2;
-    const canvas = document.createElement("canvas");
-    canvas.width = measW;
-    canvas.height = measH;
-    const ctx = canvas.getContext("2d")!;
-    ctx.clearRect(0, 0, measW, measH);
-    ctx.fillStyle = color;
-    ctx.font = `600 ${fontSize * scale}px ui-monospace,monospace,Arial`;
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
+  const scale = 4;
+  const measW = Math.max(256, text.length * fontSize * scale * 0.62 + 40);
+  const measH = fontSize * scale * 2;
+  const canvas = document.createElement("canvas");
+  canvas.width = measW;
+  canvas.height = measH;
+  const ctx = canvas.getContext("2d")!;
+  ctx.clearRect(0, 0, measW, measH);
+  ctx.fillStyle = color;
+  ctx.font = `${options.fontStyle} ${options.fontWeight} ${
+    fontSize * scale
+  }px ${options.fontFamily}`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+  if (options.letterSpacing) {
+    const spacing = options.letterSpacing * scale;
+    const chars = [...text];
+    const totalWidth =
+      chars.reduce((sum, char) => sum + ctx.measureText(char).width, 0) +
+      spacing * Math.max(chars.length - 1, 0);
+    let x = measW / 2 - totalWidth / 2;
+    for (const char of chars) {
+      const charWidth = ctx.measureText(char).width;
+      ctx.fillText(char, x + charWidth / 2, measH / 2);
+      x += charWidth + spacing;
+    }
+  } else {
     ctx.fillText(text, measW / 2, measH / 2);
-    return new THREE.CanvasTexture(canvas);
-  }, [text, color, fontSize]);
-
-  useEffect(() => () => texture.dispose(), [texture]);
-
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
   return texture;
 }
 
-function Gate3D({
+function getSharedTextTexture(
+  text: string,
+  color: string,
+  fontSize: number,
+  options: Required<TextTextureOptions>
+) {
+  const key = getTextTextureCacheKey(text, color, fontSize, options);
+  const existing = textTextureCache.get(key);
+  if (existing) {
+    existing.refs += 1;
+    return { key, texture: existing.texture };
+  }
+
+  const texture = createTextTexture(text, color, fontSize, options);
+  textTextureCache.set(key, { refs: 1, texture });
+  return { key, texture };
+}
+
+function releaseSharedTextTexture(
+  key: string,
+  fallbackTexture: THREE.CanvasTexture
+) {
+  const entry = textTextureCache.get(key);
+  if (!entry) {
+    // Cache was cleared (e.g. HMR module replacement) — dispose directly.
+    fallbackTexture.dispose();
+    return;
+  }
+
+  entry.refs -= 1;
+  if (entry.refs > 0) return;
+
+  textTextureCache.delete(key);
+  entry.texture.dispose();
+}
+
+function useTextTexture(
+  text: string,
+  color: string,
+  fontSize: number,
+  options?: TextTextureOptions
+): THREE.CanvasTexture {
+  const fontFamily = options?.fontFamily ?? "ui-monospace,monospace,Arial";
+  const fontStyle = options?.fontStyle ?? "normal";
+  const fontWeight = options?.fontWeight ?? 600;
+  const letterSpacing = options?.letterSpacing ?? 0;
+  const shared = useMemo(
+    () =>
+      getSharedTextTexture(text, color, fontSize, {
+        fontFamily,
+        fontStyle,
+        fontWeight,
+        letterSpacing,
+      }),
+    [color, fontFamily, fontSize, fontStyle, fontWeight, letterSpacing, text]
+  );
+
+  useEffect(() => {
+    const { key, texture } = shared;
+    return () => releaseSharedTextTexture(key, texture);
+  }, [shared]);
+
+  return shared.texture;
+}
+
+function FrontTextPlaneGeometry({
+  height,
+  width,
+}: {
+  height: number;
+  width: number;
+}) {
+  const geometry = useMemo(
+    () => new THREE.PlaneGeometry(width, height),
+    [height, width]
+  );
+
+  useEffect(() => () => geometry.dispose(), [geometry]);
+
+  return <primitive object={geometry} attach="geometry" />;
+}
+
+function PanelFrameFrameOnlyGate3D({
+  selected = false,
+  shape,
+  outerRef,
+  visual,
+  rot,
+}: {
+  selected?: boolean;
+  shape: GateShape;
+  outerRef?: Ref<THREE.Group>;
+  visual: PanelFrameGateVisualSpec;
+  rot: [number, number, number];
+}) {
+  const { branding, frame, panels } = visual;
+  const multigpLabelStyle = useMemo(
+    () => ({
+      fontFamily: '"Arial Narrow","Helvetica Neue Condensed",Arial,sans-serif',
+      fontStyle: "italic" as const,
+      fontWeight: 800,
+      letterSpacing: 0.3,
+    }),
+    []
+  );
+  const topTextTexture = useTextTexture(
+    branding.label,
+    branding.markColor,
+    32,
+    multigpLabelStyle
+  );
+  const sideTextTexture = useTextTexture(
+    branding.label,
+    branding.accentColor,
+    28,
+    multigpLabelStyle
+  );
+  const h = shape.height ?? 2;
+  const w = shape.width ?? 3;
+  const leftPanelWidth = panels.left.widthMeters;
+  const rightPanelWidth = panels.right.widthMeters;
+  const topPanelHeight = panels.top.heightMeters;
+  const panelDepth = 0.018;
+  const frameTube = frame.diameterMeters;
+  const frontZ = -(panelDepth / 2 + 0.012);
+  const leftPanelX = -w / 2 - leftPanelWidth / 2;
+  const rightPanelX = w / 2 + rightPanelWidth / 2;
+  const topPanelY = h + topPanelHeight / 2;
+  const topPanelW = w + leftPanelWidth + rightPanelWidth;
+  const outerLeftX = -w / 2 - leftPanelWidth;
+  const outerRightX = w / 2 + rightPanelWidth;
+  const outerTopY = h + topPanelHeight;
+  const checkerSize = Math.max(
+    Math.min(leftPanelWidth, rightPanelWidth, topPanelHeight) * 0.18,
+    0.045
+  );
+  const frameTubeMat = {
+    color: frame.color,
+    roughness: 0.55,
+    metalness: 0.08,
+    emissive: selected ? "#60a5fa" : "#000000",
+    emissiveIntensity: selected ? 0.12 : 0,
+  };
+  const frameElbowMat = {
+    color: frame.color,
+    roughness: 0.58,
+    metalness: 0.04,
+  };
+
+  return (
+    <group ref={outerRef} position={[shape.x, 0, shape.y]} rotation={rot}>
+      <mesh
+        position={[outerLeftX, outerTopY / 2, -panelDepth * 0.65]}
+        rotation={[0, 0, 0]}
+        castShadow
+      >
+        <cylinderGeometry
+          args={[frameTube / 2, frameTube / 2, outerTopY, 16]}
+        />
+        <meshStandardMaterial {...frameTubeMat} />
+      </mesh>
+      <mesh
+        position={[outerRightX, outerTopY / 2, -panelDepth * 0.65]}
+        castShadow
+      >
+        <cylinderGeometry
+          args={[frameTube / 2, frameTube / 2, outerTopY, 16]}
+        />
+        <meshStandardMaterial {...frameTubeMat} />
+      </mesh>
+      <mesh
+        position={[0, outerTopY, -panelDepth * 0.65]}
+        rotation={[0, 0, Math.PI / 2]}
+        castShadow
+      >
+        <cylinderGeometry
+          args={[frameTube / 2, frameTube / 2, outerRightX - outerLeftX, 16]}
+        />
+        <meshStandardMaterial {...frameTubeMat} />
+      </mesh>
+      {[
+        [outerLeftX, outerTopY],
+        [outerRightX, outerTopY],
+      ].map(([x, y], index) => (
+        <mesh
+          key={`pvc-elbow-${index}`}
+          position={[x, y, -panelDepth * 0.65]}
+          castShadow
+        >
+          <sphereGeometry args={[frameTube * 0.66, 16, 12]} />
+          <meshStandardMaterial {...frameElbowMat} />
+        </mesh>
+      ))}
+
+      <mesh position={[leftPanelX, h / 2, 0]} castShadow receiveShadow>
+        <boxGeometry args={[leftPanelWidth, h, panelDepth]} />
+        <meshStandardMaterial
+          color={panels.left.color}
+          roughness={0.7}
+          metalness={0.01}
+          emissive={selected ? "#60a5fa" : panels.left.color}
+          emissiveIntensity={selected ? 0.24 : 0.02}
+        />
+      </mesh>
+      <mesh position={[rightPanelX, h / 2, 0]} castShadow receiveShadow>
+        <boxGeometry args={[rightPanelWidth, h, panelDepth]} />
+        <meshStandardMaterial
+          color={panels.right.color}
+          roughness={0.7}
+          metalness={0.01}
+          emissive={selected ? "#60a5fa" : panels.right.color}
+          emissiveIntensity={selected ? 0.24 : 0.02}
+        />
+      </mesh>
+      <mesh position={[0, topPanelY, 0]} castShadow receiveShadow>
+        <boxGeometry args={[topPanelW, topPanelHeight, panelDepth]} />
+        <meshStandardMaterial
+          color={panels.top.color}
+          roughness={0.64}
+          metalness={0.03}
+          emissive={selected ? "#60a5fa" : panels.top.color}
+          emissiveIntensity={selected ? 0.28 : 0.04}
+        />
+      </mesh>
+
+      {[-1, 1].map((dir) => (
+        <group key={`side-accents-${dir}`}>
+          {Array.from({ length: 12 }).map((_, index) => {
+            const row = Math.floor(index / 3);
+            const col = index % 3;
+            if ((row + col) % 2 === 0) return null;
+            return (
+              <mesh
+                key={`${dir}-checker-${index}`}
+                position={[
+                  (dir < 0 ? leftPanelX : rightPanelX) +
+                    dir * ((col - 1) * checkerSize),
+                  h * 0.12 + row * checkerSize,
+                  frontZ - 0.004,
+                ]}
+              >
+                <boxGeometry args={[checkerSize, checkerSize, panelDepth]} />
+                <meshBasicMaterial color={branding.checkerColor} />
+              </mesh>
+            );
+          })}
+        </group>
+      ))}
+
+      <mesh
+        position={[0, topPanelY, frontZ - 0.016]}
+        rotation={[0, Math.PI, 0]}
+      >
+        <FrontTextPlaneGeometry
+          width={Math.max(w * 0.38, 0.46)}
+          height={topPanelHeight * 0.62}
+        />
+        <meshBasicMaterial
+          map={topTextTexture}
+          transparent
+          depthWrite={false}
+        />
+      </mesh>
+      {[-1, 1].map((dir) => (
+        <mesh
+          key={`side-text-${dir}`}
+          position={[
+            dir < 0 ? leftPanelX : rightPanelX,
+            h * 0.58,
+            frontZ - 0.016,
+          ]}
+          rotation={[0, Math.PI, dir > 0 ? -Math.PI / 2 : Math.PI / 2]}
+        >
+          <FrontTextPlaneGeometry
+            width={h * 0.44}
+            height={(dir < 0 ? leftPanelWidth : rightPanelWidth) * 0.62}
+          />
+          <meshBasicMaterial
+            map={sideTextTexture}
+            transparent
+            depthWrite={false}
+          />
+        </mesh>
+      ))}
+
+      <mesh position={[0, h / 2, -panelDepth / 2 - 0.004]}>
+        <planeGeometry args={[w, h]} />
+        <meshBasicMaterial
+          color={frame.color}
+          transparent
+          opacity={selected ? 0.1 : 0.045}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+function FrameOnlyGate3D({
   selected = false,
   shape,
   outerRef,
@@ -325,14 +669,28 @@ function Gate3D({
   const color = marker
     ? getTimingMarkerColor(marker)
     : (shape.color ?? "#3b82f6");
-  const thick = shape.thick ?? 0.2;
-  const h = shape.height ?? 2;
-  const w = shape.width ?? 3;
+  const visual = getGateVisualSpec(shape);
   const rot: [number, number, number] = [
     0,
     (-shape.rotation * Math.PI) / 180,
     0,
   ];
+
+  if (visual.variant === "panel-frame") {
+    return (
+      <PanelFrameFrameOnlyGate3D
+        shape={shape}
+        selected={selected}
+        outerRef={outerRef}
+        visual={visual}
+        rot={rot}
+      />
+    );
+  }
+
+  const thick = shape.thick ?? 0.2;
+  const h = shape.height ?? 2;
+  const w = shape.width ?? 3;
 
   return (
     <group ref={outerRef} position={[shape.x, 0, shape.y]} rotation={rot}>
@@ -761,7 +1119,7 @@ function Ladder3D({
   );
 }
 
-function DiveGate3D({
+function DiveFrameOnlyGate3D({
   selected = false,
   shape,
   outerRef,
@@ -1095,7 +1453,11 @@ function Shape3D({
     case "gate":
       return (
         <group onClick={(event) => onSelect(event, shape.id)}>
-          <Gate3D shape={shape} selected={isSelected} outerRef={outerRef} />
+          <FrameOnlyGate3D
+            shape={shape}
+            selected={isSelected}
+            outerRef={outerRef}
+          />
           {isSelected && <SelectionMarker3D shape={shape} />}
         </group>
       );
@@ -1153,7 +1515,7 @@ function Shape3D({
     case "divegate":
       return (
         <group onClick={(event) => onSelect(event, shape.id)}>
-          <DiveGate3D
+          <DiveFrameOnlyGate3D
             shape={shape}
             selected={isSelected}
             outerRef={outerRef}

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -11,7 +11,6 @@ import {
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
 } from "@/lib/track/elements/catalog";
-import { formatMeasurement } from "@/lib/track/units";
 import {
   getShapeTimingMarker,
   getTimingMarkerMeta,
@@ -119,18 +118,23 @@ export function SingleInspectorView({
   const catalogIdentity = getTrackElementCatalogIdentity(shape.meta);
   const catalogEntry = getTrackElementCatalogEntry(catalogIdentity?.elementId);
   const selectedGateShape = shape.kind === "gate" ? shape : null;
-  const catalogGateDimensions =
+  const hasCatalogGateDimensions =
     selectedGateShape &&
     catalogEntry?.kind === "gate" &&
     typeof catalogEntry.dimensions.widthMeters === "number" &&
-    typeof catalogEntry.dimensions.heightMeters === "number"
-      ? {
-          width: catalogEntry.dimensions.widthMeters,
-          height: catalogEntry.dimensions.heightMeters,
-        }
-      : null;
-  const isOfficialCatalogGate =
-    catalogIdentity?.official === true && catalogGateDimensions !== null;
+    typeof catalogEntry.dimensions.heightMeters === "number";
+  const hasFixedCatalogDimensions =
+    hasCatalogGateDimensions && catalogEntry.editable?.dimensions === false;
+  const hasFixedCatalogColor =
+    catalogIdentity !== null && catalogEntry?.editable?.color === false;
+  const catalogStatusLabel =
+    catalogIdentity?.official &&
+    hasFixedCatalogDimensions &&
+    hasFixedCatalogColor
+      ? "Official size and color"
+      : catalogIdentity?.official
+        ? "Official dimensions"
+        : "Catalog item";
   const canSetTimingMarker = isTimingMarkerShape(shape);
   const secondarySectionDefaultOpen = !mobileInline;
   const timingSectionDefaultOpen = !mobileInline || canSetTimingMarker;
@@ -152,17 +156,6 @@ export function SingleInspectorView({
       meta: getTimingMarkerMeta(shape.meta, marker),
     } as Partial<Shape>);
   };
-  const renderOfficialMeasurement = (valueMeters: number) => (
-    <div className="border-border/50 bg-muted/25 text-foreground/82 flex h-8 min-w-0 items-center justify-between gap-2 rounded-md border px-2.5 text-[11px] shadow-none lg:h-7 lg:px-2">
-      <span className="min-w-0 truncate font-mono">
-        {formatMeasurement(valueMeters, unitSystem, { precision: 2 })}
-      </span>
-      <span className="text-muted-foreground/70 shrink-0 text-[10px] font-medium">
-        Official
-      </span>
-    </div>
-  );
-
   return (
     <div className="flex h-full min-h-0 flex-col">
       <InspectorScrollBody mobileInline={mobileInline}>
@@ -326,9 +319,7 @@ export function SingleInspectorView({
                       : "border-border/60 bg-muted/40 text-muted-foreground"
                   }`}
                 >
-                  {catalogIdentity.official
-                    ? "Official dimensions"
-                    : "Catalog item"}
+                  {catalogStatusLabel}
                 </span>
               </Row>
             </Section>
@@ -457,73 +448,73 @@ export function SingleInspectorView({
                 />
               </Row>
             )}
-            <Row label="Color">
-              <div className="flex items-center gap-2">
-                <label className="group relative block cursor-pointer">
-                  <span
-                    className="border-border/45 block size-9 rounded-lg border shadow-xs transition-transform group-hover:scale-[1.03] lg:size-7"
-                    style={{
-                      background: `linear-gradient(135deg, ${defaultColor} 0%, color-mix(in oklab, ${defaultColor} 72%, black) 100%)`,
-                    }}
-                  />
-                  <span className="absolute inset-0 rounded-lg ring-1 ring-white/18 ring-inset" />
-                  <input
-                    type="color"
-                    className="absolute inset-0 cursor-pointer opacity-0"
-                    value={defaultColor}
-                    onFocus={startBatch}
-                    onBlur={finishBatch}
-                    onChange={(event) =>
-                      updateShape(shape.id, { color: event.target.value })
-                    }
-                    aria-label="Pick color"
-                  />
-                </label>
-                <span className="border-border/45 bg-muted/35 text-foreground/78 inline-flex h-8 items-center rounded-lg border px-2.5 font-mono text-[11px] lg:h-7">
-                  {defaultColor}
-                </span>
-              </div>
-            </Row>
+            {!hasFixedCatalogColor ? (
+              <Row label="Color">
+                <div className="flex items-center gap-2">
+                  <label className="group relative block cursor-pointer">
+                    <span
+                      className="border-border/45 block size-9 rounded-lg border shadow-xs transition-transform group-hover:scale-[1.03] lg:size-7"
+                      style={{
+                        background: `linear-gradient(135deg, ${defaultColor} 0%, color-mix(in oklab, ${defaultColor} 72%, black) 100%)`,
+                      }}
+                    />
+                    <span className="absolute inset-0 rounded-lg ring-1 ring-white/18 ring-inset" />
+                    <input
+                      type="color"
+                      className="absolute inset-0 cursor-pointer opacity-0"
+                      value={defaultColor}
+                      onFocus={startBatch}
+                      onBlur={finishBatch}
+                      onChange={(event) =>
+                        updateShape(shape.id, { color: event.target.value })
+                      }
+                      aria-label="Pick color"
+                    />
+                  </label>
+                  <span className="border-border/45 bg-muted/35 text-foreground/78 inline-flex h-8 items-center rounded-lg border px-2.5 font-mono text-[11px] lg:h-7">
+                    {defaultColor}
+                  </span>
+                </div>
+              </Row>
+            ) : null}
             {shape.kind === "gate" && (
               <>
-                <Row label="Width">
-                  {isOfficialCatalogGate && catalogGateDimensions ? (
-                    renderOfficialMeasurement(catalogGateDimensions.width)
-                  ) : (
+                {!hasFixedCatalogDimensions ? (
+                  <>
+                    <Row label="Width">
+                      <MeasurementNum
+                        valueMeters={shape.width}
+                        unitSystem={unitSystem}
+                        onChange={(value) =>
+                          updateShape(shape.id, { width: value })
+                        }
+                        minMeters={0.5}
+                      />
+                    </Row>
+                    <Row label="Height">
+                      <MeasurementNum
+                        valueMeters={shape.height}
+                        unitSystem={unitSystem}
+                        onChange={(value) =>
+                          updateShape(shape.id, { height: value })
+                        }
+                        minMeters={0.5}
+                      />
+                    </Row>
+                  </>
+                ) : null}
+                {!hasFixedCatalogDimensions ? (
+                  <Row label="Thickness">
                     <MeasurementNum
-                      valueMeters={shape.width}
+                      valueMeters={shape.thick ?? 0.2}
                       unitSystem={unitSystem}
                       onChange={(value) =>
-                        updateShape(shape.id, { width: value })
+                        updateShape(shape.id, { thick: value })
                       }
-                      minMeters={0.5}
+                      minMeters={0.05}
                     />
-                  )}
-                </Row>
-                <Row label="Height">
-                  {isOfficialCatalogGate && catalogGateDimensions ? (
-                    renderOfficialMeasurement(catalogGateDimensions.height)
-                  ) : (
-                    <MeasurementNum
-                      valueMeters={shape.height}
-                      unitSystem={unitSystem}
-                      onChange={(value) =>
-                        updateShape(shape.id, { height: value })
-                      }
-                      minMeters={0.5}
-                    />
-                  )}
-                </Row>
-                <Row label="Thickness">
-                  <MeasurementNum
-                    valueMeters={shape.thick ?? 0.2}
-                    unitSystem={unitSystem}
-                    onChange={(value) =>
-                      updateShape(shape.id, { thick: value })
-                    }
-                    minMeters={0.05}
-                  />
-                </Row>
+                  </Row>
+                ) : null}
               </>
             )}
             {shape.kind === "flag" && (

--- a/src/lib/editor-tools.ts
+++ b/src/lib/editor-tools.ts
@@ -95,7 +95,6 @@ export function createShapeForTool(
   return createCatalogShapeDraft(resolvedEntryId, {
     x: point.x,
     y: point.y,
-    rotation: 0,
     includeCatalogMetadata: resolvedEntry?.official === true,
   });
 }

--- a/src/lib/export/exportFlythrough.ts
+++ b/src/lib/export/exportFlythrough.ts
@@ -13,8 +13,10 @@ import {
   getFpvCameraPose,
   getInitialFpvCameraPose,
 } from "@/lib/track/fpvCamera";
+import { getGateVisualSpec } from "@/lib/track/elements/visual";
 import { getPolylineCurve3Derived } from "@/lib/track/polyline-derived-3d";
-import type { TrackDesign, Shape, PolylineShape } from "@/lib/types";
+import type { PanelFrameGateVisualSpec } from "@/lib/track/elements/catalog";
+import type { GateShape, TrackDesign, Shape, PolylineShape } from "@/lib/types";
 import type { FlythroughProgress, FlythroughTheme } from "@/lib/export/shared";
 
 const FPS = 60;
@@ -40,9 +42,181 @@ function makeMat(color: string, emissiveIntensity = 0.08) {
   });
 }
 
+function addBox(
+  group: THREE.Group,
+  size: [number, number, number],
+  position: [number, number, number],
+  material: THREE.Material
+) {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), material);
+  mesh.position.set(...position);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  group.add(mesh);
+}
+
+function addCylinder(
+  group: THREE.Group,
+  radius: number,
+  length: number,
+  position: [number, number, number],
+  rotation: [number, number, number],
+  material: THREE.Material
+) {
+  const mesh = new THREE.Mesh(
+    new THREE.CylinderGeometry(radius, radius, length, 16),
+    material
+  );
+  mesh.position.set(...position);
+  mesh.rotation.set(...rotation);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  group.add(mesh);
+}
+
+function createOfficialGateGroup(
+  shape: GateShape,
+  visual: PanelFrameGateVisualSpec
+): THREE.Group {
+  const { branding, frame, panels } = visual;
+  const h = shape.height ?? 2;
+  const w = shape.width ?? 3;
+  const panelBand = Math.max(Math.min(w, h) * 0.18, 0.22);
+  const leftPanelWidth = panels.left.widthMeters || panelBand;
+  const rightPanelWidth = panels.right.widthMeters || panelBand;
+  const topPanelHeight = panels.top.heightMeters || panelBand;
+  const panelDepth = 0.018;
+  const frameTube = frame.diameterMeters;
+  const frontZ = -(panelDepth / 2 + 0.012);
+  const leftPanelX = -w / 2 - leftPanelWidth / 2;
+  const rightPanelX = w / 2 + rightPanelWidth / 2;
+  const topPanelY = h + topPanelHeight / 2;
+  const topPanelW = w + leftPanelWidth + rightPanelWidth;
+  const outerLeftX = -w / 2 - leftPanelWidth;
+  const outerRightX = w / 2 + rightPanelWidth;
+  const outerTopY = h + topPanelHeight;
+  const checkerSize = Math.max(
+    Math.min(leftPanelWidth, rightPanelWidth, topPanelHeight) * 0.18,
+    0.045
+  );
+  const yaw = (-shape.rotation * Math.PI) / 180;
+
+  const group = new THREE.Group();
+  group.position.set(shape.x, 0, shape.y);
+  group.rotation.y = yaw;
+
+  const frameMat = new THREE.MeshStandardMaterial({
+    color: frame.color,
+    roughness: 0.5,
+    metalness: 0.18,
+  });
+  const leftPanelMat = new THREE.MeshStandardMaterial({
+    color: panels.left.color,
+    emissive: panels.left.color,
+    emissiveIntensity: 0.02,
+    roughness: 0.7,
+    metalness: 0.01,
+  });
+  const rightPanelMat = new THREE.MeshStandardMaterial({
+    color: panels.right.color,
+    emissive: panels.right.color,
+    emissiveIntensity: 0.02,
+    roughness: 0.7,
+    metalness: 0.01,
+  });
+  const topMat = new THREE.MeshStandardMaterial({
+    color: panels.top.color,
+    emissive: panels.top.color,
+    emissiveIntensity: 0.04,
+    roughness: 0.64,
+    metalness: 0.03,
+  });
+  const checkerMat = new THREE.MeshBasicMaterial({
+    color: branding.checkerColor,
+  });
+  addCylinder(
+    group,
+    frameTube / 2,
+    outerTopY,
+    [outerLeftX, outerTopY / 2, -panelDepth * 0.65],
+    [0, 0, 0],
+    frameMat
+  );
+  addCylinder(
+    group,
+    frameTube / 2,
+    outerTopY,
+    [outerRightX, outerTopY / 2, -panelDepth * 0.65],
+    [0, 0, 0],
+    frameMat
+  );
+  addCylinder(
+    group,
+    frameTube / 2,
+    outerRightX - outerLeftX,
+    [0, outerTopY, -panelDepth * 0.65],
+    [0, 0, Math.PI / 2],
+    frameMat
+  );
+  for (const x of [outerLeftX, outerRightX]) {
+    const elbow = new THREE.Mesh(
+      new THREE.SphereGeometry(frameTube * 0.66, 16, 12),
+      frameMat
+    );
+    elbow.position.set(x, outerTopY, -panelDepth * 0.65);
+    elbow.castShadow = true;
+    group.add(elbow);
+  }
+  addBox(
+    group,
+    [leftPanelWidth, h, panelDepth],
+    [leftPanelX, h / 2, 0],
+    leftPanelMat
+  );
+  addBox(
+    group,
+    [rightPanelWidth, h, panelDepth],
+    [rightPanelX, h / 2, 0],
+    rightPanelMat
+  );
+  addBox(
+    group,
+    [topPanelW, topPanelHeight, panelDepth],
+    [0, topPanelY, 0],
+    topMat
+  );
+
+  for (const dir of [-1, 1]) {
+    const panelX = dir < 0 ? leftPanelX : rightPanelX;
+    for (let index = 0; index < 12; index += 1) {
+      const row = Math.floor(index / 3);
+      const col = index % 3;
+      if ((row + col) % 2 === 0) continue;
+      addBox(
+        group,
+        [checkerSize, checkerSize, 0.018],
+        [
+          panelX + dir * ((col - 1) * checkerSize),
+          h * 0.12 + row * checkerSize,
+          frontZ - 0.004,
+        ],
+        checkerMat
+      );
+    }
+  }
+
+  return group;
+}
+
 function addShapes(scene: THREE.Scene, shapes: Shape[]): void {
   for (const shape of shapes) {
     if (shape.kind === "gate") {
+      const visual = getGateVisualSpec(shape);
+      if (visual.variant === "panel-frame") {
+        scene.add(createOfficialGateGroup(shape, visual));
+        continue;
+      }
+
       const color = shape.color ?? "#3b82f6";
       const thick = shape.thick ?? 0.2;
       const h = shape.height ?? 2;

--- a/src/lib/export/exportSvg.ts
+++ b/src/lib/export/exportSvg.ts
@@ -62,6 +62,18 @@ function gateToSvg(s: GateShape, ppm: number): string {
   const { depth, radius, width } = base;
   const rot = s.rotation;
 
+  if (base.variant === "panel-frame") {
+    const centerWidth = base.openingWidth;
+    const strokeColor = marker ? color : base.frame.color;
+
+    return `<g transform="translate(${cx},${cy}) rotate(${rot})">
+    <rect x="${-width / 2}" y="${-depth / 2}" width="${base.panels.leftWidth}" height="${depth}" fill="${base.panels.leftColor}" fill-opacity="0.94" rx="${radius}"/>
+    <rect x="${-centerWidth / 2}" y="${-depth / 2}" width="${centerWidth}" height="${depth}" fill="${base.panels.topColor}" fill-opacity="0.9"/>
+    <rect x="${width / 2 - base.panels.rightWidth}" y="${-depth / 2}" width="${base.panels.rightWidth}" height="${depth}" fill="${base.panels.rightColor}" fill-opacity="0.94" rx="${radius}"/>
+    <rect x="${-width / 2}" y="${-depth / 2}" width="${width}" height="${depth}" fill="none" stroke="${strokeColor}" stroke-width="${marker ? 3 : 2}" rx="${radius}"/>
+  </g>`;
+  }
+
   return `<g transform="translate(${cx},${cy}) rotate(${rot})">
     <rect x="${-width / 2}" y="${-depth / 2}" width="${width}" height="${depth}" fill="${color}" fill-opacity="0.15" rx="${radius}"/>
     <rect x="${-width / 2}" y="${-depth / 2}" width="${width}" height="${depth}" fill="none" stroke="${color}" stroke-width="${marker ? 3 : 2}" rx="${radius}"/>
@@ -266,8 +278,10 @@ function rotatePoint(
 
 function obstacleNumbersToSvg(
   design: TrackDesign,
+  shapes: Shape[],
   ppm: number,
-  theme: ExportTheme
+  theme: ExportTheme,
+  boundsCache?: Map<string, ReturnType<typeof getNumberedShapeBounds>>
 ) {
   const obstacleNumberMap = getObstacleNumberMap(design);
   if (!obstacleNumberMap.size) return "";
@@ -276,13 +290,14 @@ function obstacleNumbersToSvg(
   const badgeStroke = theme === "dark" ? "#94a3b8" : "#cbd5e1";
   const textFill = "#f8fafc";
 
-  return getDesignShapes(design)
+  return shapes
     .filter(
       (shape) => isNumberedObstacle(shape) && obstacleNumberMap.has(shape.id)
     )
     .map((shape) => {
       const number = obstacleNumberMap.get(shape.id);
-      const bounds = getNumberedShapeBounds(shape, ppm);
+      const bounds =
+        boundsCache?.get(shape.id) ?? getNumberedShapeBounds(shape, ppm);
       if (!bounds || typeof number !== "number") return "";
 
       const localPoint = {
@@ -367,17 +382,25 @@ export function designToSvg(
     gridLines += `<line x1="0" y1="${y}" x2="${W}" y2="${y}" stroke="${stroke}" stroke-width="${sw}"/>`;
   }
 
-  const shapeSvg = getDesignShapes(design);
+  const shapes = getDesignShapes(design);
   const primaryPolylineId =
-    shapeSvg.find((shape): shape is PolylineShape => shape.kind === "polyline")
+    shapes.find((shape): shape is PolylineShape => shape.kind === "polyline")
       ?.id ?? null;
-  const shapeMarkup = shapeSvg
-    .map((s) => shapeToSvg(s, ppm, primaryPolylineId))
+  const shapeBoundsCache = new Map<
+    string,
+    ReturnType<typeof getNumberedShapeBounds>
+  >();
+  const shapeMarkup = shapes
+    .map((s) => {
+      if (isNumberedObstacle(s))
+        shapeBoundsCache.set(s.id, getNumberedShapeBounds(s, ppm));
+      return shapeToSvg(s, ppm, primaryPolylineId);
+    })
     .join("\n  ");
   const obstacleNumberMarkup =
     options?.includeObstacleNumbers === false
       ? ""
-      : obstacleNumbersToSvg(design, ppm, theme);
+      : obstacleNumbersToSvg(design, shapes, ppm, theme, shapeBoundsCache);
   const titleText = design.title.trim() || "Untitled Track";
   const sizeText = formatCompactFieldSize(
     width,

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -46,12 +46,62 @@ export interface TrackElementSource {
   url: string;
 }
 
+export interface GatePanelVisualSpec {
+  widthMeters: number;
+  color: string;
+}
+
+export interface GateTopPanelVisualSpec {
+  heightMeters: number;
+  color: string;
+}
+
+export interface GateFrameVisualSpec {
+  placement: "outer" | "opening";
+  material: "pvc" | "tube";
+  color: string;
+  diameterMeters: number;
+}
+
+export interface GateBrandingVisualSpec {
+  label: string;
+  markColor: string;
+  accentColor: string;
+  checkerColor: string;
+  style: "plain" | "multigp";
+}
+
+export interface FrameOnlyGateVisualSpec {
+  kind: "gate";
+  variant: "frame-only";
+  frame: GateFrameVisualSpec;
+}
+
+export interface PanelFrameGateVisualSpec {
+  kind: "gate";
+  variant: "panel-frame";
+  panels: {
+    left: GatePanelVisualSpec;
+    right: GatePanelVisualSpec;
+    top: GateTopPanelVisualSpec;
+  };
+  frame: GateFrameVisualSpec;
+  branding: GateBrandingVisualSpec;
+}
+
+export type GateVisualSpec = FrameOnlyGateVisualSpec | PanelFrameGateVisualSpec;
+export type TrackElementVisualSpec = GateVisualSpec;
+
 export interface TrackElementCatalogEntry {
   id: TrackElementCatalogId;
   name: string;
   organization?: string;
   kind: PlaceableCatalogShape["kind"];
   official?: boolean;
+  editable?: {
+    color?: boolean;
+    dimensions?: boolean;
+  };
   dimensions: TrackElementDimensions;
   defaultShape: TrackElementShapeDraft;
   tags: string[];
@@ -62,6 +112,7 @@ export interface TrackElementCatalogEntry {
   render3d?: {
     modelHint?: string;
   };
+  visual?: TrackElementVisualSpec;
   exportHints?: {
     simulatorFriendly?: boolean;
   };
@@ -103,6 +154,7 @@ function isTrackElementCatalogIdentity(
   if (!isRecord(value)) return false;
   if (value.version !== 1) return false;
   if (typeof value.elementId !== "string") return false;
+  if (!getTrackElementCatalogEntry(value.elementId)) return false;
   if (!isPlaceableCatalogShapeKind(value.assignedKind)) return false;
   if (typeof value.official !== "boolean") return false;
   if (!isRecord(value.snapshot)) return false;
@@ -116,18 +168,18 @@ function isTrackElementCatalogIdentity(
   return typeof value.snapshot.dimensionsLabel === "string";
 }
 
-const trackdrawGateDefaults = {
+const frameOnlyGateDefaults = {
   kind: "gate",
   x: 0,
   y: 0,
-  rotation: 0,
+  rotation: 180,
   width: 2,
   height: 2,
   thick: 0.2,
   color: "#3b82f6",
 } satisfies TrackElementShapeDraft;
 
-const trackdrawFlagDefaults = {
+const flagDefaults = {
   kind: "flag",
   x: 0,
   y: 0,
@@ -137,6 +189,52 @@ const trackdrawFlagDefaults = {
   color: "#a855f7",
 } satisfies TrackElementShapeDraft;
 
+const frameOnlyGateVisual = {
+  kind: "gate",
+  variant: "frame-only",
+  frame: {
+    placement: "opening",
+    material: "tube",
+    color: frameOnlyGateDefaults.color,
+    diameterMeters: frameOnlyGateDefaults.thick,
+  },
+} satisfies GateVisualSpec;
+
+const panelFrameGateVisual = {
+  kind: "gate",
+  variant: "panel-frame",
+  panels: {
+    left: { widthMeters: feetToMeters(1), color: "#f8fafc" },
+    right: { widthMeters: feetToMeters(1), color: "#f8fafc" },
+    top: { heightMeters: feetToMeters(1), color: "#202e5d" },
+  },
+  frame: {
+    placement: "outer",
+    material: "pvc",
+    color: "#f8fafc",
+    diameterMeters: 0.055,
+  },
+  branding: {
+    label: "MULTIGP",
+    markColor: "#f8fafc",
+    accentColor: "#dc2626",
+    checkerColor: "#111827",
+    style: "multigp",
+  },
+} satisfies GateVisualSpec;
+
+const panelFrameChampionshipGateVisual = {
+  ...panelFrameGateVisual,
+  panels: {
+    ...panelFrameGateVisual.panels,
+    top: { heightMeters: feetToMeters(1), color: "#202e5d" },
+  },
+  branding: {
+    ...panelFrameGateVisual.branding,
+    accentColor: "#b91c1c",
+  },
+} satisfies GateVisualSpec;
+
 export const trackElementCatalog = [
   {
     id: TRACKDRAW_GATE_ELEMENT_ID,
@@ -144,14 +242,15 @@ export const trackElementCatalog = [
     organization: "TrackDraw",
     kind: "gate",
     dimensions: {
-      widthMeters: trackdrawGateDefaults.width,
-      heightMeters: trackdrawGateDefaults.height,
+      widthMeters: frameOnlyGateDefaults.width,
+      heightMeters: frameOnlyGateDefaults.height,
       display: { unitSystem: "metric", label: "2 x 2 m" },
     },
-    defaultShape: trackdrawGateDefaults,
-    tags: ["generic", "race", "practice"],
+    defaultShape: frameOnlyGateDefaults,
+    tags: ["race", "practice"],
     render2d: { icon: "gate" },
     render3d: { modelHint: "gate-frame" },
+    visual: frameOnlyGateVisual,
     exportHints: { simulatorFriendly: true },
   },
   {
@@ -160,17 +259,18 @@ export const trackElementCatalog = [
     organization: "MultiGP",
     kind: "gate",
     official: true,
+    editable: { color: false, dimensions: false },
     dimensions: {
       widthMeters: feetToMeters(5),
       heightMeters: feetToMeters(5),
       display: { unitSystem: "imperial", label: "5 ft x 5 ft" },
     },
     defaultShape: {
-      ...trackdrawGateDefaults,
+      ...frameOnlyGateDefaults,
       width: feetToMeters(5),
       height: feetToMeters(5),
     },
-    tags: ["official", "race", "practice", "multigp"],
+    tags: ["race", "practice", "multigp"],
     sources: [
       {
         label: "MultiGP Standard Gate 5x5",
@@ -179,6 +279,7 @@ export const trackElementCatalog = [
     ],
     render2d: { icon: "gate" },
     render3d: { modelHint: "gate-frame" },
+    visual: panelFrameGateVisual,
     exportHints: { simulatorFriendly: true },
   },
   {
@@ -187,17 +288,18 @@ export const trackElementCatalog = [
     organization: "MultiGP",
     kind: "gate",
     official: true,
+    editable: { color: false, dimensions: false },
     dimensions: {
       widthMeters: feetToMeters(7),
       heightMeters: feetToMeters(6),
       display: { unitSystem: "imperial", label: "7 ft x 6 ft" },
     },
     defaultShape: {
-      ...trackdrawGateDefaults,
+      ...frameOnlyGateDefaults,
       width: feetToMeters(7),
       height: feetToMeters(6),
     },
-    tags: ["official", "championship", "race", "multigp"],
+    tags: ["championship", "race", "multigp"],
     sources: [
       {
         label: "MultiGP Drone Race Course Obstacles",
@@ -206,6 +308,7 @@ export const trackElementCatalog = [
     ],
     render2d: { icon: "gate" },
     render3d: { modelHint: "gate-frame" },
+    visual: panelFrameChampionshipGateVisual,
     exportHints: { simulatorFriendly: true },
   },
   {
@@ -214,12 +317,12 @@ export const trackElementCatalog = [
     organization: "TrackDraw",
     kind: "flag",
     dimensions: {
-      radiusMeters: trackdrawFlagDefaults.radius,
-      heightMeters: trackdrawFlagDefaults.poleHeight,
+      radiusMeters: flagDefaults.radius,
+      heightMeters: flagDefaults.poleHeight,
       display: { unitSystem: "metric", label: "0.25 m radius, 3.5 m pole" },
     },
-    defaultShape: trackdrawFlagDefaults,
-    tags: ["generic", "race", "practice"],
+    defaultShape: flagDefaults,
+    tags: ["race", "practice"],
     render2d: { icon: "flag" },
     render3d: { modelHint: "flag-pole" },
     exportHints: { simulatorFriendly: true },
@@ -241,7 +344,7 @@ export const trackElementCatalog = [
       radius: 0.2,
       color: "#f97316",
     },
-    tags: ["generic", "practice"],
+    tags: ["practice"],
     render2d: { icon: "cone" },
     render3d: { modelHint: "cone" },
     exportHints: { simulatorFriendly: true },
@@ -263,7 +366,7 @@ export const trackElementCatalog = [
       fontSize: 18,
       color: "#e2e8f0",
     },
-    tags: ["generic", "annotation"],
+    tags: ["annotation"],
     render2d: { icon: "label" },
   },
   {
@@ -283,7 +386,7 @@ export const trackElementCatalog = [
       width: 3,
       color: "#f59e0b",
     },
-    tags: ["generic", "race", "timing-compatible"],
+    tags: ["race", "timing-compatible"],
     render2d: { icon: "startfinish" },
     render3d: { modelHint: "start-pads" },
     exportHints: { simulatorFriendly: true },
@@ -309,7 +412,7 @@ export const trackElementCatalog = [
       elevation: 0,
       color: "#14b8a6",
     },
-    tags: ["generic", "technical", "practice"],
+    tags: ["technical", "practice"],
     render2d: { icon: "ladder" },
     render3d: { modelHint: "ladder-gate" },
     exportHints: { simulatorFriendly: true },
@@ -334,7 +437,7 @@ export const trackElementCatalog = [
       elevation: 3,
       color: "#f97316",
     },
-    tags: ["generic", "technical", "practice"],
+    tags: ["technical", "practice"],
     render2d: { icon: "divegate" },
     render3d: { modelHint: "dive-gate" },
     exportHints: { simulatorFriendly: true },

--- a/src/lib/track/elements/visual.ts
+++ b/src/lib/track/elements/visual.ts
@@ -1,0 +1,47 @@
+import type { GateShape, Shape } from "@/lib/types";
+import {
+  getTrackElementCatalogEntry,
+  getTrackElementCatalogIdentity,
+  type FrameOnlyGateVisualSpec,
+  type GateVisualSpec,
+  type TrackElementVisualSpec,
+} from "@/lib/track/elements/catalog";
+
+export function getTrackElementVisualSpec(
+  shape: Shape
+): TrackElementVisualSpec | null {
+  const catalogIdentity = getTrackElementCatalogIdentity(shape.meta);
+  const catalogVisual = getTrackElementCatalogEntry(
+    catalogIdentity?.elementId
+  )?.visual;
+
+  if (catalogVisual?.kind === shape.kind) {
+    return catalogVisual;
+  }
+
+  if (shape.kind === "gate") {
+    return getFallbackGateVisualSpec(shape);
+  }
+
+  return null;
+}
+
+export function getGateVisualSpec(shape: GateShape): GateVisualSpec {
+  const visual = getTrackElementVisualSpec(shape);
+  if (visual?.kind === "gate") return visual;
+  return getFallbackGateVisualSpec(shape);
+}
+
+function getFallbackGateVisualSpec(shape: GateShape): FrameOnlyGateVisualSpec {
+  const color = shape.color ?? "#3b82f6";
+  return {
+    kind: "gate",
+    variant: "frame-only",
+    frame: {
+      placement: "opening",
+      material: "tube",
+      color,
+      diameterMeters: shape.thick ?? 0.2,
+    },
+  };
+}

--- a/src/lib/track/shape2d.ts
+++ b/src/lib/track/shape2d.ts
@@ -1,4 +1,5 @@
 import { m2px } from "@/lib/track/units";
+import { getGateVisualSpec } from "@/lib/track/elements/visual";
 import type {
   ConeShape,
   DiveGateShape,
@@ -9,13 +10,48 @@ import type {
 } from "@/lib/types";
 
 export function getGate2DShape(shape: GateShape, ppm: number) {
-  const width = m2px(shape.width, ppm);
-  const depth = m2px(shape.thick ?? 0.2, ppm);
+  const visual = getGateVisualSpec(shape);
+  const openingWidth = m2px(shape.width, ppm);
+
+  if (visual.variant === "panel-frame") {
+    const leftPanelWidth = m2px(visual.panels.left.widthMeters, ppm);
+    const rightPanelWidth = m2px(visual.panels.right.widthMeters, ppm);
+    const width = openingWidth + leftPanelWidth + rightPanelWidth;
+    const depth = Math.max(
+      m2px(visual.frame.diameterMeters, ppm),
+      m2px(0.12, ppm)
+    );
+
+    return {
+      color: visual.panels.top.color,
+      depth,
+      frame: {
+        color: visual.frame.color,
+        diameter: m2px(visual.frame.diameterMeters, ppm),
+        placement: visual.frame.placement,
+      },
+      openingWidth,
+      panels: {
+        leftColor: visual.panels.left.color,
+        leftWidth: leftPanelWidth,
+        rightColor: visual.panels.right.color,
+        rightWidth: rightPanelWidth,
+        topColor: visual.panels.top.color,
+      },
+      radius: Math.min(12, depth / 2),
+      variant: visual.variant,
+      width,
+    };
+  }
+
+  const depth = m2px(visual.frame.diameterMeters, ppm);
   return {
-    color: shape.color ?? "#3b82f6",
+    color: visual.frame.color,
     depth,
+    openingWidth,
     radius: Math.min(12, depth / 2),
-    width,
+    variant: visual.variant,
+    width: openingWidth,
   };
 }
 

--- a/tests/components/inspector/SingleInspectorView.test.tsx
+++ b/tests/components/inspector/SingleInspectorView.test.tsx
@@ -5,6 +5,10 @@ import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SingleInspectorView } from "@/components/inspector/views/single";
+import {
+  createCatalogShapeDraft,
+  MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+} from "@/lib/track/elements/catalog";
 import type { GateShape, Shape, StartFinishShape } from "@/lib/types";
 
 const gate: GateShape = {
@@ -218,5 +222,33 @@ describe("SingleInspectorView race timing controls", () => {
         "Locked on the canvas. Unlock before moving, resizing, or continuing path edits."
       )
     ).toBeTruthy();
+  });
+
+  it("hides fixed official gate size and color controls", () => {
+    const officialGate = createCatalogShapeDraft(
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+      {
+        x: 0,
+        y: 0,
+        includeCatalogMetadata: true,
+      }
+    ) as GateShape;
+
+    renderSingleInspector(officialGate);
+
+    expect(screen.getByText("Official size and color")).toBeTruthy();
+    expect(screen.queryByText("Color")).toBeNull();
+    expect(screen.queryByText("Width")).toBeNull();
+    expect(screen.queryByText("Height")).toBeNull();
+    expect(screen.queryByText("Thickness")).toBeNull();
+  });
+
+  it("keeps frame-only gate size and color controls editable", () => {
+    renderSingleInspector(gate);
+
+    expect(screen.getByText("Color")).toBeTruthy();
+    expect(screen.getByText("Width")).toBeTruthy();
+    expect(screen.getByText("Height")).toBeTruthy();
+    expect(screen.getByText("Thickness")).toBeTruthy();
   });
 });

--- a/tests/lib/editor-tools.test.ts
+++ b/tests/lib/editor-tools.test.ts
@@ -27,7 +27,7 @@ describe("editor tool helpers", () => {
       kind: "gate",
       x: 12,
       y: 7,
-      rotation: 0,
+      rotation: 180,
       width: 2,
       height: 2,
       thick: 0.2,
@@ -68,6 +68,7 @@ describe("editor tool helpers", () => {
       kind: "gate",
       x: 3,
       y: 4,
+      rotation: 180,
       width: feetToMeters(5),
       height: feetToMeters(5),
       meta: {
@@ -91,6 +92,7 @@ describe("editor tool helpers", () => {
 
     expect(shape).toMatchObject({
       kind: "gate",
+      rotation: 180,
       width: feetToMeters(7),
       height: feetToMeters(6),
       meta: {
@@ -103,7 +105,7 @@ describe("editor tool helpers", () => {
     });
   });
 
-  it("falls back to the generic gate when a non-gate catalog id is passed", () => {
+  it("falls back to the frame-only gate when a non-gate catalog id is passed", () => {
     expect(
       createShapeForTool(
         "gate",

--- a/tests/lib/editor/store-state.test.ts
+++ b/tests/lib/editor/store-state.test.ts
@@ -43,7 +43,7 @@ describe("editor store state helpers", () => {
     expect(next.rotationSession).toBeNull();
   });
 
-  it("defaults to the generic TrackDraw gate variant", () => {
+  it("defaults to the frame-only TrackDraw gate variant", () => {
     expect(createDefaultEditorUiState().activeGateElementId).toBe(
       TRACKDRAW_GATE_ELEMENT_ID
     );

--- a/tests/lib/track/elements/catalog.test.ts
+++ b/tests/lib/track/elements/catalog.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getCanvasRotationGuideAngleDeg } from "@/lib/track/orientation";
 import { feetToMeters } from "@/lib/track/units";
 import {
   createCatalogShapeDraft,
@@ -10,6 +11,7 @@ import {
   TRACKDRAW_GATE_ELEMENT_ID,
   trackElementCatalog,
 } from "@/lib/track/elements/catalog";
+import type { GateShape } from "@/lib/types";
 
 describe("track element catalog", () => {
   it("exposes unique catalog entries", () => {
@@ -32,7 +34,7 @@ describe("track element catalog", () => {
     ]);
   });
 
-  it("keeps the generic TrackDraw gate defaults unchanged", () => {
+  it("keeps the frame-only TrackDraw gate defaults unchanged", () => {
     const shape = createCatalogShapeDraft(TRACKDRAW_GATE_ELEMENT_ID, {
       x: 12,
       y: 8,
@@ -52,7 +54,21 @@ describe("track element catalog", () => {
     expect(shape.meta).toBeUndefined();
   });
 
-  it("documents the official MultiGP 5x5 gate without changing generic placement", () => {
+  it("defaults newly placed gates to a downward-facing front", () => {
+    const shape = createCatalogShapeDraft(TRACKDRAW_GATE_ELEMENT_ID, {
+      x: 0,
+      y: 0,
+    });
+
+    expect(shape).toMatchObject({
+      kind: "gate",
+      rotation: 180,
+    });
+    const gateShape = { ...shape, id: "gate-1" } as GateShape;
+    expect(getCanvasRotationGuideAngleDeg(gateShape)).toBe(90);
+  });
+
+  it("documents the MultiGP 5x5 panel-frame gate without changing default placement", () => {
     const entry = getTrackElementCatalogEntry(
       MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
     );

--- a/tests/lib/track/elements/visual.test.ts
+++ b/tests/lib/track/elements/visual.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { feetToMeters } from "@/lib/track/units";
+import {
+  createCatalogShapeDraft,
+  MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+  MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+  TRACKDRAW_GATE_ELEMENT_ID,
+} from "@/lib/track/elements/catalog";
+import {
+  getGateVisualSpec,
+  getTrackElementVisualSpec,
+} from "@/lib/track/elements/visual";
+import type { GateShape } from "@/lib/types";
+
+describe("track element visual specs", () => {
+  it("keeps frame-only TrackDraw gates on the lightweight frame-only renderer", () => {
+    const shape = createCatalogShapeDraft(TRACKDRAW_GATE_ELEMENT_ID, {
+      x: 0,
+      y: 0,
+      includeCatalogMetadata: true,
+    }) as GateShape;
+
+    expect(getGateVisualSpec(shape)).toMatchObject({
+      kind: "gate",
+      variant: "frame-only",
+      frame: {
+        placement: "opening",
+        material: "tube",
+      },
+    });
+  });
+
+  it("exposes catalog-backed MultiGP panel-frame dimensions", () => {
+    const standardGate = createCatalogShapeDraft(
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+      {
+        x: 0,
+        y: 0,
+        includeCatalogMetadata: true,
+      }
+    ) as GateShape;
+    const championshipGate = createCatalogShapeDraft(
+      MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+      {
+        x: 0,
+        y: 0,
+        includeCatalogMetadata: true,
+      }
+    ) as GateShape;
+
+    expect(getGateVisualSpec(standardGate)).toMatchObject({
+      kind: "gate",
+      variant: "panel-frame",
+      panels: {
+        left: { widthMeters: feetToMeters(1), color: "#f8fafc" },
+        right: { widthMeters: feetToMeters(1), color: "#f8fafc" },
+        top: { heightMeters: feetToMeters(1), color: "#202e5d" },
+      },
+      frame: {
+        placement: "outer",
+        material: "pvc",
+        color: "#f8fafc",
+        diameterMeters: 0.055,
+      },
+      branding: {
+        label: "MULTIGP",
+        style: "multigp",
+      },
+    });
+    expect(getGateVisualSpec(championshipGate)).toMatchObject({
+      kind: "gate",
+      variant: "panel-frame",
+      panels: {
+        top: { heightMeters: feetToMeters(1), color: "#202e5d" },
+      },
+    });
+  });
+
+  it("falls back to a frame-only visual spec for ordinary gates without catalog metadata", () => {
+    const shape: GateShape = {
+      id: "plain-gate",
+      kind: "gate",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: 2,
+      height: 2,
+      thick: 0.16,
+      color: "#22c55e",
+    };
+
+    expect(getTrackElementVisualSpec(shape)).toMatchObject({
+      kind: "gate",
+      variant: "frame-only",
+      frame: {
+        color: "#22c55e",
+        diameterMeters: 0.16,
+      },
+    });
+  });
+});

--- a/tests/lib/track/shape2d.test.ts
+++ b/tests/lib/track/shape2d.test.ts
@@ -7,6 +7,12 @@ import {
   getLadder2DShape,
   getStartFinish2DShape,
 } from "@/lib/track/shape2d";
+import { feetToMeters } from "@/lib/track/units";
+import {
+  createCatalogShapeDraft,
+  MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+} from "@/lib/track/elements/catalog";
+import type { GateShape } from "@/lib/types";
 
 describe("track 2d shape helpers", () => {
   const ppm = 20;
@@ -29,6 +35,7 @@ describe("track 2d shape helpers", () => {
       width: 40,
       depth: 4,
       color: "#3b82f6",
+      variant: "frame-only",
     });
 
     expect(
@@ -112,5 +119,28 @@ describe("track 2d shape helpers", () => {
     expect(diveGate.size).toBe(56);
     expect(diveGate.visibleDepth).toBeGreaterThan(0);
     expect(diveGate.postRadius).toBeGreaterThan(0);
+  });
+
+  it("uses catalog panel-frame dimensions for official gate 2d metrics", () => {
+    const shape = createCatalogShapeDraft(
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+      {
+        x: 0,
+        y: 0,
+        includeCatalogMetadata: true,
+      }
+    ) as GateShape;
+    const gate = getGate2DShape(shape, ppm);
+
+    expect(gate.variant).toBe("panel-frame");
+    if (gate.variant !== "panel-frame") {
+      throw new Error("expected panel-frame gate metrics");
+    }
+    expect(gate.openingWidth).toBeCloseTo(feetToMeters(5) * ppm);
+    expect(gate.width).toBeCloseTo(feetToMeters(7) * ppm);
+    expect(gate.panels.leftWidth).toBeCloseTo(feetToMeters(1) * ppm);
+    expect(gate.panels.rightWidth).toBeCloseTo(feetToMeters(1) * ppm);
+    expect(gate.panels.topColor).toBe("#202e5d");
+    expect(gate.frame.placement).toBe("outer");
   });
 });


### PR DESCRIPTION
- **`visual.ts`** — new module that resolves a `GateVisualSpec` from catalog identity or falls back to a `FrameOnlyGateVisualSpec`; all rendering paths now consume this instead of reading catalog metadata directly
- **Panel-frame rendering** — MultiGP 5x5 and 7x6 gates now render with their actual panel sizes, PVC tube frame, checker accents, and MULTIGP branding across 2D canvas, SVG export, 3D preview, and flythrough export
- **Naming refactor** — `GenericGateVisualSpec` → `FrameOnlyGateVisualSpec`, `variant: "generic"` → `"frame-only"`, `material: "generic"` → `"tube"`, `OfficialGate3D` → `PanelFrameGate3D`, `Gate3D` → `FrameOnlyGate3D`; internal catalog variables renamed from brand prefixes to structural names; ownership tags ("generic", "official") removed from catalog tag arrays
- **Mirrored text fix** — removed the erroneous UV flip from `FrontTextPlaneGeometry` that caused MULTIGP branding text to appear mirrored in the 3D preview
- **Code quality** — shared frame material props, `panelDepth` constant used consistently, `rot` computed once in `FrameOnlyGate3D` and passed down, `thick`/`h`/`w` scoped to the frame-only branch, shared text texture cache with HMR-safe disposal, double `getDesignShapes` and `getGate2DShape` calls eliminated in SVG export, `elementId` validation tightened in `isTrackElementCatalogIdentity`

