### PR TITLE
fix: Improve 3D selection controls for catalog obstacles

### DIFF
--- a/src/components/canvas/editor/TrackPreview3D.tsx
+++ b/src/components/canvas/editor/TrackPreview3D.tsx
@@ -31,6 +31,10 @@ import {
   selectSelectedPolyline,
   selectShapeRecordMap,
 } from "@/store/selectors";
+import {
+  getTrackElementCatalogEntry,
+  getTrackElementCatalogIdentity,
+} from "@/lib/track/elements/catalog";
 import { useEditor } from "@/store/editor";
 import {
   useSessionActions,
@@ -372,6 +376,10 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
               ) {
                 return null;
               }
+              const catalogEntry = getTrackElementCatalogEntry(
+                getTrackElementCatalogIdentity(shape.meta)?.elementId
+              );
+              if (catalogEntry?.editable?.dimensions === false) return null;
               return (
                 <LadderElevationHandle3D
                   key={`ladder-elevation-${shape.id}`}

--- a/src/components/canvas/editor/TrackPreview3D.tsx
+++ b/src/components/canvas/editor/TrackPreview3D.tsx
@@ -379,7 +379,12 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
               const catalogEntry = getTrackElementCatalogEntry(
                 getTrackElementCatalogIdentity(shape.meta)?.elementId
               );
-              if (catalogEntry?.editable?.dimensions === false) return null;
+              if (
+                catalogEntry?.kind === "ladder" &&
+                catalogEntry.editable?.dimensions === false
+              ) {
+                return null;
+              }
               return (
                 <LadderElevationHandle3D
                   key={`ladder-elevation-${shape.id}`}

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -1859,26 +1859,49 @@ function RaceLine3D({
   );
 }
 
+const SELECTION_MARKER_MARGIN = 0.35;
+
+function getShapeTopY(shape: Shape): number {
+  switch (shape.kind) {
+    case "gate": {
+      const gateShape = shape as GateShape;
+      const gateVisual = getGateVisualSpec(gateShape);
+      const openingH = gateShape.height ?? 2;
+      if (gateVisual.variant === "panel-frame") {
+        return openingH + gateVisual.panels.top.heightMeters;
+      }
+      return openingH;
+    }
+    case "flag":
+      return Math.max((shape as FlagShape).poleHeight ?? 3.5, 0.5);
+    case "cone": {
+      const r = (shape as ConeShape).radius ?? 0.2;
+      return Math.max(r * 1.15, 0.1);
+    }
+    case "label":
+      return (shape as LabelShape).project ? 0.1 : 2.8;
+    case "polyline":
+      return 0.6;
+    case "startfinish":
+      return 0.1;
+    case "ladder": {
+      const s = shape as LadderShape;
+      return Math.max((s.height ?? 4.5) + (s.elevation ?? 0), 0.5);
+    }
+    case "divegate": {
+      const s = shape as DiveGateShape;
+      return Math.max((s.elevation ?? 3) + (s.size ?? 2.8) / 2, 0.5);
+    }
+    default:
+      return 1.0;
+  }
+}
+
 function SelectionMarker3D({ shape }: { shape: Shape }) {
   const pulse = useRef(0);
   const meshRef = useRef<THREE.Mesh>(null);
 
-  const heightByKind: Partial<Record<Shape["kind"], number>> = {
-    gate: Math.max((shape as GateShape).height ?? 2, 1.4) + 0.45,
-    flag: Math.max((shape as FlagShape).poleHeight ?? 3.5, 1.8) + 0.35,
-    cone: Math.max(((shape as ConeShape).radius ?? 0.2) * 2.5, 0.5) + 0.35,
-    label: (shape as LabelShape).project ? 0.8 : 3.1,
-    polyline: 0.95,
-    startfinish: 0.55,
-    ladder:
-      Math.max(
-        ((shape as LadderShape).height ?? 4.5) +
-          ((shape as LadderShape).elevation ?? 0),
-        1.8
-      ) + 0.35,
-    divegate: Math.max((shape as DiveGateShape).elevation ?? 3, 1.8) + 0.55,
-  };
-  const markerY = heightByKind[shape.kind] ?? 1.2;
+  const markerY = getShapeTopY(shape) + SELECTION_MARKER_MARGIN;
 
   useFrame((_, delta) => {
     pulse.current += delta * 3.4;
@@ -1976,6 +1999,7 @@ function Shape3D({
             outerRef={outerRef}
             elevationOverrideRef={elevationOverrideRef}
           />
+          {isSelected && <SelectionMarker3D shape={shape} />}
         </group>
       );
     case "divegate":

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -1732,6 +1732,12 @@ function DiveGate3D({
   );
 }
 
+const POLYLINE_3D_HEIGHT_OFFSET = 0.5;
+
+function getPolylineTubeRadius(shape: PolylineShape) {
+  return Math.max(0.02, (shape.strokeWidth ?? 0.26) / 2);
+}
+
 function RaceLine3D({
   editing = false,
   isPrimary = false,
@@ -1744,7 +1750,7 @@ function RaceLine3D({
   shape: PolylineShape;
 }) {
   const previewPoints = useMemo(
-    () => getPolylinePreview3DPoints(shape, 0.5),
+    () => getPolylinePreview3DPoints(shape, POLYLINE_3D_HEIGHT_OFFSET),
     [shape]
   );
   const warningSegments = useMemo(
@@ -1763,7 +1769,7 @@ function RaceLine3D({
     [shape]
   );
   const showWarningVisuals = selected || isPrimary;
-  const tubeRadius = Math.max(0.02, (shape.strokeWidth ?? 0.26) / 2);
+  const tubeRadius = getPolylineTubeRadius(shape);
   const segmentedGeometries = useMemo(() => {
     if (!showWarningVisuals || !warningSegments.length) return null;
 
@@ -1789,7 +1795,7 @@ function RaceLine3D({
   const geometry = useMemo(() => {
     if (editing) return null;
     const curveData = getPolylineCurve3Derived(shape, {
-      heightOffset: 0.5,
+      heightOffset: POLYLINE_3D_HEIGHT_OFFSET,
       samplesPerSegment: 18,
       density: 12,
     });
@@ -1861,6 +1867,23 @@ function RaceLine3D({
 
 const SELECTION_MARKER_MARGIN = 0.35;
 
+function getPolylineTopY(shape: PolylineShape): number {
+  const maxPointZ = shape.points.reduce(
+    (maxZ, point) => Math.max(maxZ, point.z ?? 0),
+    0
+  );
+  return (
+    Math.max(maxPointZ, 0) +
+    POLYLINE_3D_HEIGHT_OFFSET +
+    getPolylineTubeRadius(shape)
+  );
+}
+
+function getDiveGateTopY(shape: DiveGateShape): number {
+  const tiltRad = ((shape.tilt ?? 0) * Math.PI) / 180;
+  return (shape.elevation ?? 3) + ((shape.size ?? 2.8) / 2) * Math.sin(tiltRad);
+}
+
 function getShapeTopY(shape: Shape): number {
   switch (shape.kind) {
     case "gate": {
@@ -1881,7 +1904,7 @@ function getShapeTopY(shape: Shape): number {
     case "label":
       return (shape as LabelShape).project ? 0.1 : 2.8;
     case "polyline":
-      return 0.6;
+      return getPolylineTopY(shape as PolylineShape);
     case "startfinish":
       return 0.1;
     case "ladder": {
@@ -1890,7 +1913,7 @@ function getShapeTopY(shape: Shape): number {
     }
     case "divegate": {
       const s = shape as DiveGateShape;
-      return Math.max((s.elevation ?? 3) + (s.size ?? 2.8) / 2, 0.5);
+      return Math.max(getDiveGateTopY(s), 0.5);
     }
     default:
       return 1.0;

--- a/src/lib/track/orientation.ts
+++ b/src/lib/track/orientation.ts
@@ -39,13 +39,13 @@ const ORIENTATION_BASE_OFFSETS: Record<
   ShapeKind,
   Partial<Record<OrientationSurface, number>>
 > = {
-  gate: { facing: 0, canvasGuide: -90, previewGuide: 0 },
+  gate: { facing: 0, canvasGuide: 90, previewGuide: 0 },
   flag: { facing: 0, canvasGuide: 0, previewGuide: -90 },
   cone: { facing: 0, canvasGuide: -90, previewGuide: 0 },
   label: { facing: 0, canvasGuide: -90, previewGuide: 0 },
   polyline: { facing: 0, canvasGuide: -90, previewGuide: 0 },
   startfinish: { facing: 0, canvasGuide: -90, previewGuide: 0 },
-  ladder: { facing: 0, canvasGuide: -90, previewGuide: 0 },
+  ladder: { facing: 0, canvasGuide: 90, previewGuide: 0 },
   divegate: { facing: 90, canvasGuide: 90, previewGuide: 0 },
 };
 

--- a/tests/lib/track/elements/catalog.test.ts
+++ b/tests/lib/track/elements/catalog.test.ts
@@ -63,7 +63,7 @@ describe("track element catalog", () => {
       rotation: 0,
     });
     const gateShape = { ...shape, id: "gate-1" } as GateShape;
-    expect(getCanvasRotationGuideAngleDeg(gateShape)).toBe(270);
+    expect(getCanvasRotationGuideAngleDeg(gateShape)).toBe(90);
   });
 
   it("documents the MultiGP 5x5 panel-frame gate without changing default placement", () => {

--- a/tests/lib/track/orientation.test.ts
+++ b/tests/lib/track/orientation.test.ts
@@ -50,7 +50,7 @@ describe("track orientation helpers", () => {
     };
 
     expect(getShapeFacingDegrees(gate)).toBe(60);
-    expect(getCanvasRotationGuideAngleDeg(gate)).toBe(330);
+    expect(getCanvasRotationGuideAngleDeg(gate)).toBe(150);
     expect(getPreviewRotationGuideDegrees(gate)).toBe(60);
   });
 


### PR DESCRIPTION
Refines 3D editor selection controls so the blue selection marker sits above the rendered shape instead of using coarse per-kind offsets. The marker now accounts for panel-frame gate height, elevated race lines with stroke width, ladder elevation, and dive gate tilt.

Also hides the 3D ladder elevation handle for fixed-dimension catalog ladders, while guarding against stale or mismatched catalog metadata. The canvas rotation guide offset for gates and ladders is corrected so the 2D guide matches the current forward-facing orientation convention.