### PR TITLE
fix: Attach canvas viewport listeners after stage mount

### DIFF
--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -424,6 +424,11 @@ const TrackCanvas = memo(
       [design.field.ppm]
     );
     const stageRef = useRef<KonvaStage | null>(null);
+    const [stageInstance, setStageInstance] = useState<KonvaStage | null>(null);
+    const handleStageRef = useCallback((stage: KonvaStage | null) => {
+      stageRef.current = stage;
+      setStageInstance(stage);
+    }, []);
     const containerRef = useRef<HTMLDivElement | null>(null);
     const shapeRefs = useRef<Record<string, KonvaGroup | null>>({});
     const dragSnapRef = useRef<boolean>(true);
@@ -1150,6 +1155,7 @@ const TrackCanvas = memo(
       setManualView,
       setViewportSize,
       stageRef,
+      stageInstance,
       syncTransform,
     });
 
@@ -1979,7 +1985,7 @@ const TrackCanvas = memo(
             <Stage
               width={viewportSize.width}
               height={viewportSize.height}
-              ref={stageRef}
+              ref={handleStageRef}
               draggable={activeTool === "grab" && !readOnly}
               onDragStart={onStageDragStart}
               onDragMove={onStageDragMove}

--- a/src/components/canvas/share/TrackCanvas.tsx
+++ b/src/components/canvas/share/TrackCanvas.tsx
@@ -67,6 +67,11 @@ const TrackCanvas = memo(
       precision: 1,
     });
     const stageRef = useRef<KonvaStage | null>(null);
+    const [stageInstance, setStageInstance] = useState<KonvaStage | null>(null);
+    const handleStageRef = useCallback((stage: KonvaStage | null) => {
+      stageRef.current = stage;
+      setStageInstance(stage);
+    }, []);
     const containerRef = useRef<HTMLDivElement | null>(null);
     const contentDragActiveRef = useRef(false);
     const hasManualViewRef = useRef(false);
@@ -165,6 +170,7 @@ const TrackCanvas = memo(
       setManualView,
       setViewportSize,
       stageRef,
+      stageInstance,
       syncTransform,
     });
 
@@ -432,7 +438,7 @@ const TrackCanvas = memo(
         <Stage
           width={viewportSize.width}
           height={viewportSize.height}
-          ref={stageRef}
+          ref={handleStageRef}
           draggable
           onDragStart={() => {
             setManualView(true);

--- a/src/components/canvas/useTrackCanvasViewport.ts
+++ b/src/components/canvas/useTrackCanvasViewport.ts
@@ -11,6 +11,7 @@ interface TrackCanvasViewportParams {
   setManualView: (value: boolean) => void;
   setViewportSize: (size: { width: number; height: number }) => void;
   stageRef: RefObject<KonvaStage | null>;
+  stageInstance: KonvaStage | null;
   syncTransform: () => void;
 }
 
@@ -22,10 +23,11 @@ export function useTrackCanvasViewport({
   setManualView,
   setViewportSize,
   stageRef,
+  stageInstance,
   syncTransform,
 }: TrackCanvasViewportParams) {
   useEffect(() => {
-    const stage = stageRef.current;
+    const stage = stageInstance;
     if (!stage) return;
 
     const syncStageTransform = () => {
@@ -44,7 +46,7 @@ export function useTrackCanvasViewport({
         syncStageTransform
       );
     };
-  }, [stageRef, syncTransform]);
+  }, [stageInstance, syncTransform]);
 
   useEffect(() => {
     const element = containerRef.current;


### PR DESCRIPTION
Updates the editor and shared read-only canvases to track the mounted Konva stage instance explicitly. The viewport hook now attaches wheel and transform listeners once the stage is available, instead of depending on a ref object that does not trigger effects when populated.

This keeps viewport sync behavior consistent after mount for both editable and shared canvases while preserving the existing `stageRef` access used by other canvas interactions.