### PR TITLE
feat: Add MultiGP flags and ladders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,12 @@ Run `npm run lint`, `npm run test`, and `npm run type` after non-trivial code ch
 - Apply the `enhancement` label for product/code improvements and the `dependencies` label for dependency-only PRs.
 - When this workflow matures, prefer an agentic PR template with consistent sections for intent, changes, validation, risk, and follow-up instead of ad hoc prose.
 
+## Design Schema
+
+`TrackDesign.version` is currently `2`. `normalizeDesign` auto-migrates version 1 designs by shifting gate and ladder rotations by −180° so the visual result is unchanged. Always create new designs with `version: 2`. Do not write code that assumes `version: 1` as the current schema.
+
+Gate and ladder shapes use `rotation: 0` as the forward-facing direction (the side that faces toward a typical viewer). The 2D canvas and 3D renderer both apply an internal +180° offset so the stored value and visual agree. Do not add extra offsets elsewhere; the convention is handled in `shape-node.tsx` (Konva) and `trackPreview3DSharedSceneContent.tsx` (Three.js).
+
 ## Change Heuristics
 
 - For landing-page work, protect SEO metadata, structured data, and conversion paths into `/studio`.

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -22,16 +22,16 @@ Labels used below:
 
 ## Current Priority
 
-The completed release-sized work is archived below. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, MultiGP obstacle catalog expansion, focused 3D item controls, generated flightpath assistance, multilingual-readiness for international users, and account-backed project lifecycle depth beyond the shipped conflict/retry baseline.
+The completed release-sized work is archived below. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, focused 3D item controls, generated flightpath assistance, multilingual-readiness for international users, and account-backed project lifecycle depth beyond the shipped conflict/retry baseline.
 
 ## Follow-up
 
-- [ ] MultiGP obstacle catalog expansion (`No account required`)
-      Extend the catalog with additional official MultiGP obstacles beyond gates, such as flags and ladders, so users can place and identify standard competition obstacles with the same catalog-backed identity, visual rendering, and inspector treatment already in place for gates.
-  - [ ] MultiGP flag and marker entries
-        Add catalog entries for official MultiGP-style flag/marker obstacles with catalog identity, 2D canvas rendering, 3D preview, and source links.
-  - [ ] MultiGP ladder and other obstacle entries
-        Add catalog entries for official MultiGP ladder-style obstacles and any other common competition elements with the same catalog pipeline.
+- [x] MultiGP obstacle catalog expansion (`No account required`)
+      Extended the catalog with official MultiGP flags and ladders. Users can place and identify standard competition obstacles with the same catalog-backed identity, visual rendering, inspector treatment, and in-place type switching already in place for gates.
+  - [x] MultiGP flag and marker entries
+        Added the MultiGP Corner Flag (10 ft feather flag) with realistic 3D rendering, catalog identity, inspector type switching, and an official source link.
+  - [x] MultiGP ladder and other obstacle entries
+        Added MultiGP Standard Ladder 5x5 and Championship Ladder 7x6 with panel-frame 3D rendering matching the real obstacle, and the same catalog pipeline as gates and flags.
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -385,8 +385,8 @@ const TrackCanvas = memo(
     } = useTrackActions();
     const activeTool = useEditor((state) => state.ui.activeTool);
     const activePresetId = useEditor((state) => state.ui.activePresetId);
-    const activeGateElementId = useEditor(
-      (state) => state.ui.activeGateElementId
+    const activePlacementElementId = useEditor(
+      (state) => state.ui.activePlacementElementId
     );
     const snapEnabled = useEditor((state) => state.ui.snapEnabled);
     const segmentSel = useEditor((state) => state.ui.segmentSelection);
@@ -1171,7 +1171,7 @@ const TrackCanvas = memo(
     } = useTrackCanvasInteractions({
       activeTool,
       activePresetId,
-      activeGateElementId,
+      activePlacementElementId,
       addShape,
       addShapes,
       contentDragActiveRef,

--- a/src/components/canvas/renderers/shape-node.tsx
+++ b/src/components/canvas/renderers/shape-node.tsx
@@ -237,7 +237,11 @@ function TrackShapeNodeComponent({
         m2px(shape.kind === "polyline" ? 0 : shape.y, designPpm) +
         (groupDragOffsetPx?.y ?? 0)
       }
-      rotation={shape.rotation}
+      rotation={
+        shape.kind === "gate" || shape.kind === "ladder"
+          ? shape.rotation + 180
+          : shape.rotation
+      }
       draggable={
         allowInteraction &&
         !shape.locked &&

--- a/src/components/canvas/renderers/shape-renderers.tsx
+++ b/src/components/canvas/renderers/shape-renderers.tsx
@@ -396,16 +396,18 @@ export function renderLadder(
   selected: boolean,
   ppm: number
 ) {
-  const { color, depth, radius, width } = getLadder2DShape(shape, ppm);
-  const barHeight = Math.max(depth, 6);
+  const ladder2d = getLadder2DShape(shape, ppm);
+  const barHeight = Math.max(ladder2d.depth, 8);
+  const selectionPad = m2px(0.3, ppm);
+  const { color, radius, width } = ladder2d;
   return (
     <>
       {selected && (
         <Rect
-          width={width + m2px(0.3, ppm)}
-          height={barHeight + m2px(0.3, ppm)}
-          offsetX={(width + m2px(0.3, ppm)) / 2}
-          offsetY={(barHeight + m2px(0.3, ppm)) / 2}
+          width={width + selectionPad}
+          height={barHeight + selectionPad}
+          offsetX={(width + selectionPad) / 2}
+          offsetY={(barHeight + selectionPad) / 2}
           stroke="#60a5fa"
           strokeWidth={1}
           opacity={0.85}

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -672,7 +672,7 @@ function Gate3D({
   const visual = getGateVisualSpec(shape);
   const rot: [number, number, number] = [
     0,
-    (-shape.rotation * Math.PI) / 180,
+    (-(shape.rotation + 180) * Math.PI) / 180,
     0,
   ];
 
@@ -1150,7 +1150,7 @@ function PanelFrameLadder3D({
   const rungs = Math.max(1, shape.rungs ?? 3);
   const baseY = Math.max(shape.elevation ?? 0, 0);
   const gateH = totalH / rungs;
-  const rot: [number, number, number] = [0, (-shape.rotation * Math.PI) / 180, 0];
+  const rot: [number, number, number] = [0, (-(shape.rotation + 180) * Math.PI) / 180, 0];
 
   const leftPanelWidth = panels.left.widthMeters;
   const rightPanelWidth = panels.right.widthMeters;
@@ -1371,7 +1371,7 @@ function Ladder3D({
   const lowerBarRef = useRef<THREE.Mesh>(null);
   const rot: [number, number, number] = [
     0,
-    (-shape.rotation * Math.PI) / 180,
+    (-(shape.rotation + 180) * Math.PI) / 180,
     0,
   ];
   const setGroupRefs = useCallback(

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -22,9 +22,9 @@ import {
   getPolylineCurve3Derived,
   getPolylinePreview3DPoints,
 } from "@/lib/track/polyline-derived-3d";
-import { getGateVisualSpec } from "@/lib/track/elements/visual";
+import { getFlagVisualSpec, getGateVisualSpec } from "@/lib/track/elements/visual";
 import { getShapeTimingMarker, getTimingMarkerColor } from "@/lib/track/timing";
-import type { PanelFrameGateVisualSpec } from "@/lib/track/elements/catalog";
+import type { CornerMarkerFlagVisualSpec, PanelFrameGateVisualSpec } from "@/lib/track/elements/catalog";
 import type {
   ConeShape,
   DiveGateShape,
@@ -722,6 +722,115 @@ function Gate3D({
   );
 }
 
+function CornerMarkerFlag3D({
+  selected = false,
+  shape,
+  visual,
+}: {
+  selected?: boolean;
+  shape: FlagShape;
+  visual: CornerMarkerFlagVisualSpec;
+}) {
+  const ph = shape.poleHeight ?? 3.0;
+  const yawRad = (-shape.rotation * Math.PI) / 180;
+  const poleRadius = 0.030;
+  const pw = ph * 0.18;
+  const topCurveX = pw * 0.65;
+  const panelDepth = ph * 0.012;
+
+  const poleCurve = useMemo(
+    () =>
+      new THREE.CatmullRomCurve3([
+        new THREE.Vector3(0, 0, 0),
+        new THREE.Vector3(0, ph * 0.85, 0),
+        new THREE.Vector3(topCurveX * 0.28, ph * 0.93, 0),
+        new THREE.Vector3(topCurveX, ph, 0),
+      ]),
+    [ph, topCurveX]
+  );
+
+  // panel starts ~8% above ground so the pole base is visible below the fabric
+  const panelStartY = ph * 0.08;
+  const splitY = panelStartY + ph * 0.24;
+
+  // pole tip in panel-local coords (panel is shifted right by poleRadius)
+  const poleTipLocalX = topCurveX - poleRadius;
+
+  const upperShape = useMemo(() => {
+    const s = new THREE.Shape();
+    s.moveTo(0, splitY);
+    s.lineTo(pw, splitY);
+    // right edge: straight up, then curves inward to reach the pole tip
+    s.lineTo(pw, ph * 0.70);
+    s.bezierCurveTo(pw * 0.95, ph * 0.83, poleTipLocalX + pw * 0.08, ph * 0.94, poleTipLocalX, ph);
+    // top arc: follows inside of pole bend back to where curve starts (left edge)
+    s.bezierCurveTo(poleTipLocalX * 0.52, ph * 0.97, 0, ph * 0.91, 0, ph * 0.85);
+    s.lineTo(0, splitY);
+    return s;
+  }, [ph, pw, splitY, poleTipLocalX]);
+
+  const lowerShape = useMemo(() => {
+    const s = new THREE.Shape();
+    s.moveTo(0, panelStartY);
+    s.lineTo(0, splitY);
+    // right edge: straight down, tapers to a point at the bottom
+    s.lineTo(pw, splitY);
+    s.bezierCurveTo(
+      pw, splitY - ph * 0.08,
+      pw * 0.45, panelStartY + ph * 0.01,
+      pw * 0.08, panelStartY
+    );
+    s.lineTo(0, panelStartY);
+    return s;
+  }, [ph, pw, splitY, panelStartY]);
+
+  const extrudeSettings = useMemo(
+    () => ({ depth: panelDepth, bevelEnabled: false }),
+    [panelDepth]
+  );
+
+  return (
+    <group position={[shape.x, 0, shape.y]} rotation={[0, yawRad, 0]}>
+      <mesh position={[0, 0.02, 0]} receiveShadow rotation={[-Math.PI / 2, 0, 0]}>
+        <ringGeometry args={[0.04, 0.13, 24]} />
+        <meshBasicMaterial color="#888" transparent opacity={0.18} side={THREE.DoubleSide} />
+      </mesh>
+      {/* Panel at z=0, left edge touching the pole's right surface */}
+      <mesh receiveShadow castShadow position={[poleRadius, 0, 0]}>
+        <extrudeGeometry args={[upperShape, extrudeSettings]} />
+        <meshStandardMaterial
+          color={visual.panelUpperColor}
+          roughness={0.78}
+          metalness={0}
+          emissive={selected ? "#60a5fa" : visual.panelUpperColor}
+          emissiveIntensity={selected ? 0.18 : 0.01}
+        />
+      </mesh>
+      <mesh receiveShadow castShadow position={[poleRadius, 0, 0]}>
+        <extrudeGeometry args={[lowerShape, extrudeSettings]} />
+        <meshStandardMaterial
+          color={visual.panelLowerColor}
+          roughness={0.78}
+          metalness={0}
+          emissive={selected ? "#60a5fa" : visual.panelLowerColor}
+          emissiveIntensity={selected ? 0.18 : 0.04}
+        />
+      </mesh>
+      {/* Pole at z=0 — no x-overlap with panel (panel starts at x=poleRadius) */}
+      <mesh castShadow>
+        <tubeGeometry args={[poleCurve, 40, poleRadius, 12, false]} />
+        <meshStandardMaterial
+          color={visual.poleColor}
+          roughness={0.38}
+          metalness={0.42}
+          emissive={selected ? "#60a5fa" : "#000000"}
+          emissiveIntensity={selected ? 0.14 : 0}
+        />
+      </mesh>
+    </group>
+  );
+}
+
 function Flag3D({
   selected = false,
   shape,
@@ -729,6 +838,13 @@ function Flag3D({
   selected?: boolean;
   shape: FlagShape;
 }) {
+  const flagVisual = getFlagVisualSpec(shape);
+  if (flagVisual?.variant === "corner-marker") {
+    return (
+      <CornerMarkerFlag3D shape={shape} selected={selected} visual={flagVisual} />
+    );
+  }
+
   const color = shape.color ?? "#a855f7";
   const ph = shape.poleHeight ?? 3.5;
   const yawRad = (-shape.rotation * Math.PI) / 180;

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -22,9 +22,9 @@ import {
   getPolylineCurve3Derived,
   getPolylinePreview3DPoints,
 } from "@/lib/track/polyline-derived-3d";
-import { getFlagVisualSpec, getGateVisualSpec } from "@/lib/track/elements/visual";
+import { getFlagVisualSpec, getGateVisualSpec, getLadderVisualSpec } from "@/lib/track/elements/visual";
 import { getShapeTimingMarker, getTimingMarkerColor } from "@/lib/track/timing";
-import type { CornerMarkerFlagVisualSpec, PanelFrameGateVisualSpec } from "@/lib/track/elements/catalog";
+import type { CornerMarkerFlagVisualSpec, PanelFrameGateVisualSpec, PanelRunsLadderVisualSpec } from "@/lib/track/elements/catalog";
 import type {
   ConeShape,
   DiveGateShape,
@@ -1130,6 +1130,212 @@ function StartFinish3D({
   );
 }
 
+function PanelFrameLadder3D({
+  selected = false,
+  shape,
+  outerRef,
+  elevationOverrideRef,
+  visual,
+}: {
+  selected?: boolean;
+  shape: LadderShape;
+  outerRef?: Ref<THREE.Group>;
+  elevationOverrideRef?: RefObject<number | null>;
+  visual: PanelRunsLadderVisualSpec;
+}) {
+  const { branding, frame, panels } = visual;
+  // shape.width = inner opening (same convention as gates)
+  const w = shape.width ?? 1.5;
+  const totalH = shape.height ?? 4.5;
+  const rungs = Math.max(1, shape.rungs ?? 3);
+  const baseY = Math.max(shape.elevation ?? 0, 0);
+  const gateH = totalH / rungs;
+  const rot: [number, number, number] = [0, (-shape.rotation * Math.PI) / 180, 0];
+
+  const leftPanelWidth = panels.left.widthMeters;
+  const rightPanelWidth = panels.right.widthMeters;
+  const topPanelHeight = panels.top.heightMeters;
+  const panelDepth = 0.018;
+  const frameTube = frame.diameterMeters;
+  const outerLeftX = -w / 2 - leftPanelWidth;
+  const outerRightX = w / 2 + rightPanelWidth;
+  const outerW = outerRightX - outerLeftX;
+
+  const multigpLabelStyle = useMemo(
+    () => ({
+      fontFamily: '"Arial Narrow","Helvetica Neue Condensed",Arial,sans-serif',
+      fontStyle: "italic" as const,
+      fontWeight: 800,
+      letterSpacing: 0.3,
+    }),
+    []
+  );
+  const topTextTexture = useTextTexture(branding.label, branding.markColor, 32, multigpLabelStyle);
+  const sideTextTexture = useTextTexture(branding.label, branding.accentColor, 28, multigpLabelStyle);
+
+  const groupRef = useRef<THREE.Group>(null);
+  const lowerBarRef = useRef<THREE.Mesh>(null);
+  const setGroupRefs = useCallback(
+    (node: THREE.Group | null) => {
+      groupRef.current = node;
+      assignGroupRef(outerRef, node);
+    },
+    [outerRef]
+  );
+
+  useFrame(() => {
+    if (!groupRef.current || !elevationOverrideRef) return;
+    const liveElevation = elevationOverrideRef.current;
+    if (liveElevation === null) return;
+    groupRef.current.position.set(shape.x, Math.max(liveElevation, 0), shape.y);
+    if (lowerBarRef.current) {
+      lowerBarRef.current.visible = liveElevation > 0;
+    }
+  });
+
+  const frameTubeMat = {
+    color: frame.color,
+    roughness: 0.55,
+    metalness: 0.08,
+    emissive: selected ? "#60a5fa" : "#000000",
+    emissiveIntensity: selected ? 0.12 : 0,
+  };
+  const panelEmissiveIntensity = selected ? 0.24 : 0.02;
+
+  // Each gate rung has height = gateH (opening) + topPanelHeight (cap)
+  // Rung i sits at y = i * rungStep so gates stack without overlap
+  // Banner fits WITHIN each section: gateH = openingH + bannerH, total = shape.height
+  const bannerH = topPanelHeight;
+  const openingH = gateH - bannerH;
+  const frontZ = -(panelDepth / 2 + 0.012);
+  const checkerSize = Math.max(
+    Math.min(leftPanelWidth, rightPanelWidth, bannerH) * 0.18,
+    0.035
+  );
+  const tJunctionRadius = frameTube * 0.8;
+
+  return (
+    <group ref={setGroupRefs} position={[shape.x, baseY, shape.y]} rotation={rot}>
+      {/* Continuous posts — exactly totalH tall */}
+      <mesh position={[outerLeftX, totalH / 2, -panelDepth * 0.65]} castShadow>
+        <cylinderGeometry args={[frameTube / 2, frameTube / 2, totalH, 16]} />
+        <meshStandardMaterial {...frameTubeMat} />
+      </mesh>
+      <mesh position={[outerRightX, totalH / 2, -panelDepth * 0.65]} castShadow>
+        <cylinderGeometry args={[frameTube / 2, frameTube / 2, totalH, 16]} />
+        <meshStandardMaterial {...frameTubeMat} />
+      </mesh>
+
+      {/* Bottom bar when elevated */}
+      <mesh ref={lowerBarRef} position={[0, 0, -panelDepth * 0.65]} rotation={[0, 0, Math.PI / 2]} castShadow visible={baseY > 0}>
+        <cylinderGeometry args={[frameTube / 2, frameTube / 2, outerW, 16]} />
+        <meshStandardMaterial {...frameTubeMat} />
+      </mesh>
+
+      {/* Top corner elbows — at very top (totalH) */}
+      {[outerLeftX, outerRightX].map((x, idx) => (
+        <mesh key={`elbow-${idx}`} position={[x, totalH, -panelDepth * 0.65]} castShadow>
+          <sphereGeometry args={[frameTube * 0.66, 16, 12]} />
+          <meshStandardMaterial color={frame.color} roughness={0.58} metalness={0.04} />
+        </mesh>
+      ))}
+
+      {/* Per section: bar at TOP → banner hangs below bar → opening below banner */}
+      {Array.from({ length: rungs }).map((_, i) => {
+        const sectionY = i * gateH;
+        const barY = (i + 1) * gateH;        // bar at the TOP of each section
+        const bannerMidY = barY - bannerH / 2; // banner hangs BELOW the bar
+        const openingMidY = sectionY + openingH / 2;
+        const isIntermediate = i < rungs - 1;
+
+        return (
+          <group key={i}>
+            {/* Horizontal bar at top of opening */}
+            <mesh position={[0, barY, -panelDepth * 0.65]} rotation={[0, 0, Math.PI / 2]} castShadow>
+              <cylinderGeometry args={[frameTube / 2, frameTube / 2, outerW, 16]} />
+              <meshStandardMaterial {...frameTubeMat} />
+            </mesh>
+            {/* T-junction connectors on intermediate bars */}
+            {isIntermediate && [outerLeftX, outerRightX].map((x, idx) => (
+              <mesh key={idx} position={[x, barY, -panelDepth * 0.65]}>
+                <cylinderGeometry args={[tJunctionRadius, tJunctionRadius, frameTube * 2.4, 12]} />
+                <meshStandardMaterial color={frame.color} roughness={0.5} metalness={0.1} />
+              </mesh>
+            ))}
+            {/* Navy banner */}
+            <mesh position={[0, bannerMidY, 0]} castShadow receiveShadow>
+              <boxGeometry args={[outerW, bannerH, panelDepth]} />
+              <meshStandardMaterial color={panels.top.color} roughness={0.64} metalness={0.03}
+                emissive={selected ? "#60a5fa" : panels.top.color} emissiveIntensity={selected ? 0.28 : 0.04} />
+            </mesh>
+            <mesh position={[0, bannerMidY, frontZ - 0.016]} rotation={[0, Math.PI, 0]}>
+              <FrontTextPlaneGeometry width={Math.max(w * 0.38, 0.46)} height={bannerH * 0.62} />
+              <meshBasicMaterial map={topTextTexture} transparent depthWrite={false} />
+            </mesh>
+            {/* White left panel */}
+            <mesh position={[-w / 2 - leftPanelWidth / 2, openingMidY, 0]} castShadow receiveShadow>
+              <boxGeometry args={[leftPanelWidth, openingH, panelDepth]} />
+              <meshStandardMaterial color={panels.left.color} roughness={0.7} metalness={0.01}
+                emissive={selected ? "#60a5fa" : panels.left.color} emissiveIntensity={panelEmissiveIntensity} />
+            </mesh>
+            {/* White right panel */}
+            <mesh position={[w / 2 + rightPanelWidth / 2, openingMidY, 0]} castShadow receiveShadow>
+              <boxGeometry args={[rightPanelWidth, openingH, panelDepth]} />
+              <meshStandardMaterial color={panels.right.color} roughness={0.7} metalness={0.01}
+                emissive={selected ? "#60a5fa" : panels.right.color} emissiveIntensity={panelEmissiveIntensity} />
+            </mesh>
+            {/* Checker accents */}
+            {[-1, 1].map((dir) =>
+              Array.from({ length: 12 }).map((__, idx) => {
+                const row = Math.floor(idx / 3);
+                const col = idx % 3;
+                if ((row + col) % 2 === 0) return null;
+                return (
+                  <mesh
+                    key={`${dir}-c-${idx}`}
+                    position={[
+                      (dir < 0 ? -w / 2 - leftPanelWidth / 2 : w / 2 + rightPanelWidth / 2) +
+                        dir * ((col - 1) * checkerSize),
+                      sectionY + openingH * 0.12 + row * checkerSize,
+                      frontZ - 0.004,
+                    ]}
+                  >
+                    <boxGeometry args={[checkerSize, checkerSize, panelDepth]} />
+                    <meshBasicMaterial color={branding.checkerColor} />
+                  </mesh>
+                );
+              })
+            )}
+            {/* Side text — y at 58% of opening height, matching gate alignment */}
+            {[-1, 1].map((dir) => (
+              <mesh
+                key={`st-${dir}`}
+                position={[
+                  dir < 0 ? -w / 2 - leftPanelWidth / 2 : w / 2 + rightPanelWidth / 2,
+                  sectionY + openingH * 0.58,
+                  frontZ - 0.016,
+                ]}
+                rotation={[0, Math.PI, dir > 0 ? Math.PI / 2 : -Math.PI / 2]}
+              >
+                <FrontTextPlaneGeometry
+                  width={openingH * 0.44}
+                  height={(dir < 0 ? leftPanelWidth : rightPanelWidth) * 0.62}
+                />
+                <meshBasicMaterial map={sideTextTexture} transparent depthWrite={false} />
+              </mesh>
+            ))}
+            {/* Opening fill */}
+            <mesh position={[0, openingMidY, -panelDepth / 2 - 0.004]}>
+              <planeGeometry args={[w, openingH]} />
+              <meshBasicMaterial color={frame.color} transparent opacity={selected ? 0.1 : 0.045} side={THREE.DoubleSide} />
+            </mesh>
+          </group>
+        );
+      })}
+    </group>
+  );
+}
+
 function Ladder3D({
   selected = false,
   shape,
@@ -1141,6 +1347,19 @@ function Ladder3D({
   outerRef?: Ref<THREE.Group>;
   elevationOverrideRef?: RefObject<number | null>;
 }) {
+  const ladderVisual = getLadderVisualSpec(shape);
+  if (ladderVisual?.variant === "panel-rungs") {
+    return (
+      <PanelFrameLadder3D
+        shape={shape}
+        selected={selected}
+        outerRef={outerRef}
+        elevationOverrideRef={elevationOverrideRef}
+        visual={ladderVisual}
+      />
+    );
+  }
+
   const color = shape.color ?? "#3b82f6";
   const w = shape.width ?? 1.5;
   const totalH = shape.height ?? 4.5;

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -22,9 +22,17 @@ import {
   getPolylineCurve3Derived,
   getPolylinePreview3DPoints,
 } from "@/lib/track/polyline-derived-3d";
-import { getFlagVisualSpec, getGateVisualSpec, getLadderVisualSpec } from "@/lib/track/elements/visual";
+import {
+  getFlagVisualSpec,
+  getGateVisualSpec,
+  getLadderVisualSpec,
+} from "@/lib/track/elements/visual";
 import { getShapeTimingMarker, getTimingMarkerColor } from "@/lib/track/timing";
-import type { CornerMarkerFlagVisualSpec, PanelFrameGateVisualSpec, PanelRunsLadderVisualSpec } from "@/lib/track/elements/catalog";
+import type {
+  CornerMarkerFlagVisualSpec,
+  PanelFrameGateVisualSpec,
+  PanelRunsLadderVisualSpec,
+} from "@/lib/track/elements/catalog";
 import type {
   ConeShape,
   DiveGateShape,
@@ -733,7 +741,7 @@ function CornerMarkerFlag3D({
 }) {
   const ph = shape.poleHeight ?? 3.0;
   const yawRad = (-shape.rotation * Math.PI) / 180;
-  const poleRadius = 0.030;
+  const poleRadius = 0.03;
   const pw = ph * 0.18;
   const topCurveX = pw * 0.65;
   const panelDepth = ph * 0.012;
@@ -761,10 +769,24 @@ function CornerMarkerFlag3D({
     s.moveTo(0, splitY);
     s.lineTo(pw, splitY);
     // right edge: straight up, then curves inward to reach the pole tip
-    s.lineTo(pw, ph * 0.70);
-    s.bezierCurveTo(pw * 0.95, ph * 0.83, poleTipLocalX + pw * 0.08, ph * 0.94, poleTipLocalX, ph);
+    s.lineTo(pw, ph * 0.7);
+    s.bezierCurveTo(
+      pw * 0.95,
+      ph * 0.83,
+      poleTipLocalX + pw * 0.08,
+      ph * 0.94,
+      poleTipLocalX,
+      ph
+    );
     // top arc: follows inside of pole bend back to where curve starts (left edge)
-    s.bezierCurveTo(poleTipLocalX * 0.52, ph * 0.97, 0, ph * 0.91, 0, ph * 0.85);
+    s.bezierCurveTo(
+      poleTipLocalX * 0.52,
+      ph * 0.97,
+      0,
+      ph * 0.91,
+      0,
+      ph * 0.85
+    );
     s.lineTo(0, splitY);
     return s;
   }, [ph, pw, splitY, poleTipLocalX]);
@@ -776,9 +798,12 @@ function CornerMarkerFlag3D({
     // right edge: straight down, tapers to a point at the bottom
     s.lineTo(pw, splitY);
     s.bezierCurveTo(
-      pw, splitY - ph * 0.08,
-      pw * 0.45, panelStartY + ph * 0.01,
-      pw * 0.08, panelStartY
+      pw,
+      splitY - ph * 0.08,
+      pw * 0.45,
+      panelStartY + ph * 0.01,
+      pw * 0.08,
+      panelStartY
     );
     s.lineTo(0, panelStartY);
     return s;
@@ -791,9 +816,18 @@ function CornerMarkerFlag3D({
 
   return (
     <group position={[shape.x, 0, shape.y]} rotation={[0, yawRad, 0]}>
-      <mesh position={[0, 0.02, 0]} receiveShadow rotation={[-Math.PI / 2, 0, 0]}>
+      <mesh
+        position={[0, 0.02, 0]}
+        receiveShadow
+        rotation={[-Math.PI / 2, 0, 0]}
+      >
         <ringGeometry args={[0.04, 0.13, 24]} />
-        <meshBasicMaterial color="#888" transparent opacity={0.18} side={THREE.DoubleSide} />
+        <meshBasicMaterial
+          color="#888"
+          transparent
+          opacity={0.18}
+          side={THREE.DoubleSide}
+        />
       </mesh>
       {/* Panel at z=0, left edge touching the pole's right surface */}
       <mesh receiveShadow castShadow position={[poleRadius, 0, 0]}>
@@ -841,7 +875,11 @@ function Flag3D({
   const flagVisual = getFlagVisualSpec(shape);
   if (flagVisual?.variant === "corner-marker") {
     return (
-      <CornerMarkerFlag3D shape={shape} selected={selected} visual={flagVisual} />
+      <CornerMarkerFlag3D
+        shape={shape}
+        selected={selected}
+        visual={flagVisual}
+      />
     );
   }
 
@@ -1150,7 +1188,11 @@ function PanelFrameLadder3D({
   const rungs = Math.max(1, shape.rungs ?? 3);
   const baseY = Math.max(shape.elevation ?? 0, 0);
   const gateH = totalH / rungs;
-  const rot: [number, number, number] = [0, (-(shape.rotation + 180) * Math.PI) / 180, 0];
+  const rot: [number, number, number] = [
+    0,
+    (-(shape.rotation + 180) * Math.PI) / 180,
+    0,
+  ];
 
   const leftPanelWidth = panels.left.widthMeters;
   const rightPanelWidth = panels.right.widthMeters;
@@ -1170,8 +1212,18 @@ function PanelFrameLadder3D({
     }),
     []
   );
-  const topTextTexture = useTextTexture(branding.label, branding.markColor, 32, multigpLabelStyle);
-  const sideTextTexture = useTextTexture(branding.label, branding.accentColor, 28, multigpLabelStyle);
+  const topTextTexture = useTextTexture(
+    branding.label,
+    branding.markColor,
+    32,
+    multigpLabelStyle
+  );
+  const sideTextTexture = useTextTexture(
+    branding.label,
+    branding.accentColor,
+    28,
+    multigpLabelStyle
+  );
 
   const groupRef = useRef<THREE.Group>(null);
   const lowerBarRef = useRef<THREE.Mesh>(null);
@@ -1215,7 +1267,11 @@ function PanelFrameLadder3D({
   const tJunctionRadius = frameTube * 0.8;
 
   return (
-    <group ref={setGroupRefs} position={[shape.x, baseY, shape.y]} rotation={rot}>
+    <group
+      ref={setGroupRefs}
+      position={[shape.x, baseY, shape.y]}
+      rotation={rot}
+    >
       {/* Continuous posts — exactly totalH tall */}
       <mesh position={[outerLeftX, totalH / 2, -panelDepth * 0.65]} castShadow>
         <cylinderGeometry args={[frameTube / 2, frameTube / 2, totalH, 16]} />
@@ -1227,23 +1283,37 @@ function PanelFrameLadder3D({
       </mesh>
 
       {/* Bottom bar when elevated */}
-      <mesh ref={lowerBarRef} position={[0, 0, -panelDepth * 0.65]} rotation={[0, 0, Math.PI / 2]} castShadow visible={baseY > 0}>
+      <mesh
+        ref={lowerBarRef}
+        position={[0, 0, -panelDepth * 0.65]}
+        rotation={[0, 0, Math.PI / 2]}
+        castShadow
+        visible={baseY > 0}
+      >
         <cylinderGeometry args={[frameTube / 2, frameTube / 2, outerW, 16]} />
         <meshStandardMaterial {...frameTubeMat} />
       </mesh>
 
       {/* Top corner elbows — at very top (totalH) */}
       {[outerLeftX, outerRightX].map((x, idx) => (
-        <mesh key={`elbow-${idx}`} position={[x, totalH, -panelDepth * 0.65]} castShadow>
+        <mesh
+          key={`elbow-${idx}`}
+          position={[x, totalH, -panelDepth * 0.65]}
+          castShadow
+        >
           <sphereGeometry args={[frameTube * 0.66, 16, 12]} />
-          <meshStandardMaterial color={frame.color} roughness={0.58} metalness={0.04} />
+          <meshStandardMaterial
+            color={frame.color}
+            roughness={0.58}
+            metalness={0.04}
+          />
         </mesh>
       ))}
 
       {/* Per section: bar at TOP → banner hangs below bar → opening below banner */}
       {Array.from({ length: rungs }).map((_, i) => {
         const sectionY = i * gateH;
-        const barY = (i + 1) * gateH;        // bar at the TOP of each section
+        const barY = (i + 1) * gateH; // bar at the TOP of each section
         const bannerMidY = barY - bannerH / 2; // banner hangs BELOW the bar
         const openingMidY = sectionY + openingH / 2;
         const isIntermediate = i < rungs - 1;
@@ -1251,38 +1321,89 @@ function PanelFrameLadder3D({
         return (
           <group key={i}>
             {/* Horizontal bar at top of opening */}
-            <mesh position={[0, barY, -panelDepth * 0.65]} rotation={[0, 0, Math.PI / 2]} castShadow>
-              <cylinderGeometry args={[frameTube / 2, frameTube / 2, outerW, 16]} />
+            <mesh
+              position={[0, barY, -panelDepth * 0.65]}
+              rotation={[0, 0, Math.PI / 2]}
+              castShadow
+            >
+              <cylinderGeometry
+                args={[frameTube / 2, frameTube / 2, outerW, 16]}
+              />
               <meshStandardMaterial {...frameTubeMat} />
             </mesh>
             {/* T-junction connectors on intermediate bars */}
-            {isIntermediate && [outerLeftX, outerRightX].map((x, idx) => (
-              <mesh key={idx} position={[x, barY, -panelDepth * 0.65]}>
-                <cylinderGeometry args={[tJunctionRadius, tJunctionRadius, frameTube * 2.4, 12]} />
-                <meshStandardMaterial color={frame.color} roughness={0.5} metalness={0.1} />
-              </mesh>
-            ))}
+            {isIntermediate &&
+              [outerLeftX, outerRightX].map((x, idx) => (
+                <mesh key={idx} position={[x, barY, -panelDepth * 0.65]}>
+                  <cylinderGeometry
+                    args={[
+                      tJunctionRadius,
+                      tJunctionRadius,
+                      frameTube * 2.4,
+                      12,
+                    ]}
+                  />
+                  <meshStandardMaterial
+                    color={frame.color}
+                    roughness={0.5}
+                    metalness={0.1}
+                  />
+                </mesh>
+              ))}
             {/* Navy banner */}
             <mesh position={[0, bannerMidY, 0]} castShadow receiveShadow>
               <boxGeometry args={[outerW, bannerH, panelDepth]} />
-              <meshStandardMaterial color={panels.top.color} roughness={0.64} metalness={0.03}
-                emissive={selected ? "#60a5fa" : panels.top.color} emissiveIntensity={selected ? 0.28 : 0.04} />
+              <meshStandardMaterial
+                color={panels.top.color}
+                roughness={0.64}
+                metalness={0.03}
+                emissive={selected ? "#60a5fa" : panels.top.color}
+                emissiveIntensity={selected ? 0.28 : 0.04}
+              />
             </mesh>
-            <mesh position={[0, bannerMidY, frontZ - 0.016]} rotation={[0, Math.PI, 0]}>
-              <FrontTextPlaneGeometry width={Math.max(w * 0.38, 0.46)} height={bannerH * 0.62} />
-              <meshBasicMaterial map={topTextTexture} transparent depthWrite={false} />
+            <mesh
+              position={[0, bannerMidY, frontZ - 0.016]}
+              rotation={[0, Math.PI, 0]}
+            >
+              <FrontTextPlaneGeometry
+                width={Math.max(w * 0.38, 0.46)}
+                height={bannerH * 0.62}
+              />
+              <meshBasicMaterial
+                map={topTextTexture}
+                transparent
+                depthWrite={false}
+              />
             </mesh>
             {/* White left panel */}
-            <mesh position={[-w / 2 - leftPanelWidth / 2, openingMidY, 0]} castShadow receiveShadow>
+            <mesh
+              position={[-w / 2 - leftPanelWidth / 2, openingMidY, 0]}
+              castShadow
+              receiveShadow
+            >
               <boxGeometry args={[leftPanelWidth, openingH, panelDepth]} />
-              <meshStandardMaterial color={panels.left.color} roughness={0.7} metalness={0.01}
-                emissive={selected ? "#60a5fa" : panels.left.color} emissiveIntensity={panelEmissiveIntensity} />
+              <meshStandardMaterial
+                color={panels.left.color}
+                roughness={0.7}
+                metalness={0.01}
+                emissive={selected ? "#60a5fa" : panels.left.color}
+                emissiveIntensity={panelEmissiveIntensity}
+              />
             </mesh>
             {/* White right panel */}
-            <mesh position={[w / 2 + rightPanelWidth / 2, openingMidY, 0]} castShadow receiveShadow>
+            <mesh
+              position={[w / 2 + rightPanelWidth / 2, openingMidY, 0]}
+              castShadow
+              receiveShadow
+            >
               <boxGeometry args={[rightPanelWidth, openingH, panelDepth]} />
-              <meshStandardMaterial color={panels.right.color} roughness={0.7} metalness={0.01}
-                emissive={selected ? "#60a5fa" : panels.right.color} emissiveIntensity={panelEmissiveIntensity} />
+              <meshStandardMaterial
+                color={panels.right.color}
+                roughness={0.7}
+                metalness={0.01}
+                emissive={selected ? "#60a5fa" : panels.right.color}
+                emissiveIntensity={panelEmissiveIntensity}
+              />
             </mesh>
             {/* Checker accents */}
             {[-1, 1].map((dir) =>
@@ -1294,13 +1415,17 @@ function PanelFrameLadder3D({
                   <mesh
                     key={`${dir}-c-${idx}`}
                     position={[
-                      (dir < 0 ? -w / 2 - leftPanelWidth / 2 : w / 2 + rightPanelWidth / 2) +
+                      (dir < 0
+                        ? -w / 2 - leftPanelWidth / 2
+                        : w / 2 + rightPanelWidth / 2) +
                         dir * ((col - 1) * checkerSize),
                       sectionY + openingH * 0.12 + row * checkerSize,
                       frontZ - 0.004,
                     ]}
                   >
-                    <boxGeometry args={[checkerSize, checkerSize, panelDepth]} />
+                    <boxGeometry
+                      args={[checkerSize, checkerSize, panelDepth]}
+                    />
                     <meshBasicMaterial color={branding.checkerColor} />
                   </mesh>
                 );
@@ -1311,7 +1436,9 @@ function PanelFrameLadder3D({
               <mesh
                 key={`st-${dir}`}
                 position={[
-                  dir < 0 ? -w / 2 - leftPanelWidth / 2 : w / 2 + rightPanelWidth / 2,
+                  dir < 0
+                    ? -w / 2 - leftPanelWidth / 2
+                    : w / 2 + rightPanelWidth / 2,
                   sectionY + openingH * 0.58,
                   frontZ - 0.016,
                 ]}
@@ -1321,13 +1448,22 @@ function PanelFrameLadder3D({
                   width={openingH * 0.44}
                   height={(dir < 0 ? leftPanelWidth : rightPanelWidth) * 0.62}
                 />
-                <meshBasicMaterial map={sideTextTexture} transparent depthWrite={false} />
+                <meshBasicMaterial
+                  map={sideTextTexture}
+                  transparent
+                  depthWrite={false}
+                />
               </mesh>
             ))}
             {/* Opening fill */}
             <mesh position={[0, openingMidY, -panelDepth / 2 - 0.004]}>
               <planeGeometry args={[w, openingH]} />
-              <meshBasicMaterial color={frame.color} transparent opacity={selected ? 0.1 : 0.045} side={THREE.DoubleSide} />
+              <meshBasicMaterial
+                color={frame.color}
+                transparent
+                opacity={selected ? 0.1 : 0.045}
+                side={THREE.DoubleSide}
+              />
             </mesh>
           </group>
         );

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -873,16 +873,6 @@ function Flag3D({
   shape: FlagShape;
 }) {
   const flagVisual = getFlagVisualSpec(shape);
-  if (flagVisual?.variant === "corner-marker") {
-    return (
-      <CornerMarkerFlag3D
-        shape={shape}
-        selected={selected}
-        visual={flagVisual}
-      />
-    );
-  }
-
   const color = shape.color ?? "#a855f7";
   const ph = shape.poleHeight ?? 3.5;
   const yawRad = (-shape.rotation * Math.PI) / 180;
@@ -931,6 +921,16 @@ function Flag3D({
     );
     return banner;
   }, [bannerBottom, bannerTop, bannerWidth, ph]);
+
+  if (flagVisual?.variant === "corner-marker") {
+    return (
+      <CornerMarkerFlag3D
+        shape={shape}
+        selected={selected}
+        visual={flagVisual}
+      />
+    );
+  }
 
   return (
     <group position={[shape.x, 0, shape.y]} rotation={[0, yawRad, 0]}>
@@ -1484,18 +1484,6 @@ function Ladder3D({
   elevationOverrideRef?: RefObject<number | null>;
 }) {
   const ladderVisual = getLadderVisualSpec(shape);
-  if (ladderVisual?.variant === "panel-rungs") {
-    return (
-      <PanelFrameLadder3D
-        shape={shape}
-        selected={selected}
-        outerRef={outerRef}
-        elevationOverrideRef={elevationOverrideRef}
-        visual={ladderVisual}
-      />
-    );
-  }
-
   const color = shape.color ?? "#3b82f6";
   const w = shape.width ?? 1.5;
   const totalH = shape.height ?? 4.5;
@@ -1527,6 +1515,18 @@ function Ladder3D({
       lowerBarRef.current.visible = liveElevation > 0;
     }
   });
+
+  if (ladderVisual?.variant === "panel-rungs") {
+    return (
+      <PanelFrameLadder3D
+        shape={shape}
+        selected={selected}
+        outerRef={outerRef}
+        elevationOverrideRef={elevationOverrideRef}
+        visual={ladderVisual}
+      />
+    );
+  }
 
   return (
     <group

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -31,7 +31,7 @@ import { getShapeTimingMarker, getTimingMarkerColor } from "@/lib/track/timing";
 import type {
   CornerMarkerFlagVisualSpec,
   PanelFrameGateVisualSpec,
-  PanelRunsLadderVisualSpec,
+  PanelFrameLadderVisualSpec,
 } from "@/lib/track/elements/catalog";
 import type {
   ConeShape,
@@ -1179,7 +1179,7 @@ function PanelFrameLadder3D({
   shape: LadderShape;
   outerRef?: Ref<THREE.Group>;
   elevationOverrideRef?: RefObject<number | null>;
-  visual: PanelRunsLadderVisualSpec;
+  visual: PanelFrameLadderVisualSpec;
 }) {
   const { branding, frame, panels } = visual;
   // shape.width = inner opening (same convention as gates)
@@ -1516,7 +1516,7 @@ function Ladder3D({
     }
   });
 
-  if (ladderVisual?.variant === "panel-rungs") {
+  if (ladderVisual?.variant === "panel-frame") {
     return (
       <PanelFrameLadder3D
         shape={shape}

--- a/src/components/canvas/useTrackCanvasInteractions.ts
+++ b/src/components/canvas/useTrackCanvasInteractions.ts
@@ -40,7 +40,7 @@ import type { PolylineShape, Shape, ShapeDraft } from "@/lib/types";
 interface TrackCanvasInteractionsParams {
   activeTool: EditorTool;
   activePresetId: string | null;
-  activeGateElementId: TrackElementCatalogId | null;
+  activePlacementElementId: Partial<Record<EditorTool, TrackElementCatalogId>>;
   addShape: (shape: ShapeDraft) => string;
   addShapes: (shapes: ShapeDraft[]) => string[];
   contentDragActiveRef: React.RefObject<boolean>;
@@ -103,7 +103,7 @@ interface TrackCanvasInteractionsParams {
 export function useTrackCanvasInteractions({
   activeTool,
   activePresetId,
-  activeGateElementId,
+  activePlacementElementId,
   addShape,
   addShapes,
   contentDragActiveRef,
@@ -617,7 +617,7 @@ export function useTrackCanvasInteractions({
           return;
         }
         const shape = createShapeForTool(activeTool, meters, {
-          gateElementId: activeGateElementId,
+          activePlacementElementId,
         });
         if (!shape) return;
         const id = addShape(shape);
@@ -639,7 +639,7 @@ export function useTrackCanvasInteractions({
     [
       activeTool,
       activePresetId,
-      activeGateElementId,
+      activePlacementElementId,
       addShape,
       addShapes,
       finalizePath,
@@ -848,7 +848,7 @@ export function useTrackCanvasInteractions({
           return;
         }
         const shape = createShapeForTool(activeTool, meters, {
-          gateElementId: activeGateElementId,
+          activePlacementElementId,
         });
         if (!shape) return;
         const id = addShape(shape);
@@ -883,7 +883,7 @@ export function useTrackCanvasInteractions({
     [
       activeTool,
       activePresetId,
-      activeGateElementId,
+      activePlacementElementId,
       addShape,
       addShapes,
       marqueeAdditiveRef,

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -104,8 +104,8 @@ export default function EditorShell({
   const design = useEditor((state) => state.track.design);
   const activeTool = useEditor((state) => state.ui.activeTool);
   const activePresetId = useEditor((state) => state.ui.activePresetId);
-  const activeGateElementId = useEditor(
-    (state) => state.ui.activeGateElementId
+  const activePlacementElementId = useEditor(
+    (state) => state.ui.activePlacementElementId
   );
   const snapEnabled = useEditor((state) => state.ui.snapEnabled);
   const {
@@ -123,7 +123,7 @@ export default function EditorShell({
   } = useTrackActions();
   const {
     setActiveTool,
-    setActiveGateElementId,
+    setActivePlacementElementId,
     setActivePresetId,
     setSegmentSelection,
     toggleSnapEnabled,
@@ -407,17 +407,17 @@ export default function EditorShell({
     setMobilePathBuilderPinnedOpen(false);
   }, [activeTool, mobileDraftPathState.active]);
 
-  const handleGateElementSelect = useCallback(
-    (entryId: TrackElementCatalogId) => {
+  const handlePlacementElementSelect = useCallback(
+    (tool: EditorTool, entryId: TrackElementCatalogId) => {
       setSelection([]);
       setMobileMultiSelectEnabled(false);
       setMobilePathBuilderPinnedOpen(false);
-      setActiveGateElementId(entryId);
-      setActiveTool("gate");
+      setActivePlacementElementId(tool, entryId);
+      setActiveTool(tool);
       setMobileToolsOpen(false);
     },
     [
-      setActiveGateElementId,
+      setActivePlacementElementId,
       setActiveTool,
       setMobileMultiSelectEnabled,
       setMobilePathBuilderPinnedOpen,
@@ -648,7 +648,7 @@ export default function EditorShell({
         {isMobile && !readOnly ? (
           <EditorMobilePanels
             activeTool={activeTool}
-            activeGateElementId={activeGateElementId}
+            activePlacementElementId={activePlacementElementId}
             activePresetLabel={activePresetLabel}
             draftPathActive={mobileDraftPathState.active}
             draftPathClosed={mobileDraftPathState.closed}
@@ -803,7 +803,7 @@ export default function EditorShell({
               setMobileMultiSelectEnabled(false);
               setSelection([]);
             }}
-            onSelectGateElement={handleGateElementSelect}
+            onSelectPlacementElement={handlePlacementElementSelect}
             onSelectTool={(tool) => {
               setSelection([]);
               setMobileMultiSelectEnabled(false);
@@ -814,7 +814,11 @@ export default function EditorShell({
               }
               setMobilePathBuilderPinnedOpen(tool === "polyline");
               setActiveTool(tool);
-              setMobileToolsOpen(false);
+              // Keep drawer open for catalog tools so the type list stays visible
+              const catalogTools: EditorTool[] = ["gate", "flag", "ladder"];
+              if (!catalogTools.includes(tool)) {
+                setMobileToolsOpen(false);
+              }
             }}
             onSetMobileToolsOpen={setMobileToolsOpen}
             onSetMobileViewOpen={setMobileViewOpen}

--- a/src/components/editor/ElementPlacementControl.tsx
+++ b/src/components/editor/ElementPlacementControl.tsx
@@ -41,7 +41,10 @@ const labelByTool: Partial<Record<EditorTool, string>> = {
 };
 
 function getControlWidthCh(entries: { name: string }[]) {
-  return Math.max(22, Math.min(32, Math.max(...entries.map((e) => e.name.length)) + 5));
+  return Math.max(
+    22,
+    Math.min(32, Math.max(...entries.map((e) => e.name.length)) + 5)
+  );
 }
 
 export function ElementPlacementControl() {
@@ -80,101 +83,105 @@ export function ElementPlacementControl() {
             transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
             className="pointer-events-auto"
           >
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger
-          style={controlWidthStyle}
-          className="group border-border/55 bg-sidebar/96 hover:border-border/80 hover:bg-sidebar grid h-12 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 rounded-xl border px-3 text-left shadow-[0_8px_32px_rgba(15,23,42,0.18)] backdrop-blur-md transition-all"
-        >
-          <span className="border-border/40 text-muted-foreground rounded-md border px-2 py-1 text-[9px] leading-none font-semibold tracking-widest uppercase">
-            {toolLabel}
-          </span>
-          <span className="min-w-0">
-            <span className="text-foreground block truncate text-[13px] leading-none font-semibold">
-              {activeEntry.name}
-            </span>
-            <span className="mt-1.5 flex min-w-0 items-center gap-1.5">
-              <span className="text-muted-foreground/70 truncate text-[11px] leading-none">
-                {activeEntry.dimensions.display.label}
-              </span>
-              {activeEntry.official ? (
-                <span className="bg-brand-primary/14 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-[0.06em] uppercase">
-                  Official
+            <Popover open={open} onOpenChange={setOpen}>
+              <PopoverTrigger
+                style={controlWidthStyle}
+                className="group border-border/55 bg-sidebar/96 hover:border-border/80 hover:bg-sidebar grid h-12 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 rounded-xl border px-3 text-left shadow-[0_8px_32px_rgba(15,23,42,0.18)] backdrop-blur-md transition-all"
+              >
+                <span className="border-border/40 text-muted-foreground rounded-md border px-2 py-1 text-[9px] leading-none font-semibold tracking-widest uppercase">
+                  {toolLabel}
                 </span>
-              ) : null}
-            </span>
-          </span>
-          <ChevronDown
-            className={cn(
-              "text-muted-foreground/60 size-4 shrink-0 transition-transform duration-200",
-              open && "rotate-180"
-            )}
-          />
-        </PopoverTrigger>
-        <PopoverContent
-          align="center"
-          side="top"
-          sideOffset={10}
-          style={controlWidthStyle}
-          className="overflow-hidden rounded-xl p-0 shadow-[0_8px_32px_rgba(15,23,42,0.18)]"
-        >
-          <div className="px-3 pt-3 pb-1.5">
-            <p className="text-muted-foreground/60 text-[10px] font-semibold tracking-widest uppercase">
-              {toolLabel} type
-            </p>
-          </div>
-          <div className="max-h-72 space-y-0.5 overflow-y-auto px-1.5 pb-1.5">
-            {entries.map((entry) => {
-              const active = activeId === entry.id;
-              return (
-                <button
-                  key={entry.id}
-                  type="button"
-                  onClick={() => {
-                    setSelection([]);
-                    setActivePlacementElementId(activeTool, entry.id);
-                    setOpen(false);
-                  }}
-                  className={cn(
-                    "flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-left transition-colors",
-                    active
-                      ? "bg-brand-primary/10 text-foreground"
-                      : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
-                  )}
-                >
-                  <span className="min-w-0 flex-1">
-                    <span className={cn(
-                      "block truncate text-[13px] leading-tight font-semibold",
-                      active ? "text-foreground" : "text-foreground/80"
-                    )}>
-                      {entry.name}
-                    </span>
-                    <span className="mt-1 flex min-w-0 items-center gap-1.5">
-                      <span className="text-muted-foreground/65 truncate text-[11px] leading-none">
-                        {entry.dimensions.display.label}
-                      </span>
-                      {entry.official ? (
-                        <span className="bg-brand-primary/12 text-brand-primary rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-[0.06em] uppercase shrink-0">
-                          Official
-                        </span>
-                      ) : null}
-                    </span>
+                <span className="min-w-0">
+                  <span className="text-foreground block truncate text-[13px] leading-none font-semibold">
+                    {activeEntry.name}
                   </span>
-                  <div className={cn(
-                    "size-4 shrink-0 rounded-full border-2 transition-all",
-                    active
-                      ? "border-brand-primary bg-brand-primary"
-                      : "border-border/50"
-                  )}>
-                    {active && (
-                      <Check className="text-background size-full p-0.75" />
-                    )}
-                  </div>
-                </button>
-              );
-            })}
-          </div>
-        </PopoverContent>
-      </Popover>
+                  <span className="mt-1.5 flex min-w-0 items-center gap-1.5">
+                    <span className="text-muted-foreground/70 truncate text-[11px] leading-none">
+                      {activeEntry.dimensions.display.label}
+                    </span>
+                    {activeEntry.official ? (
+                      <span className="bg-brand-primary/14 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-[0.06em] uppercase">
+                        Official
+                      </span>
+                    ) : null}
+                  </span>
+                </span>
+                <ChevronDown
+                  className={cn(
+                    "text-muted-foreground/60 size-4 shrink-0 transition-transform duration-200",
+                    open && "rotate-180"
+                  )}
+                />
+              </PopoverTrigger>
+              <PopoverContent
+                align="center"
+                side="top"
+                sideOffset={10}
+                style={controlWidthStyle}
+                className="overflow-hidden rounded-xl p-0 shadow-[0_8px_32px_rgba(15,23,42,0.18)]"
+              >
+                <div className="px-3 pt-3 pb-1.5">
+                  <p className="text-muted-foreground/60 text-[10px] font-semibold tracking-widest uppercase">
+                    {toolLabel} type
+                  </p>
+                </div>
+                <div className="max-h-72 space-y-0.5 overflow-y-auto px-1.5 pb-1.5">
+                  {entries.map((entry) => {
+                    const active = activeId === entry.id;
+                    return (
+                      <button
+                        key={entry.id}
+                        type="button"
+                        onClick={() => {
+                          setSelection([]);
+                          setActivePlacementElementId(activeTool, entry.id);
+                          setOpen(false);
+                        }}
+                        className={cn(
+                          "flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-left transition-colors",
+                          active
+                            ? "bg-brand-primary/10 text-foreground"
+                            : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
+                        )}
+                      >
+                        <span className="min-w-0 flex-1">
+                          <span
+                            className={cn(
+                              "block truncate text-[13px] leading-tight font-semibold",
+                              active ? "text-foreground" : "text-foreground/80"
+                            )}
+                          >
+                            {entry.name}
+                          </span>
+                          <span className="mt-1 flex min-w-0 items-center gap-1.5">
+                            <span className="text-muted-foreground/65 truncate text-[11px] leading-none">
+                              {entry.dimensions.display.label}
+                            </span>
+                            {entry.official ? (
+                              <span className="bg-brand-primary/12 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-[0.06em] uppercase">
+                                Official
+                              </span>
+                            ) : null}
+                          </span>
+                        </span>
+                        <div
+                          className={cn(
+                            "size-4 shrink-0 rounded-full border-2 transition-all",
+                            active
+                              ? "border-brand-primary bg-brand-primary"
+                              : "border-border/50"
+                          )}
+                        >
+                          {active && (
+                            <Check className="text-background size-full p-0.75" />
+                          )}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              </PopoverContent>
+            </Popover>
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/editor/ElementPlacementControl.tsx
+++ b/src/components/editor/ElementPlacementControl.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type CSSProperties, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import { Check, ChevronDown } from "lucide-react";
 import {
   Popover,
@@ -9,130 +10,174 @@ import {
 } from "@/components/ui/popover";
 import {
   getCatalogEntriesByKind,
+  TRACKDRAW_FLAG_ELEMENT_ID,
   TRACKDRAW_GATE_ELEMENT_ID,
+  TRACKDRAW_LADDER_ELEMENT_ID,
+  type TrackElementCatalogId,
 } from "@/lib/track/elements/catalog";
 import { cn } from "@/lib/utils";
 import { useSessionActions, useUiActions } from "@/store/actions";
 import { useEditor } from "@/store/editor";
+import type { EditorTool } from "@/lib/editor-tools";
 
-const gateCatalogEntries = getCatalogEntriesByKind("gate");
-const placementControlWidthCh = Math.max(
-  22,
-  Math.min(
-    32,
-    Math.max(...gateCatalogEntries.map((entry) => entry.name.length)) + 5
-  )
-);
+const catalogEntriesByTool: Partial<
+  Record<EditorTool, ReturnType<typeof getCatalogEntriesByKind>>
+> = {
+  gate: getCatalogEntriesByKind("gate"),
+  flag: getCatalogEntriesByKind("flag"),
+  ladder: getCatalogEntriesByKind("ladder"),
+};
+
+const defaultIdByTool: Partial<Record<EditorTool, TrackElementCatalogId>> = {
+  gate: TRACKDRAW_GATE_ELEMENT_ID,
+  flag: TRACKDRAW_FLAG_ELEMENT_ID,
+  ladder: TRACKDRAW_LADDER_ELEMENT_ID,
+};
+
+const labelByTool: Partial<Record<EditorTool, string>> = {
+  gate: "Gate",
+  flag: "Flag",
+  ladder: "Ladder",
+};
+
+function getControlWidthCh(entries: { name: string }[]) {
+  return Math.max(22, Math.min(32, Math.max(...entries.map((e) => e.name.length)) + 5));
+}
 
 export function ElementPlacementControl() {
   const [open, setOpen] = useState(false);
   const activeTool = useEditor((state) => state.ui.activeTool);
-  const activeGateElementId =
-    useEditor((state) => state.ui.activeGateElementId) ??
-    TRACKDRAW_GATE_ELEMENT_ID;
-  const { setActiveGateElementId } = useUiActions();
+  const activePlacementElementId = useEditor(
+    (state) => state.ui.activePlacementElementId
+  );
+  const { setActivePlacementElementId } = useUiActions();
   const { setSelection } = useSessionActions();
-  const activeEntry =
-    gateCatalogEntries.find((entry) => entry.id === activeGateElementId) ??
-    gateCatalogEntries[0];
+
+  const entries = catalogEntriesByTool[activeTool];
+  const visible = !!entries && entries.length > 1;
+  const activeId = visible
+    ? (activePlacementElementId[activeTool] ?? defaultIdByTool[activeTool])
+    : undefined;
+  const activeEntry = visible
+    ? (entries!.find((e) => e.id === activeId) ?? entries![0])
+    : undefined;
+  const toolLabel = labelByTool[activeTool] ?? activeTool;
   const controlWidthStyle = {
-    width: `min(${placementControlWidthCh}ch, calc(100vw - 2rem))`,
+    width: visible
+      ? `min(${getControlWidthCh(entries!)}ch, calc(100vw - 2rem))`
+      : "auto",
   } satisfies CSSProperties;
 
-  if (activeTool !== "gate" || !activeEntry) return null;
-
   return (
-    <div className="pointer-events-auto absolute bottom-3 left-1/2 z-20 hidden -translate-x-1/2 lg:block">
+    <div className="pointer-events-none absolute bottom-3 left-1/2 z-20 hidden -translate-x-1/2 lg:block">
+      <AnimatePresence>
+        {visible && activeEntry && (
+          <motion.div
+            key={activeTool}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 10 }}
+            transition={{ duration: 0.18, ease: [0.16, 1, 0.3, 1] }}
+            className="pointer-events-auto"
+          >
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger
           style={controlWidthStyle}
-          className="group border-border/65 bg-sidebar/94 hover:border-border hover:bg-sidebar grid h-11 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 rounded-md border px-2.5 text-left shadow-[0_10px_30px_rgba(15,23,42,0.16)] backdrop-blur-md transition-colors"
+          className="group border-border/55 bg-sidebar/96 hover:border-border/80 hover:bg-sidebar grid h-12 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 rounded-xl border px-3 text-left shadow-[0_8px_32px_rgba(15,23,42,0.18)] backdrop-blur-md transition-all"
         >
-          <span className="bg-muted text-muted-foreground rounded-sm px-1.5 py-1 font-mono text-[9px] leading-none font-semibold tracking-[0.12em] uppercase">
-            Gate
+          <span className="border-border/40 text-muted-foreground rounded-md border px-2 py-1 text-[9px] leading-none font-semibold tracking-widest uppercase">
+            {toolLabel}
           </span>
           <span className="min-w-0">
-            <span className="text-foreground block truncate text-xs leading-none font-medium">
+            <span className="text-foreground block truncate text-[13px] leading-none font-semibold">
               {activeEntry.name}
             </span>
-            <span className="mt-1 flex min-w-0 items-center gap-1.5">
-              <span className="text-muted-foreground truncate text-[11px] leading-none">
+            <span className="mt-1.5 flex min-w-0 items-center gap-1.5">
+              <span className="text-muted-foreground/70 truncate text-[11px] leading-none">
                 {activeEntry.dimensions.display.label}
               </span>
               {activeEntry.official ? (
-                <span className="bg-brand-primary/12 text-brand-primary shrink-0 rounded-[3px] px-1 py-0.5 text-[9px] leading-none font-semibold tracking-[0.08em] uppercase">
+                <span className="bg-brand-primary/14 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-[0.06em] uppercase">
                   Official
                 </span>
               ) : null}
             </span>
           </span>
-          <span className="flex shrink-0 items-center">
-            <ChevronDown
-              className={cn(
-                "text-muted-foreground size-3.5 transition-transform",
-                open && "rotate-180"
-              )}
-            />
-          </span>
+          <ChevronDown
+            className={cn(
+              "text-muted-foreground/60 size-4 shrink-0 transition-transform duration-200",
+              open && "rotate-180"
+            )}
+          />
         </PopoverTrigger>
         <PopoverContent
           align="center"
           side="top"
-          sideOffset={8}
+          sideOffset={10}
           style={controlWidthStyle}
-          className="overflow-hidden p-0"
+          className="overflow-hidden rounded-xl p-0 shadow-[0_8px_32px_rgba(15,23,42,0.18)]"
         >
-          <div className="border-border/70 border-b px-3 py-2">
-            <p className="text-muted-foreground text-[11px] font-semibold tracking-[0.08em] uppercase">
-              Choose gate type
+          <div className="px-3 pt-3 pb-1.5">
+            <p className="text-muted-foreground/60 text-[10px] font-semibold tracking-widest uppercase">
+              {toolLabel} type
             </p>
           </div>
-          <div className="max-h-72 space-y-1 overflow-y-auto p-1.5">
-            {gateCatalogEntries.map((entry) => {
-              const active = activeGateElementId === entry.id;
+          <div className="max-h-72 space-y-0.5 overflow-y-auto px-1.5 pb-1.5">
+            {entries.map((entry) => {
+              const active = activeId === entry.id;
               return (
                 <button
                   key={entry.id}
                   type="button"
                   onClick={() => {
                     setSelection([]);
-                    setActiveGateElementId(entry.id);
+                    setActivePlacementElementId(activeTool, entry.id);
                     setOpen(false);
                   }}
                   className={cn(
-                    "flex w-full items-center gap-3 rounded-md px-2.5 py-2 text-left transition-colors",
+                    "flex w-full items-center gap-3 rounded-lg px-2.5 py-2.5 text-left transition-colors",
                     active
                       ? "bg-brand-primary/10 text-foreground"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                      : "text-muted-foreground hover:bg-muted/60 hover:text-foreground"
                   )}
                 >
                   <span className="min-w-0 flex-1">
-                    <span className="block truncate text-sm leading-tight font-medium">
+                    <span className={cn(
+                      "block truncate text-[13px] leading-tight font-semibold",
+                      active ? "text-foreground" : "text-foreground/80"
+                    )}>
                       {entry.name}
                     </span>
-                    <span className="mt-1 flex min-w-0 items-center gap-1.5 text-xs opacity-75">
-                      <span className="truncate">
+                    <span className="mt-1 flex min-w-0 items-center gap-1.5">
+                      <span className="text-muted-foreground/65 truncate text-[11px] leading-none">
                         {entry.dimensions.display.label}
                       </span>
                       {entry.official ? (
-                        <span className="bg-muted rounded-[3px] px-1 py-0.5 text-[9px] leading-none font-semibold tracking-[0.08em] uppercase">
+                        <span className="bg-brand-primary/12 text-brand-primary rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-[0.06em] uppercase shrink-0">
                           Official
                         </span>
                       ) : null}
                     </span>
                   </span>
-                  <Check
-                    className={cn(
-                      "text-brand-primary size-4 shrink-0 transition-opacity",
-                      active ? "opacity-100" : "opacity-0"
+                  <div className={cn(
+                    "size-4 shrink-0 rounded-full border-2 transition-all",
+                    active
+                      ? "border-brand-primary bg-brand-primary"
+                      : "border-border/50"
+                  )}>
+                    {active && (
+                      <Check className="text-background size-full p-0.75" />
                     )}
-                  />
+                  </div>
                 </button>
               );
             })}
           </div>
         </PopoverContent>
       </Popover>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/editor/mobile/EditorMobilePanels.tsx
+++ b/src/components/editor/mobile/EditorMobilePanels.tsx
@@ -39,7 +39,7 @@ export type EditorViewportTab = "2d" | "3d";
 
 interface EditorMobilePanelsProps {
   activeTool: EditorTool;
-  activeGateElementId: TrackElementCatalogId | null;
+  activePlacementElementId: Partial<Record<EditorTool, TrackElementCatalogId>>;
   activePresetLabel?: string | null;
   draftPathActive: boolean;
   draftPathClosed: boolean;
@@ -97,7 +97,7 @@ interface EditorMobilePanelsProps {
   onSetMobileGizmoEnabled: (enabled: boolean) => void;
   onSetMobileObstacleNumbersEnabled: (enabled: boolean) => void;
   onToggleSnapEnabled: () => void;
-  onSelectGateElement: (entryId: TrackElementCatalogId) => void;
+  onSelectPlacementElement: (tool: EditorTool, entryId: TrackElementCatalogId) => void;
   onSelectTool: (tool: EditorTool) => void;
   onSetMobileToolsOpen: (open: boolean) => void;
   onSetMobileViewOpen: (open: boolean) => void;
@@ -320,7 +320,7 @@ function MobileQuickActionsOverlay({
 
 export function EditorMobilePanels({
   activeTool,
-  activeGateElementId,
+  activePlacementElementId,
   activePresetLabel,
   canAddWaypoint = false,
   canDeleteWaypoint = false,
@@ -381,7 +381,7 @@ export function EditorMobilePanels({
   onSetMobileGizmoEnabled,
   onSetMobileObstacleNumbersEnabled,
   onToggleSnapEnabled,
-  onSelectGateElement,
+  onSelectPlacementElement,
   onSelectTool,
   onSetMobileToolsOpen,
   onSetMobileViewOpen,
@@ -702,12 +702,12 @@ export function EditorMobilePanels({
         >
           <ToolsControls
             activeTool={activeTool}
-            activeGateElementId={activeGateElementId}
+            activePlacementElementId={activePlacementElementId}
             canRedo={canRedo}
             canUndo={canUndo}
             tab={tab}
             onRedo={onRedo}
-            onSelectGateElement={onSelectGateElement}
+            onSelectPlacementElement={onSelectPlacementElement}
             onSelectTool={onSelectTool}
             onUndo={onUndo}
           />

--- a/src/components/editor/mobile/EditorMobilePanels.tsx
+++ b/src/components/editor/mobile/EditorMobilePanels.tsx
@@ -97,7 +97,10 @@ interface EditorMobilePanelsProps {
   onSetMobileGizmoEnabled: (enabled: boolean) => void;
   onSetMobileObstacleNumbersEnabled: (enabled: boolean) => void;
   onToggleSnapEnabled: () => void;
-  onSelectPlacementElement: (tool: EditorTool, entryId: TrackElementCatalogId) => void;
+  onSelectPlacementElement: (
+    tool: EditorTool,
+    entryId: TrackElementCatalogId
+  ) => void;
   onSelectTool: (tool: EditorTool) => void;
   onSetMobileToolsOpen: (open: boolean) => void;
   onSetMobileViewOpen: (open: boolean) => void;

--- a/src/components/editor/mobile/ToolsControls.tsx
+++ b/src/components/editor/mobile/ToolsControls.tsx
@@ -35,7 +35,10 @@ interface ToolsControlsProps {
   canUndo: boolean;
   tab: EditorViewportTab;
   onRedo: () => void;
-  onSelectPlacementElement: (tool: EditorTool, id: TrackElementCatalogId) => void;
+  onSelectPlacementElement: (
+    tool: EditorTool,
+    id: TrackElementCatalogId
+  ) => void;
   onSelectTool: (tool: EditorTool) => void;
   onUndo: () => void;
 }
@@ -89,7 +92,9 @@ export function ToolsControls({
           <div className="mb-2 space-y-2">
             {catalogToolIds.map((toolId) => {
               const entries =
-                catalogEntriesByTool[toolId as keyof typeof catalogEntriesByTool];
+                catalogEntriesByTool[
+                  toolId as keyof typeof catalogEntriesByTool
+                ];
               const toolEntry = mobileToolEntries.find((t) => t.id === toolId);
               const activeId =
                 activePlacementElementId[toolId] ?? defaultIdByTool[toolId];
@@ -127,7 +132,7 @@ export function ToolsControls({
                     <div className="min-w-0 flex-1">
                       <p
                         className={cn(
-                          "text-sm font-semibold leading-tight",
+                          "text-sm leading-tight font-semibold",
                           isActiveTool
                             ? "text-foreground"
                             : "text-foreground/75"
@@ -159,9 +164,14 @@ export function ToolsControls({
                           exit="hidden"
                           variants={{
                             hidden: {},
-                            visible: { transition: { staggerChildren: 0.045, delayChildren: 0.06 } },
+                            visible: {
+                              transition: {
+                                staggerChildren: 0.045,
+                                delayChildren: 0.06,
+                              },
+                            },
                           }}
-                          className="border-brand-primary/20 space-y-0.5 border-t px-2 pb-2 pt-1.5"
+                          className="border-brand-primary/20 space-y-0.5 border-t px-2 pt-1.5 pb-2"
                         >
                           {entries.map((entry) => {
                             const isActiveType = activeEntry?.id === entry.id;
@@ -171,7 +181,14 @@ export function ToolsControls({
                                 type="button"
                                 variants={{
                                   hidden: { opacity: 0, y: -6 },
-                                  visible: { opacity: 1, y: 0, transition: { duration: 0.18, ease: [0.16, 1, 0.3, 1] } },
+                                  visible: {
+                                    opacity: 1,
+                                    y: 0,
+                                    transition: {
+                                      duration: 0.18,
+                                      ease: [0.16, 1, 0.3, 1],
+                                    },
+                                  },
                                 }}
                                 onClick={() =>
                                   runAction(() =>
@@ -200,7 +217,7 @@ export function ToolsControls({
                                 <span className="min-w-0 flex-1">
                                   <span
                                     className={cn(
-                                      "block truncate text-[13px] font-semibold leading-tight",
+                                      "block truncate text-[13px] leading-tight font-semibold",
                                       isActiveType
                                         ? "text-foreground"
                                         : "text-foreground/80"
@@ -213,7 +230,7 @@ export function ToolsControls({
                                       {entry.dimensions.display.label}
                                     </span>
                                     {entry.official ? (
-                                      <span className="bg-brand-primary/12 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-semibold leading-none tracking-widest uppercase">
+                                      <span className="bg-brand-primary/12 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-widest uppercase">
                                         Official
                                       </span>
                                     ) : null}

--- a/src/components/editor/mobile/ToolsControls.tsx
+++ b/src/components/editor/mobile/ToolsControls.tsx
@@ -1,27 +1,41 @@
 "use client";
 
-import { useState } from "react";
-import { Check, ChevronDown, Redo2, Undo2 } from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Check, Redo2, Undo2 } from "lucide-react";
 import { mobileToolEntries } from "@/components/editor/tool-icons";
 import {
   getCatalogEntriesByKind,
+  TRACKDRAW_FLAG_ELEMENT_ID,
+  TRACKDRAW_GATE_ELEMENT_ID,
+  TRACKDRAW_LADDER_ELEMENT_ID,
   type TrackElementCatalogId,
 } from "@/lib/track/elements/catalog";
 import type { EditorTool } from "@/lib/editor-tools";
 import { cn } from "@/lib/utils";
 import type { EditorViewportTab } from "./Panels";
 
-const gateCatalogEntries = getCatalogEntriesByKind("gate");
-const mobileGateToolEntry = mobileToolEntries.find((t) => t.id === "gate");
+const catalogEntriesByTool = {
+  gate: getCatalogEntriesByKind("gate"),
+  flag: getCatalogEntriesByKind("flag"),
+  ladder: getCatalogEntriesByKind("ladder"),
+} as const;
+
+const defaultIdByTool: Partial<Record<EditorTool, TrackElementCatalogId>> = {
+  gate: TRACKDRAW_GATE_ELEMENT_ID,
+  flag: TRACKDRAW_FLAG_ELEMENT_ID,
+  ladder: TRACKDRAW_LADDER_ELEMENT_ID,
+};
+
+const catalogToolIds = Object.keys(catalogEntriesByTool) as EditorTool[];
 
 interface ToolsControlsProps {
   activeTool: EditorTool;
-  activeGateElementId: TrackElementCatalogId | null;
+  activePlacementElementId: Partial<Record<EditorTool, TrackElementCatalogId>>;
   canRedo: boolean;
   canUndo: boolean;
   tab: EditorViewportTab;
   onRedo: () => void;
-  onSelectGateElement: (id: TrackElementCatalogId) => void;
+  onSelectPlacementElement: (tool: EditorTool, id: TrackElementCatalogId) => void;
   onSelectTool: (tool: EditorTool) => void;
   onUndo: () => void;
 }
@@ -34,24 +48,18 @@ function runAction(action: () => void) {
 
 export function ToolsControls({
   activeTool,
-  activeGateElementId,
+  activePlacementElementId,
   canRedo,
   canUndo,
   tab,
   onRedo,
-  onSelectGateElement,
+  onSelectPlacementElement,
   onSelectTool,
   onUndo,
 }: ToolsControlsProps) {
-  const [gateTypesOpen, setGateTypesOpen] = useState(false);
-
-  const activeGateEntry =
-    gateCatalogEntries.find((e) => e.id === activeGateElementId) ??
-    gateCatalogEntries[0];
-
   return (
     <>
-      {/* Compact undo / redo — no section header */}
+      {/* Undo / redo */}
       <div className="grid grid-cols-2 gap-2">
         <button
           onClick={() => runAction(onUndo)}
@@ -77,99 +85,160 @@ export function ToolsControls({
             Tools
           </p>
 
-          {/* Gate — full-width card with inline type picker */}
-          <div className="border-border/50 bg-muted/14 mb-2 overflow-hidden rounded-2xl border">
-            <button
-              type="button"
-              onClick={() => runAction(() => onSelectTool("gate"))}
-              className={cn(
-                "flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-all",
-                activeTool === "gate"
-                  ? "bg-muted/55 text-foreground"
-                  : "text-muted-foreground hover:bg-muted/28 hover:text-foreground"
-              )}
-            >
-              <div className="flex min-w-0 items-center gap-3">
-                <span className="border-border/45 bg-background/50 flex size-10 shrink-0 items-center justify-center rounded-xl border">
-                  {mobileGateToolEntry?.icon}
-                </span>
-                <div className="min-w-0">
-                  <p className="text-sm font-medium">Gate</p>
-                  <p className="truncate pt-0.5 text-[11px] opacity-70">
-                    {activeGateEntry
-                      ? `${activeGateEntry.name} · ${activeGateEntry.dimensions.display.label}`
-                      : "Place a gate"}
-                  </p>
-                </div>
-              </div>
-              {activeGateEntry?.official ? (
-                <span className="bg-brand-primary/12 text-brand-primary shrink-0 rounded-md px-1.5 py-1 text-[9px] leading-none font-semibold tracking-[0.08em] uppercase">
-                  Official
-                </span>
-              ) : null}
-            </button>
-            <button
-              type="button"
-              onClick={() => setGateTypesOpen((c) => !c)}
-              className="border-border/25 text-muted-foreground hover:bg-muted/22 hover:text-foreground flex min-h-9 w-full items-center justify-between gap-2 border-t px-4 text-left text-[11px] font-medium transition-colors"
-              aria-expanded={gateTypesOpen}
-            >
-              <span>Change gate type</span>
-              <ChevronDown
-                className={cn(
-                  "size-3.5 transition-transform",
-                  gateTypesOpen && "rotate-180"
-                )}
-              />
-            </button>
-            {gateTypesOpen ? (
-              <div className="border-border/25 space-y-1 border-t p-1.5">
-                {gateCatalogEntries.map((entry) => {
-                  const active = activeGateEntry?.id === entry.id;
-                  return (
-                    <button
-                      key={entry.id}
-                      type="button"
-                      onClick={() =>
-                        runAction(() => onSelectGateElement(entry.id))
-                      }
+          {/* Catalog tools — active one auto-expands with type list */}
+          <div className="mb-2 space-y-2">
+            {catalogToolIds.map((toolId) => {
+              const entries =
+                catalogEntriesByTool[toolId as keyof typeof catalogEntriesByTool];
+              const toolEntry = mobileToolEntries.find((t) => t.id === toolId);
+              const activeId =
+                activePlacementElementId[toolId] ?? defaultIdByTool[toolId];
+              const activeEntry =
+                entries.find((e) => e.id === activeId) ?? entries[0];
+              const isActiveTool = activeTool === toolId;
+              const toolLabel = toolEntry?.label ?? toolId;
+
+              return (
+                <div
+                  key={toolId}
+                  className={cn(
+                    "overflow-hidden rounded-2xl border transition-all duration-200",
+                    isActiveTool
+                      ? "border-brand-primary/25 bg-brand-primary/5"
+                      : "border-border/50 bg-muted/14"
+                  )}
+                >
+                  {/* Tool header — always visible */}
+                  <button
+                    type="button"
+                    onClick={() => runAction(() => onSelectTool(toolId))}
+                    className="flex w-full items-center gap-3 px-4 py-3 text-left"
+                  >
+                    <span
                       className={cn(
-                        "flex min-h-11 w-full items-center gap-2 rounded-xl px-2.5 py-2 text-left transition-colors",
-                        active
-                          ? "bg-muted/60 text-foreground"
-                          : "text-muted-foreground hover:bg-muted/28 hover:text-foreground"
+                        "flex size-10 shrink-0 items-center justify-center rounded-xl border transition-all",
+                        isActiveTool
+                          ? "border-brand-primary/30 bg-brand-primary/10 text-brand-primary"
+                          : "border-border/45 bg-background/50 text-muted-foreground"
                       )}
                     >
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate text-[12px] font-medium">
-                          {entry.name}
-                        </span>
-                        <span className="mt-0.5 block truncate text-[10px] opacity-75">
-                          {entry.dimensions.display.label}
-                          {entry.official ? " · Official" : ""}
-                        </span>
-                      </span>
-                      <Check
+                      {toolEntry?.icon}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p
                         className={cn(
-                          "text-brand-primary size-3.5 shrink-0 transition-opacity",
-                          active ? "opacity-100" : "opacity-0"
+                          "text-sm font-semibold leading-tight",
+                          isActiveTool
+                            ? "text-foreground"
+                            : "text-foreground/75"
                         )}
-                      />
-                    </button>
-                  );
-                })}
-              </div>
-            ) : null}
+                      >
+                        {toolLabel}
+                      </p>
+                      <p className="text-muted-foreground/60 mt-0.5 truncate text-[11px]">
+                        {activeEntry?.name ?? "—"}
+                        {activeEntry?.official ? " · Official" : ""}
+                      </p>
+                    </div>
+                  </button>
+
+                  {/* Type list — only visible when this tool is active */}
+                  <AnimatePresence initial={false}>
+                    {isActiveTool && (
+                      <motion.div
+                        key="type-list"
+                        initial={{ height: 0 }}
+                        animate={{ height: "auto" }}
+                        exit={{ height: 0 }}
+                        transition={{ duration: 0.24, ease: [0.16, 1, 0.3, 1] }}
+                        className="overflow-hidden"
+                      >
+                        <motion.div
+                          initial="hidden"
+                          animate="visible"
+                          exit="hidden"
+                          variants={{
+                            hidden: {},
+                            visible: { transition: { staggerChildren: 0.045, delayChildren: 0.06 } },
+                          }}
+                          className="border-brand-primary/20 space-y-0.5 border-t px-2 pb-2 pt-1.5"
+                        >
+                          {entries.map((entry) => {
+                            const isActiveType = activeEntry?.id === entry.id;
+                            return (
+                              <motion.button
+                                key={entry.id}
+                                type="button"
+                                variants={{
+                                  hidden: { opacity: 0, y: -6 },
+                                  visible: { opacity: 1, y: 0, transition: { duration: 0.18, ease: [0.16, 1, 0.3, 1] } },
+                                }}
+                                onClick={() =>
+                                  runAction(() =>
+                                    onSelectPlacementElement(toolId, entry.id)
+                                  )
+                                }
+                                className={cn(
+                                  "flex min-h-11 w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors",
+                                  isActiveType
+                                    ? "bg-brand-primary/10 text-foreground"
+                                    : "text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+                                )}
+                              >
+                                <div
+                                  className={cn(
+                                    "size-4 shrink-0 rounded-full border-2 transition-all",
+                                    isActiveType
+                                      ? "border-brand-primary bg-brand-primary"
+                                      : "border-border/50"
+                                  )}
+                                >
+                                  {isActiveType && (
+                                    <Check className="text-background size-full p-0.5" />
+                                  )}
+                                </div>
+                                <span className="min-w-0 flex-1">
+                                  <span
+                                    className={cn(
+                                      "block truncate text-[13px] font-semibold leading-tight",
+                                      isActiveType
+                                        ? "text-foreground"
+                                        : "text-foreground/80"
+                                    )}
+                                  >
+                                    {entry.name}
+                                  </span>
+                                  <span className="text-muted-foreground/60 mt-0.5 flex items-center gap-1.5 text-[11px]">
+                                    <span className="truncate">
+                                      {entry.dimensions.display.label}
+                                    </span>
+                                    {entry.official ? (
+                                      <span className="bg-brand-primary/12 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-semibold leading-none tracking-widest uppercase">
+                                        Official
+                                      </span>
+                                    ) : null}
+                                  </span>
+                                </span>
+                              </motion.button>
+                            );
+                          })}
+                        </motion.div>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </div>
+              );
+            })}
           </div>
 
-          {/* Drawing tools grid — preset excluded */}
+          {/* Remaining tools — compact 3-col grid */}
           <div className="grid grid-cols-3 gap-2">
             {mobileToolEntries
               .filter(
                 (tool) =>
                   tool.id !== "grab" &&
-                  tool.id !== "gate" &&
-                  tool.id !== "preset"
+                  tool.id !== "preset" &&
+                  !catalogToolIds.includes(tool.id as EditorTool)
               )
               .map((tool) => {
                 const active = activeTool === tool.id;
@@ -180,7 +249,7 @@ export function ToolsControls({
                     className={cn(
                       "flex flex-col items-center gap-1.5 rounded-2xl border px-2 py-3 transition-all",
                       active
-                        ? "border-border/80 bg-muted/55 text-foreground"
+                        ? "border-brand-primary/25 bg-brand-primary/8 text-brand-primary"
                         : "border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground"
                     )}
                   >

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -11,10 +11,16 @@ import {
   getCatalogEntriesByKind,
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
+  TRACKDRAW_FLAG_ELEMENT_ID,
   TRACKDRAW_GATE_ELEMENT_ID,
+  TRACKDRAW_LADDER_ELEMENT_ID,
   type TrackElementCatalogId,
 } from "@/lib/track/elements/catalog";
-import { buildGateCatalogTypePatch } from "@/lib/editor-tools";
+import {
+  buildFlagCatalogTypePatch,
+  buildGateCatalogTypePatch,
+  buildLadderCatalogTypePatch,
+} from "@/lib/editor-tools";
 import {
   getShapeTimingMarker,
   getTimingMarkerMeta,
@@ -143,6 +149,33 @@ export function SingleInspectorView({
     typeof catalogEntry.dimensions.heightMeters === "number";
   const hasFixedCatalogDimensions =
     hasCatalogGateDimensions && catalogEntry.editable?.dimensions === false;
+
+  const selectedFlagShape = shape.kind === "flag" ? shape : null;
+  const flagCatalogEntries = selectedFlagShape
+    ? getCatalogEntriesByKind("flag")
+    : null;
+  const activeFlagEntryId: TrackElementCatalogId =
+    catalogEntry?.kind === "flag"
+      ? (catalogIdentity!.elementId as TrackElementCatalogId)
+      : TRACKDRAW_FLAG_ELEMENT_ID;
+  const hasFixedFlagDimensions =
+    selectedFlagShape &&
+    catalogEntry?.kind === "flag" &&
+    catalogEntry.editable?.dimensions === false;
+
+  const selectedLadderShape = shape.kind === "ladder" ? shape : null;
+  const ladderCatalogEntries = selectedLadderShape
+    ? getCatalogEntriesByKind("ladder")
+    : null;
+  const activeLadderEntryId: TrackElementCatalogId =
+    catalogEntry?.kind === "ladder"
+      ? (catalogIdentity!.elementId as TrackElementCatalogId)
+      : TRACKDRAW_LADDER_ELEMENT_ID;
+  const hasFixedLadderDimensions =
+    selectedLadderShape &&
+    catalogEntry?.kind === "ladder" &&
+    catalogEntry.editable?.dimensions === false;
+
   const hasFixedCatalogColor =
     catalogIdentity !== null && catalogEntry?.editable?.color === false;
   const canSetTimingMarker = isTimingMarkerShape(shape);
@@ -317,6 +350,122 @@ export function SingleInspectorView({
                   </SelectTrigger>
                   <SelectContent>
                     {gateCatalogEntries.map((entry) => (
+                      <SelectItem
+                        key={entry.id}
+                        value={entry.id}
+                        className="text-xs lg:text-[11px]"
+                      >
+                        {entry.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Row>
+              {catalogIdentity?.snapshot.organization ? (
+                <Row label="Source">
+                  {catalogEntry?.sources?.[0]?.url ? (
+                    <a
+                      href={catalogEntry.sources[0].url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-foreground hover:text-foreground/70 text-[12px] underline underline-offset-2 transition-colors"
+                    >
+                      {catalogIdentity.snapshot.organization}
+                    </a>
+                  ) : (
+                    <span className="text-foreground text-[12px]">
+                      {catalogIdentity.snapshot.organization}
+                    </span>
+                  )}
+                </Row>
+              ) : null}
+              {catalogIdentity ? (
+                <Row label="Official size">
+                  <span className="text-foreground text-[12px]">
+                    {catalogIdentity.snapshot.dimensionsLabel}
+                  </span>
+                </Row>
+              ) : null}
+            </Section>
+          ) : null}
+          {flagCatalogEntries ? (
+            <Section title="Catalog" defaultOpen>
+              <Row label="Type">
+                <Select
+                  value={activeFlagEntryId}
+                  disabled={shape.locked}
+                  onValueChange={(value) => {
+                    const patch = buildFlagCatalogTypePatch(
+                      selectedFlagShape!,
+                      value as TrackElementCatalogId
+                    );
+                    if (patch)
+                      updateShape(shape.id, patch as Partial<typeof shape>);
+                  }}
+                >
+                  <SelectTrigger className="border-border/40 bg-muted/40 h-9 w-full text-xs shadow-none lg:h-7 lg:text-[11px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {flagCatalogEntries.map((entry) => (
+                      <SelectItem
+                        key={entry.id}
+                        value={entry.id}
+                        className="text-xs lg:text-[11px]"
+                      >
+                        {entry.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Row>
+              {catalogIdentity?.snapshot.organization ? (
+                <Row label="Source">
+                  {catalogEntry?.sources?.[0]?.url ? (
+                    <a
+                      href={catalogEntry.sources[0].url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-foreground hover:text-foreground/70 text-[12px] underline underline-offset-2 transition-colors"
+                    >
+                      {catalogIdentity.snapshot.organization}
+                    </a>
+                  ) : (
+                    <span className="text-foreground text-[12px]">
+                      {catalogIdentity.snapshot.organization}
+                    </span>
+                  )}
+                </Row>
+              ) : null}
+              {catalogIdentity ? (
+                <Row label="Official size">
+                  <span className="text-foreground text-[12px]">
+                    {catalogIdentity.snapshot.dimensionsLabel}
+                  </span>
+                </Row>
+              ) : null}
+            </Section>
+          ) : null}
+          {ladderCatalogEntries ? (
+            <Section title="Catalog" defaultOpen>
+              <Row label="Type">
+                <Select
+                  value={activeLadderEntryId}
+                  disabled={shape.locked}
+                  onValueChange={(value) => {
+                    const patch = buildLadderCatalogTypePatch(
+                      selectedLadderShape!,
+                      value as TrackElementCatalogId
+                    );
+                    if (patch)
+                      updateShape(shape.id, patch as Partial<typeof shape>);
+                  }}
+                >
+                  <SelectTrigger className="border-border/40 bg-muted/40 h-9 w-full text-xs shadow-none lg:h-7 lg:text-[11px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ladderCatalogEntries.map((entry) => (
                       <SelectItem
                         key={entry.id}
                         value={entry.id}
@@ -548,7 +697,7 @@ export function SingleInspectorView({
                 ) : null}
               </>
             )}
-            {shape.kind === "flag" && (
+            {shape.kind === "flag" && !hasFixedFlagDimensions && (
               <>
                 <Row label="Radius">
                   <MeasurementNum
@@ -606,26 +755,30 @@ export function SingleInspectorView({
             )}
             {shape.kind === "ladder" && (
               <>
-                <Row label="Width">
-                  <MeasurementNum
-                    valueMeters={shape.width}
-                    unitSystem={unitSystem}
-                    onChange={(value) =>
-                      updateShape(shape.id, { width: value })
-                    }
-                    minMeters={0.5}
-                  />
-                </Row>
-                <Row label="Height">
-                  <MeasurementNum
-                    valueMeters={shape.height}
-                    unitSystem={unitSystem}
-                    onChange={(value) =>
-                      updateShape(shape.id, { height: value })
-                    }
-                    minMeters={0.5}
-                  />
-                </Row>
+                {!hasFixedLadderDimensions && (
+                  <>
+                    <Row label="Width">
+                      <MeasurementNum
+                        valueMeters={shape.width}
+                        unitSystem={unitSystem}
+                        onChange={(value) =>
+                          updateShape(shape.id, { width: value })
+                        }
+                        minMeters={0.5}
+                      />
+                    </Row>
+                    <Row label="Height">
+                      <MeasurementNum
+                        valueMeters={shape.height}
+                        unitSystem={unitSystem}
+                        onChange={(value) =>
+                          updateShape(shape.id, { height: value })
+                        }
+                        minMeters={0.5}
+                      />
+                    </Row>
+                  </>
+                )}
                 <Row label="Elevation">
                   <MeasurementNum
                     valueMeters={shape.elevation ?? 0}
@@ -719,7 +872,7 @@ export function SingleInspectorView({
             </Section>
           )}
 
-          {shape.kind === "ladder" && (
+          {shape.kind === "ladder" && !hasFixedLadderDimensions && (
             <Section title="Ladder" defaultOpen={secondarySectionDefaultOpen}>
               <Row label="Gates">
                 <Num

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -661,7 +661,7 @@ export function SingleInspectorView({
               <>
                 {!hasFixedCatalogDimensions ? (
                   <>
-                    <Row label="Width">
+                    <Row label={`Width (${unitLabel})`}>
                       <MeasurementNum
                         valueMeters={shape.width}
                         unitSystem={unitSystem}
@@ -671,7 +671,7 @@ export function SingleInspectorView({
                         minMeters={0.5}
                       />
                     </Row>
-                    <Row label="Height">
+                    <Row label={`Height (${unitLabel})`}>
                       <MeasurementNum
                         valueMeters={shape.height}
                         unitSystem={unitSystem}
@@ -684,7 +684,7 @@ export function SingleInspectorView({
                   </>
                 ) : null}
                 {!hasFixedCatalogDimensions ? (
-                  <Row label="Thickness">
+                  <Row label={`Thickness (${unitLabel})`}>
                     <MeasurementNum
                       valueMeters={shape.thick ?? 0.2}
                       unitSystem={unitSystem}
@@ -699,7 +699,7 @@ export function SingleInspectorView({
             )}
             {shape.kind === "flag" && !hasFixedFlagDimensions && (
               <>
-                <Row label="Radius">
+                <Row label={`Radius (${unitLabel})`}>
                   <MeasurementNum
                     valueMeters={shape.radius}
                     unitSystem={unitSystem}
@@ -709,7 +709,7 @@ export function SingleInspectorView({
                     minMeters={0.05}
                   />
                 </Row>
-                <Row label="Pole height">
+                <Row label={`Pole height (${unitLabel})`}>
                   <MeasurementNum
                     valueMeters={shape.poleHeight ?? 3.5}
                     unitSystem={unitSystem}
@@ -722,7 +722,7 @@ export function SingleInspectorView({
               </>
             )}
             {shape.kind === "cone" && (
-              <Row label="Radius">
+              <Row label={`Radius (${unitLabel})`}>
                 <MeasurementNum
                   valueMeters={shape.radius}
                   unitSystem={unitSystem}
@@ -744,7 +744,7 @@ export function SingleInspectorView({
               </Row>
             )}
             {shape.kind === "startfinish" && (
-              <Row label="Width">
+              <Row label={`Width (${unitLabel})`}>
                 <MeasurementNum
                   valueMeters={shape.width}
                   unitSystem={unitSystem}
@@ -757,7 +757,7 @@ export function SingleInspectorView({
               <>
                 {!hasFixedLadderDimensions && (
                   <>
-                    <Row label="Width">
+                    <Row label={`Width (${unitLabel})`}>
                       <MeasurementNum
                         valueMeters={shape.width}
                         unitSystem={unitSystem}
@@ -767,7 +767,7 @@ export function SingleInspectorView({
                         minMeters={0.5}
                       />
                     </Row>
-                    <Row label="Height">
+                    <Row label={`Height (${unitLabel})`}>
                       <MeasurementNum
                         valueMeters={shape.height}
                         unitSystem={unitSystem}
@@ -777,25 +777,25 @@ export function SingleInspectorView({
                         minMeters={0.5}
                       />
                     </Row>
+                    <Row label={`Elevation (${unitLabel})`}>
+                      <MeasurementNum
+                        valueMeters={shape.elevation ?? 0}
+                        unitSystem={unitSystem}
+                        onChange={(value) =>
+                          updateShape(shape.id, {
+                            elevation: Math.max(0, value),
+                          })
+                        }
+                        minMeters={0}
+                      />
+                    </Row>
                   </>
                 )}
-                <Row label="Elevation">
-                  <MeasurementNum
-                    valueMeters={shape.elevation ?? 0}
-                    unitSystem={unitSystem}
-                    onChange={(value) =>
-                      updateShape(shape.id, {
-                        elevation: Math.max(0, value),
-                      })
-                    }
-                    minMeters={0}
-                  />
-                </Row>
               </>
             )}
             {shape.kind === "divegate" && (
               <>
-                <Row label="Size">
+                <Row label={`Size (${unitLabel})`}>
                   <MeasurementNum
                     valueMeters={shape.size}
                     unitSystem={unitSystem}
@@ -803,7 +803,7 @@ export function SingleInspectorView({
                     minMeters={0.5}
                   />
                 </Row>
-                <Row label="Elevation">
+                <Row label={`Elevation (${unitLabel})`}>
                   <MeasurementNum
                     valueMeters={shape.elevation ?? 3}
                     unitSystem={unitSystem}
@@ -813,7 +813,7 @@ export function SingleInspectorView({
                     minMeters={0.1}
                   />
                 </Row>
-                <Row label="Thickness">
+                <Row label={`Thickness (${unitLabel})`}>
                   <MeasurementNum
                     valueMeters={shape.thick ?? 0.2}
                     unitSystem={unitSystem}
@@ -898,7 +898,7 @@ export function SingleInspectorView({
               title="Race Line"
               defaultOpen={secondarySectionDefaultOpen}
             >
-              <Row label="Stroke width">
+              <Row label={`Stroke width (${unitLabel})`}>
                 <MeasurementNum
                   valueMeters={shape.strokeWidth ?? 0.26}
                   unitSystem={unitSystem}
@@ -943,7 +943,7 @@ export function SingleInspectorView({
                 </Row>
               )}
               {shape.showArrows && (
-                <Row label="Arrow spacing">
+                <Row label={`Arrow spacing (${unitLabel})`}>
                   <MeasurementNum
                     valueMeters={shape.arrowSpacing ?? 15}
                     unitSystem={unitSystem}

--- a/src/lib/editor-tools.ts
+++ b/src/lib/editor-tools.ts
@@ -10,8 +10,9 @@ import {
   TRACKDRAW_LADDER_ELEMENT_ID,
   TRACKDRAW_START_FINISH_ELEMENT_ID,
   type TrackElementCatalogId,
+  type TrackElementCatalogEntry,
 } from "@/lib/track/elements/catalog";
-import type { GateShape, ShapeDraft, ShapeKind } from "@/lib/types";
+import type { FlagShape, GateShape, LadderShape, ShapeDraft, ShapeKind } from "@/lib/types";
 
 export type EditorTool =
   | "select"
@@ -78,18 +79,23 @@ const toolCatalogEntryIds: Partial<Record<EditorTool, TrackElementCatalogId>> =
 export function createShapeForTool(
   tool: EditorTool,
   point: { x: number; y: number },
-  options: { gateElementId?: TrackElementCatalogId | null } = {}
+  options: {
+    activePlacementElementId?: Partial<Record<EditorTool, TrackElementCatalogId>>;
+  } = {}
 ): ShapeDraft | null {
   const entryId =
-    tool === "gate"
-      ? options.gateElementId || TRACKDRAW_GATE_ELEMENT_ID
-      : toolCatalogEntryIds[tool];
+    options.activePlacementElementId?.[tool] ?? toolCatalogEntryIds[tool];
   if (!entryId) return null;
 
   const entry = getTrackElementCatalogEntry(entryId);
+  const defaultForTool = toolCatalogEntryIds[tool];
+  const defaultEntry = defaultForTool
+    ? getTrackElementCatalogEntry(defaultForTool)
+    : null;
+  // Safety: if the entry's kind doesn't match the tool's expected kind, fall back
   const resolvedEntryId =
-    tool === "gate" && entry?.kind !== "gate"
-      ? TRACKDRAW_GATE_ELEMENT_ID
+    defaultEntry && entry?.kind !== defaultEntry.kind
+      ? (defaultForTool ?? entryId)
       : entryId;
   const resolvedEntry = getTrackElementCatalogEntry(resolvedEntryId);
 
@@ -100,14 +106,11 @@ export function createShapeForTool(
   });
 }
 
-export function buildGateCatalogTypePatch(
-  shape: GateShape,
-  targetEntryId: TrackElementCatalogId
-): Partial<GateShape> | null {
-  const entry = getTrackElementCatalogEntry(targetEntryId);
-  if (!entry || entry.kind !== "gate") return null;
-
-  const draft = createCatalogShapeDraft(targetEntryId, {
+function buildCatalogTypePatchInner<S extends GateShape | FlagShape | LadderShape>(
+  shape: S,
+  entry: TrackElementCatalogEntry
+): Partial<S> {
+  const draft = createCatalogShapeDraft(entry.id, {
     x: shape.x,
     y: shape.y,
     rotation: shape.rotation,
@@ -128,5 +131,32 @@ export function buildGateCatalogTypePatch(
       ? { ...strippedMeta, catalog: newCatalogIdentity }
       : undefined;
 
-  return { ...draft, meta: newMeta } as Partial<GateShape>;
+  return { ...draft, meta: newMeta } as unknown as Partial<S>;
+}
+
+export function buildGateCatalogTypePatch(
+  shape: GateShape,
+  targetEntryId: TrackElementCatalogId
+): Partial<GateShape> | null {
+  const entry = getTrackElementCatalogEntry(targetEntryId);
+  if (!entry || entry.kind !== "gate") return null;
+  return buildCatalogTypePatchInner(shape, entry);
+}
+
+export function buildFlagCatalogTypePatch(
+  shape: FlagShape,
+  targetEntryId: TrackElementCatalogId
+): Partial<FlagShape> | null {
+  const entry = getTrackElementCatalogEntry(targetEntryId);
+  if (!entry || entry.kind !== "flag") return null;
+  return buildCatalogTypePatchInner(shape, entry);
+}
+
+export function buildLadderCatalogTypePatch(
+  shape: LadderShape,
+  targetEntryId: TrackElementCatalogId
+): Partial<LadderShape> | null {
+  const entry = getTrackElementCatalogEntry(targetEntryId);
+  if (!entry || entry.kind !== "ladder") return null;
+  return buildCatalogTypePatchInner(shape, entry);
 }

--- a/src/lib/editor-tools.ts
+++ b/src/lib/editor-tools.ts
@@ -12,7 +12,13 @@ import {
   type TrackElementCatalogId,
   type TrackElementCatalogEntry,
 } from "@/lib/track/elements/catalog";
-import type { FlagShape, GateShape, LadderShape, ShapeDraft, ShapeKind } from "@/lib/types";
+import type {
+  FlagShape,
+  GateShape,
+  LadderShape,
+  ShapeDraft,
+  ShapeKind,
+} from "@/lib/types";
 
 export type EditorTool =
   | "select"
@@ -80,7 +86,9 @@ export function createShapeForTool(
   tool: EditorTool,
   point: { x: number; y: number },
   options: {
-    activePlacementElementId?: Partial<Record<EditorTool, TrackElementCatalogId>>;
+    activePlacementElementId?: Partial<
+      Record<EditorTool, TrackElementCatalogId>
+    >;
   } = {}
 ): ShapeDraft | null {
   const entryId =
@@ -106,10 +114,9 @@ export function createShapeForTool(
   });
 }
 
-function buildCatalogTypePatchInner<S extends GateShape | FlagShape | LadderShape>(
-  shape: S,
-  entry: TrackElementCatalogEntry
-): Partial<S> {
+function buildCatalogTypePatchInner<
+  S extends GateShape | FlagShape | LadderShape,
+>(shape: S, entry: TrackElementCatalogEntry): Partial<S> {
   const draft = createCatalogShapeDraft(entry.id, {
     x: shape.x,
     y: shape.y,

--- a/src/lib/editor/store-state.ts
+++ b/src/lib/editor/store-state.ts
@@ -58,8 +58,9 @@ export function resetEditorUiState(
 ): EditorUiState {
   return createDefaultEditorUiState({
     activePresetId: options.activePresetId ?? current.activePresetId,
-    activePlacementElementId:
-      options.activePlacementElementId ?? { ...current.activePlacementElementId },
+    activePlacementElementId: options.activePlacementElementId ?? {
+      ...current.activePlacementElementId,
+    },
     zoom: options.zoom ?? current.zoom,
     panOffset: options.panOffset ?? current.panOffset,
   });

--- a/src/lib/editor/store-state.ts
+++ b/src/lib/editor/store-state.ts
@@ -1,8 +1,9 @@
 import { DEFAULT_LAYOUT_PRESET_ID } from "@/lib/planning/layout-presets";
 import { createDefaultDesign } from "@/lib/track/design";
 import {
+  TRACKDRAW_FLAG_ELEMENT_ID,
   TRACKDRAW_GATE_ELEMENT_ID,
-  type TrackElementCatalogId,
+  TRACKDRAW_LADDER_ELEMENT_ID,
 } from "@/lib/track/elements/catalog";
 import type {
   EditorSessionState,
@@ -12,7 +13,7 @@ import type {
 
 interface EditorUiResetOptions {
   activePresetId?: string | null;
-  activeGateElementId?: TrackElementCatalogId | null;
+  activePlacementElementId?: EditorUiState["activePlacementElementId"];
   zoom?: number;
   panOffset?: { x: number; y: number };
 }
@@ -29,8 +30,11 @@ export function createDefaultEditorUiState(
   return {
     activeTool: "select",
     activePresetId: options.activePresetId ?? DEFAULT_LAYOUT_PRESET_ID,
-    activeGateElementId:
-      options.activeGateElementId ?? TRACKDRAW_GATE_ELEMENT_ID,
+    activePlacementElementId: options.activePlacementElementId ?? {
+      gate: TRACKDRAW_GATE_ELEMENT_ID,
+      flag: TRACKDRAW_FLAG_ELEMENT_ID,
+      ladder: TRACKDRAW_LADDER_ELEMENT_ID,
+    },
     snapEnabled: true,
     zoom: options.zoom ?? 1,
     panOffset: options.panOffset ?? { x: 0, y: 0 },
@@ -54,8 +58,8 @@ export function resetEditorUiState(
 ): EditorUiState {
   return createDefaultEditorUiState({
     activePresetId: options.activePresetId ?? current.activePresetId,
-    activeGateElementId:
-      options.activeGateElementId ?? current.activeGateElementId,
+    activePlacementElementId:
+      options.activePlacementElementId ?? { ...current.activePlacementElementId },
     zoom: options.zoom ?? current.zoom,
     panOffset: options.panOffset ?? current.panOffset,
   });

--- a/src/lib/editor/store-types.ts
+++ b/src/lib/editor/store-types.ts
@@ -18,7 +18,7 @@ export interface EditorTrackState {
 export interface EditorUiState {
   activeTool: EditorTool;
   activePresetId: string | null;
-  activeGateElementId: TrackElementCatalogId | null;
+  activePlacementElementId: Partial<Record<EditorTool, TrackElementCatalogId>>;
   snapEnabled: boolean;
   zoom: number;
   panOffset: { x: number; y: number };
@@ -125,7 +125,7 @@ export interface EditorSessionActions {
 export interface EditorUiActions {
   setActiveTool: (tool: EditorTool) => void;
   setActivePresetId: (presetId: string | null) => void;
-  setActiveGateElementId: (entryId: TrackElementCatalogId | null) => void;
+  setActivePlacementElementId: (tool: EditorTool, entryId: TrackElementCatalogId | null) => void;
   setSnapEnabled: (enabled: boolean) => void;
   toggleSnapEnabled: () => void;
   setZoom: (zoom: number) => void;
@@ -247,7 +247,7 @@ export const editorStateOwnership = {
   ui: [
     "activeTool",
     "activePresetId",
-    "activeGateElementId",
+    "activePlacementElementId",
     "snapEnabled",
     "zoom",
     "panOffset",
@@ -306,7 +306,7 @@ export const editorActionOwnership = {
   ui: [
     "setActiveTool",
     "setActivePresetId",
-    "setActiveGateElementId",
+    "setActivePlacementElementId",
     "setSnapEnabled",
     "toggleSnapEnabled",
     "setZoom",

--- a/src/lib/editor/store-types.ts
+++ b/src/lib/editor/store-types.ts
@@ -125,7 +125,10 @@ export interface EditorSessionActions {
 export interface EditorUiActions {
   setActiveTool: (tool: EditorTool) => void;
   setActivePresetId: (presetId: string | null) => void;
-  setActivePlacementElementId: (tool: EditorTool, entryId: TrackElementCatalogId | null) => void;
+  setActivePlacementElementId: (
+    tool: EditorTool,
+    entryId: TrackElementCatalogId | null
+  ) => void;
   setSnapEnabled: (enabled: boolean) => void;
   toggleSnapEnabled: () => void;
   setZoom: (zoom: number) => void;

--- a/src/lib/track/design.ts
+++ b/src/lib/track/design.ts
@@ -144,20 +144,42 @@ export function serializeDesignForShare(
   return serializeDesign(design, { includeMapReference: false });
 }
 
+function migrateV1ShapeRotations(
+  shapeById: Record<string, Shape>
+): Record<string, Shape> {
+  const result: Record<string, Shape> = {};
+  for (const [id, shape] of Object.entries(shapeById)) {
+    if (shape.kind === "gate" || shape.kind === "ladder") {
+      result[id] = {
+        ...shape,
+        rotation: ((shape.rotation ?? 0) - 180 + 360) % 360,
+      };
+    } else {
+      result[id] = shape;
+    }
+  }
+  return result;
+}
+
 export function normalizeDesign(
   design: TrackDesign | SerializedTrackDesign
 ): TrackDesign {
+  const inputVersion = (design as { version?: number }).version;
   const { shapeById, shapeOrder } = normalizeShapes(getRawDesignShapes(design));
+  const migratedShapeById =
+    inputVersion === 1 || inputVersion === undefined
+      ? migrateV1ShapeRotations(shapeById)
+      : shapeById;
   return {
     ...design,
-    version: 1,
+    version: 2,
     inventory: normalizeInventoryProfile(
       (design as Partial<TrackDesign>).inventory
     ),
     mapReference: normalizeMapReference(
       (design as Partial<TrackDesign>).mapReference
     ),
-    shapeById,
+    shapeById: migratedShapeById,
     shapeOrder,
   };
 }
@@ -166,7 +188,7 @@ export function createDefaultDesign(): TrackDesign {
   const timestamp = nowIso();
   return {
     id: nanoid(),
-    version: 1,
+    version: 2,
     title: "New Track",
     description: "",
     tags: [],

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -205,7 +205,7 @@ const frameOnlyGateDefaults = {
   kind: "gate",
   x: 0,
   y: 0,
-  rotation: 180,
+  rotation: 0,
   width: 2,
   height: 2,
   thick: 0.2,

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -110,9 +110,9 @@ export interface CornerMarkerFlagVisualSpec {
 
 export type FlagVisualSpec = CornerMarkerFlagVisualSpec;
 
-export interface PanelRunsLadderVisualSpec {
+export interface PanelFrameLadderVisualSpec {
   kind: "ladder";
-  variant: "panel-rungs";
+  variant: "panel-frame";
   panels: {
     left: GatePanelVisualSpec;
     right: GatePanelVisualSpec;
@@ -122,7 +122,7 @@ export interface PanelRunsLadderVisualSpec {
   branding: GateBrandingVisualSpec;
 }
 
-export type LadderVisualSpec = PanelRunsLadderVisualSpec;
+export type LadderVisualSpec = PanelFrameLadderVisualSpec;
 export type TrackElementVisualSpec =
   | GateVisualSpec
   | FlagVisualSpec
@@ -526,7 +526,7 @@ export const trackElementCatalog = [
     render3d: { modelHint: "ladder-gate" },
     visual: {
       kind: "ladder",
-      variant: "panel-rungs",
+      variant: "panel-frame",
       panels: {
         left: { widthMeters: feetToMeters(1), color: "#f8fafc" },
         right: { widthMeters: feetToMeters(1), color: "#f8fafc" },
@@ -585,7 +585,7 @@ export const trackElementCatalog = [
     render3d: { modelHint: "ladder-gate" },
     visual: {
       kind: "ladder",
-      variant: "panel-rungs",
+      variant: "panel-frame",
       panels: {
         left: { widthMeters: feetToMeters(1), color: "#f8fafc" },
         right: { widthMeters: feetToMeters(1), color: "#f8fafc" },

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -9,9 +9,15 @@ export const TRACKDRAW_START_FINISH_ELEMENT_ID =
   "trackdraw-generic-start-finish";
 export const TRACKDRAW_LADDER_ELEMENT_ID = "trackdraw-generic-ladder";
 export const TRACKDRAW_DIVE_GATE_ELEMENT_ID = "trackdraw-generic-dive-gate";
+
 export const MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID = "multigp-standard-gate-5x5";
 export const MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID =
   "multigp-championship-gate-7x6";
+export const MULTIGP_CORNER_FLAG_ELEMENT_ID = "multigp-corner-flag";
+export const MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID =
+  "multigp-standard-ladder-5x5";
+export const MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID =
+  "multigp-championship-ladder-7x6";
 
 export type TrackElementCatalogId =
   | typeof TRACKDRAW_GATE_ELEMENT_ID
@@ -22,7 +28,10 @@ export type TrackElementCatalogId =
   | typeof TRACKDRAW_LADDER_ELEMENT_ID
   | typeof TRACKDRAW_DIVE_GATE_ELEMENT_ID
   | typeof MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
-  | typeof MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID;
+  | typeof MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID
+  | typeof MULTIGP_CORNER_FLAG_ELEMENT_ID
+  | typeof MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID
+  | typeof MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID;
 
 type PlaceableCatalogShape = Exclude<Shape, PolylineShape>;
 export type TrackElementShapeDraft = ShapeDraft<PlaceableCatalogShape>;
@@ -90,7 +99,17 @@ export interface PanelFrameGateVisualSpec {
 }
 
 export type GateVisualSpec = FrameOnlyGateVisualSpec | PanelFrameGateVisualSpec;
-export type TrackElementVisualSpec = GateVisualSpec;
+
+export interface CornerMarkerFlagVisualSpec {
+  kind: "flag";
+  variant: "corner-marker";
+  poleColor: string;
+  panelUpperColor: string;
+  panelLowerColor: string;
+}
+
+export type FlagVisualSpec = CornerMarkerFlagVisualSpec;
+export type TrackElementVisualSpec = GateVisualSpec | FlagVisualSpec;
 
 export interface TrackElementCatalogEntry {
   id: TrackElementCatalogId;
@@ -328,6 +347,42 @@ export const trackElementCatalog = [
     exportHints: { simulatorFriendly: true },
   },
   {
+    id: MULTIGP_CORNER_FLAG_ELEMENT_ID,
+    name: "MultiGP Corner Flag",
+    organization: "MultiGP",
+    kind: "flag",
+    official: true,
+    editable: { color: false, dimensions: false },
+    dimensions: {
+      radiusMeters: 0.2,
+      heightMeters: feetToMeters(10),
+      display: { unitSystem: "imperial", label: "10 ft" },
+    },
+    defaultShape: {
+      ...flagDefaults,
+      radius: 0.2,
+      poleHeight: feetToMeters(10),
+      color: "#b91c1c",
+    } satisfies TrackElementShapeDraft,
+    tags: ["race", "practice", "multigp", "marker"],
+    sources: [
+      {
+        label: "MultiGP Drone Racing Flag",
+        url: "https://shop.multigp.com/product/drone-racing-flag-fabric/",
+      },
+    ],
+    render2d: { icon: "flag" },
+    render3d: { modelHint: "flag-pole" },
+    visual: {
+      kind: "flag",
+      variant: "corner-marker",
+      poleColor: "#1c1c1c",
+      panelUpperColor: "#f8fafc",
+      panelLowerColor: "#7f1d1d",
+    } satisfies FlagVisualSpec,
+    exportHints: { simulatorFriendly: true },
+  },
+  {
     id: TRACKDRAW_CONE_ELEMENT_ID,
     name: "TrackDraw Cone",
     organization: "TrackDraw",
@@ -413,6 +468,74 @@ export const trackElementCatalog = [
       color: "#14b8a6",
     },
     tags: ["technical", "practice"],
+    render2d: { icon: "ladder" },
+    render3d: { modelHint: "ladder-gate" },
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID,
+    name: "MultiGP Standard Ladder 5x5",
+    organization: "MultiGP",
+    kind: "ladder",
+    official: true,
+    editable: { color: false, dimensions: false },
+    dimensions: {
+      widthMeters: feetToMeters(5),
+      heightMeters: feetToMeters(5) * 3,
+      display: { unitSystem: "imperial", label: "5 ft wide, 3 × 5 ft rungs" },
+    },
+    defaultShape: {
+      kind: "ladder",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: feetToMeters(5),
+      height: feetToMeters(5) * 3,
+      rungs: 3,
+      elevation: 0,
+      color: "#f8fafc",
+    } satisfies TrackElementShapeDraft,
+    tags: ["race", "technical", "multigp"],
+    sources: [
+      {
+        label: "MultiGP Drone Race Course Obstacles",
+        url: "https://www.multigp.com/multigp-drone-race-course-obstacles/",
+      },
+    ],
+    render2d: { icon: "ladder" },
+    render3d: { modelHint: "ladder-gate" },
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID,
+    name: "MultiGP Championship Ladder 7x6",
+    organization: "MultiGP",
+    kind: "ladder",
+    official: true,
+    editable: { color: false, dimensions: false },
+    dimensions: {
+      widthMeters: feetToMeters(7),
+      heightMeters: feetToMeters(6) * 3,
+      display: { unitSystem: "imperial", label: "7 ft wide, 3 × 6 ft rungs" },
+    },
+    defaultShape: {
+      kind: "ladder",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: feetToMeters(7),
+      height: feetToMeters(6) * 3,
+      rungs: 3,
+      elevation: 0,
+      color: "#f8fafc",
+    } satisfies TrackElementShapeDraft,
+    tags: ["championship", "race", "technical", "multigp"],
+    sources: [
+      {
+        label: "MultiGP Drone Race Course Obstacles",
+        url: "https://www.multigp.com/multigp-drone-race-course-obstacles/",
+      },
+    ],
     render2d: { icon: "ladder" },
     render3d: { modelHint: "ladder-gate" },
     exportHints: { simulatorFriendly: true },

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -123,7 +123,10 @@ export interface PanelRunsLadderVisualSpec {
 }
 
 export type LadderVisualSpec = PanelRunsLadderVisualSpec;
-export type TrackElementVisualSpec = GateVisualSpec | FlagVisualSpec | LadderVisualSpec;
+export type TrackElementVisualSpec =
+  | GateVisualSpec
+  | FlagVisualSpec
+  | LadderVisualSpec;
 
 export interface TrackElementCatalogEntry {
   id: TrackElementCatalogId;
@@ -496,7 +499,10 @@ export const trackElementCatalog = [
     dimensions: {
       widthMeters: feetToMeters(5),
       heightMeters: feetToMeters(5) * 3,
-      display: { unitSystem: "imperial", label: "5 ft wide, 3 × 5 ft sections" },
+      display: {
+        unitSystem: "imperial",
+        label: "5 ft wide, 3 × 5 ft sections",
+      },
     },
     defaultShape: {
       kind: "ladder",
@@ -526,8 +532,19 @@ export const trackElementCatalog = [
         right: { widthMeters: feetToMeters(1), color: "#f8fafc" },
         top: { heightMeters: feetToMeters(1), color: "#202e5d" },
       },
-      frame: { placement: "outer", material: "pvc", color: "#f8fafc", diameterMeters: 0.055 },
-      branding: { label: "MULTIGP", markColor: "#f8fafc", accentColor: "#dc2626", checkerColor: "#111827", style: "multigp" },
+      frame: {
+        placement: "outer",
+        material: "pvc",
+        color: "#f8fafc",
+        diameterMeters: 0.055,
+      },
+      branding: {
+        label: "MULTIGP",
+        markColor: "#f8fafc",
+        accentColor: "#dc2626",
+        checkerColor: "#111827",
+        style: "multigp",
+      },
     } satisfies LadderVisualSpec,
     exportHints: { simulatorFriendly: true },
   },
@@ -541,7 +558,10 @@ export const trackElementCatalog = [
     dimensions: {
       widthMeters: feetToMeters(7),
       heightMeters: feetToMeters(6) * 3,
-      display: { unitSystem: "imperial", label: "7 ft wide, 3 × 6 ft openings" },
+      display: {
+        unitSystem: "imperial",
+        label: "7 ft wide, 3 × 6 ft openings",
+      },
     },
     defaultShape: {
       kind: "ladder",
@@ -571,8 +591,19 @@ export const trackElementCatalog = [
         right: { widthMeters: feetToMeters(1), color: "#f8fafc" },
         top: { heightMeters: feetToMeters(1), color: "#202e5d" },
       },
-      frame: { placement: "outer", material: "pvc", color: "#f8fafc", diameterMeters: 0.055 },
-      branding: { label: "MULTIGP", markColor: "#f8fafc", accentColor: "#b91c1c", checkerColor: "#111827", style: "multigp" },
+      frame: {
+        placement: "outer",
+        material: "pvc",
+        color: "#f8fafc",
+        diameterMeters: 0.055,
+      },
+      branding: {
+        label: "MULTIGP",
+        markColor: "#f8fafc",
+        accentColor: "#b91c1c",
+        checkerColor: "#111827",
+        style: "multigp",
+      },
     } satisfies LadderVisualSpec,
     exportHints: { simulatorFriendly: true },
   },

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -109,7 +109,21 @@ export interface CornerMarkerFlagVisualSpec {
 }
 
 export type FlagVisualSpec = CornerMarkerFlagVisualSpec;
-export type TrackElementVisualSpec = GateVisualSpec | FlagVisualSpec;
+
+export interface PanelRunsLadderVisualSpec {
+  kind: "ladder";
+  variant: "panel-rungs";
+  panels: {
+    left: GatePanelVisualSpec;
+    right: GatePanelVisualSpec;
+    top: GateTopPanelVisualSpec;
+  };
+  frame: GateFrameVisualSpec;
+  branding: GateBrandingVisualSpec;
+}
+
+export type LadderVisualSpec = PanelRunsLadderVisualSpec;
+export type TrackElementVisualSpec = GateVisualSpec | FlagVisualSpec | LadderVisualSpec;
 
 export interface TrackElementCatalogEntry {
   id: TrackElementCatalogId;
@@ -482,7 +496,7 @@ export const trackElementCatalog = [
     dimensions: {
       widthMeters: feetToMeters(5),
       heightMeters: feetToMeters(5) * 3,
-      display: { unitSystem: "imperial", label: "5 ft wide, 3 × 5 ft rungs" },
+      display: { unitSystem: "imperial", label: "5 ft wide, 3 × 5 ft sections" },
     },
     defaultShape: {
       kind: "ladder",
@@ -504,6 +518,17 @@ export const trackElementCatalog = [
     ],
     render2d: { icon: "ladder" },
     render3d: { modelHint: "ladder-gate" },
+    visual: {
+      kind: "ladder",
+      variant: "panel-rungs",
+      panels: {
+        left: { widthMeters: feetToMeters(1), color: "#f8fafc" },
+        right: { widthMeters: feetToMeters(1), color: "#f8fafc" },
+        top: { heightMeters: feetToMeters(1), color: "#202e5d" },
+      },
+      frame: { placement: "outer", material: "pvc", color: "#f8fafc", diameterMeters: 0.055 },
+      branding: { label: "MULTIGP", markColor: "#f8fafc", accentColor: "#dc2626", checkerColor: "#111827", style: "multigp" },
+    } satisfies LadderVisualSpec,
     exportHints: { simulatorFriendly: true },
   },
   {
@@ -516,7 +541,7 @@ export const trackElementCatalog = [
     dimensions: {
       widthMeters: feetToMeters(7),
       heightMeters: feetToMeters(6) * 3,
-      display: { unitSystem: "imperial", label: "7 ft wide, 3 × 6 ft rungs" },
+      display: { unitSystem: "imperial", label: "7 ft wide, 3 × 6 ft openings" },
     },
     defaultShape: {
       kind: "ladder",
@@ -538,6 +563,17 @@ export const trackElementCatalog = [
     ],
     render2d: { icon: "ladder" },
     render3d: { modelHint: "ladder-gate" },
+    visual: {
+      kind: "ladder",
+      variant: "panel-rungs",
+      panels: {
+        left: { widthMeters: feetToMeters(1), color: "#f8fafc" },
+        right: { widthMeters: feetToMeters(1), color: "#f8fafc" },
+        top: { heightMeters: feetToMeters(1), color: "#202e5d" },
+      },
+      frame: { placement: "outer", material: "pvc", color: "#f8fafc", diameterMeters: 0.055 },
+      branding: { label: "MULTIGP", markColor: "#f8fafc", accentColor: "#b91c1c", checkerColor: "#111827", style: "multigp" },
+    } satisfies LadderVisualSpec,
     exportHints: { simulatorFriendly: true },
   },
   {

--- a/src/lib/track/elements/visual.ts
+++ b/src/lib/track/elements/visual.ts
@@ -1,10 +1,11 @@
-import type { FlagShape, GateShape, Shape } from "@/lib/types";
+import type { FlagShape, GateShape, LadderShape, Shape } from "@/lib/types";
 import {
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
   type FrameOnlyGateVisualSpec,
   type FlagVisualSpec,
   type GateVisualSpec,
+  type LadderVisualSpec,
   type TrackElementVisualSpec,
 } from "@/lib/track/elements/catalog";
 
@@ -36,6 +37,12 @@ export function getGateVisualSpec(shape: GateShape): GateVisualSpec {
 export function getFlagVisualSpec(shape: FlagShape): FlagVisualSpec | null {
   const visual = getTrackElementVisualSpec(shape);
   if (visual?.kind === "flag") return visual;
+  return null;
+}
+
+export function getLadderVisualSpec(shape: LadderShape): LadderVisualSpec | null {
+  const visual = getTrackElementVisualSpec(shape);
+  if (visual?.kind === "ladder") return visual;
   return null;
 }
 

--- a/src/lib/track/elements/visual.ts
+++ b/src/lib/track/elements/visual.ts
@@ -40,7 +40,9 @@ export function getFlagVisualSpec(shape: FlagShape): FlagVisualSpec | null {
   return null;
 }
 
-export function getLadderVisualSpec(shape: LadderShape): LadderVisualSpec | null {
+export function getLadderVisualSpec(
+  shape: LadderShape
+): LadderVisualSpec | null {
   const visual = getTrackElementVisualSpec(shape);
   if (visual?.kind === "ladder") return visual;
   return null;

--- a/src/lib/track/elements/visual.ts
+++ b/src/lib/track/elements/visual.ts
@@ -1,8 +1,9 @@
-import type { GateShape, Shape } from "@/lib/types";
+import type { FlagShape, GateShape, Shape } from "@/lib/types";
 import {
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
   type FrameOnlyGateVisualSpec,
+  type FlagVisualSpec,
   type GateVisualSpec,
   type TrackElementVisualSpec,
 } from "@/lib/track/elements/catalog";
@@ -30,6 +31,12 @@ export function getGateVisualSpec(shape: GateShape): GateVisualSpec {
   const visual = getTrackElementVisualSpec(shape);
   if (visual?.kind === "gate") return visual;
   return getFallbackGateVisualSpec(shape);
+}
+
+export function getFlagVisualSpec(shape: FlagShape): FlagVisualSpec | null {
+  const visual = getTrackElementVisualSpec(shape);
+  if (visual?.kind === "flag") return visual;
+  return null;
 }
 
 function getFallbackGateVisualSpec(shape: GateShape): FrameOnlyGateVisualSpec {

--- a/src/lib/track/orientation.ts
+++ b/src/lib/track/orientation.ts
@@ -39,13 +39,13 @@ const ORIENTATION_BASE_OFFSETS: Record<
   ShapeKind,
   Partial<Record<OrientationSurface, number>>
 > = {
-  gate: { facing: 0, canvasGuide: -90, previewGuide: 180 },
+  gate: { facing: 0, canvasGuide: -90, previewGuide: 0 },
   flag: { facing: 0, canvasGuide: 0, previewGuide: -90 },
   cone: { facing: 0, canvasGuide: -90, previewGuide: 0 },
   label: { facing: 0, canvasGuide: -90, previewGuide: 0 },
   polyline: { facing: 0, canvasGuide: -90, previewGuide: 0 },
   startfinish: { facing: 0, canvasGuide: -90, previewGuide: 0 },
-  ladder: { facing: 0, canvasGuide: -90, previewGuide: 180 },
+  ladder: { facing: 0, canvasGuide: -90, previewGuide: 0 },
   divegate: { facing: 90, canvasGuide: 90, previewGuide: 0 },
 };
 

--- a/src/lib/track/shape2d.ts
+++ b/src/lib/track/shape2d.ts
@@ -1,5 +1,8 @@
 import { m2px } from "@/lib/track/units";
-import { getGateVisualSpec } from "@/lib/track/elements/visual";
+import {
+  getGateVisualSpec,
+  getLadderVisualSpec,
+} from "@/lib/track/elements/visual";
 import type {
   ConeShape,
   DiveGateShape,
@@ -115,13 +118,29 @@ export function getStartFinish2DShape(shape: StartFinishShape, ppm: number) {
 }
 
 export function getLadder2DShape(shape: LadderShape, ppm: number) {
-  const width = m2px(shape.width ?? 2, ppm);
+  const ladderVisual = getLadderVisualSpec(shape);
+  const openingWidth = m2px(shape.width ?? 2, ppm);
   const depth = m2px(0.18, ppm);
+
+  if (ladderVisual?.variant === "panel-rungs") {
+    const leftPanelWidth = m2px(ladderVisual.panels.left.widthMeters, ppm);
+    const rightPanelWidth = m2px(ladderVisual.panels.right.widthMeters, ppm);
+    const width = openingWidth + leftPanelWidth + rightPanelWidth;
+    return {
+      color: ladderVisual.panels.top.color,
+      depth,
+      radius: Math.min(12, depth / 2),
+      variant: "panel-rungs" as const,
+      width,
+    };
+  }
+
   return {
     color: shape.color ?? "#14b8a6",
     depth,
     radius: Math.min(12, depth / 2),
-    width,
+    variant: "frame-only" as const,
+    width: openingWidth,
   };
 }
 

--- a/src/lib/track/shape2d.ts
+++ b/src/lib/track/shape2d.ts
@@ -122,7 +122,7 @@ export function getLadder2DShape(shape: LadderShape, ppm: number) {
   const openingWidth = m2px(shape.width ?? 2, ppm);
   const depth = m2px(0.18, ppm);
 
-  if (ladderVisual?.variant === "panel-rungs") {
+  if (ladderVisual?.variant === "panel-frame") {
     const leftPanelWidth = m2px(ladderVisual.panels.left.widthMeters, ppm);
     const rightPanelWidth = m2px(ladderVisual.panels.right.widthMeters, ppm);
     const width = openingWidth + leftPanelWidth + rightPanelWidth;
@@ -130,7 +130,7 @@ export function getLadder2DShape(shape: LadderShape, ppm: number) {
       color: ladderVisual.panels.top.color,
       depth,
       radius: Math.min(12, depth / 2),
-      variant: "panel-rungs" as const,
+      variant: "panel-frame" as const,
       width,
     };
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -129,7 +129,7 @@ export interface MapReference {
 
 export interface TrackDesign {
   id: UUID;
-  version: 1;
+  version: 2;
   title: string;
   description?: string;
   tags?: string[];
@@ -145,7 +145,7 @@ export interface TrackDesign {
 
 export interface SerializedTrackDesign {
   id: UUID;
-  version: 1;
+  version: 1 | 2;
   title: string;
   description?: string;
   tags?: string[];

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -99,8 +99,8 @@ export function useSessionActions() {
 export function useUiActions() {
   const setActiveTool = useEditor((state) => state.setActiveTool);
   const setActivePresetId = useEditor((state) => state.setActivePresetId);
-  const setActiveGateElementId = useEditor(
-    (state) => state.setActiveGateElementId
+  const setActivePlacementElementId = useEditor(
+    (state) => state.setActivePlacementElementId
   );
   const setSnapEnabled = useEditor((state) => state.setSnapEnabled);
   const toggleSnapEnabled = useEditor((state) => state.toggleSnapEnabled);
@@ -124,7 +124,7 @@ export function useUiActions() {
   return {
     setActiveTool,
     setActivePresetId,
-    setActiveGateElementId,
+    setActivePlacementElementId,
     setSnapEnabled,
     toggleSnapEnabled,
     setZoom,

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -94,7 +94,7 @@ interface EditorState {
   sanitizeHistoryState: EditorSessionActions["sanitizeHistoryState"];
   setActiveTool: EditorUiActions["setActiveTool"];
   setActivePresetId: EditorUiActions["setActivePresetId"];
-  setActiveGateElementId: EditorUiActions["setActiveGateElementId"];
+  setActivePlacementElementId: EditorUiActions["setActivePlacementElementId"];
   setSnapEnabled: EditorUiActions["setSnapEnabled"];
   toggleSnapEnabled: EditorUiActions["toggleSnapEnabled"];
   setZoom: EditorUiActions["setZoom"];
@@ -481,9 +481,13 @@ export const useEditor = create<EditorState>()(
           draft.ui.activePresetId = presetId;
         }),
 
-      setActiveGateElementId: (entryId) =>
+      setActivePlacementElementId: (tool, entryId) =>
         set((draft) => {
-          draft.ui.activeGateElementId = entryId;
+          if (entryId === null) {
+            delete draft.ui.activePlacementElementId[tool];
+          } else {
+            draft.ui.activePlacementElementId[tool] = entryId;
+          }
         }),
 
       setSnapEnabled: (enabled) =>

--- a/tests/components/inspector/SingleInspectorView.test.tsx
+++ b/tests/components/inspector/SingleInspectorView.test.tsx
@@ -238,17 +238,17 @@ describe("SingleInspectorView race timing controls", () => {
 
     expect(screen.getByText("MultiGP Standard Gate 5x5")).toBeTruthy();
     expect(screen.queryByText("Color")).toBeNull();
-    expect(screen.queryByText("Width")).toBeNull();
-    expect(screen.queryByText("Height")).toBeNull();
-    expect(screen.queryByText("Thickness")).toBeNull();
+    expect(screen.queryByText(/^Width/)).toBeNull();
+    expect(screen.queryByText(/^Height/)).toBeNull();
+    expect(screen.queryByText(/^Thickness/)).toBeNull();
   });
 
   it("keeps frame-only gate size and color controls editable", () => {
     renderSingleInspector(gate);
 
     expect(screen.getByText("Color")).toBeTruthy();
-    expect(screen.getByText("Width")).toBeTruthy();
-    expect(screen.getByText("Height")).toBeTruthy();
-    expect(screen.getByText("Thickness")).toBeTruthy();
+    expect(screen.getByText(/^Width/)).toBeTruthy();
+    expect(screen.getByText(/^Height/)).toBeTruthy();
+    expect(screen.getByText(/^Thickness/)).toBeTruthy();
   });
 });

--- a/tests/lib/editor-tools.test.ts
+++ b/tests/lib/editor-tools.test.ts
@@ -31,7 +31,7 @@ describe("editor tool helpers", () => {
       kind: "gate",
       x: 12,
       y: 7,
-      rotation: 180,
+      rotation: 0,
       width: 2,
       height: 2,
       thick: 0.2,
@@ -72,7 +72,7 @@ describe("editor tool helpers", () => {
       kind: "gate",
       x: 3,
       y: 4,
-      rotation: 180,
+      rotation: 0,
       width: feetToMeters(5),
       height: feetToMeters(5),
       meta: {
@@ -96,7 +96,7 @@ describe("editor tool helpers", () => {
 
     expect(shape).toMatchObject({
       kind: "gate",
-      rotation: 180,
+      rotation: 0,
       width: feetToMeters(7),
       height: feetToMeters(6),
       meta: {

--- a/tests/lib/editor-tools.test.ts
+++ b/tests/lib/editor-tools.test.ts
@@ -64,7 +64,9 @@ describe("editor tool helpers", () => {
       "gate",
       { x: 3, y: 4 },
       {
-        activePlacementElementId: { gate: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID },
+        activePlacementElementId: {
+          gate: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+        },
       }
     );
 
@@ -90,7 +92,9 @@ describe("editor tool helpers", () => {
       "gate",
       { x: 6, y: 8 },
       {
-        activePlacementElementId: { gate: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID },
+        activePlacementElementId: {
+          gate: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+        },
       }
     );
 

--- a/tests/lib/editor-tools.test.ts
+++ b/tests/lib/editor-tools.test.ts
@@ -64,7 +64,7 @@ describe("editor tool helpers", () => {
       "gate",
       { x: 3, y: 4 },
       {
-        gateElementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+        activePlacementElementId: { gate: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID },
       }
     );
 
@@ -90,7 +90,7 @@ describe("editor tool helpers", () => {
       "gate",
       { x: 6, y: 8 },
       {
-        gateElementId: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+        activePlacementElementId: { gate: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID },
       }
     );
 
@@ -115,7 +115,7 @@ describe("editor tool helpers", () => {
         "gate",
         { x: 1, y: 2 },
         {
-          gateElementId: TRACKDRAW_FLAG_ELEMENT_ID,
+          activePlacementElementId: { gate: TRACKDRAW_FLAG_ELEMENT_ID },
         }
       )
     ).toMatchObject({

--- a/tests/lib/editor/store-state.test.ts
+++ b/tests/lib/editor/store-state.test.ts
@@ -36,7 +36,9 @@ describe("editor store state helpers", () => {
     });
 
     expect(next.activePresetId).toBe("straight-gate-run");
-    expect(next.activePlacementElementId.gate).toBe(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
+    expect(next.activePlacementElementId.gate).toBe(
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
+    );
     expect(next.zoom).toBe(1);
     expect(next.panOffset).toEqual({ x: 0, y: 0 });
     expect(next.hoveredShapeId).toBeNull();

--- a/tests/lib/editor/store-state.test.ts
+++ b/tests/lib/editor/store-state.test.ts
@@ -16,7 +16,7 @@ describe("editor store state helpers", () => {
     const current: EditorUiState = {
       ...createDefaultEditorUiState(),
       activePresetId: "straight-gate-run",
-      activeGateElementId: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+      activePlacementElementId: { gate: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID },
       zoom: 2.25,
       panOffset: { x: 120, y: 75 },
       hoveredShapeId: "shape-1",
@@ -36,7 +36,7 @@ describe("editor store state helpers", () => {
     });
 
     expect(next.activePresetId).toBe("straight-gate-run");
-    expect(next.activeGateElementId).toBe(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
+    expect(next.activePlacementElementId.gate).toBe(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
     expect(next.zoom).toBe(1);
     expect(next.panOffset).toEqual({ x: 0, y: 0 });
     expect(next.hoveredShapeId).toBeNull();
@@ -44,7 +44,7 @@ describe("editor store state helpers", () => {
   });
 
   it("defaults to the frame-only TrackDraw gate variant", () => {
-    expect(createDefaultEditorUiState().activeGateElementId).toBe(
+    expect(createDefaultEditorUiState().activePlacementElementId.gate).toBe(
       TRACKDRAW_GATE_ELEMENT_ID
     );
   });

--- a/tests/lib/server/api-projects.test.ts
+++ b/tests/lib/server/api-projects.test.ts
@@ -23,7 +23,7 @@ const inventory = {
 function makeDesign(shapes: Shape[]): TrackDesign {
   return normalizeDesign({
     id: "design-1",
-    version: 1,
+    version: 2,
     title: "API test",
     description: "Editor-only description",
     tags: ["private"],

--- a/tests/lib/track/elements/catalog.test.ts
+++ b/tests/lib/track/elements/catalog.test.ts
@@ -52,7 +52,7 @@ describe("track element catalog", () => {
     expect(shape.meta).toBeUndefined();
   });
 
-  it("defaults newly placed gates to a downward-facing front", () => {
+  it("defaults newly placed gates to a forward-facing front (rotation 0)", () => {
     const shape = createCatalogShapeDraft(TRACKDRAW_GATE_ELEMENT_ID, {
       x: 0,
       y: 0,
@@ -60,10 +60,10 @@ describe("track element catalog", () => {
 
     expect(shape).toMatchObject({
       kind: "gate",
-      rotation: 180,
+      rotation: 0,
     });
     const gateShape = { ...shape, id: "gate-1" } as GateShape;
-    expect(getCanvasRotationGuideAngleDeg(gateShape)).toBe(90);
+    expect(getCanvasRotationGuideAngleDeg(gateShape)).toBe(270);
   });
 
   it("documents the MultiGP 5x5 panel-frame gate without changing default placement", () => {

--- a/tests/lib/track/orientation.test.ts
+++ b/tests/lib/track/orientation.test.ts
@@ -51,7 +51,7 @@ describe("track orientation helpers", () => {
 
     expect(getShapeFacingDegrees(gate)).toBe(60);
     expect(getCanvasRotationGuideAngleDeg(gate)).toBe(330);
-    expect(getPreviewRotationGuideDegrees(gate)).toBe(240);
+    expect(getPreviewRotationGuideDegrees(gate)).toBe(60);
   });
 
   it("uses dive gate specific orientation offsets", () => {

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -922,7 +922,7 @@ describe("editor store history", () => {
 
     state.replaceDesign({
       id: "replacement",
-      version: 1,
+      version: 2,
       title: "Replacement",
       description: "",
       tags: [],


### PR DESCRIPTION
Adds official MultiGP flags and ladders to the obstacle catalog, so users can place standard competition obstacles with the same picker, inspector, 2D canvas, and 3D preview treatment already used for gates.

The new MultiGP ladders now use their visual specs in both 2D and 3D, including panel-aware widths and more accurate selection bounds. This also updates gate and ladder orientation so `0°` is the forward-facing direction, with automatic migration for existing designs so saved tracks keep their visual orientation.

Mobile catalog tools now expand before placement, inspector measurement labels show the active unit system, and the roadmap/agent guidance has been updated for the new design schema and completed catalog expansion.