### PR TITLE
feat: Add batch catalog type editing

### DIFF
--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -2025,6 +2025,7 @@ const TrackCanvas = memo(
                 {mobileShapeHitTargets}
                 {activeTool === "select" &&
                   !readOnly &&
+                  !mobileMultiSelectEnabled &&
                   selection.length > 1 &&
                   selectionFrame && (
                     <Group

--- a/src/components/canvas/renderers/polyline-shape.tsx
+++ b/src/components/canvas/renderers/polyline-shape.tsx
@@ -550,9 +550,11 @@ export function PolylineShapeContent({
 
   if (!pointsPxMemo.length) return null;
 
+  const canSelectPath = allowInteraction && !path.locked;
+
   return (
     <>
-      {allowInteraction && (
+      {canSelectPath && (
         <Line
           points={smoothPx.length >= 4 ? smoothPx : pointsPxMemo}
           stroke="#000000"
@@ -644,9 +646,8 @@ export function PolylineShapeContent({
           );
         })}
       </Group>
-      {allowInteraction &&
+      {canSelectPath &&
         isMobile &&
-        !path.locked &&
         selectedSegmentIndex !== null &&
         selectedSegmentPoint &&
         (() => {
@@ -673,8 +674,7 @@ export function PolylineShapeContent({
             </Group>
           );
         })()}
-      {allowInteraction &&
-        !path.locked &&
+      {canSelectPath &&
         displayPath.points.map((point, index) => {
           const x = m2px(point.x, designPpm);
           const y = m2px(point.y, designPpm);

--- a/src/components/canvas/renderers/shape-node.tsx
+++ b/src/components/canvas/renderers/shape-node.tsx
@@ -9,6 +9,7 @@ import { m2px, px2m } from "@/lib/track/units";
 import type { PolylinePoint, Shape } from "@/lib/types";
 import {
   renderLockedIndicator,
+  renderLockedPathSelectBadge,
   renderHoverIndicator,
   renderGate,
   renderFlag,
@@ -371,6 +372,7 @@ function TrackShapeNodeComponent({
         )}
       </Group>
       {shape.locked && renderLockedIndicator(shape, highlighted, designPpm)}
+      {shape.locked && renderLockedPathSelectBadge(shape, designPpm)}
     </Group>
   );
 }

--- a/src/components/canvas/renderers/shape-node.tsx
+++ b/src/components/canvas/renderers/shape-node.tsx
@@ -372,7 +372,9 @@ function TrackShapeNodeComponent({
         )}
       </Group>
       {shape.locked && renderLockedIndicator(shape, highlighted, designPpm)}
-      {shape.locked && <LockedPathSelectBadge shape={shape} ppm={designPpm} />}
+      {shape.locked && allowInteraction && (
+        <LockedPathSelectBadge shape={shape} ppm={designPpm} />
+      )}
     </Group>
   );
 }

--- a/src/components/canvas/renderers/shape-node.tsx
+++ b/src/components/canvas/renderers/shape-node.tsx
@@ -9,7 +9,7 @@ import { m2px, px2m } from "@/lib/track/units";
 import type { PolylinePoint, Shape } from "@/lib/types";
 import {
   renderLockedIndicator,
-  renderLockedPathSelectBadge,
+  LockedPathSelectBadge,
   renderHoverIndicator,
   renderGate,
   renderFlag,
@@ -372,7 +372,9 @@ function TrackShapeNodeComponent({
         )}
       </Group>
       {shape.locked && renderLockedIndicator(shape, highlighted, designPpm)}
-      {shape.locked && renderLockedPathSelectBadge(shape, designPpm)}
+      {shape.locked && (
+        <LockedPathSelectBadge shape={shape} ppm={designPpm} />
+      )}
     </Group>
   );
 }

--- a/src/components/canvas/renderers/shape-node.tsx
+++ b/src/components/canvas/renderers/shape-node.tsx
@@ -372,9 +372,7 @@ function TrackShapeNodeComponent({
         )}
       </Group>
       {shape.locked && renderLockedIndicator(shape, highlighted, designPpm)}
-      {shape.locked && (
-        <LockedPathSelectBadge shape={shape} ppm={designPpm} />
-      )}
+      {shape.locked && <LockedPathSelectBadge shape={shape} ppm={designPpm} />}
     </Group>
   );
 }

--- a/src/components/canvas/renderers/shape-renderers.tsx
+++ b/src/components/canvas/renderers/shape-renderers.tsx
@@ -92,6 +92,43 @@ export function renderLockedIndicator(
   );
 }
 
+export function renderLockedPathSelectBadge(shape: Shape, ppm: number) {
+  if (shape.kind !== "polyline") return null;
+  const bounds = getShapeLocalBounds(shape, ppm);
+  if (!bounds) return null;
+
+  const width = 34;
+  const height = 16;
+  const x = bounds.x - 6;
+  const y = bounds.y - height - 8;
+
+  return (
+    <Group x={x} y={y}>
+      <Rect
+        width={width}
+        height={height}
+        fill="#f59e0b"
+        opacity={0.92}
+        cornerRadius={5}
+        shadowColor="#0f172a"
+        shadowOpacity={0.18}
+        shadowBlur={6}
+        shadowOffsetY={2}
+      />
+      <Text
+        width={width}
+        height={height}
+        text="LOCK"
+        fill="#111827"
+        fontSize={8}
+        fontStyle="700"
+        align="center"
+        verticalAlign="middle"
+      />
+    </Group>
+  );
+}
+
 export function renderHoverIndicator(shape: Shape, ppm: number) {
   const bounds = getShapeLocalBounds(shape, ppm);
   if (!bounds) return null;

--- a/src/components/canvas/renderers/shape-renderers.tsx
+++ b/src/components/canvas/renderers/shape-renderers.tsx
@@ -8,6 +8,7 @@ import {
   Shape as KonvaShape,
   Text,
 } from "react-konva";
+import { useTheme } from "@/hooks/useTheme";
 import { m2px } from "@/lib/track/units";
 import {
   getCone2DShape,
@@ -92,36 +93,43 @@ export function renderLockedIndicator(
   );
 }
 
-export function renderLockedPathSelectBadge(shape: Shape, ppm: number) {
+export function LockedPathSelectBadge({
+  shape,
+  ppm,
+}: {
+  shape: Shape;
+  ppm: number;
+}) {
+  const isDark = useTheme() === "dark";
+
   if (shape.kind !== "polyline") return null;
   const bounds = getShapeLocalBounds(shape, ppm);
   if (!bounds) return null;
 
-  const width = 34;
+  const pad = 6;
+  const width = 46;
   const height = 16;
-  const x = bounds.x - 6;
-  const y = bounds.y - height - 8;
+  const x = bounds.x - pad;
+  const y = bounds.y - pad - height - 5;
 
   return (
     <Group x={x} y={y}>
       <Rect
         width={width}
         height={height}
-        fill="#f59e0b"
-        opacity={0.92}
-        cornerRadius={5}
-        shadowColor="#0f172a"
-        shadowOpacity={0.18}
-        shadowBlur={6}
-        shadowOffsetY={2}
+        fill={isDark ? "#451a03" : "#fffbeb"}
+        stroke="#f59e0b"
+        strokeWidth={1}
+        cornerRadius={999}
+        opacity={0.94}
       />
       <Text
         width={width}
         height={height}
-        text="LOCK"
-        fill="#111827"
-        fontSize={8}
-        fontStyle="700"
+        text="Locked"
+        fill={isDark ? "#fde68a" : "#92400e"}
+        fontSize={9}
+        fontStyle="600"
         align="center"
         verticalAlign="middle"
       />

--- a/src/components/canvas/useTrackCanvasInteractions.ts
+++ b/src/components/canvas/useTrackCanvasInteractions.ts
@@ -171,6 +171,15 @@ export function useTrackCanvasInteractions({
       ),
     [designShapes]
   );
+  const marqueeExcludeIds = useMemo(
+    () =>
+      new Set(
+        designShapes
+          .filter((shape) => shape.kind === "polyline" && shape.locked)
+          .map((shape) => shape.id)
+      ),
+    [designShapes]
+  );
 
   const getNearbySnapCandidates = useCallback(
     (meters: { x: number; y: number }) => {
@@ -867,6 +876,7 @@ export function useTrackCanvasInteractions({
       marqueeOriginRef.current = null;
       setMarqueeRect(null);
       const marqueeSelection = getSelectedIdsInMarquee({
+        excludeIds: marqueeExcludeIds,
         marqueeRect: rect,
         shapeRefs: shapeRefs.current,
         stage,
@@ -888,6 +898,7 @@ export function useTrackCanvasInteractions({
       addShapes,
       marqueeAdditiveRef,
       marqueeOriginRef,
+      marqueeExcludeIds,
       marqueeRect,
       pointerToMeters,
       readOnly,

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -708,6 +708,7 @@ export default function EditorShell({
             }}
             onOpenInspector={() => {
               setMobileToolsOpen(false);
+              setMobileMultiSelectEnabled(false);
               setMobileInspectorOpen(true);
             }}
             onResumeSelectedPath={() => {

--- a/src/components/editor/mobile/EditorMobilePanels.tsx
+++ b/src/components/editor/mobile/EditorMobilePanels.tsx
@@ -107,6 +107,7 @@ interface EditorMobilePanelsProps {
   onSetReadOnlyMenuOpen: (open: boolean) => void;
   onShare: () => void;
   onSetGroupName?: (name: string) => void;
+
   onStartFlyThrough: () => void;
   studioHref?: string;
   onUngroupSelection: () => void;
@@ -442,7 +443,6 @@ export function EditorMobilePanels({
       mediaQuery.removeEventListener("change", updateLandscapeMobile);
   }, []);
 
-  const canOpenInspector = !mobileMultiSelectEnabled;
   const {
     mobileStatusTitle,
     mobileStatusValue,
@@ -458,11 +458,8 @@ export function EditorMobilePanels({
     selectedCount,
     tab,
   });
-  const inspectorHint = canOpenInspector
-    ? selectedCount > 0
-      ? `${selectedCount} selected`
-      : "Design settings"
-    : "Finish multi-select to inspect";
+  const inspectorHint =
+    selectedCount > 0 ? `${selectedCount} selected` : "Design settings";
   const handleMobileSelectButton = () => {
     if (mobileMultiSelectEnabled) {
       onExitMobileMultiSelect();
@@ -519,13 +516,7 @@ export function EditorMobilePanels({
             </div>
             <button
               onClick={openInspectorDrawer}
-              disabled={!canOpenInspector}
-              className={cn(
-                "flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium transition-colors landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5",
-                canOpenInspector
-                  ? "text-white/72 hover:bg-white/10 hover:text-white"
-                  : "text-white/38"
-              )}
+              className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5"
             >
               <SlidersHorizontal className="size-3.5" />
               <span>Inspect</span>

--- a/src/components/inspector/Inspector.tsx
+++ b/src/components/inspector/Inspector.tsx
@@ -33,6 +33,7 @@ function Inspector({
   const selection = useEditor((state) => state.session.selection);
   const {
     updateShape,
+    updateShapesCatalogType,
     setShapesLocked,
     updatePolylinePoint,
     insertPolylinePoint,
@@ -101,6 +102,7 @@ function Inspector({
         setGroupName={setGroupName}
         setSelection={setSelection}
         ungroupSelection={ungroupSelection}
+        updateShapesCatalogType={updateShapesCatalogType}
       />
     );
   } else if (count === 1) {

--- a/src/components/inspector/views/multi.tsx
+++ b/src/components/inspector/views/multi.tsx
@@ -5,12 +5,28 @@ import ElevationChart from "@/components/inspector/ElevationChart";
 import { Input } from "@/components/ui/input";
 import { shapeKindLabels } from "@/lib/editor-tools";
 import {
+  getCatalogEntriesByKind,
+  getTrackElementCatalogEntry,
+  getTrackElementCatalogIdentity,
+  TRACKDRAW_FLAG_ELEMENT_ID,
+  TRACKDRAW_GATE_ELEMENT_ID,
+  TRACKDRAW_LADDER_ELEMENT_ID,
+  type TrackElementCatalogId,
+} from "@/lib/track/elements/catalog";
+import {
   getShapeGroupId,
   getShapeGroupName,
   selectionHasGroupedShapes,
 } from "@/lib/track/shape-groups";
 import type { Shape } from "@/lib/types";
 import { Copy, GitMerge, Group, Trash2, Ungroup } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   IconBtn,
   Row,
@@ -34,7 +50,41 @@ export interface MultiInspectorViewProps {
   setGroupName: (ids: string[], name: string) => void;
   setSelection: Dispatch<SetStateAction<string[]>> | ((ids: string[]) => void);
   ungroupSelection: (ids: string[]) => void;
+  updateShapesCatalogType: (
+    ids: string[],
+    entryId: TrackElementCatalogId
+  ) => void;
   mobileInline?: boolean;
+}
+
+export type BatchCatalogKind = "gate" | "flag" | "ladder";
+
+const defaultCatalogEntryByKind: Record<
+  BatchCatalogKind,
+  TrackElementCatalogId
+> = {
+  gate: TRACKDRAW_GATE_ELEMENT_ID,
+  flag: TRACKDRAW_FLAG_ELEMENT_ID,
+  ladder: TRACKDRAW_LADDER_ELEMENT_ID,
+};
+
+export function getBatchCatalogKind(shapes: Shape[]): BatchCatalogKind | null {
+  const firstKind = shapes[0]?.kind;
+  if (firstKind !== "gate" && firstKind !== "flag" && firstKind !== "ladder") {
+    return null;
+  }
+  return shapes.every((shape) => shape.kind === firstKind) ? firstKind : null;
+}
+
+export function getBatchCatalogEntryId(
+  shape: Shape,
+  kind: BatchCatalogKind
+): TrackElementCatalogId {
+  const catalogId = getTrackElementCatalogIdentity(shape.meta)?.elementId;
+  const catalogEntry = getTrackElementCatalogEntry(catalogId);
+  return catalogEntry?.kind === kind
+    ? catalogEntry.id
+    : defaultCatalogEntryByKind[kind];
 }
 
 export function MultiInspectorView({
@@ -47,6 +97,7 @@ export function MultiInspectorView({
   setGroupName,
   setSelection,
   ungroupSelection,
+  updateShapesCatalogType,
   mobileInline = false,
 }: MultiInspectorViewProps) {
   const { startBatch, finishBatch } = useInspectorInputBatch();
@@ -76,6 +127,22 @@ export function MultiInspectorView({
   const activeGroupName =
     groupCount === 1 ? (getShapeGroupName(selectedShapes[0]) ?? "") : "";
   const canGroupSelection = selection.length > 1 && !hasGroupedShapes;
+  const batchCatalogKind = getBatchCatalogKind(selectedShapes);
+  const batchCatalogEntries = batchCatalogKind
+    ? getCatalogEntriesByKind(batchCatalogKind)
+    : null;
+  const editableCatalogShapes = batchCatalogKind
+    ? selectedShapes.filter((shape) => !shape.locked)
+    : [];
+  const editableCatalogSelectionCount = editableCatalogShapes.length;
+  const editableCatalogIds = editableCatalogShapes.map((shape) =>
+    getBatchCatalogEntryId(shape, batchCatalogKind!)
+  );
+  const activeBatchCatalogId =
+    editableCatalogIds.length > 0 &&
+    editableCatalogIds.every((id) => id === editableCatalogIds[0])
+      ? editableCatalogIds[0]
+      : undefined;
   const meta = [
     ...(groupCount > 0
       ? [`${groupCount} group${groupCount === 1 ? "" : "s"}`]
@@ -154,6 +221,42 @@ export function MultiInspectorView({
                 </div>
               ))}
           </div>
+          {batchCatalogEntries ? (
+            <Section title="Catalog" defaultOpen>
+              <Row label="Type">
+                <Select
+                  value={activeBatchCatalogId}
+                  disabled={editableCatalogSelectionCount === 0}
+                  onValueChange={(value) =>
+                    updateShapesCatalogType(
+                      selection,
+                      value as TrackElementCatalogId
+                    )
+                  }
+                >
+                  <SelectTrigger className="border-border/40 bg-muted/40 h-9 w-full text-xs shadow-none lg:h-7 lg:text-[11px]">
+                    <SelectValue placeholder="Mixed types" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {batchCatalogEntries.map((entry) => (
+                      <SelectItem
+                        key={entry.id}
+                        value={entry.id}
+                        className="text-xs lg:text-[11px]"
+                      >
+                        {entry.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Row>
+              {editableCatalogSelectionCount < selectedShapes.length ? (
+                <p className="text-muted-foreground px-0.5 text-[10px] leading-relaxed">
+                  Locked items stay unchanged.
+                </p>
+              ) : null}
+            </Section>
+          ) : null}
           {groupCount === 1 && (
             <Section title="Group">
               <Row label="Group name">

--- a/src/lib/canvas/interaction-helpers.ts
+++ b/src/lib/canvas/interaction-helpers.ts
@@ -296,11 +296,12 @@ export function getTouchInteractionMode(options: {
 }
 
 export function getSelectedIdsInMarquee(options: {
+  excludeIds?: ReadonlySet<string>;
   marqueeRect: { x: number; y: number; width: number; height: number };
   shapeRefs: Record<string, KonvaGroup | null>;
   stage: KonvaStage;
 }) {
-  const { marqueeRect, shapeRefs, stage } = options;
+  const { excludeIds, marqueeRect, shapeRefs, stage } = options;
   if (
     marqueeRect.width < MIN_MARQUEE_SIZE &&
     marqueeRect.height < MIN_MARQUEE_SIZE
@@ -309,6 +310,7 @@ export function getSelectedIdsInMarquee(options: {
   }
 
   const ids = Object.entries(shapeRefs)
+    .filter(([id]) => !excludeIds?.has(id))
     .filter(
       (entry): entry is [string, NonNullable<(typeof shapeRefs)[string]>] =>
         Boolean(entry[1])

--- a/src/lib/editor/store-types.ts
+++ b/src/lib/editor/store-types.ts
@@ -63,6 +63,10 @@ export interface EditorTrackActions {
   addShapes: (shapes: ShapeDraft[]) => string[];
   updateShape: (id: string, patch: Partial<Shape>) => void;
   updateShapes: (ids: string[], patch: Partial<Shape>) => void;
+  updateShapesCatalogType: (
+    ids: string[],
+    entryId: TrackElementCatalogId
+  ) => void;
   setShapesLocked: (ids: string[], locked: boolean) => void;
   setPolylinePoints: (id: string, points: PolylinePoint[]) => void;
   updatePolylinePoint: (

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -5,6 +5,9 @@ export function useTrackActions() {
   const addShapes = useEditor((state) => state.addShapes);
   const updateShape = useEditor((state) => state.updateShape);
   const updateShapes = useEditor((state) => state.updateShapes);
+  const updateShapesCatalogType = useEditor(
+    (state) => state.updateShapesCatalogType
+  );
   const setShapesLocked = useEditor((state) => state.setShapesLocked);
   const setPolylinePoints = useEditor((state) => state.setPolylinePoints);
   const updatePolylinePoint = useEditor((state) => state.updatePolylinePoint);
@@ -47,6 +50,7 @@ export function useTrackActions() {
     addShapes,
     updateShape,
     updateShapes,
+    updateShapesCatalogType,
     setShapesLocked,
     setPolylinePoints,
     updatePolylinePoint,

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -4,7 +4,14 @@ import { create } from "zustand";
 import { temporal } from "zundo";
 import { immer } from "zustand/middleware/immer";
 import { nanoid } from "nanoid";
-import type { PolylineShape, Shape, TrackDesign } from "@/lib/types";
+import type {
+  FlagShape,
+  GateShape,
+  LadderShape,
+  PolylineShape,
+  Shape,
+  TrackDesign,
+} from "@/lib/types";
 import { normalizeMapReference } from "@/lib/map-reference/geometry";
 import { clamp } from "@/lib/canvas/shared";
 import {
@@ -46,6 +53,11 @@ import {
   expandGroupedSelection,
   getShapeGroupId,
 } from "@/lib/track/shape-groups";
+import {
+  buildFlagCatalogTypePatch,
+  buildGateCatalogTypePatch,
+  buildLadderCatalogTypePatch,
+} from "@/lib/editor-tools";
 
 export type { EditorTool } from "@/lib/editor-tools";
 
@@ -58,6 +70,7 @@ interface EditorState {
   addShapes: EditorTrackActions["addShapes"];
   updateShape: EditorTrackActions["updateShape"];
   updateShapes: EditorTrackActions["updateShapes"];
+  updateShapesCatalogType: EditorTrackActions["updateShapesCatalogType"];
   setShapesLocked: EditorTrackActions["setShapesLocked"];
   setPolylinePoints: EditorTrackActions["setPolylinePoints"];
   updatePolylinePoint: EditorTrackActions["updatePolylinePoint"];
@@ -192,6 +205,38 @@ export const useEditor = create<EditorState>()(
             const shape = draft.track.design.shapeById[id];
             if (!shape || shape.locked) continue;
             if (applyShapePatch(shape, patch)) {
+              changed = true;
+            }
+          }
+
+          if (changed) {
+            touchTrackDesign(draft);
+          }
+        }),
+
+      updateShapesCatalogType: (ids, entryId) =>
+        set((draft) => {
+          let changed = false;
+          const patchBuilders = {
+            gate: (s: Shape) =>
+              buildGateCatalogTypePatch(s as GateShape, entryId),
+            flag: (s: Shape) =>
+              buildFlagCatalogTypePatch(s as FlagShape, entryId),
+            ladder: (s: Shape) =>
+              buildLadderCatalogTypePatch(s as LadderShape, entryId),
+          } as const;
+
+          for (const id of ids) {
+            const shape = draft.track.design.shapeById[id];
+            if (!shape || shape.locked) continue;
+
+            const builder =
+              shape.kind in patchBuilders
+                ? patchBuilders[shape.kind as keyof typeof patchBuilders]
+                : null;
+            const patch = builder ? builder(shape) : null;
+
+            if (patch && applyShapePatch(shape, patch as Partial<Shape>)) {
               changed = true;
             }
           }

--- a/tests/components/inspector/multi-helpers.test.ts
+++ b/tests/components/inspector/multi-helpers.test.ts
@@ -59,7 +59,14 @@ describe("getBatchCatalogKind", () => {
   });
 
   it("returns null for non-catalog kind", () => {
-    const cone = { id: "c1", kind: "cone", x: 0, y: 0, rotation: 0, radius: 1 } as Shape;
+    const cone = {
+      id: "c1",
+      kind: "cone",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      radius: 1,
+    } as Shape;
     expect(getBatchCatalogKind([cone])).toBeNull();
   });
 
@@ -72,15 +79,21 @@ describe("getBatchCatalogKind", () => {
   });
 
   it("returns 'gate' for all gates", () => {
-    expect(getBatchCatalogKind([gate({ id: "g1" }), gate({ id: "g2" })])).toBe("gate");
+    expect(getBatchCatalogKind([gate({ id: "g1" }), gate({ id: "g2" })])).toBe(
+      "gate"
+    );
   });
 
   it("returns 'flag' for all flags", () => {
-    expect(getBatchCatalogKind([flag({ id: "f1" }), flag({ id: "f2" })])).toBe("flag");
+    expect(getBatchCatalogKind([flag({ id: "f1" }), flag({ id: "f2" })])).toBe(
+      "flag"
+    );
   });
 
   it("returns 'ladder' for all ladders", () => {
-    expect(getBatchCatalogKind([ladder({ id: "l1" }), ladder({ id: "l2" })])).toBe("ladder");
+    expect(
+      getBatchCatalogKind([ladder({ id: "l1" }), ladder({ id: "l2" })])
+    ).toBe("ladder");
   });
 
   it("returns kind for a single shape", () => {
@@ -90,22 +103,32 @@ describe("getBatchCatalogKind", () => {
 
 describe("getBatchCatalogEntryId", () => {
   it("returns default gate ID when shape has no catalog meta", () => {
-    expect(getBatchCatalogEntryId(gate(), "gate")).toBe(TRACKDRAW_GATE_ELEMENT_ID);
+    expect(getBatchCatalogEntryId(gate(), "gate")).toBe(
+      TRACKDRAW_GATE_ELEMENT_ID
+    );
   });
 
   it("returns default flag ID when shape has no catalog meta", () => {
-    expect(getBatchCatalogEntryId(flag(), "flag")).toBe(TRACKDRAW_FLAG_ELEMENT_ID);
+    expect(getBatchCatalogEntryId(flag(), "flag")).toBe(
+      TRACKDRAW_FLAG_ELEMENT_ID
+    );
   });
 
   it("returns default ladder ID when shape has no catalog meta", () => {
-    expect(getBatchCatalogEntryId(ladder(), "ladder")).toBe(TRACKDRAW_LADDER_ELEMENT_ID);
+    expect(getBatchCatalogEntryId(ladder(), "ladder")).toBe(
+      TRACKDRAW_LADDER_ELEMENT_ID
+    );
   });
 
   it("returns the catalog entry ID when shape has matching catalog meta", () => {
-    const entry = getTrackElementCatalogEntry(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID)!;
+    const entry = getTrackElementCatalogEntry(
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
+    )!;
     const meta = { catalog: createTrackElementCatalogIdentity(entry) };
     const shape = gate({ meta });
-    expect(getBatchCatalogEntryId(shape, "gate")).toBe(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
+    expect(getBatchCatalogEntryId(shape, "gate")).toBe(
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
+    );
   });
 
   it("returns default ID when catalog meta kind doesn't match requested kind", () => {
@@ -113,6 +136,8 @@ describe("getBatchCatalogEntryId", () => {
     const entry = getTrackElementCatalogEntry(MULTIGP_CORNER_FLAG_ELEMENT_ID)!;
     const meta = { catalog: createTrackElementCatalogIdentity(entry) };
     const shape = gate({ meta });
-    expect(getBatchCatalogEntryId(shape, "gate")).toBe(TRACKDRAW_GATE_ELEMENT_ID);
+    expect(getBatchCatalogEntryId(shape, "gate")).toBe(
+      TRACKDRAW_GATE_ELEMENT_ID
+    );
   });
 });

--- a/tests/components/inspector/multi-helpers.test.ts
+++ b/tests/components/inspector/multi-helpers.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBatchCatalogKind,
+  getBatchCatalogEntryId,
+} from "@/components/inspector/views/multi";
+import {
+  TRACKDRAW_GATE_ELEMENT_ID,
+  TRACKDRAW_FLAG_ELEMENT_ID,
+  TRACKDRAW_LADDER_ELEMENT_ID,
+  MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+  MULTIGP_CORNER_FLAG_ELEMENT_ID,
+  createTrackElementCatalogIdentity,
+  getTrackElementCatalogEntry,
+} from "@/lib/track/elements/catalog";
+import type { Shape } from "@/lib/types";
+
+function gate(overrides: Partial<Shape> = {}): Shape {
+  return {
+    id: "g1",
+    kind: "gate",
+    x: 0,
+    y: 0,
+    rotation: 0,
+    width: 3,
+    height: 3,
+    ...overrides,
+  } as Shape;
+}
+
+function flag(overrides: Partial<Shape> = {}): Shape {
+  return {
+    id: "f1",
+    kind: "flag",
+    x: 0,
+    y: 0,
+    rotation: 0,
+    radius: 1,
+    ...overrides,
+  } as Shape;
+}
+
+function ladder(overrides: Partial<Shape> = {}): Shape {
+  return {
+    id: "l1",
+    kind: "ladder",
+    x: 0,
+    y: 0,
+    rotation: 0,
+    width: 2,
+    height: 2,
+    rungs: 3,
+    ...overrides,
+  } as Shape;
+}
+
+describe("getBatchCatalogKind", () => {
+  it("returns null for empty array", () => {
+    expect(getBatchCatalogKind([])).toBeNull();
+  });
+
+  it("returns null for non-catalog kind", () => {
+    const cone = { id: "c1", kind: "cone", x: 0, y: 0, rotation: 0, radius: 1 } as Shape;
+    expect(getBatchCatalogKind([cone])).toBeNull();
+  });
+
+  it("returns null for mixed kinds", () => {
+    expect(getBatchCatalogKind([gate(), flag()])).toBeNull();
+  });
+
+  it("returns null for mixed obstacle kinds", () => {
+    expect(getBatchCatalogKind([gate(), ladder()])).toBeNull();
+  });
+
+  it("returns 'gate' for all gates", () => {
+    expect(getBatchCatalogKind([gate({ id: "g1" }), gate({ id: "g2" })])).toBe("gate");
+  });
+
+  it("returns 'flag' for all flags", () => {
+    expect(getBatchCatalogKind([flag({ id: "f1" }), flag({ id: "f2" })])).toBe("flag");
+  });
+
+  it("returns 'ladder' for all ladders", () => {
+    expect(getBatchCatalogKind([ladder({ id: "l1" }), ladder({ id: "l2" })])).toBe("ladder");
+  });
+
+  it("returns kind for a single shape", () => {
+    expect(getBatchCatalogKind([gate()])).toBe("gate");
+  });
+});
+
+describe("getBatchCatalogEntryId", () => {
+  it("returns default gate ID when shape has no catalog meta", () => {
+    expect(getBatchCatalogEntryId(gate(), "gate")).toBe(TRACKDRAW_GATE_ELEMENT_ID);
+  });
+
+  it("returns default flag ID when shape has no catalog meta", () => {
+    expect(getBatchCatalogEntryId(flag(), "flag")).toBe(TRACKDRAW_FLAG_ELEMENT_ID);
+  });
+
+  it("returns default ladder ID when shape has no catalog meta", () => {
+    expect(getBatchCatalogEntryId(ladder(), "ladder")).toBe(TRACKDRAW_LADDER_ELEMENT_ID);
+  });
+
+  it("returns the catalog entry ID when shape has matching catalog meta", () => {
+    const entry = getTrackElementCatalogEntry(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID)!;
+    const meta = { catalog: createTrackElementCatalogIdentity(entry) };
+    const shape = gate({ meta });
+    expect(getBatchCatalogEntryId(shape, "gate")).toBe(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
+  });
+
+  it("returns default ID when catalog meta kind doesn't match requested kind", () => {
+    // A gate shape that somehow has a flag catalog entry — falls back to default
+    const entry = getTrackElementCatalogEntry(MULTIGP_CORNER_FLAG_ELEMENT_ID)!;
+    const meta = { catalog: createTrackElementCatalogIdentity(entry) };
+    const shape = gate({ meta });
+    expect(getBatchCatalogEntryId(shape, "gate")).toBe(TRACKDRAW_GATE_ELEMENT_ID);
+  });
+});

--- a/tests/lib/canvas/interaction-helpers.test.ts
+++ b/tests/lib/canvas/interaction-helpers.test.ts
@@ -224,9 +224,13 @@ describe("canvas interaction helpers", () => {
 
   it("collects marquee-selected ids and respects the minimum marquee size", () => {
     const result = getSelectedIdsInMarquee({
+      excludeIds: new Set(["locked-path"]),
       marqueeRect: { x: 0, y: 0, width: 20, height: 20 },
       shapeRefs: {
         a: {
+          getClientRect: () => ({ x: 5, y: 5, width: 4, height: 4 }),
+        } as never,
+        "locked-path": {
           getClientRect: () => ({ x: 5, y: 5, width: 4, height: 4 }),
         } as never,
         b: {

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -535,9 +535,8 @@ describe("editor store history", () => {
       expect(editableGate.height).toBeCloseTo(1.524);
     }
     expect(
-      getTrackElementCatalogIdentity(
-        nextDesign.shapeById[editableGateId]?.meta
-      )?.elementId
+      getTrackElementCatalogIdentity(nextDesign.shapeById[editableGateId]?.meta)
+        ?.elementId
     ).toBe(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
     expect(nextDesign.updatedAt).toBe("2026-04-13T10:10:07.000Z");
     expect(getPastStatesCount()).toBe(1);
@@ -1079,9 +1078,27 @@ describe("editor store history", () => {
 
   it("reorderShapes moves a shape before another", () => {
     const state = useEditor.getState();
-    const a = state.addShape({ kind: "cone", x: 0, y: 0, rotation: 0, radius: 1 });
-    const b = state.addShape({ kind: "cone", x: 1, y: 0, rotation: 0, radius: 1 });
-    const c = state.addShape({ kind: "cone", x: 2, y: 0, rotation: 0, radius: 1 });
+    const a = state.addShape({
+      kind: "cone",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      radius: 1,
+    });
+    const b = state.addShape({
+      kind: "cone",
+      x: 1,
+      y: 0,
+      rotation: 0,
+      radius: 1,
+    });
+    const c = state.addShape({
+      kind: "cone",
+      x: 2,
+      y: 0,
+      rotation: 0,
+      radius: 1,
+    });
 
     state.reorderShapes(c, a);
     expect(useEditor.getState().track.design.shapeOrder).toEqual([c, a, b]);
@@ -1089,9 +1106,27 @@ describe("editor store history", () => {
 
   it("reorderShapes with null beforeId moves shape to end", () => {
     const state = useEditor.getState();
-    const a = state.addShape({ kind: "cone", x: 0, y: 0, rotation: 0, radius: 1 });
-    const b = state.addShape({ kind: "cone", x: 1, y: 0, rotation: 0, radius: 1 });
-    const c = state.addShape({ kind: "cone", x: 2, y: 0, rotation: 0, radius: 1 });
+    const a = state.addShape({
+      kind: "cone",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      radius: 1,
+    });
+    const b = state.addShape({
+      kind: "cone",
+      x: 1,
+      y: 0,
+      rotation: 0,
+      radius: 1,
+    });
+    const c = state.addShape({
+      kind: "cone",
+      x: 2,
+      y: 0,
+      rotation: 0,
+      radius: 1,
+    });
 
     state.reorderShapes(a, null);
     expect(useEditor.getState().track.design.shapeOrder).toEqual([b, c, a]);
@@ -1099,8 +1134,14 @@ describe("editor store history", () => {
 
   it("reorderShapes is a no-op when fromId equals beforeId", () => {
     const state = useEditor.getState();
-    const a = state.addShape({ kind: "cone", x: 0, y: 0, rotation: 0, radius: 1 });
-    const b = state.addShape({ kind: "cone", x: 1, y: 0, rotation: 0, radius: 1 });
+    const a = state.addShape({
+      kind: "cone",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      radius: 1,
+    });
+    state.addShape({ kind: "cone", x: 1, y: 0, rotation: 0, radius: 1 });
 
     const orderBefore = [...useEditor.getState().track.design.shapeOrder];
     state.reorderShapes(a, a);
@@ -1125,7 +1166,10 @@ describe("editor store history", () => {
       locked: true,
     });
 
-    state.updateShapesCatalogType([editableId, lockedId], MULTIGP_CORNER_FLAG_ELEMENT_ID);
+    state.updateShapesCatalogType(
+      [editableId, lockedId],
+      MULTIGP_CORNER_FLAG_ELEMENT_ID
+    );
 
     expect(
       getTrackElementCatalogIdentity(
@@ -1175,7 +1219,9 @@ describe("editor store history", () => {
 
     state.updateShapesCatalogType([id], MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
 
-    expect(useEditor.getState().track.design.shapeById[id]?.meta).toBeUndefined();
+    expect(
+      useEditor.getState().track.design.shapeById[id]?.meta
+    ).toBeUndefined();
     expect(getPastStatesCount()).toBe(0);
   });
 });

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditor } from "@/store/editor";
+import {
+  MULTIGP_CORNER_FLAG_ELEMENT_ID,
+  MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+  MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID,
+  getTrackElementCatalogIdentity,
+} from "@/lib/track/elements/catalog";
 
 function getPastStatesCount() {
   return useEditor.temporal.getState().pastStates.length;
@@ -479,6 +485,61 @@ describe("editor store history", () => {
       width: 4,
     });
     expect(nextDesign.updatedAt).toBe("2026-04-13T10:10:06.000Z");
+    expect(getPastStatesCount()).toBe(1);
+  });
+
+  it("batch switches catalog gate types while leaving locked gates unchanged", () => {
+    const state = useEditor.getState();
+    const lockedGateId = state.addShape({
+      kind: "gate",
+      x: 10,
+      y: 8,
+      rotation: 35,
+      width: 2,
+      height: 2,
+      locked: true,
+    });
+    const editableGateId = state.addShape({
+      kind: "gate",
+      x: 12,
+      y: 9,
+      rotation: 45,
+      width: 2,
+      height: 2,
+    });
+
+    state.clearHistory();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-13T10:10:07.000Z"));
+
+    state.updateShapesCatalogType(
+      [lockedGateId, editableGateId],
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
+    );
+
+    const nextDesign = useEditor.getState().track.design;
+    expect(nextDesign.shapeById[lockedGateId]).toMatchObject({
+      width: 2,
+      height: 2,
+      rotation: 35,
+    });
+    expect(nextDesign.shapeById[editableGateId]).toMatchObject({
+      x: 12,
+      y: 9,
+      rotation: 45,
+    });
+    const editableGate = nextDesign.shapeById[editableGateId];
+    expect(editableGate?.kind).toBe("gate");
+    if (editableGate?.kind === "gate") {
+      expect(editableGate.width).toBeCloseTo(1.524);
+      expect(editableGate.height).toBeCloseTo(1.524);
+    }
+    expect(
+      getTrackElementCatalogIdentity(
+        nextDesign.shapeById[editableGateId]?.meta
+      )?.elementId
+    ).toBe(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
+    expect(nextDesign.updatedAt).toBe("2026-04-13T10:10:07.000Z");
     expect(getPastStatesCount()).toBe(1);
   });
 
@@ -1014,5 +1075,107 @@ describe("editor store history", () => {
       thirdId,
       firstId,
     ]);
+  });
+
+  it("reorderShapes moves a shape before another", () => {
+    const state = useEditor.getState();
+    const a = state.addShape({ kind: "cone", x: 0, y: 0, rotation: 0, radius: 1 });
+    const b = state.addShape({ kind: "cone", x: 1, y: 0, rotation: 0, radius: 1 });
+    const c = state.addShape({ kind: "cone", x: 2, y: 0, rotation: 0, radius: 1 });
+
+    state.reorderShapes(c, a);
+    expect(useEditor.getState().track.design.shapeOrder).toEqual([c, a, b]);
+  });
+
+  it("reorderShapes with null beforeId moves shape to end", () => {
+    const state = useEditor.getState();
+    const a = state.addShape({ kind: "cone", x: 0, y: 0, rotation: 0, radius: 1 });
+    const b = state.addShape({ kind: "cone", x: 1, y: 0, rotation: 0, radius: 1 });
+    const c = state.addShape({ kind: "cone", x: 2, y: 0, rotation: 0, radius: 1 });
+
+    state.reorderShapes(a, null);
+    expect(useEditor.getState().track.design.shapeOrder).toEqual([b, c, a]);
+  });
+
+  it("reorderShapes is a no-op when fromId equals beforeId", () => {
+    const state = useEditor.getState();
+    const a = state.addShape({ kind: "cone", x: 0, y: 0, rotation: 0, radius: 1 });
+    const b = state.addShape({ kind: "cone", x: 1, y: 0, rotation: 0, radius: 1 });
+
+    const orderBefore = [...useEditor.getState().track.design.shapeOrder];
+    state.reorderShapes(a, a);
+    expect(useEditor.getState().track.design.shapeOrder).toEqual(orderBefore);
+  });
+
+  it("updateShapesCatalogType switches flag types and skips locked flags", () => {
+    const state = useEditor.getState();
+    const editableId = state.addShape({
+      kind: "flag",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      radius: 1,
+    });
+    const lockedId = state.addShape({
+      kind: "flag",
+      x: 1,
+      y: 0,
+      rotation: 0,
+      radius: 1,
+      locked: true,
+    });
+
+    state.updateShapesCatalogType([editableId, lockedId], MULTIGP_CORNER_FLAG_ELEMENT_ID);
+
+    expect(
+      getTrackElementCatalogIdentity(
+        useEditor.getState().track.design.shapeById[editableId]?.meta
+      )?.elementId
+    ).toBe(MULTIGP_CORNER_FLAG_ELEMENT_ID);
+    expect(
+      getTrackElementCatalogIdentity(
+        useEditor.getState().track.design.shapeById[lockedId]?.meta
+      )
+    ).toBeNull();
+  });
+
+  it("updateShapesCatalogType switches ladder types", () => {
+    const state = useEditor.getState();
+    const id = state.addShape({
+      kind: "ladder",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: 2,
+      height: 2,
+      rungs: 3,
+    });
+
+    state.updateShapesCatalogType([id], MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID);
+
+    expect(
+      getTrackElementCatalogIdentity(
+        useEditor.getState().track.design.shapeById[id]?.meta
+      )?.elementId
+    ).toBe(MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID);
+  });
+
+  it("updateShapesCatalogType does nothing when all shapes are locked", () => {
+    const state = useEditor.getState();
+    const id = state.addShape({
+      kind: "gate",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: 3,
+      height: 3,
+      locked: true,
+    });
+    state.clearHistory();
+
+    state.updateShapesCatalogType([id], MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
+
+    expect(useEditor.getState().track.design.shapeById[id]?.meta).toBeUndefined();
+    expect(getPastStatesCount()).toBe(0);
   });
 });


### PR DESCRIPTION
Adds bulk catalog type editing for multi-selected gates, flags, and ladders. When the selection contains one compatible catalog kind, the multi-select inspector now shows a Catalog Type dropdown and applies the same catalog patch behavior used by the single-item inspector. Locked items stay unchanged.

Also improves locked race-line ergonomics: locked paths no longer intercept canvas clicks or marquee selection, making it easier to select nearby gates, while a small LOCK badge remains clickable so the path can still be selected and unlocked from the inspector. On mobile, opening the inspector now exits multi-select so batch controls are reachable.