### PR TITLE
feat: Improve track items list names and filters

### DIFF
--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -36,12 +36,14 @@ The completed release-sized work is archived below. The next TrackDraw priority 
 - [x] Flag real-time rotation in 3D (`No account required`)
       Flags now rotate visually in real-time during 3D drag, matching gates and ladders. The fix was passing `outerRef` from `Shape3D` through `Flag3D` and `CornerMarkerFlag3D` to their root groups, so the rotation drag handler can mutate the group transform directly each animation frame.
 
-- [ ] Track items list improvements (`No account required`)
-      The layout track items list currently uses internal shape kind labels. Two improvements: use the placed element's catalog name or custom name so the list is more meaningful, and add a drag handle per item so users can reorder track elements directly in the list.
-  - [ ] Catalog-aware item names
-        Show the catalog entry name (e.g. "MultiGP Standard Gate 5x5") or the user-assigned name instead of the generic kind label in the track items list.
-  - [ ] Drag-to-reorder items
-        Add a drag handle to each row in the track items list so users can change the draw/render order of elements without deleting and re-placing them.
+- [x] Track items list improvements (`No account required`)
+      The layout track items list now shows catalog names and supports filtering by type. The list is intentionally designed as a foundation for the upcoming auto path generator: the order of race obstacles in the list (backed by `shapeOrder`) will define the intended race sequence, which the path generator can use to connect them automatically. Drag-to-reorder is not yet exposed in the UI — it will be added as part of the path generation feature once reordering has an immediate, visible effect.
+  - [x] Catalog-aware item names
+        The primary label now resolves to the user custom name → catalog entry name (e.g. "MultiGP Standard Gate 5x5") → generic kind label. The kind label stays visible as a secondary subtitle. Filter search also matches catalog names.
+  - [x] Obstacle / all filter pills
+        Two pills — "All" and "Obstacles" — let users focus the list on race obstacles (gates, ladders, dive gates) or see everything. Non-obstacle elements (flags, cones, labels) remain visible under "All" but are not the primary focus.
+  - [ ] Drag-to-reorder obstacles
+        Once the auto path generator is in place, expose drag handles on the obstacles list so users can define the exact intended race sequence. The `reorderShapes` store action is already in place; only the UI needs to be wired up at that point.
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.
@@ -49,9 +51,11 @@ The completed release-sized work is archived below. The next TrackDraw priority 
         Prototype selected-item controls for elevation, rotation, scale, and orientation only where the behavior is predictable across 2D and 3D.
 
 - [ ] Generated flightpath assistance (`Research`, `No account required`)
-      Research generated flightpaths from placed elements as an optional drafting/review aid that users can accept and edit.
+      Research generated flightpaths from placed obstacles as an optional drafting aid. The intended race sequence is defined by the obstacle order in the track items list (backed by `shapeOrder`), which users can set via drag-to-reorder once this feature ships. The generator connects obstacles in that order and produces an editable race line — it assists authoring rather than replacing it.
   - [ ] Generated flightpath research
-        Prototype flightpath generation from placed elements as an assistive review/drafting feature that can be accepted or edited, not as a replacement for explicit race-line authoring.
+        Prototype flightpath generation from the ordered obstacle list as an assistive review/drafting feature. The output should be an editable race line, not a locked result. Validate that the sequence-based model (list order → path) is intuitive before committing to the full UI.
+  - [ ] Drag-to-reorder obstacles (prerequisite)
+        Wire up the drag handles in the track items list so users can explicitly set the intended race sequence before generating a path. The store action is ready; this is a UI-only change gated on the path generator being useful enough to justify the interaction.
 
 - [ ] Multilingual product experience (`Research`, `No account required`)
       Use the regional measurement work as a first locale-aware foundation, then evaluate a full i18n layer for the public site, editor, share pages, and exported handoff copy.

--- a/src/components/inspector/views/list-panel.tsx
+++ b/src/components/inspector/views/list-panel.tsx
@@ -13,6 +13,10 @@ import type { Shape, TrackDesign } from "@/lib/types";
 import { X } from "lucide-react";
 import { fmt, Section } from "@/components/inspector/shared";
 import { MetaPill } from "./layout";
+import {
+  getTrackElementCatalogEntry,
+  getTrackElementCatalogIdentity,
+} from "@/lib/track/elements/catalog";
 
 export type DesignMetaPatch = Partial<
   Pick<
@@ -73,11 +77,26 @@ export function ListPanel({
   );
 }
 
+function getShapeDisplayName(shape: Shape): string {
+  if (shape.name?.trim()) return shape.name.trim();
+  const catalogId = getTrackElementCatalogIdentity(shape.meta)?.elementId;
+  const entry = getTrackElementCatalogEntry(catalogId);
+  return entry?.name ?? shapeKindLabels[shape.kind];
+}
+
+type ViewFilter = "all" | "obstacles";
+
+const VIEW_FILTERS: { value: ViewFilter; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "obstacles", label: "Obstacles" },
+];
+
 export function ItemOverviewList({
   design,
   shapes,
   setSelection,
   removeShapes,
+
   setHoveredShapeId,
   grow = false,
   obstacleNumberingReport,
@@ -91,28 +110,20 @@ export function ItemOverviewList({
   obstacleNumberingReport?: ObstacleNumberingReport;
 }) {
   const [query, setQuery] = useState("");
-  const filteredShapes = useMemo(() => {
-    const normalizedQuery = query.trim().toLowerCase();
-    if (!normalizedQuery) return shapes;
-    return shapes.filter((shape, index) => {
-      const name =
-        shape.name?.trim() || `${shapeKindLabels[shape.kind]} ${index + 1}`;
-      const position = `${fmt(shape.x)}, ${fmt(shape.y)}`;
-      return (
-        name.toLowerCase().includes(normalizedQuery) ||
-        shapeKindLabels[shape.kind].toLowerCase().includes(normalizedQuery) ||
-        position.includes(normalizedQuery)
-      );
-    });
-  }, [query, shapes]);
+  const [viewFilter, setViewFilter] = useState<ViewFilter>("all");
+
+  const normalizedQuery = query.trim().toLowerCase();
+
   const shapeOrder = useMemo(
     () => new Map(shapes.map((shape, index) => [shape.id, index + 1] as const)),
     [shapes]
   );
+
   const numberingReport = useMemo(
     () => obstacleNumberingReport ?? getObstacleNumberingReport(design),
     [design, obstacleNumberingReport]
   );
+
   const unmappedObstacleIds = useMemo(
     () =>
       new Set(
@@ -127,6 +138,27 @@ export function ItemOverviewList({
       ),
     [numberingReport, shapes]
   );
+
+  const obstacleCount = useMemo(
+    () => shapes.filter(isNumberedObstacle).length,
+    [shapes]
+  );
+
+  const filteredShapes = useMemo(() => {
+    return shapes.filter((shape) => {
+      if (viewFilter === "obstacles" && !isNumberedObstacle(shape))
+        return false;
+      if (!normalizedQuery) return true;
+      const displayName = getShapeDisplayName(shape);
+      const kindLabel = shapeKindLabels[shape.kind];
+      const position = `${fmt(shape.x)}, ${fmt(shape.y)}`;
+      return (
+        displayName.toLowerCase().includes(normalizedQuery) ||
+        kindLabel.toLowerCase().includes(normalizedQuery) ||
+        position.includes(normalizedQuery)
+      );
+    });
+  }, [shapes, viewFilter, normalizedQuery]);
 
   return (
     <Section
@@ -147,6 +179,38 @@ export function ItemOverviewList({
             {filteredShapes.length}/{shapes.length}
           </MetaPill>
         </div>
+
+        <div className="flex shrink-0 items-center gap-1">
+          {VIEW_FILTERS.map(({ value, label }) => {
+            const count = value === "obstacles" ? obstacleCount : shapes.length;
+            return (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setViewFilter(value)}
+                className={cn(
+                  "flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors",
+                  viewFilter === value
+                    ? "bg-brand-primary/12 text-brand-primary"
+                    : "text-muted-foreground/65 hover:text-foreground/80 hover:bg-muted/40"
+                )}
+              >
+                {label}
+                <span
+                  className={cn(
+                    "rounded px-1 font-mono text-[10px]",
+                    viewFilter === value
+                      ? "bg-brand-primary/15 text-brand-primary"
+                      : "bg-muted/60 text-muted-foreground/55"
+                  )}
+                >
+                  {count}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
         <ListPanel
           title="Placed items"
           subtitle="Select an item from the list."
@@ -159,7 +223,7 @@ export function ItemOverviewList({
         >
           <div className="border-border/15 grid shrink-0 grid-cols-[32px_minmax(0,1fr)_48px_28px] items-center gap-3 border-b px-3 py-1.5">
             <span className="text-muted-foreground/55 text-[10px] font-medium tracking-[0.08em] uppercase">
-              Id
+              #
             </span>
             <span className="text-muted-foreground/55 text-[10px] font-medium tracking-[0.08em] uppercase">
               Item
@@ -178,68 +242,74 @@ export function ItemOverviewList({
           >
             <div className="divide-border/15 divide-y">
               {filteredShapes.length ? (
-                filteredShapes.map((shape) => (
-                  <div
-                    key={shape.id}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => setSelection([shape.id])}
-                    className="group/item hover:bg-brand-primary/8 focus-visible:ring-brand-primary/20 relative grid w-full grid-cols-[32px_minmax(0,1fr)_48px_28px] items-center gap-3 px-3 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
-                    onMouseEnter={() => setHoveredShapeId(shape.id)}
-                    onMouseLeave={() => setHoveredShapeId(null)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        setSelection([shape.id]);
-                      }
-                    }}
-                  >
-                    <span className="bg-brand-primary absolute top-1.5 bottom-1.5 left-0 w-0.5 rounded-r-full opacity-0 transition-opacity group-hover/item:opacity-100" />
-                    <div className="flex min-w-0 items-center">
-                      <span className="border-border/30 bg-muted/35 text-muted-foreground/85 flex h-5 w-6 shrink-0 items-center justify-center rounded-md border font-mono text-[10px]">
-                        {shapeOrder.get(shape.id)}
-                      </span>
-                    </div>
-                    <div className="flex min-w-0 items-center gap-2">
-                      <div className="min-w-0">
-                        <p className="text-foreground truncate text-[11px] font-medium">
-                          {shape.name?.trim() || shapeKindLabels[shape.kind]}
-                        </p>
-                        <p className="text-muted-foreground/60 truncate text-[10px] tracking-[0.06em] uppercase">
-                          {shapeKindLabels[shape.kind]}
-                        </p>
+                filteredShapes.map((shape) => {
+                  const displayName = getShapeDisplayName(shape);
+                  const kindLabel = shapeKindLabels[shape.kind];
+                  const pathNumber = numberingReport.obstacleNumberMap.get(
+                    shape.id
+                  );
+                  return (
+                    <div
+                      key={shape.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => setSelection([shape.id])}
+                      className="group/item hover:bg-brand-primary/8 focus-visible:ring-brand-primary/20 relative grid w-full grid-cols-[32px_minmax(0,1fr)_48px_28px] items-center gap-3 px-3 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
+                      onMouseEnter={() => setHoveredShapeId(shape.id)}
+                      onMouseLeave={() => setHoveredShapeId(null)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          setSelection([shape.id]);
+                        }
+                      }}
+                    >
+                      <span className="bg-brand-primary absolute top-1.5 bottom-1.5 left-0 w-0.5 rounded-r-full opacity-0 transition-opacity group-hover/item:opacity-100" />
+                      <div className="flex min-w-0 items-center">
+                        <span className="border-border/30 bg-muted/35 text-muted-foreground/85 flex h-5 w-6 shrink-0 items-center justify-center rounded-md border font-mono text-[10px]">
+                          {shapeOrder.get(shape.id)}
+                        </span>
+                      </div>
+                      <div className="flex min-w-0 items-center">
+                        <div className="min-w-0">
+                          <p className="text-foreground truncate text-[11px] font-medium">
+                            {displayName}
+                          </p>
+                          <p className="text-muted-foreground/60 truncate text-[10px] tracking-[0.06em] uppercase">
+                            {kindLabel}
+                          </p>
+                        </div>
+                      </div>
+                      {typeof pathNumber === "number" ? (
+                        <span className="border-brand-primary/20 bg-brand-primary/8 text-brand-primary flex h-5 w-12 shrink-0 items-center justify-center rounded-md border font-mono text-[10px]">
+                          #{pathNumber}
+                        </span>
+                      ) : unmappedObstacleIds.has(shape.id) ? (
+                        <span className="flex h-5 w-12 shrink-0 items-center justify-center rounded-md border border-amber-500/25 bg-amber-500/10 font-mono text-[10px] font-medium text-amber-500">
+                          off
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground/30 flex h-5 w-12 shrink-0 items-center justify-center font-mono text-[10px]">
+                          –
+                        </span>
+                      )}
+                      <div className="flex items-center justify-end opacity-100 transition-opacity lg:opacity-0 lg:group-hover/item:opacity-100">
+                        <button
+                          type="button"
+                          title="Remove item"
+                          className="text-muted-foreground/55 hover:bg-brand-primary/10 hover:text-brand-primary flex size-5 items-center justify-center rounded-md transition-colors"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            removeShapes([shape.id]);
+                            setHoveredShapeId(null);
+                          }}
+                        >
+                          <X className="size-3" />
+                        </button>
                       </div>
                     </div>
-                    {typeof numberingReport.obstacleNumberMap.get(shape.id) ===
-                    "number" ? (
-                      <span className="border-brand-primary/20 bg-brand-primary/8 text-brand-primary flex h-5 w-12 shrink-0 items-center justify-center rounded-md border font-mono text-[10px]">
-                        #{numberingReport.obstacleNumberMap.get(shape.id)}
-                      </span>
-                    ) : unmappedObstacleIds.has(shape.id) ? (
-                      <span className="flex h-5 w-12 shrink-0 items-center justify-center rounded-md border border-amber-500/25 bg-amber-500/10 font-mono text-[10px] font-medium text-amber-500">
-                        off
-                      </span>
-                    ) : (
-                      <span className="text-muted-foreground/30 flex h-5 w-12 shrink-0 items-center justify-center font-mono text-[10px]">
-                        –
-                      </span>
-                    )}
-                    <div className="flex items-center justify-end opacity-100 transition-opacity lg:opacity-0 lg:group-hover/item:opacity-100">
-                      <button
-                        type="button"
-                        title="Remove item"
-                        className="text-muted-foreground/55 hover:bg-brand-primary/10 hover:text-brand-primary flex size-5 items-center justify-center rounded-md transition-colors"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          removeShapes([shape.id]);
-                          setHoveredShapeId(null);
-                        }}
-                      >
-                        <X className="size-3" />
-                      </button>
-                    </div>
-                  </div>
-                ))
+                  );
+                })
               ) : (
                 <div className="px-3 py-4 text-center">
                   <p className="text-muted-foreground/55 text-[11px]">

--- a/src/lib/editor/store-types.ts
+++ b/src/lib/editor/store-types.ts
@@ -110,6 +110,7 @@ export interface EditorTrackActions {
   newProject: () => void;
   bringForward: (id: string) => void;
   sendBackward: (id: string) => void;
+  reorderShapes: (fromId: string, beforeId: string | null) => void;
 }
 
 export interface EditorSessionActions {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -40,6 +40,7 @@ export function useTrackActions() {
   const newProject = useEditor((state) => state.newProject);
   const bringForward = useEditor((state) => state.bringForward);
   const sendBackward = useEditor((state) => state.sendBackward);
+  const reorderShapes = useEditor((state) => state.reorderShapes);
 
   return {
     addShape,
@@ -73,6 +74,7 @@ export function useTrackActions() {
     newProject,
     bringForward,
     sendBackward,
+    reorderShapes,
   };
 }
 

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -687,6 +687,7 @@ export const useEditor = create<EditorState>()(
 
       reorderShapes: (fromId: string, beforeId: string | null) =>
         set((draft) => {
+          if (beforeId === fromId) return;
           const order = draft.track.design.shapeOrder;
           const fromIdx = order.indexOf(fromId);
           if (fromIdx === -1) return;

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -85,6 +85,7 @@ interface EditorState {
   newProject: EditorTrackActions["newProject"];
   bringForward: EditorTrackActions["bringForward"];
   sendBackward: EditorTrackActions["sendBackward"];
+  reorderShapes: EditorTrackActions["reorderShapes"];
   setSelection: EditorSessionActions["setSelection"];
   pauseHistory: EditorSessionActions["pauseHistory"];
   resumeHistory: EditorSessionActions["resumeHistory"];
@@ -682,6 +683,21 @@ export const useEditor = create<EditorState>()(
             draft.track.design.shapeOrder.splice(idx - 1, 0, shapeId);
             touchTrackDesign(draft);
           }
+        }),
+
+      reorderShapes: (fromId: string, beforeId: string | null) =>
+        set((draft) => {
+          const order = draft.track.design.shapeOrder;
+          const fromIdx = order.indexOf(fromId);
+          if (fromIdx === -1) return;
+          const [shapeId] = order.splice(fromIdx, 1);
+          if (beforeId === null) {
+            order.push(shapeId);
+          } else {
+            const toIdx = order.indexOf(beforeId);
+            order.splice(toIdx === -1 ? order.length : toIdx, 0, shapeId);
+          }
+          touchTrackDesign(draft);
         }),
 
       pauseHistory: () => {


### PR DESCRIPTION
Improves the track items list so placed elements use clearer labels: custom name first, then catalog entry name, then the generic shape kind. Search now also matches catalog names, and the kind remains visible as secondary context.

Adds All and Obstacles filters to make race obstacles easier to scan, while keeping non-obstacle items available in the full list. This also introduces a `reorderShapes` store action as groundwork for future drag-to-reorder behavior and generated flightpath sequencing.