### PR TITLE
feat: in-place gate catalog type switching from the inspector

### DIFF
--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -26,18 +26,18 @@ The completed release-sized work is archived below. The REST API, live race over
 
 ## Follow-up
 
-- [ ] Track element catalog (`Research`, `No account required`)
-      Build a catalog-backed element model for official gates, richer placement defaults, and future equipment/library expansion before changing default race-gate sizing. This track owns element identity, source metadata, dimensions, and placement selection, not high-fidelity 3D rendering.
+- [x] Track element catalog (`Research`, `No account required`)
+      Built a catalog-backed element model for official gates with typed entries for names, dimensions, source references, 2D/3D rendering, and export compatibility. Includes placement selection, inspector identity display, in-place type switching, and catalog-driven visual rendering across 2D, 3D, and export paths.
   - [x] Local element catalog foundation
         Define typed catalog entries for official names, dimensions, source references, 2D defaults, 3D render hints, and export compatibility while keeping saved project geometry meter-based.
-  - [ ] Official gate and obstacle entries
-        Expose entries such as the cataloged MultiGP-style standard gate through deliberate placement/library UI, with custom sizing kept on the standard TrackDraw Gate and no automatic migration of existing projects.
+  - [x] Official gate and obstacle entries
+        Covered by the placement selector, catalog identity in inspector, and in-place type switching sub-items. MultiGP-style gates are accessible through deliberate placement and inspector UI, custom sizing remains on the standard TrackDraw Gate, and no existing projects were migrated.
   - [x] MultiGP gate placement selector
         Keep Gate as the primary placement tool while letting users switch the active gate type between the generic TrackDraw gate and catalog-backed MultiGP-style 5x5 and 7x6 variants through compact desktop and mobile type pickers.
   - [x] Catalog identity in inspector
         Show placed catalog-backed elements with their official type, source, official size, and dimension status while keeping official gate width and height fixed in normal editing.
-  - [ ] In-place catalog type switching (`No account required`)
-        Let users change the catalog type of an already-placed gate directly from the inspector — for example switching a frame-only TrackDraw gate to a MultiGP Standard Gate 5x5 or back — without needing to delete and re-place the element. The switch should apply the new catalog entry's visual spec, locked dimensions, and identity while preserving position, rotation, and route connections.
+  - [x] In-place catalog type switching (`No account required`)
+        Let users change the catalog type of an already-placed gate directly from the inspector without needing to delete and re-place. The type picker uses the shadcn Select and shows for all placed gates, including frame-only TrackDraw gates. Switching resets to the target entry's defaults while preserving position, rotation, and route connections, and preserves non-catalog meta such as timing markers. The source organization links to the entry's first source URL. getCatalogEntriesByKind replaces the gate-specific helper to support future element types.
 
 - [x] 3D preview realism and lighting (`Research`, `No account required`)
       Improved the 3D preview's readability and realism with stronger contrast, sun/directional lighting, shadows, and more recognizable gates/flags while keeping mobile performance safe. Catalog metadata drives official variant rendering, including a realistic MultiGP Standard Gate 5x5.
@@ -45,6 +45,13 @@ The completed release-sized work is archived below. The REST API, live race over
         Tuned directional lighting with a warm sun tint, lowered ambient intensity for stronger shadow contrast, raised shadow map resolution to 2048, set shadow camera frustum to track bounds to eliminate shadow coverage gaps on large tracks, added shadow-bias to prevent acne, and removed polyline shadow casting to reduce visual noise. Unified the lighting theme across editor, share, and gallery into a single shared constant.
   - [x] Catalog-aware 3D element rendering
         Use catalog-owned visual metadata to render catalog-backed MultiGP-style 5x5 and 7x6 gates with recognizable panel sizes, PVC frame placement, colors, and branding treatment across 2D canvas/SVG output, the live preview, and flythrough export while keeping generic gates lightweight.
+
+- [ ] MultiGP obstacle catalog expansion (`No account required`)
+      Extend the catalog with additional official MultiGP obstacles beyond gates, such as flags and ladders, so users can place and identify standard competition obstacles with the same catalog-backed identity, visual rendering, and inspector treatment already in place for gates.
+  - [ ] MultiGP flag and marker entries
+        Add catalog entries for official MultiGP-style flag/marker obstacles with catalog identity, 2D canvas rendering, 3D preview, and source links.
+  - [ ] MultiGP ladder and other obstacle entries
+        Add catalog entries for official MultiGP ladder-style obstacles and any other common competition elements with the same catalog pipeline.
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -629,7 +629,7 @@ function PanelFrameGate3D({
             h * 0.58,
             frontZ - 0.016,
           ]}
-          rotation={[0, Math.PI, dir > 0 ? -Math.PI / 2 : Math.PI / 2]}
+          rotation={[0, Math.PI, dir > 0 ? Math.PI / 2 : -Math.PI / 2]}
         >
           <FrontTextPlaneGeometry
             width={h * 0.44}

--- a/src/components/editor/ElementPlacementControl.tsx
+++ b/src/components/editor/ElementPlacementControl.tsx
@@ -8,14 +8,14 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import {
-  getGateTrackElementCatalogEntries,
+  getCatalogEntriesByKind,
   TRACKDRAW_GATE_ELEMENT_ID,
 } from "@/lib/track/elements/catalog";
 import { cn } from "@/lib/utils";
 import { useSessionActions, useUiActions } from "@/store/actions";
 import { useEditor } from "@/store/editor";
 
-const gateCatalogEntries = getGateTrackElementCatalogEntries();
+const gateCatalogEntries = getCatalogEntriesByKind("gate");
 const placementControlWidthCh = Math.max(
   22,
   Math.min(

--- a/src/components/editor/mobile/ToolsControls.tsx
+++ b/src/components/editor/mobile/ToolsControls.tsx
@@ -4,14 +4,14 @@ import { useState } from "react";
 import { Check, ChevronDown, Redo2, Undo2 } from "lucide-react";
 import { mobileToolEntries } from "@/components/editor/tool-icons";
 import {
-  getGateTrackElementCatalogEntries,
+  getCatalogEntriesByKind,
   type TrackElementCatalogId,
 } from "@/lib/track/elements/catalog";
 import type { EditorTool } from "@/lib/editor-tools";
 import { cn } from "@/lib/utils";
 import type { EditorViewportTab } from "./Panels";
 
-const gateCatalogEntries = getGateTrackElementCatalogEntries();
+const gateCatalogEntries = getCatalogEntriesByKind("gate");
 const mobileGateToolEntry = mobileToolEntries.find((t) => t.id === "gate");
 
 interface ToolsControlsProps {

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -8,9 +8,13 @@ import { shapeKindLabels } from "@/lib/editor-tools";
 import { getSingleInspectorViewModel } from "@/lib/inspector/single/view-model";
 import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import {
+  getCatalogEntriesByKind,
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
+  TRACKDRAW_GATE_ELEMENT_ID,
+  type TrackElementCatalogId,
 } from "@/lib/track/elements/catalog";
+import { buildGateCatalogTypePatch } from "@/lib/editor-tools";
 import {
   getShapeTimingMarker,
   getTimingMarkerMeta,
@@ -27,6 +31,13 @@ import {
   Trash2,
   Ungroup,
 } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   fmt,
   IconBtn,
@@ -118,6 +129,12 @@ export function SingleInspectorView({
   const catalogIdentity = getTrackElementCatalogIdentity(shape.meta);
   const catalogEntry = getTrackElementCatalogEntry(catalogIdentity?.elementId);
   const selectedGateShape = shape.kind === "gate" ? shape : null;
+  const gateCatalogEntries = selectedGateShape
+    ? getCatalogEntriesByKind("gate")
+    : null;
+  const activeGateEntryId: TrackElementCatalogId =
+    (catalogIdentity?.elementId as TrackElementCatalogId | undefined) ??
+    TRACKDRAW_GATE_ELEMENT_ID;
   const hasCatalogGateDimensions =
     selectedGateShape &&
     catalogEntry?.kind === "gate" &&
@@ -127,14 +144,6 @@ export function SingleInspectorView({
     hasCatalogGateDimensions && catalogEntry.editable?.dimensions === false;
   const hasFixedCatalogColor =
     catalogIdentity !== null && catalogEntry?.editable?.color === false;
-  const catalogStatusLabel =
-    catalogIdentity?.official &&
-    hasFixedCatalogDimensions &&
-    hasFixedCatalogColor
-      ? "Official size and color"
-      : catalogIdentity?.official
-        ? "Official dimensions"
-        : "Catalog item";
   const canSetTimingMarker = isTimingMarkerShape(shape);
   const secondarySectionDefaultOpen = !mobileInline;
   const timingSectionDefaultOpen = !mobileInline || canSetTimingMarker;
@@ -287,41 +296,62 @@ export function SingleInspectorView({
               </div>
             </Section>
           )}
-          {catalogIdentity ? (
+          {gateCatalogEntries ? (
             <Section title="Catalog" defaultOpen>
               <Row label="Type">
-                <div className="min-w-0">
-                  <p className="text-foreground truncate text-[12px] font-medium">
-                    {catalogIdentity.snapshot.name}
-                  </p>
-                  <p className="text-muted-foreground mt-0.5 text-[11px]">
-                    {shapeKindLabels[catalogIdentity.assignedKind]}
-                  </p>
-                </div>
+                <Select
+                  value={activeGateEntryId}
+                  disabled={shape.locked}
+                  onValueChange={(value) => {
+                    const patch = buildGateCatalogTypePatch(
+                      selectedGateShape!,
+                      value as TrackElementCatalogId
+                    );
+                    if (patch)
+                      updateShape(shape.id, patch as Partial<typeof shape>);
+                  }}
+                >
+                  <SelectTrigger className="border-border/40 bg-muted/40 h-9 w-full text-xs shadow-none lg:h-7 lg:text-[11px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {gateCatalogEntries.map((entry) => (
+                      <SelectItem
+                        key={entry.id}
+                        value={entry.id}
+                        className="text-xs lg:text-[11px]"
+                      >
+                        {entry.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </Row>
-              {catalogIdentity.snapshot.organization ? (
+              {catalogIdentity?.snapshot.organization ? (
                 <Row label="Source">
+                  {catalogEntry?.sources?.[0]?.url ? (
+                    <a
+                      href={catalogEntry.sources[0].url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-foreground hover:text-foreground/70 text-[12px] underline underline-offset-2 transition-colors"
+                    >
+                      {catalogIdentity.snapshot.organization}
+                    </a>
+                  ) : (
+                    <span className="text-foreground text-[12px]">
+                      {catalogIdentity.snapshot.organization}
+                    </span>
+                  )}
+                </Row>
+              ) : null}
+              {catalogIdentity ? (
+                <Row label="Official size">
                   <span className="text-foreground text-[12px]">
-                    {catalogIdentity.snapshot.organization}
+                    {catalogIdentity.snapshot.dimensionsLabel}
                   </span>
                 </Row>
               ) : null}
-              <Row label="Official size">
-                <span className="text-foreground text-[12px]">
-                  {catalogIdentity.snapshot.dimensionsLabel}
-                </span>
-              </Row>
-              <Row label="Status">
-                <span
-                  className={`inline-flex min-h-6 items-center rounded-md border px-2 py-1 text-[11px] font-medium ${
-                    catalogIdentity.official
-                      ? "border-emerald-500/25 bg-emerald-500/8 text-emerald-700 dark:text-emerald-300"
-                      : "border-border/60 bg-muted/40 text-muted-foreground"
-                  }`}
-                >
-                  {catalogStatusLabel}
-                </span>
-              </Row>
             </Section>
           ) : null}
 

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -133,8 +133,9 @@ export function SingleInspectorView({
     ? getCatalogEntriesByKind("gate")
     : null;
   const activeGateEntryId: TrackElementCatalogId =
-    (catalogIdentity?.elementId as TrackElementCatalogId | undefined) ??
-    TRACKDRAW_GATE_ELEMENT_ID;
+    catalogEntry?.kind === "gate"
+      ? (catalogIdentity!.elementId as TrackElementCatalogId)
+      : TRACKDRAW_GATE_ELEMENT_ID;
   const hasCatalogGateDimensions =
     selectedGateShape &&
     catalogEntry?.kind === "gate" &&

--- a/src/lib/editor-tools.ts
+++ b/src/lib/editor-tools.ts
@@ -1,5 +1,6 @@
 import {
   createCatalogShapeDraft,
+  createTrackElementCatalogIdentity,
   getTrackElementCatalogEntry,
   TRACKDRAW_CONE_ELEMENT_ID,
   TRACKDRAW_DIVE_GATE_ELEMENT_ID,
@@ -10,7 +11,7 @@ import {
   TRACKDRAW_START_FINISH_ELEMENT_ID,
   type TrackElementCatalogId,
 } from "@/lib/track/elements/catalog";
-import type { ShapeDraft, ShapeKind } from "@/lib/types";
+import type { GateShape, ShapeDraft, ShapeKind } from "@/lib/types";
 
 export type EditorTool =
   | "select"
@@ -97,4 +98,35 @@ export function createShapeForTool(
     y: point.y,
     includeCatalogMetadata: resolvedEntry?.official === true,
   });
+}
+
+export function buildGateCatalogTypePatch(
+  shape: GateShape,
+  targetEntryId: TrackElementCatalogId
+): Partial<GateShape> | null {
+  const entry = getTrackElementCatalogEntry(targetEntryId);
+  if (!entry || entry.kind !== "gate") return null;
+
+  const draft = createCatalogShapeDraft(targetEntryId, {
+    x: shape.x,
+    y: shape.y,
+    rotation: shape.rotation,
+    includeCatalogMetadata: false,
+  });
+
+  // Preserve non-catalog meta (timing markers, group membership, etc.)
+  const strippedMeta = shape.meta
+    ? Object.fromEntries(
+        Object.entries(shape.meta).filter(([k]) => k !== "catalog")
+      )
+    : {};
+  const newCatalogIdentity = entry.official
+    ? createTrackElementCatalogIdentity(entry)
+    : undefined;
+  const newMeta =
+    newCatalogIdentity || Object.keys(strippedMeta).length > 0
+      ? { ...strippedMeta, catalog: newCatalogIdentity }
+      : undefined;
+
+  return { ...draft, meta: newMeta } as Partial<GateShape>;
 }

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -455,9 +455,12 @@ export function getTrackElementCatalogEntry(
   return trackElementCatalogMap.get(id as TrackElementCatalogId) ?? null;
 }
 
-export function getGateTrackElementCatalogEntries(): GateTrackElementCatalogEntry[] {
+export function getCatalogEntriesByKind<
+  K extends PlaceableCatalogShape["kind"],
+>(kind: K): (TrackElementCatalogEntry & { kind: K })[] {
   return (trackElementCatalog as readonly TrackElementCatalogEntry[]).filter(
-    (entry): entry is GateTrackElementCatalogEntry => entry.kind === "gate"
+    (entry): entry is TrackElementCatalogEntry & { kind: K } =>
+      entry.kind === kind
   );
 }
 

--- a/tests/components/inspector/SingleInspectorView.test.tsx
+++ b/tests/components/inspector/SingleInspectorView.test.tsx
@@ -236,7 +236,7 @@ describe("SingleInspectorView race timing controls", () => {
 
     renderSingleInspector(officialGate);
 
-    expect(screen.getByText("Official size and color")).toBeTruthy();
+    expect(screen.getByText("MultiGP Standard Gate 5x5")).toBeTruthy();
     expect(screen.queryByText("Color")).toBeNull();
     expect(screen.queryByText("Width")).toBeNull();
     expect(screen.queryByText("Height")).toBeNull();

--- a/tests/lib/editor-tools.test.ts
+++ b/tests/lib/editor-tools.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildGateCatalogTypePatch,
   createShapeForTool,
   shapeKindLabels,
   toolLabels,
   toolShortcuts,
 } from "@/lib/editor-tools";
 import {
+  createCatalogShapeDraft,
   MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
   MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
   TRACKDRAW_FLAG_ELEMENT_ID,
+  TRACKDRAW_GATE_ELEMENT_ID,
 } from "@/lib/track/elements/catalog";
+import type { GateShape } from "@/lib/types";
 import { feetToMeters } from "@/lib/track/units";
 
 describe("editor tool helpers", () => {
@@ -126,5 +130,75 @@ describe("editor tool helpers", () => {
     expect(createShapeForTool("grab", { x: 1, y: 2 })).toBeNull();
     expect(createShapeForTool("preset", { x: 1, y: 2 })).toBeNull();
     expect(createShapeForTool("polyline", { x: 1, y: 2 })).toBeNull();
+  });
+});
+
+describe("buildGateCatalogTypePatch", () => {
+  const baseShape = createCatalogShapeDraft(TRACKDRAW_GATE_ELEMENT_ID, {
+    x: 5,
+    y: 8,
+    rotation: 90,
+  }) as GateShape & { id: string };
+  baseShape.id = "gate-1";
+
+  it("switches to a catalog-backed entry and applies its defaults", () => {
+    const patch = buildGateCatalogTypePatch(
+      baseShape,
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
+    );
+
+    expect(patch).toMatchObject({
+      kind: "gate",
+      x: 5,
+      y: 8,
+      rotation: 90,
+      meta: {
+        catalog: expect.objectContaining({
+          elementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+          official: true,
+        }),
+      },
+    });
+  });
+
+  it("resets to frame-only defaults and clears catalog identity when switching to TrackDraw Gate", () => {
+    const catalogShape = createCatalogShapeDraft(
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+      { x: 3, y: 4, rotation: 45, includeCatalogMetadata: true }
+    ) as GateShape & { id: string };
+    catalogShape.id = "gate-2";
+
+    const patch = buildGateCatalogTypePatch(
+      catalogShape,
+      TRACKDRAW_GATE_ELEMENT_ID
+    );
+
+    expect(patch).toMatchObject({ kind: "gate", x: 3, y: 4, rotation: 45 });
+    expect(patch?.meta?.catalog).toBeUndefined();
+  });
+
+  it("preserves non-catalog meta when switching type", () => {
+    const shapeWithTiming = {
+      ...baseShape,
+      meta: { timing: { role: "split", timingId: "t1" } },
+    } as unknown as GateShape;
+
+    const patch = buildGateCatalogTypePatch(
+      shapeWithTiming,
+      MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID
+    );
+
+    expect(patch?.meta).toMatchObject({
+      timing: { role: "split", timingId: "t1" },
+      catalog: expect.objectContaining({
+        elementId: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+      }),
+    });
+  });
+
+  it("returns null for a non-gate catalog id", () => {
+    expect(
+      buildGateCatalogTypePatch(baseShape, TRACKDRAW_FLAG_ELEMENT_ID)
+    ).toBeNull();
   });
 });

--- a/tests/lib/track/elements/catalog.test.ts
+++ b/tests/lib/track/elements/catalog.test.ts
@@ -3,7 +3,7 @@ import { getCanvasRotationGuideAngleDeg } from "@/lib/track/orientation";
 import { feetToMeters } from "@/lib/track/units";
 import {
   createCatalogShapeDraft,
-  getGateTrackElementCatalogEntries,
+  getCatalogEntriesByKind,
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
   MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
@@ -25,9 +25,7 @@ describe("track element catalog", () => {
   });
 
   it("exposes gate entries for placement controls", () => {
-    expect(
-      getGateTrackElementCatalogEntries().map((entry) => entry.id)
-    ).toEqual([
+    expect(getCatalogEntriesByKind("gate").map((entry) => entry.id)).toEqual([
       TRACKDRAW_GATE_ELEMENT_ID,
       MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
       MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,


### PR DESCRIPTION
- **In-place type switching** — placed gates can now switch catalog type directly from the inspector via a shadcn Select without deleting and re-placing. The switch resets to the target entry's defaults while preserving position, rotation, route connections, and non-catalog meta (e.g. timing markers). Works for all gates including non-catalog frame-only gates.
- **`getCatalogEntriesByKind(kind)`** — replaces the gate-specific `getGateTrackElementCatalogEntries` with a generic helper that works for any shape kind, ready for future flag and ladder catalog entries.
- **Inspector cleanup** — removed the redundant "Status" badge ("Official size and color") from the Catalog section. Source organization is now a clickable link to the entry's first source URL.
