### PR TITLE
feat: 3D preview lighting and shadow pass with shared scene theme

### DIFF
--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -39,10 +39,10 @@ The completed release-sized work is archived below. The REST API, live race over
   - [ ] In-place catalog type switching (`No account required`)
         Let users change the catalog type of an already-placed gate directly from the inspector — for example switching a frame-only TrackDraw gate to a MultiGP Standard Gate 5x5 or back — without needing to delete and re-place the element. The switch should apply the new catalog entry's visual spec, locked dimensions, and identity while preserving position, rotation, and route connections.
 
-- [ ] 3D preview realism and lighting (`Research`, `No account required`)
-      Improve the 3D preview's readability and realism with stronger contrast, sun/directional lighting, shadows, and more recognizable gates/flags while keeping mobile performance safe. Use catalog metadata to render official variants differently where helpful, such as a more realistic MultiGP Standard Gate 5x5.
-  - [ ] 3D readability and realism pass
-        Evaluate sun/directional lighting, stronger contrast, more realistic gates/flags, and shadow treatment without making the scene visually noisy.
+- [x] 3D preview realism and lighting (`Research`, `No account required`)
+      Improved the 3D preview's readability and realism with stronger contrast, sun/directional lighting, shadows, and more recognizable gates/flags while keeping mobile performance safe. Catalog metadata drives official variant rendering, including a realistic MultiGP Standard Gate 5x5.
+  - [x] 3D readability and realism pass
+        Tuned directional lighting with a warm sun tint, lowered ambient intensity for stronger shadow contrast, raised shadow map resolution to 2048, set shadow camera frustum to track bounds to eliminate shadow coverage gaps on large tracks, added shadow-bias to prevent acne, and removed polyline shadow casting to reduce visual noise. Unified the lighting theme across editor, share, and gallery into a single shared constant.
   - [x] Catalog-aware 3D element rendering
         Use catalog-owned visual metadata to render catalog-backed MultiGP-style 5x5 and 7x6 gates with recognizable panel sizes, PVC frame placement, colors, and branding treatment across 2D canvas/SVG output, the live preview, and flythrough export while keeping generic gates lightweight.
 

--- a/src/components/canvas/editor/TrackPreview3D.tsx
+++ b/src/components/canvas/editor/TrackPreview3D.tsx
@@ -14,6 +14,7 @@ import {
   useState,
 } from "react";
 import * as THREE from "three";
+import { SCENE_3D_THEME } from "@/components/canvas/scene3DTheme";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { useTheme } from "@/hooks/useTheme";
@@ -79,27 +80,6 @@ export interface TrackPreview3DProps {
   readOnly?: boolean;
 }
 
-const THEME = {
-  dark: {
-    bg: "#0b1018",
-    fog: "#0b1018" as `#${string}`,
-    ambientIntensity: 0.7,
-    dirIntensity: 1.4,
-    groundColor: "#0f1824",
-    gridCell: "#1e293b",
-    gridSection: "#3d5068",
-  },
-  light: {
-    bg: "#e8edf3",
-    fog: "#e8edf3" as `#${string}`,
-    ambientIntensity: 1.2,
-    dirIntensity: 1.8,
-    groundColor: "#d0d8e4",
-    gridCell: "#b0bcc8",
-    gridSection: "#7a96b0",
-  },
-};
-
 const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
   function TrackPreview3D(
     {
@@ -128,7 +108,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
     const selectedPolyline = useEditor(selectSelectedPolyline);
     const theme = useTheme();
     const isMobile = useIsMobile();
-    const t = THEME[theme];
+    const t = SCENE_3D_THEME[theme];
     const cx = field.width / 2;
     const cz = field.height / 2;
     const longest = Math.max(field.width, field.height);
@@ -291,19 +271,27 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
           <ambientLight intensity={t.ambientIntensity} />
           <directionalLight
             position={[cx + 12, 28, cz + 8]}
+            color={t.dirColor}
             intensity={t.dirIntensity}
             castShadow
-            shadow-mapSize-width={1536}
-            shadow-mapSize-height={1536}
+            shadow-mapSize-width={2048}
+            shadow-mapSize-height={2048}
+            shadow-bias={-0.0005}
+            shadow-camera-left={-longest * 0.7}
+            shadow-camera-right={longest * 0.7}
+            shadow-camera-top={longest * 0.7}
+            shadow-camera-bottom={-longest * 0.7}
+            shadow-camera-near={1}
+            shadow-camera-far={longest * 2 + 60}
           />
           <pointLight
             position={[cx - 10, 8, cz - 5]}
-            intensity={0.3}
+            intensity={0.18}
             color="#2dd4bf"
           />
           <pointLight
             position={[cx + 15, 6, cz + 12]}
-            intensity={0.25}
+            intensity={0.15}
             color="#60a5fa"
           />
 

--- a/src/components/canvas/scene3DTheme.ts
+++ b/src/components/canvas/scene3DTheme.ts
@@ -1,0 +1,24 @@
+export const SCENE_3D_THEME = {
+  dark: {
+    bg: "#0b1018" as `#${string}`,
+    fog: "#0b1018" as `#${string}`,
+    ambientIntensity: 0.45,
+    dirIntensity: 1.6,
+    dirColor: "#fff4e6" as `#${string}`,
+    groundColor: "#0f1824",
+    gridCell: "#28384f",
+    gridSection: "#4a6580",
+  },
+  light: {
+    bg: "#e8edf3" as `#${string}`,
+    fog: "#e8edf3" as `#${string}`,
+    ambientIntensity: 1.0,
+    dirIntensity: 2.0,
+    dirColor: "#fffaf5" as `#${string}`,
+    groundColor: "#d0d8e4",
+    gridCell: "#b0bcc8",
+    gridSection: "#7a96b0",
+  },
+} as const;
+
+export type Scene3DTheme = (typeof SCENE_3D_THEME)[keyof typeof SCENE_3D_THEME];

--- a/src/components/canvas/share/TrackPreview3D.tsx
+++ b/src/components/canvas/share/TrackPreview3D.tsx
@@ -18,6 +18,7 @@ import * as THREE from "three";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { useTheme } from "@/hooks/useTheme";
+import { SCENE_3D_THEME } from "@/components/canvas/scene3DTheme";
 import { useEditor } from "@/store/editor";
 import { selectDesignShapes, selectHasPath } from "@/store/selectors";
 import {
@@ -46,27 +47,6 @@ const DroneCamera = dynamic(
   { ssr: false }
 );
 
-const THEME = {
-  dark: {
-    bg: "#0b1018",
-    fog: "#0b1018" as `#${string}`,
-    ambientIntensity: 0.7,
-    dirIntensity: 1.4,
-    groundColor: "#0f1824",
-    gridCell: "#1e293b",
-    gridSection: "#3d5068",
-  },
-  light: {
-    bg: "#e8edf3",
-    fog: "#e8edf3" as `#${string}`,
-    ambientIntensity: 1.2,
-    dirIntensity: 1.8,
-    groundColor: "#d0d8e4",
-    gridCell: "#b0bcc8",
-    gridSection: "#7a96b0",
-  },
-};
-
 const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
   function TrackPreview3D(
     { showGizmo = true, onFlyModeChange }: TrackPreview3DProps,
@@ -79,7 +59,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
     const hasPath = useEditor(selectHasPath);
     const theme = useTheme();
     const isMobile = useIsMobile();
-    const t = THEME[theme];
+    const t = SCENE_3D_THEME[theme];
     const cx = field.width / 2;
     const cz = field.height / 2;
     const longest = Math.max(field.width, field.height);
@@ -165,19 +145,27 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
           <ambientLight intensity={t.ambientIntensity} />
           <directionalLight
             position={[cx + 12, 28, cz + 8]}
+            color={t.dirColor}
             intensity={t.dirIntensity}
             castShadow
-            shadow-mapSize-width={1536}
-            shadow-mapSize-height={1536}
+            shadow-mapSize-width={2048}
+            shadow-mapSize-height={2048}
+            shadow-bias={-0.0005}
+            shadow-camera-left={-longest * 0.7}
+            shadow-camera-right={longest * 0.7}
+            shadow-camera-top={longest * 0.7}
+            shadow-camera-bottom={-longest * 0.7}
+            shadow-camera-near={1}
+            shadow-camera-far={longest * 2 + 60}
           />
           <pointLight
             position={[cx - 10, 8, cz - 5]}
-            intensity={0.3}
+            intensity={0.18}
             color="#2dd4bf"
           />
           <pointLight
             position={[cx + 15, 6, cz + 12]}
-            intensity={0.25}
+            intensity={0.15}
             color="#60a5fa"
           />
 

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -440,7 +440,7 @@ function FrontTextPlaneGeometry({
   return <primitive object={geometry} attach="geometry" />;
 }
 
-function PanelFrameFrameOnlyGate3D({
+function PanelFrameGate3D({
   selected = false,
   shape,
   outerRef,
@@ -656,7 +656,7 @@ function PanelFrameFrameOnlyGate3D({
   );
 }
 
-function FrameOnlyGate3D({
+function Gate3D({
   selected = false,
   shape,
   outerRef,
@@ -678,7 +678,7 @@ function FrameOnlyGate3D({
 
   if (visual.variant === "panel-frame") {
     return (
-      <PanelFrameFrameOnlyGate3D
+      <PanelFrameGate3D
         shape={shape}
         selected={selected}
         outerRef={outerRef}
@@ -1119,7 +1119,7 @@ function Ladder3D({
   );
 }
 
-function DiveFrameOnlyGate3D({
+function DiveGate3D({
   selected = false,
   shape,
   outerRef,
@@ -1364,7 +1364,6 @@ function RaceLine3D({
             <mesh
               key={`${shape.id}-segment-${segmentIndex}`}
               geometry={segmentGeometry}
-              castShadow
             >
               <meshStandardMaterial
                 color={color}
@@ -1376,7 +1375,7 @@ function RaceLine3D({
           );
         })
       ) : (
-        <mesh geometry={geometry} castShadow>
+        <mesh geometry={geometry}>
           <meshStandardMaterial
             color={selected ? "#93c5fd" : (shape.color ?? "#3b82f6")}
             emissive={selected ? "#60a5fa" : "#000000"}
@@ -1453,11 +1452,7 @@ function Shape3D({
     case "gate":
       return (
         <group onClick={(event) => onSelect(event, shape.id)}>
-          <FrameOnlyGate3D
-            shape={shape}
-            selected={isSelected}
-            outerRef={outerRef}
-          />
+          <Gate3D shape={shape} selected={isSelected} outerRef={outerRef} />
           {isSelected && <SelectionMarker3D shape={shape} />}
         </group>
       );
@@ -1515,7 +1510,7 @@ function Shape3D({
     case "divegate":
       return (
         <group onClick={(event) => onSelect(event, shape.id)}>
-          <DiveFrameOnlyGate3D
+          <DiveGate3D
             shape={shape}
             selected={isSelected}
             outerRef={outerRef}

--- a/src/components/gallery/GalleryPreviewRenderer.tsx
+++ b/src/components/gallery/GalleryPreviewRenderer.tsx
@@ -78,6 +78,7 @@ export function GalleryPreviewRenderer({ onCapture }: Props) {
       aria-hidden="true"
     >
       <Canvas
+        shadows="percentage"
         gl={{ antialias: true, preserveDrawingBuffer: true }}
         camera={{
           // Lower, closer diagonal angle from the opposite side for stronger card previews.
@@ -98,6 +99,8 @@ export function GalleryPreviewRenderer({ onCapture }: Props) {
           color={t.dirColor}
           intensity={t.dirIntensity}
           castShadow
+          shadow-mapSize-width={2048}
+          shadow-mapSize-height={2048}
           shadow-bias={-0.0005}
           shadow-camera-left={-longest * 0.7}
           shadow-camera-right={longest * 0.7}

--- a/src/components/gallery/GalleryPreviewRenderer.tsx
+++ b/src/components/gallery/GalleryPreviewRenderer.tsx
@@ -6,31 +6,11 @@ import { Suspense, useCallback, useMemo } from "react";
 import { useEditor } from "@/store/editor";
 import { selectDesignShapes } from "@/store/selectors";
 import { useTheme } from "@/hooks/useTheme";
+import { SCENE_3D_THEME } from "@/components/canvas/scene3DTheme";
 import {
   MemoShape3D,
   ScreenshotHelper,
 } from "@/components/canvas/trackPreview3DSharedSceneContent";
-
-const THEME = {
-  dark: {
-    bg: "#0b1018",
-    fog: "#0b1018" as `#${string}`,
-    ambientIntensity: 0.7,
-    dirIntensity: 1.4,
-    groundColor: "#0f1824",
-    gridCell: "#1e293b",
-    gridSection: "#3d5068",
-  },
-  light: {
-    bg: "#e8edf3",
-    fog: "#e8edf3" as `#${string}`,
-    ambientIntensity: 1.2,
-    dirIntensity: 1.8,
-    groundColor: "#d0d8e4",
-    gridCell: "#b0bcc8",
-    gridSection: "#7a96b0",
-  },
-};
 
 type Props = {
   /** Called once with the PNG data URL after the scene has rendered. */
@@ -45,7 +25,7 @@ export function GalleryPreviewRenderer({ onCapture }: Props) {
   const field = useEditor((s) => s.track.design.field);
   const shapes = useEditor(selectDesignShapes);
   const theme = useTheme();
-  const t = THEME[theme];
+  const t = SCENE_3D_THEME[theme];
 
   const cx = field.width / 2;
   const cz = field.height / 2;
@@ -115,8 +95,16 @@ export function GalleryPreviewRenderer({ onCapture }: Props) {
         <ambientLight intensity={t.ambientIntensity} />
         <directionalLight
           position={[cx + longest * 0.5, longest, cz + longest * 0.3]}
+          color={t.dirColor}
           intensity={t.dirIntensity}
           castShadow
+          shadow-bias={-0.0005}
+          shadow-camera-left={-longest * 0.7}
+          shadow-camera-right={longest * 0.7}
+          shadow-camera-top={longest * 0.7}
+          shadow-camera-bottom={-longest * 0.7}
+          shadow-camera-near={1}
+          shadow-camera-far={longest * 2 + 60}
         />
         <Suspense fallback={null}>
           <mesh


### PR DESCRIPTION
- **Lighting** — warmer directional sun tint (`#fff4e6` dark / `#fffaf5` light), lower ambient for stronger shadow contrast (0.7 → 0.45 dark, 1.2 → 1.0 light), shadow map resolution raised to 2048, shadow frustum sized to track bounds so large tracks have full shadow coverage, `shadow-bias` added to prevent acne, point lights toned down so they don't compete with the sun
- **Polyline shadow** — race line no longer casts a shadow on the ground, which was visually noisy
- **Shared theme** — extracted `SCENE_3D_THEME` into `scene3DTheme.ts`; editor, share, and gallery canvases now all draw from one constant instead of three independent copies
- **Naming fixes** — corrected `PanelFrameFrameOnlyGate3D` → `PanelFrameGate3D`, `DiveFrameOnlyGate3D` → `DiveGate3D`, `FrameOnlyGate3D` → `Gate3D` (regression from previous branch's replace_all rename)
