### PR TITLE
fix: Restore 3D flag rotation updates

### DIFF
--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -33,6 +33,16 @@ The completed release-sized work is archived below. The next TrackDraw priority 
   - [x] MultiGP ladder and other obstacle entries
         Added MultiGP Standard Ladder 5x5 and Championship Ladder 7x6 with panel-frame 3D rendering matching the real obstacle, and the same catalog pipeline as gates and flags.
 
+- [ ] Flag real-time rotation in 3D (`No account required`)
+      Rotating a flag in the 3D editor no longer updates the visual in real-time. The flag only reflects the new rotation after the interaction ends. Investigate whether the rotation formula change for gates/ladders or the hooks restructuring caused a regression in the flag render path.
+
+- [ ] Track items list improvements (`No account required`)
+      The layout track items list currently uses internal shape kind labels. Two improvements: use the placed element's catalog name or custom name so the list is more meaningful, and add a drag handle per item so users can reorder track elements directly in the list.
+  - [ ] Catalog-aware item names
+        Show the catalog entry name (e.g. "MultiGP Standard Gate 5x5") or the user-assigned name instead of the generic kind label in the track items list.
+  - [ ] Drag-to-reorder items
+        Add a drag handle to each row in the track items list so users can change the draw/render order of elements without deleting and re-placing them.
+
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.
   - [ ] 3D transform handles

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -33,8 +33,8 @@ The completed release-sized work is archived below. The next TrackDraw priority 
   - [x] MultiGP ladder and other obstacle entries
         Added MultiGP Standard Ladder 5x5 and Championship Ladder 7x6 with panel-frame 3D rendering matching the real obstacle, and the same catalog pipeline as gates and flags.
 
-- [ ] Flag real-time rotation in 3D (`No account required`)
-      Rotating a flag in the 3D editor no longer updates the visual in real-time. The flag only reflects the new rotation after the interaction ends. Investigate whether the rotation formula change for gates/ladders or the hooks restructuring caused a regression in the flag render path.
+- [x] Flag real-time rotation in 3D (`No account required`)
+      Flags now rotate visually in real-time during 3D drag, matching gates and ladders. The fix was passing `outerRef` from `Shape3D` through `Flag3D` and `CornerMarkerFlag3D` to their root groups, so the rotation drag handler can mutate the group transform directly each animation frame.
 
 - [ ] Track items list improvements (`No account required`)
       The layout track items list currently uses internal shape kind labels. Two improvements: use the placed element's catalog name or custom name so the list is more meaningful, and add a drag handle per item so users can reorder track elements directly in the list.

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -734,10 +734,12 @@ function CornerMarkerFlag3D({
   selected = false,
   shape,
   visual,
+  outerRef,
 }: {
   selected?: boolean;
   shape: FlagShape;
   visual: CornerMarkerFlagVisualSpec;
+  outerRef?: Ref<THREE.Group>;
 }) {
   const ph = shape.poleHeight ?? 3.0;
   const yawRad = (-shape.rotation * Math.PI) / 180;
@@ -815,7 +817,7 @@ function CornerMarkerFlag3D({
   );
 
   return (
-    <group position={[shape.x, 0, shape.y]} rotation={[0, yawRad, 0]}>
+    <group ref={outerRef} position={[shape.x, 0, shape.y]} rotation={[0, yawRad, 0]}>
       <mesh
         position={[0, 0.02, 0]}
         receiveShadow
@@ -868,9 +870,11 @@ function CornerMarkerFlag3D({
 function Flag3D({
   selected = false,
   shape,
+  outerRef,
 }: {
   selected?: boolean;
   shape: FlagShape;
+  outerRef?: Ref<THREE.Group>;
 }) {
   const flagVisual = getFlagVisualSpec(shape);
   const color = shape.color ?? "#a855f7";
@@ -928,12 +932,13 @@ function Flag3D({
         shape={shape}
         selected={selected}
         visual={flagVisual}
+        outerRef={outerRef}
       />
     );
   }
 
   return (
-    <group position={[shape.x, 0, shape.y]} rotation={[0, yawRad, 0]}>
+    <group ref={outerRef} position={[shape.x, 0, shape.y]} rotation={[0, yawRad, 0]}>
       <mesh
         position={[0, 0.025, 0]}
         receiveShadow
@@ -1976,7 +1981,7 @@ function Shape3D({
     case "flag":
       return (
         <group onClick={(event) => onSelect(event, shape.id)}>
-          <Flag3D shape={shape} selected={isSelected} />
+          <Flag3D shape={shape} selected={isSelected} outerRef={outerRef} />
           {isSelected && <SelectionMarker3D shape={shape} />}
         </group>
       );

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -817,7 +817,11 @@ function CornerMarkerFlag3D({
   );
 
   return (
-    <group ref={outerRef} position={[shape.x, 0, shape.y]} rotation={[0, yawRad, 0]}>
+    <group
+      ref={outerRef}
+      position={[shape.x, 0, shape.y]}
+      rotation={[0, yawRad, 0]}
+    >
       <mesh
         position={[0, 0.02, 0]}
         receiveShadow
@@ -938,7 +942,11 @@ function Flag3D({
   }
 
   return (
-    <group ref={outerRef} position={[shape.x, 0, shape.y]} rotation={[0, yawRad, 0]}>
+    <group
+      ref={outerRef}
+      position={[shape.x, 0, shape.y]}
+      rotation={[0, yawRad, 0]}
+    >
       <mesh
         position={[0, 0.025, 0]}
         receiveShadow


### PR DESCRIPTION
Restores real-time 3D rotation updates for flags by passing the shared rotation group ref through the flag render path, including the MultiGP corner flag visual. Flags now behave consistently with other rotatable 3D obstacles while dragging rotation handles.