### PR TITLE
fix: Improve path waypoint selection UX

### DIFF
--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -42,8 +42,6 @@ The completed release-sized work is archived below. The next TrackDraw priority 
         The primary label now resolves to the user custom name → catalog entry name (e.g. "MultiGP Standard Gate 5x5") → generic kind label. The kind label stays visible as a secondary subtitle. Filter search also matches catalog names.
   - [x] Obstacle / all filter pills
         Two pills — "All" and "Obstacles" — let users focus the list on race obstacles (gates, ladders, dive gates) or see everything. Non-obstacle elements (flags, cones, labels) remain visible under "All" but are not the primary focus.
-  - [ ] Drag-to-reorder obstacles
-        Once the auto path generator is in place, expose drag handles on the obstacles list so users can define the exact intended race sequence. The `reorderShapes` store action is already in place; only the UI needs to be wired up at that point.
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,7 +60,6 @@ import {
   Orbit,
   Route,
   Share2,
-  Waves,
   FileText,
 } from "lucide-react";
 import { Screenshot } from "@/components/landing/Screenshot";
@@ -111,18 +110,18 @@ const features = [
     surface:
       "from-brand-secondary/[0.13] via-brand-secondary/[0.035] to-transparent",
     glow: "#F0761D",
-    title: "Built-in obstacle set",
-    text: "Design with the obstacles race crews actually use, from gates and flags to ladders, dive gates, and race lines.",
+    title: "MultiGP obstacle catalog",
+    text: "Place MultiGP gates, flags, and ladders with real dimensions and source references, or use the generic set for custom builds.",
   },
   {
-    icon: Waves,
+    icon: Orbit,
     color: "text-emerald-400",
     bg: "bg-emerald-500/12",
     border: "border-emerald-500/20",
     surface: "from-emerald-500/[0.13] via-emerald-500/[0.035] to-transparent",
     glow: "#34d399",
-    title: "Elevation-aware planning",
-    text: "Add height to the race line while you plan so vertical problems show up before build day.",
+    title: "Realistic 3D preview",
+    text: "Orbit the layout in 3D, add elevation to the race line, and fly through the route cinematically to catch flow problems before build day.",
   },
   {
     icon: Share2,
@@ -151,8 +150,8 @@ const features = [
     border: "border-rose-500/20",
     surface: "from-rose-500/[0.13] via-rose-500/[0.035] to-transparent",
     glow: "#fb7185",
-    title: "Portable deliverables",
-    text: "Export briefing files, print assets, and reusable project data from the same layout.",
+    title: "Race Pack and export",
+    text: "Generate a pilot briefing PDF with obstacle layout, route map, and setup notes. Also export SVG, PNG, and JSON from the same design.",
   },
 ];
 
@@ -356,9 +355,9 @@ export default function Home() {
               <Reveal delay={0.23}>
                 <ul className="mt-8 grid grid-cols-2 gap-x-4 gap-y-2.5">
                   {[
-                    "5+ element types",
-                    "2D and 3D preview",
-                    "PDF, SVG and PNG export",
+                    "MultiGP catalog",
+                    "3D preview and flythrough",
+                    "Race Pack PDF and SVG",
                     "Read-only sharing",
                   ].map((item) => (
                     <li

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -61,7 +61,7 @@ import {
 } from "@/lib/track/orientation";
 import type { PolylinePoint, PolylineShape, Shape } from "@/lib/types";
 import { distance2D, getPolyline2DPoints } from "@/lib/track/geometry";
-import { getPolylineSmoothSegmentPointsPx } from "@/lib/track/polyline-derived";
+import { findPolylineTarget } from "@/lib/canvas/polyline-targeting";
 import { getObstacleNumberMap } from "@/lib/track/obstacleNumbering";
 import {
   getShapeGroupId,
@@ -99,93 +99,6 @@ const TrackCanvasEditorOverlays = dynamic(
   () => import("@/components/canvas/editor/TrackCanvasEditorOverlays"),
   { ssr: false }
 );
-
-function resolveClosestPointOnPolyline(points: number[], pointer: Vector2d) {
-  let bestPoint = { x: pointer.x, y: pointer.y };
-  let bestDistanceSq = Number.POSITIVE_INFINITY;
-
-  for (let index = 0; index <= points.length - 4; index += 2) {
-    const startX = points[index];
-    const startY = points[index + 1];
-    const endX = points[index + 2];
-    const endY = points[index + 3];
-    const dx = endX - startX;
-    const dy = endY - startY;
-    const lengthSq = dx * dx + dy * dy;
-    const t =
-      lengthSq > 0
-        ? Math.max(
-            0,
-            Math.min(
-              1,
-              ((pointer.x - startX) * dx + (pointer.y - startY) * dy) / lengthSq
-            )
-          )
-        : 0;
-    const projectedX = startX + dx * t;
-    const projectedY = startY + dy * t;
-    const distanceSq =
-      (pointer.x - projectedX) ** 2 + (pointer.y - projectedY) ** 2;
-
-    if (distanceSq < bestDistanceSq) {
-      bestDistanceSq = distanceSq;
-      bestPoint = { x: projectedX, y: projectedY };
-    }
-  }
-
-  return { distanceSq: bestDistanceSq, pointPx: bestPoint };
-}
-
-type PolylineContextMenuHit = {
-  distanceSq: number;
-  pointPx: Vector2d;
-  segmentIndex: number;
-  shape: PolylineShape;
-};
-
-function findPolylineContextMenuHit({
-  designPpm,
-  maxDistancePx,
-  pointer,
-  shapes,
-}: {
-  designPpm: number;
-  maxDistancePx: number;
-  pointer: Vector2d;
-  shapes: Shape[];
-}): PolylineContextMenuHit | null {
-  let best: PolylineContextMenuHit | null = null;
-  const maxDistanceSq = maxDistancePx * maxDistancePx;
-
-  for (const shape of shapes) {
-    if (shape.kind !== "polyline" || shape.locked || shape.points.length < 2) {
-      continue;
-    }
-
-    const segmentPoints = getPolylineSmoothSegmentPointsPx(shape, designPpm);
-    for (
-      let segmentIndex = 0;
-      segmentIndex < segmentPoints.length;
-      segmentIndex += 1
-    ) {
-      const points = segmentPoints[segmentIndex];
-      if (points.length < 4) continue;
-      const candidate = resolveClosestPointOnPolyline(points, pointer);
-      if (
-        candidate.distanceSq <= maxDistanceSq &&
-        (!best || candidate.distanceSq < best.distanceSq)
-      ) {
-        best = {
-          ...candidate,
-          segmentIndex,
-          shape,
-        };
-      }
-    }
-  }
-
-  return best;
-}
 
 export interface TrackCanvasHandle {
   getStage: () => KonvaStage | null;
@@ -1120,7 +1033,7 @@ const TrackCanvas = memo(
               .map((id) => shapeById[id])
               .filter((shape): shape is Shape => Boolean(shape))
           : designShapes;
-        const hit = findPolylineContextMenuHit({
+        const hit = findPolylineTarget({
           designPpm: design.field.ppm,
           maxDistancePx:
             options.maxDistanceScreenPx / Math.max(stageTransform.scale, 0.1),
@@ -1340,7 +1253,7 @@ const TrackCanvas = memo(
         });
         if (!pointer) return;
         const maxDistancePx = 28 / Math.max(stageTransform.scale, 0.1);
-        const hit = findPolylineContextMenuHit({
+        const hit = findPolylineTarget({
           designPpm: design.field.ppm,
           maxDistancePx,
           pointer,

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -61,6 +61,7 @@ import {
 } from "@/lib/track/orientation";
 import type { PolylinePoint, PolylineShape, Shape } from "@/lib/types";
 import { distance2D, getPolyline2DPoints } from "@/lib/track/geometry";
+import { getPolylineSmoothSegmentPointsPx } from "@/lib/track/polyline-derived";
 import { getObstacleNumberMap } from "@/lib/track/obstacleNumbering";
 import {
   getShapeGroupId,
@@ -70,7 +71,7 @@ import {
 import { CanvasRuler, RULER_SIZE } from "@/components/canvas/CanvasRuler";
 import { useTheme } from "@/hooks/useTheme";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { shapeKindLabels } from "@/lib/editor-tools";
+import { getShapeDisplayLabel } from "@/lib/editor-tools";
 import {
   Tooltip,
   TooltipContent,
@@ -98,6 +99,93 @@ const TrackCanvasEditorOverlays = dynamic(
   () => import("@/components/canvas/editor/TrackCanvasEditorOverlays"),
   { ssr: false }
 );
+
+function resolveClosestPointOnPolyline(points: number[], pointer: Vector2d) {
+  let bestPoint = { x: pointer.x, y: pointer.y };
+  let bestDistanceSq = Number.POSITIVE_INFINITY;
+
+  for (let index = 0; index <= points.length - 4; index += 2) {
+    const startX = points[index];
+    const startY = points[index + 1];
+    const endX = points[index + 2];
+    const endY = points[index + 3];
+    const dx = endX - startX;
+    const dy = endY - startY;
+    const lengthSq = dx * dx + dy * dy;
+    const t =
+      lengthSq > 0
+        ? Math.max(
+            0,
+            Math.min(
+              1,
+              ((pointer.x - startX) * dx + (pointer.y - startY) * dy) / lengthSq
+            )
+          )
+        : 0;
+    const projectedX = startX + dx * t;
+    const projectedY = startY + dy * t;
+    const distanceSq =
+      (pointer.x - projectedX) ** 2 + (pointer.y - projectedY) ** 2;
+
+    if (distanceSq < bestDistanceSq) {
+      bestDistanceSq = distanceSq;
+      bestPoint = { x: projectedX, y: projectedY };
+    }
+  }
+
+  return { distanceSq: bestDistanceSq, pointPx: bestPoint };
+}
+
+type PolylineContextMenuHit = {
+  distanceSq: number;
+  pointPx: Vector2d;
+  segmentIndex: number;
+  shape: PolylineShape;
+};
+
+function findPolylineContextMenuHit({
+  designPpm,
+  maxDistancePx,
+  pointer,
+  shapes,
+}: {
+  designPpm: number;
+  maxDistancePx: number;
+  pointer: Vector2d;
+  shapes: Shape[];
+}): PolylineContextMenuHit | null {
+  let best: PolylineContextMenuHit | null = null;
+  const maxDistanceSq = maxDistancePx * maxDistancePx;
+
+  for (const shape of shapes) {
+    if (shape.kind !== "polyline" || shape.locked || shape.points.length < 2) {
+      continue;
+    }
+
+    const segmentPoints = getPolylineSmoothSegmentPointsPx(shape, designPpm);
+    for (
+      let segmentIndex = 0;
+      segmentIndex < segmentPoints.length;
+      segmentIndex += 1
+    ) {
+      const points = segmentPoints[segmentIndex];
+      if (points.length < 4) continue;
+      const candidate = resolveClosestPointOnPolyline(points, pointer);
+      if (
+        candidate.distanceSq <= maxDistanceSq &&
+        (!best || candidate.distanceSq < best.distanceSq)
+      ) {
+        best = {
+          ...candidate,
+          segmentIndex,
+          shape,
+        };
+      }
+    }
+  }
+
+  return best;
+}
 
 export interface TrackCanvasHandle {
   getStage: () => KonvaStage | null;
@@ -444,6 +532,16 @@ const TrackCanvas = memo(
     const contentDragActiveRef = useRef(false);
     const touchMovedRef = useRef(false);
     const suppressTapRef = useRef(false);
+    const mobilePathPointerRef = useRef<{
+      clientX: number;
+      clientY: number;
+      pointerId: number;
+    } | null>(null);
+    const mobilePathTouchRef = useRef<{
+      clientX: number;
+      clientY: number;
+      identifier: number;
+    } | null>(null);
     const touchInteractionModeRef = useRef<
       "none" | "pan" | "content" | "viewportGesture"
     >("none");
@@ -493,6 +591,7 @@ const TrackCanvas = memo(
     const [contextMenu, setContextMenu] = useState<ContextMenuData | null>(
       null
     );
+    const contextMenuHandledRef = useRef(false);
     const hasManualViewRef = useRef(false);
     const isDark = useTheme() === "dark";
     const obstacleNumberMap = useMemo(
@@ -878,7 +977,9 @@ const TrackCanvas = memo(
         clickedShape?: Shape,
         options?: { segmentIndex?: number | null }
       ) => {
-        if (activeTool !== "select" || readOnly || ids.length === 0) return;
+        if (activeTool !== "select" || readOnly || ids.length === 0) {
+          return false;
+        }
 
         const nextSelection =
           clickedShape && !ids.includes(clickedShape.id)
@@ -974,7 +1075,7 @@ const TrackCanvas = memo(
             nextSelection.length > 1
               ? `${nextSelection.length} items`
               : primaryShape
-                ? shapeKindLabels[primaryShape.kind]
+                ? getShapeDisplayLabel(primaryShape)
                 : "Selection",
           locked: nextSelection.every((id) => {
             const shape = shapeById[id];
@@ -982,6 +1083,8 @@ const TrackCanvas = memo(
           }),
           rotatableIds,
         });
+        contextMenuHandledRef.current = true;
+        return true;
       },
       [
         activeTool,
@@ -1002,6 +1105,275 @@ const TrackCanvas = memo(
         openContextMenuForSelection(ids, clickedShape, options);
       },
       [openContextMenuForSelection]
+    );
+
+    const selectPolylineSegmentAtPointer = useCallback(
+      (
+        pointer: Vector2d,
+        options: {
+          maxDistanceScreenPx: number;
+          shapeIds?: string[];
+        }
+      ) => {
+        const shapes = options.shapeIds
+          ? options.shapeIds
+              .map((id) => shapeById[id])
+              .filter((shape): shape is Shape => Boolean(shape))
+          : designShapes;
+        const hit = findPolylineContextMenuHit({
+          designPpm: design.field.ppm,
+          maxDistancePx:
+            options.maxDistanceScreenPx / Math.max(stageTransform.scale, 0.1),
+          pointer,
+          shapes,
+        });
+
+        if (!hit) return false;
+
+        if (
+          selectionRef.current.length !== 1 ||
+          selectionRef.current[0] !== hit.shape.id
+        ) {
+          setSelection([hit.shape.id]);
+        }
+        setSegmentSel({
+          shapeId: hit.shape.id,
+          segmentIndex: hit.segmentIndex,
+          point: {
+            x: px2m(hit.pointPx.x, design.field.ppm),
+            y: px2m(hit.pointPx.y, design.field.ppm),
+          },
+        });
+        setVertexSel(null);
+        return true;
+      },
+      [
+        design.field.ppm,
+        designShapes,
+        setSegmentSel,
+        setSelection,
+        setVertexSel,
+        shapeById,
+        stageTransform.scale,
+      ]
+    );
+
+    const handleMobileSelectedPathSegmentTap = useCallback(
+      (pointer: Vector2d) => {
+        const selectedPathIds = selectionRef.current.filter((id) => {
+          const shape = shapeById[id];
+          return shape?.kind === "polyline" && !shape.locked;
+        });
+
+        if (selectedPathIds.length !== 1) return false;
+
+        return selectPolylineSegmentAtPointer(pointer, {
+          maxDistanceScreenPx: 48,
+          shapeIds: selectedPathIds,
+        });
+      },
+      [selectPolylineSegmentAtPointer, shapeById]
+    );
+
+    const getStagePointFromClient = useCallback((client: Vector2d) => {
+      const stage = stageRef.current;
+      if (!stage) return null;
+
+      const stageBox = stage.container().getBoundingClientRect();
+      const scaleX = stage.scaleX() || 1;
+      const scaleY = stage.scaleY() || 1;
+      return {
+        x: (client.x - stageBox.left - stage.x()) / scaleX,
+        y: (client.y - stageBox.top - stage.y()) / scaleY,
+      };
+    }, []);
+
+    const isStageDomTarget = useCallback((target: EventTarget | null) => {
+      return (
+        target instanceof Node &&
+        (stageRef.current?.container().contains(target) ?? false)
+      );
+    }, []);
+
+    const handleCanvasPointerDown = useCallback(
+      (event: React.PointerEvent<HTMLDivElement>) => {
+        if (!isMobile || readOnly || activeTool !== "select") return;
+        if (event.pointerType !== "touch" && event.pointerType !== "pen")
+          return;
+        if (!isStageDomTarget(event.target)) return;
+
+        mobilePathPointerRef.current = {
+          clientX: event.clientX,
+          clientY: event.clientY,
+          pointerId: event.pointerId,
+        };
+      },
+      [activeTool, isMobile, isStageDomTarget, readOnly]
+    );
+
+    const clearMobilePathPointer = useCallback(() => {
+      mobilePathPointerRef.current = null;
+      mobilePathTouchRef.current = null;
+    }, []);
+
+    const finishMobilePathRetarget = useCallback(
+      (pointer: Vector2d) => {
+        if (!handleMobileSelectedPathSegmentTap(pointer)) return false;
+        suppressTapRef.current = true;
+        touchMovedRef.current = false;
+        lastTouchStagePointRef.current = null;
+        touchInteractionModeRef.current = "none";
+        return true;
+      },
+      [handleMobileSelectedPathSegmentTap]
+    );
+
+    const handleCanvasPointerUp = useCallback(
+      (event: React.PointerEvent<HTMLDivElement>) => {
+        const start = mobilePathPointerRef.current;
+        mobilePathPointerRef.current = null;
+        if (!start || start.pointerId !== event.pointerId) return;
+        if (!isMobile || readOnly || activeTool !== "select") return;
+        if (event.pointerType !== "touch" && event.pointerType !== "pen")
+          return;
+        if (!isStageDomTarget(event.target)) return;
+
+        const movedPx = Math.hypot(
+          event.clientX - start.clientX,
+          event.clientY - start.clientY
+        );
+        if (movedPx > 12) return;
+
+        const pointer = getStagePointFromClient({
+          x: event.clientX,
+          y: event.clientY,
+        });
+        if (!pointer) return;
+
+        if (finishMobilePathRetarget(pointer)) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      },
+      [
+        activeTool,
+        finishMobilePathRetarget,
+        getStagePointFromClient,
+        isMobile,
+        isStageDomTarget,
+        readOnly,
+      ]
+    );
+
+    const handleCanvasTouchStartCapture = useCallback(
+      (event: React.TouchEvent<HTMLDivElement>) => {
+        mobilePathTouchRef.current = null;
+        if (!isMobile || readOnly || activeTool !== "select") return;
+        if (event.touches.length !== 1) return;
+        if (!isStageDomTarget(event.target)) return;
+
+        const touch = event.touches[0];
+        mobilePathTouchRef.current = {
+          clientX: touch.clientX,
+          clientY: touch.clientY,
+          identifier: touch.identifier,
+        };
+      },
+      [activeTool, isMobile, isStageDomTarget, readOnly]
+    );
+
+    const handleCanvasTouchEndCapture = useCallback(
+      (event: React.TouchEvent<HTMLDivElement>) => {
+        const start = mobilePathTouchRef.current;
+        if (!start) return;
+        const touch = Array.from(event.changedTouches).find(
+          (candidate) => candidate.identifier === start.identifier
+        );
+        if (!touch) return;
+        mobilePathTouchRef.current = null;
+        if (!isMobile || readOnly || activeTool !== "select") return;
+        if (!isStageDomTarget(event.target)) return;
+
+        const movedPx = Math.hypot(
+          touch.clientX - start.clientX,
+          touch.clientY - start.clientY
+        );
+        if (movedPx > 12) return;
+
+        const pointer = getStagePointFromClient({
+          x: touch.clientX,
+          y: touch.clientY,
+        });
+        if (!pointer) return;
+
+        if (finishMobilePathRetarget(pointer)) {
+          event.preventDefault();
+          event.stopPropagation();
+        }
+      },
+      [
+        activeTool,
+        finishMobilePathRetarget,
+        getStagePointFromClient,
+        isMobile,
+        isStageDomTarget,
+        readOnly,
+      ]
+    );
+
+    const handleCanvasContextMenu = useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        if (contextMenuHandledRef.current) {
+          contextMenuHandledRef.current = false;
+          return;
+        }
+
+        if (!(event.target instanceof HTMLCanvasElement)) return;
+        if (activeTool !== "select" || readOnly) return;
+
+        const stage = stageRef.current;
+        if (!stage) return;
+
+        const pointer = getStagePointFromClient({
+          x: event.clientX,
+          y: event.clientY,
+        });
+        if (!pointer) return;
+        const maxDistancePx = 28 / Math.max(stageTransform.scale, 0.1);
+        const hit = findPolylineContextMenuHit({
+          designPpm: design.field.ppm,
+          maxDistancePx,
+          pointer,
+          shapes: designShapes,
+        });
+
+        if (!hit) return;
+
+        setSegmentSel({
+          shapeId: hit.shape.id,
+          segmentIndex: hit.segmentIndex,
+          point: {
+            x: px2m(hit.pointPx.x, design.field.ppm),
+            y: px2m(hit.pointPx.y, design.field.ppm),
+          },
+        });
+        setVertexSel(null);
+        openContextMenuForSelection([hit.shape.id], hit.shape, {
+          segmentIndex: hit.segmentIndex,
+        });
+        contextMenuHandledRef.current = false;
+      },
+      [
+        activeTool,
+        design.field.ppm,
+        designShapes,
+        getStagePointFromClient,
+        openContextMenuForSelection,
+        readOnly,
+        setSegmentSel,
+        setVertexSel,
+        stageTransform.scale,
+      ]
     );
 
     const addWaypointToSelectedSegment = useCallback(
@@ -1196,6 +1568,7 @@ const TrackCanvas = memo(
       marqueeOriginRef: marqueeOrigin,
       marqueeRect,
       onCursorChange,
+      onMobileSelectedPathSegmentTap: handleMobileSelectedPathSegmentTap,
       onSnapChange,
       mobileMultiSelectEnabled,
       readOnly,
@@ -1844,7 +2217,13 @@ const TrackCanvas = memo(
     ]);
 
     return (
-      <ContextMenu onOpenChange={(open) => !open && setContextMenu(null)}>
+      <ContextMenu
+        onOpenChange={(open) => {
+          if (open) return;
+          contextMenuHandledRef.current = false;
+          setContextMenu(null);
+        }}
+      >
         {!readOnly ? (
           <TrackCanvasShortcuts
             activeTool={activeTool}
@@ -1878,6 +2257,14 @@ const TrackCanvas = memo(
           <div
             ref={containerRef}
             className="relative h-full w-full overflow-hidden"
+            onContextMenu={handleCanvasContextMenu}
+            onPointerCancel={clearMobilePathPointer}
+            onPointerDownCapture={handleCanvasPointerDown}
+            onPointerLeave={clearMobilePathPointer}
+            onPointerUpCapture={handleCanvasPointerUp}
+            onTouchCancelCapture={clearMobilePathPointer}
+            onTouchEndCapture={handleCanvasTouchEndCapture}
+            onTouchStartCapture={handleCanvasTouchStartCapture}
             style={{ cursor: cursorStyle, touchAction: "none" }}
           >
             <div

--- a/src/components/canvas/renderers/polyline-shape.tsx
+++ b/src/components/canvas/renderers/polyline-shape.tsx
@@ -49,6 +49,7 @@ export interface PolylineShapeContentProps {
   ) => void;
   setVertexSel: (value: { shapeId: string; idx: number } | null) => void;
   setPolylinePoints: (id: string, points: PolylinePoint[]) => void;
+  viewportScale: number;
   zmax: number;
   zmin: number;
 }
@@ -73,6 +74,7 @@ export function PolylineShapeContent({
   setSegmentSelection,
   setVertexSel,
   setPolylinePoints,
+  viewportScale,
   zmax,
   zmin,
 }: PolylineShapeContentProps) {
@@ -104,9 +106,11 @@ export function PolylineShapeContent({
     [path, previewPoints]
   );
   const strokePx = m2px(displayPath.strokeWidth ?? 0.26, designPpm);
+  const minSelectionStrokePx =
+    (isMobile ? 44 : 30) / Math.max(viewportScale, 0.1);
   const selectionStrokePx = isMobile
-    ? Math.max(22, strokePx + 18)
-    : Math.max(14, strokePx + 10);
+    ? Math.max(22, minSelectionStrokePx, strokePx + 18)
+    : Math.max(14, minSelectionStrokePx, strokePx + 10);
   const polylineMetrics = useMemo(
     () => getPolyline2DDerived(displayPath),
     [displayPath]
@@ -477,101 +481,83 @@ export function PolylineShapeContent({
     ]
   );
 
-  const handleSegmentSelection = useCallback(
-    (event: KonvaEventObject<MouseEvent | TouchEvent>) => {
-      const stage = event.target.getStage();
-      const pointer = stage?.getRelativePointerPosition();
-      if (!pointer) return;
-      const selection = selectNearestSegment(pointer);
-      if (!selection) return;
-
-      event.cancelBubble = true;
-      setSelection([path.id]);
+  // Shared core: commits segment + vertex state for a given pointer position.
+  // Returns the resolved segment index, or null if no segment was found.
+  const selectSegmentAtPointer = useCallback(
+    (pointer: Vector2d): number | null => {
+      const result = selectNearestSegment(pointer);
+      if (!result) return null;
       setSegmentSelection({
         shapeId: path.id,
-        segmentIndex: selection.segmentIndex,
+        segmentIndex: result.segmentIndex,
         point: {
-          x: px2m(selection.pointPx.x, designPpm),
-          y: px2m(selection.pointPx.y, designPpm),
+          x: px2m(result.pointPx.x, designPpm),
+          y: px2m(result.pointPx.y, designPpm),
         },
       });
       setVertexSel(null);
+      return result.segmentIndex;
     },
     [
       designPpm,
       path.id,
       selectNearestSegment,
       setSegmentSelection,
-      setSelection,
       setVertexSel,
     ]
   );
 
-  const handleMobileSegmentTouchEnd = useCallback(
-    (event: KonvaEventObject<TouchEvent>) => {
-      if (!isMobile || !isSelected) return;
-      handleSegmentSelection(event);
+  const handleSegmentSelection = useCallback(
+    (event: KonvaEventObject<MouseEvent | TouchEvent>) => {
+      const pointer = event.target.getStage()?.getRelativePointerPosition();
+      if (!pointer) return;
+      const segmentIndex = selectSegmentAtPointer(pointer);
+      if (segmentIndex === null) return;
+      event.cancelBubble = true;
+      if (!isSelected) setSelection([path.id]);
     },
-    [handleSegmentSelection, isMobile, isSelected]
+    [isSelected, path.id, selectSegmentAtPointer, setSelection]
   );
 
   const handlePathContextMenu = useCallback(
     (event: KonvaEventObject<PointerEvent>) => {
       event.evt.preventDefault();
-      const stage = event.target.getStage();
-      const pointer = stage?.getRelativePointerPosition();
+      const pointer = event.target.getStage()?.getRelativePointerPosition();
       if (!pointer) return;
-      const selection = selectNearestSegment(pointer);
-      if (!selection) return;
-
+      const segmentIndex = selectSegmentAtPointer(pointer);
+      if (segmentIndex === null) return;
       event.cancelBubble = true;
       setSelection([path.id]);
-      setSegmentSelection({
-        shapeId: path.id,
-        segmentIndex: selection.segmentIndex,
-        point: {
-          x: px2m(selection.pointPx.x, designPpm),
-          y: px2m(selection.pointPx.y, designPpm),
-        },
-      });
-      setVertexSel(null);
-      onPathContextMenu?.(selection.segmentIndex);
+      onPathContextMenu?.(segmentIndex);
     },
-    [
-      designPpm,
-      onPathContextMenu,
-      path.id,
-      selectNearestSegment,
-      setSegmentSelection,
-      setSelection,
-      setVertexSel,
-    ]
+    [onPathContextMenu, path.id, selectSegmentAtPointer, setSelection]
   );
 
   if (!pointsPxMemo.length) return null;
 
   const canSelectPath = allowInteraction && !path.locked;
+  const displayPts = smoothPx.length >= 4 ? smoothPx : pointsPxMemo;
 
   return (
     <>
       {canSelectPath && (
         <Line
-          points={smoothPx.length >= 4 ? smoothPx : pointsPxMemo}
+          points={displayPts}
           stroke="#000000"
           strokeWidth={selectionStrokePx}
+          hitStrokeWidth={selectionStrokePx}
           opacity={0.001}
           lineCap="round"
           lineJoin="round"
-          onMouseDown={handlePathSelect}
-          onMouseUp={handleSegmentSelection}
-          onTouchEnd={handleMobileSegmentTouchEnd}
+          onMouseDown={isMobile ? undefined : handlePathSelect}
+          onMouseUp={isMobile ? undefined : handleSegmentSelection}
           onTap={handleSegmentSelection}
           onContextMenu={handlePathContextMenu}
         />
       )}
       {isSelected && (
         <Line
-          points={smoothPx.length >= 4 ? smoothPx : pointsPxMemo}
+          points={displayPts}
           stroke="#3b82f6"
           strokeWidth={strokePx + 4}
           lineCap="round"
@@ -604,7 +590,7 @@ export function PolylineShapeContent({
           })
         ) : (
           <Line
-            points={smoothPx.length >= 4 ? smoothPx : pointsPxMemo}
+            points={displayPts}
             stroke={
               path.color
                 ? color
@@ -691,7 +677,6 @@ export function PolylineShapeContent({
           ) => {
             event.cancelBubble = true;
             setSelection([path.id]);
-            setSegmentSelection(null);
             setVertexSel({ shapeId: path.id, idx: index });
             const stage = event.target.getStage();
             if (!stage) return;

--- a/src/components/canvas/renderers/polyline-shape.tsx
+++ b/src/components/canvas/renderers/polyline-shape.tsx
@@ -481,56 +481,59 @@ export function PolylineShapeContent({
     ]
   );
 
-  // Shared core: commits segment + vertex state for a given pointer position.
-  // Returns the resolved segment index, or null if no segment was found.
-  const selectSegmentAtPointer = useCallback(
-    (pointer: Vector2d): number | null => {
-      const result = selectNearestSegment(pointer);
-      if (!result) return null;
+  const commitSegmentSelection = useCallback(
+    (selection: { segmentIndex: number; pointPx: Vector2d }) => {
       setSegmentSelection({
         shapeId: path.id,
-        segmentIndex: result.segmentIndex,
+        segmentIndex: selection.segmentIndex,
         point: {
-          x: px2m(result.pointPx.x, designPpm),
-          y: px2m(result.pointPx.y, designPpm),
+          x: px2m(selection.pointPx.x, designPpm),
+          y: px2m(selection.pointPx.y, designPpm),
         },
       });
       setVertexSel(null);
-      return result.segmentIndex;
     },
-    [
-      designPpm,
-      path.id,
-      selectNearestSegment,
-      setSegmentSelection,
-      setVertexSel,
-    ]
+    [designPpm, path.id, setSegmentSelection, setVertexSel]
   );
 
   const handleSegmentSelection = useCallback(
     (event: KonvaEventObject<MouseEvent | TouchEvent>) => {
       const pointer = event.target.getStage()?.getRelativePointerPosition();
       if (!pointer) return;
-      const segmentIndex = selectSegmentAtPointer(pointer);
-      if (segmentIndex === null) return;
+      const selection = selectNearestSegment(pointer);
+      if (!selection) return;
       event.cancelBubble = true;
       if (!isSelected) setSelection([path.id]);
+      commitSegmentSelection(selection);
     },
-    [isSelected, path.id, selectSegmentAtPointer, setSelection]
+    [
+      commitSegmentSelection,
+      isSelected,
+      path.id,
+      selectNearestSegment,
+      setSelection,
+    ]
   );
 
   const handlePathContextMenu = useCallback(
     (event: KonvaEventObject<PointerEvent>) => {
-      event.evt.preventDefault();
       const pointer = event.target.getStage()?.getRelativePointerPosition();
       if (!pointer) return;
-      const segmentIndex = selectSegmentAtPointer(pointer);
-      if (segmentIndex === null) return;
+      const selection = selectNearestSegment(pointer);
+      if (!selection) return;
       event.cancelBubble = true;
-      setSelection([path.id]);
-      onPathContextMenu?.(segmentIndex);
+      if (!isSelected) setSelection([path.id]);
+      commitSegmentSelection(selection);
+      onPathContextMenu?.(selection.segmentIndex);
     },
-    [onPathContextMenu, path.id, selectSegmentAtPointer, setSelection]
+    [
+      commitSegmentSelection,
+      isSelected,
+      onPathContextMenu,
+      path.id,
+      selectNearestSegment,
+      setSelection,
+    ]
   );
 
   if (!pointsPxMemo.length) return null;

--- a/src/components/canvas/renderers/shape-node.tsx
+++ b/src/components/canvas/renderers/shape-node.tsx
@@ -87,6 +87,13 @@ function sameOffset(
   return Math.abs(a.x - b.x) < 0.001 && Math.abs(a.y - b.y) < 0.001;
 }
 
+function samePoint(
+  a: { x: number; y: number } | null | undefined,
+  b: { x: number; y: number } | null | undefined
+) {
+  return sameOffset(a, b);
+}
+
 function TrackShapeNodeComponent({
   allowInteraction,
   contentDragActiveRef,
@@ -352,7 +359,7 @@ function TrackShapeNodeComponent({
             hoveredWaypoint={hoveredWaypoint}
             isPrimaryPolyline={isPrimaryPolyline}
             isMobile={isMobile}
-            isSelected={highlighted}
+            isSelected={selected}
             onPathContextMenu={(segmentIndex) =>
               onShapeContextMenu?.(shape, { segmentIndex })
             }
@@ -366,6 +373,7 @@ function TrackShapeNodeComponent({
             setSegmentSelection={setSegmentSelection}
             setVertexSel={setVertexSel}
             setPolylinePoints={setPolylinePoints}
+            viewportScale={viewportScale}
             zmax={zmax}
             zmin={zmin}
           />
@@ -407,6 +415,8 @@ export const TrackShapeNode = memo(TrackShapeNodeComponent, (prev, next) => {
     prev.isSelected === next.isSelected &&
     prev.isPrimaryPolyline === next.isPrimaryPolyline &&
     prev.snapEnabled === next.snapEnabled &&
+    prev.selectedSegmentIndex === next.selectedSegmentIndex &&
+    samePoint(prev.selectedSegmentPoint, next.selectedSegmentPoint) &&
     prev.selectionCount === next.selectionCount &&
     prev.shape === next.shape &&
     prev.zmin === next.zmin &&

--- a/src/components/canvas/useTrackCanvasInteractions.ts
+++ b/src/components/canvas/useTrackCanvasInteractions.ts
@@ -67,6 +67,7 @@ interface TrackCanvasInteractionsParams {
   marqueeRect: RectLike | null;
   mobileMultiSelectEnabled?: boolean;
   onCursorChange?: (pos: { x: number; y: number } | null) => void;
+  onMobileSelectedPathSegmentTap?: (pointer: Vector2d) => boolean;
   onSnapChange?: (active: boolean) => void;
   readOnly: boolean;
   snapEnabled: boolean;
@@ -124,6 +125,7 @@ export function useTrackCanvasInteractions({
   marqueeRect,
   mobileMultiSelectEnabled: _mobileMultiSelectEnabled,
   onCursorChange,
+  onMobileSelectedPathSegmentTap,
   onSnapChange,
   readOnly,
   snapEnabled,
@@ -409,8 +411,7 @@ export function useTrackCanvasInteractions({
           targetIsStage: event.target === stage,
         });
         touchInteractionModeRef.current = nextTouchMode;
-        lastTouchStagePointRef.current =
-          nextTouchMode === "content" ? touchToStagePoint(touch, stage) : null;
+        lastTouchStagePointRef.current = touchToStagePoint(touch, stage);
       }
     },
     [
@@ -540,9 +541,6 @@ export function useTrackCanvasInteractions({
         lastPinchCenterRef.current = null;
         lastTouchPosRef.current = null;
         lastTouchStartClientRef.current = null;
-        lastTouchStagePointRef.current = null;
-        touchMovedRef.current = false;
-        touchInteractionModeRef.current = "none";
         return;
       }
 
@@ -561,17 +559,21 @@ export function useTrackCanvasInteractions({
       lastPinchCenterRef,
       lastPinchDistRef,
       lastTouchPosRef,
-      lastTouchStagePointRef,
       lastTouchStartClientRef,
       suppressTapRef,
-      touchMovedRef,
       touchInteractionModeRef,
     ]
   );
 
   const onTap = useCallback(
     (event: { target: unknown }) => {
-      if (event.target !== stageRef.current) return;
+      if (event.target !== stageRef.current) {
+        suppressTapRef.current = false;
+        touchMovedRef.current = false;
+        lastTouchStagePointRef.current = null;
+        touchInteractionModeRef.current = "none";
+        return;
+      }
       if (
         suppressTapRef.current ||
         touchMovedRef.current ||
@@ -586,10 +588,9 @@ export function useTrackCanvasInteractions({
 
       const stage = stageRef.current;
       if (!stage) return;
-      const pointer =
-        isMobile && touchInteractionModeRef.current === "content"
-          ? lastTouchStagePointRef.current
-          : stage.getRelativePointerPosition();
+      const pointer = isMobile
+        ? (lastTouchStagePointRef.current ?? stage.getRelativePointerPosition())
+        : stage.getRelativePointerPosition();
       lastTouchStagePointRef.current = null;
       if (!pointer) return;
 
@@ -639,6 +640,11 @@ export function useTrackCanvasInteractions({
       }
 
       if (activeTool === "select") {
+        if (isMobile && onMobileSelectedPathSegmentTap?.(pointer)) {
+          touchMovedRef.current = false;
+          touchInteractionModeRef.current = "none";
+          return;
+        }
         setSelection([]);
       }
 
@@ -653,6 +659,7 @@ export function useTrackCanvasInteractions({
       addShapes,
       finalizePath,
       isMobile,
+      onMobileSelectedPathSegmentTap,
       pointerToMeters,
       readOnly,
       setActiveTool,

--- a/src/lib/canvas/polyline-targeting.ts
+++ b/src/lib/canvas/polyline-targeting.ts
@@ -1,0 +1,93 @@
+import type { Vector2d } from "konva/lib/types";
+import type { PolylineShape, Shape } from "@/lib/types";
+import { getPolylineSmoothSegmentPointsPx } from "@/lib/track/polyline-derived";
+
+export type PolylineTarget = {
+  distanceSq: number;
+  pointPx: Vector2d;
+  segmentIndex: number;
+  shape: PolylineShape;
+};
+
+export function resolveClosestPointOnPolyline(
+  points: number[],
+  pointer: Vector2d
+) {
+  let bestPoint = { x: pointer.x, y: pointer.y };
+  let bestDistanceSq = Number.POSITIVE_INFINITY;
+
+  for (let index = 0; index <= points.length - 4; index += 2) {
+    const startX = points[index];
+    const startY = points[index + 1];
+    const endX = points[index + 2];
+    const endY = points[index + 3];
+    const dx = endX - startX;
+    const dy = endY - startY;
+    const lengthSq = dx * dx + dy * dy;
+    const t =
+      lengthSq > 0
+        ? Math.max(
+            0,
+            Math.min(
+              1,
+              ((pointer.x - startX) * dx + (pointer.y - startY) * dy) / lengthSq
+            )
+          )
+        : 0;
+    const projectedX = startX + dx * t;
+    const projectedY = startY + dy * t;
+    const distanceSq =
+      (pointer.x - projectedX) ** 2 + (pointer.y - projectedY) ** 2;
+
+    if (distanceSq < bestDistanceSq) {
+      bestDistanceSq = distanceSq;
+      bestPoint = { x: projectedX, y: projectedY };
+    }
+  }
+
+  return { distanceSq: bestDistanceSq, pointPx: bestPoint };
+}
+
+export function findPolylineTarget({
+  designPpm,
+  maxDistancePx,
+  pointer,
+  shapes,
+}: {
+  designPpm: number;
+  maxDistancePx: number;
+  pointer: Vector2d;
+  shapes: Shape[];
+}): PolylineTarget | null {
+  let best: PolylineTarget | null = null;
+  const maxDistanceSq = maxDistancePx * maxDistancePx;
+
+  for (const shape of shapes) {
+    if (shape.kind !== "polyline" || shape.locked || shape.points.length < 2) {
+      continue;
+    }
+
+    const segmentPoints = getPolylineSmoothSegmentPointsPx(shape, designPpm);
+    for (
+      let segmentIndex = 0;
+      segmentIndex < segmentPoints.length;
+      segmentIndex += 1
+    ) {
+      const points = segmentPoints[segmentIndex];
+      if (points.length < 4) continue;
+      const candidate = resolveClosestPointOnPolyline(points, pointer);
+      if (
+        candidate.distanceSq <= maxDistanceSq &&
+        (!best || candidate.distanceSq < best.distanceSq)
+      ) {
+        best = {
+          ...candidate,
+          segmentIndex,
+          shape,
+        };
+      }
+    }
+  }
+
+  return best;
+}

--- a/src/lib/editor-tools.ts
+++ b/src/lib/editor-tools.ts
@@ -1,6 +1,7 @@
 import {
   createCatalogShapeDraft,
   createTrackElementCatalogIdentity,
+  getTrackElementCatalogIdentity,
   getTrackElementCatalogEntry,
   TRACKDRAW_CONE_ELEMENT_ID,
   TRACKDRAW_DIVE_GATE_ELEMENT_ID,
@@ -16,6 +17,7 @@ import type {
   FlagShape,
   GateShape,
   LadderShape,
+  Shape,
   ShapeDraft,
   ShapeKind,
 } from "@/lib/types";
@@ -43,6 +45,15 @@ export const shapeKindLabels: Record<ShapeKind, string> = {
   ladder: "Ladder",
   divegate: "Dive Gate",
 };
+
+export function getShapeDisplayLabel(shape: Shape): string {
+  const catalogIdentity = getTrackElementCatalogIdentity(shape.meta);
+  if (catalogIdentity?.assignedKind === shape.kind) {
+    return catalogIdentity.snapshot.name;
+  }
+
+  return shapeKindLabels[shape.kind];
+}
 
 export const toolLabels: Record<EditorTool, string> = {
   select: "Select",

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -61,6 +61,10 @@ import {
 
 export type { EditorTool } from "@/lib/editor-tools";
 
+function sameSelection(a: string[], b: string[]) {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}
+
 interface EditorState {
   track: EditorTrackState;
   session: EditorSessionState;
@@ -507,11 +511,15 @@ export const useEditor = create<EditorState>()(
 
       setSelection: (ids) =>
         set((draft) => {
-          draft.session.selection = expandGroupedSelection(
-            draft.track.design,
-            ids
+          const nextSelection = expandGroupedSelection(draft.track.design, ids);
+          const selectionChanged = !sameSelection(
+            draft.session.selection,
+            nextSelection
           );
-          draft.ui.segmentSelection = null;
+          draft.session.selection = nextSelection;
+          if (selectionChanged) {
+            draft.ui.segmentSelection = null;
+          }
           if (draft.session.selection.length !== 1) {
             draft.ui.vertexSelection = null;
           }

--- a/tests/components/canvas/CanvasContextMenu.test.tsx
+++ b/tests/components/canvas/CanvasContextMenu.test.tsx
@@ -89,6 +89,14 @@ const baseContextMenu: ContextMenuData = {
   rotatableIds: ["gate-1"],
 };
 
+const polylineContextMenu: ContextMenuData = {
+  ...baseContextMenu,
+  ids: ["path-1"],
+  label: "Race route",
+  editablePolylineId: "path-1",
+  rotatableIds: [],
+};
+
 function renderContextMenu(
   contextMenu: Partial<ContextMenuData> = {},
   callbacks: Partial<React.ComponentProps<typeof CanvasContextMenuContent>> = {}
@@ -121,6 +129,8 @@ describe("CanvasContextMenuContent", () => {
     cleanup();
   });
 
+  // ── Lock / unlock ──────────────────────────────────────────────
+
   it("disables duplicate and delete actions when the selection contains locked shapes", async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
@@ -135,12 +145,7 @@ describe("CanvasContextMenuContent", () => {
         label: "Mixed selection",
         rotatableIds: ["gate-1"],
       },
-      {
-        onClose,
-        onDelete,
-        onDuplicate,
-        onToggleLock,
-      }
+      { onClose, onDelete, onDuplicate, onToggleLock }
     );
 
     expect(
@@ -160,6 +165,257 @@ describe("CanvasContextMenuContent", () => {
     expect(onDuplicate).not.toHaveBeenCalled();
     expect(onDelete).not.toHaveBeenCalled();
     expect(onToggleLock).toHaveBeenCalledWith(["gate-1", "gate-2"], true);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows Unlock when shape is locked and calls onToggleLock with false", async () => {
+    const user = userEvent.setup();
+    const onToggleLock = vi.fn();
+    const onClose = vi.fn();
+
+    renderContextMenu({ locked: true }, { onToggleLock, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Unlock" }));
+
+    expect(onToggleLock).toHaveBeenCalledWith(["gate-1"], false);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  // ── Waypoint actions ───────────────────────────────────────────
+
+  it("does not show Add waypoint without editablePolylineId", () => {
+    renderContextMenu({ addWaypointSegmentIndex: 2 });
+    expect(screen.queryByRole("button", { name: /add waypoint/i })).toBeNull();
+  });
+
+  it("does not show Add waypoint when editablePolylineId is set but segmentIndex is null", () => {
+    renderContextMenu({ editablePolylineId: "path-1" });
+    expect(screen.queryByRole("button", { name: /add waypoint/i })).toBeNull();
+  });
+
+  it("shows Add waypoint when editablePolylineId and addWaypointSegmentIndex are both set", () => {
+    renderContextMenu({
+      ...polylineContextMenu,
+      addWaypointSegmentIndex: 3,
+    });
+    expect(screen.getByRole("button", { name: /add waypoint/i })).toBeDefined();
+  });
+
+  it("clicking Add waypoint calls onAddWaypoint with correct args and closes", async () => {
+    const user = userEvent.setup();
+    const onAddWaypoint = vi.fn();
+    const onClose = vi.fn();
+
+    renderContextMenu(
+      { ...polylineContextMenu, addWaypointSegmentIndex: 3 },
+      { onAddWaypoint, onClose }
+    );
+
+    await user.click(screen.getByRole("button", { name: /add waypoint/i }));
+
+    expect(onAddWaypoint).toHaveBeenCalledWith("path-1", 3);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows Delete waypoint only when editablePolylineId and deleteWaypointIndex are both set", () => {
+    renderContextMenu({ editablePolylineId: "path-1", deleteWaypointIndex: 1 });
+    expect(
+      screen.getByRole("button", { name: /delete waypoint/i })
+    ).toBeDefined();
+  });
+
+  it("clicking Delete waypoint calls onDeleteWaypoint with correct args and closes", async () => {
+    const user = userEvent.setup();
+    const onDeleteWaypoint = vi.fn();
+    const onClose = vi.fn();
+
+    renderContextMenu(
+      { ...polylineContextMenu, deleteWaypointIndex: 2 },
+      { onDeleteWaypoint, onClose }
+    );
+
+    await user.click(screen.getByRole("button", { name: /delete waypoint/i }));
+
+    expect(onDeleteWaypoint).toHaveBeenCalledWith("path-1", 2);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  // ── Path actions ───────────────────────────────────────────────
+
+  it("shows Continue editing when editablePolylineId is set", () => {
+    renderContextMenu({ editablePolylineId: "path-1" });
+    expect(
+      screen.getByRole("button", { name: /continue editing/i })
+    ).toBeDefined();
+  });
+
+  it("clicking Continue editing calls onContinueEditing with the polyline id and closes", async () => {
+    const user = userEvent.setup();
+    const onContinueEditing = vi.fn();
+    const onClose = vi.fn();
+
+    renderContextMenu(
+      { editablePolylineId: "path-1" },
+      { onContinueEditing, onClose }
+    );
+
+    await user.click(screen.getByRole("button", { name: /continue editing/i }));
+
+    expect(onContinueEditing).toHaveBeenCalledWith("path-1");
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows Connect ends when closablePolylineId is set", () => {
+    renderContextMenu({ closablePolylineId: "path-1" });
+    expect(screen.getByRole("button", { name: /connect ends/i })).toBeDefined();
+  });
+
+  it("clicking Connect ends calls onClosePolyline with the polyline id and closes", async () => {
+    const user = userEvent.setup();
+    const onClosePolyline = vi.fn();
+    const onClose = vi.fn();
+
+    renderContextMenu(
+      { closablePolylineId: "path-1" },
+      { onClosePolyline, onClose }
+    );
+
+    await user.click(screen.getByRole("button", { name: /connect ends/i }));
+
+    expect(onClosePolyline).toHaveBeenCalledWith("path-1");
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not show path action group when neither editablePolylineId nor closablePolylineId is set", () => {
+    renderContextMenu();
+    expect(
+      screen.queryByRole("button", { name: /continue editing/i })
+    ).toBeNull();
+    expect(screen.queryByRole("button", { name: /connect ends/i })).toBeNull();
+  });
+
+  // ── Multi-selection actions ────────────────────────────────────
+
+  it("shows Group selection when canGroup is true and selection is not grouped", () => {
+    renderContextMenu({
+      canGroup: true,
+      hasGroupedShapes: false,
+      ids: ["gate-1", "gate-2"],
+    });
+    expect(
+      screen.getByRole("button", { name: /group selection/i })
+    ).toBeDefined();
+  });
+
+  it("clicking Group selection calls onGroupSelection with all ids and closes", async () => {
+    const user = userEvent.setup();
+    const onGroupSelection = vi.fn();
+    const onClose = vi.fn();
+
+    renderContextMenu(
+      { canGroup: true, hasGroupedShapes: false, ids: ["a", "b"] },
+      { onGroupSelection, onClose }
+    );
+
+    await user.click(screen.getByRole("button", { name: /group selection/i }));
+
+    expect(onGroupSelection).toHaveBeenCalledWith(["a", "b"]);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows Ungroup selection when hasGroupedShapes is true and canGroup is false", () => {
+    renderContextMenu({
+      canGroup: false,
+      hasGroupedShapes: true,
+      ids: ["gate-1", "gate-2"],
+    });
+    expect(
+      screen.getByRole("button", { name: /ungroup selection/i })
+    ).toBeDefined();
+  });
+
+  it("shows Join paths when joinablePolylineIds has two or more entries", () => {
+    renderContextMenu({
+      joinablePolylineIds: ["path-1", "path-2"],
+      ids: ["path-1", "path-2"],
+    });
+    expect(screen.getByRole("button", { name: /join paths/i })).toBeDefined();
+  });
+
+  it("does not show Join paths with fewer than two joinable polylines", () => {
+    renderContextMenu({ joinablePolylineIds: ["path-1"] });
+    expect(screen.queryByRole("button", { name: /join paths/i })).toBeNull();
+  });
+
+  it("clicking Join paths calls onJoinPolylines with joinable ids and closes", async () => {
+    const user = userEvent.setup();
+    const onJoinPolylines = vi.fn();
+    const onClose = vi.fn();
+
+    renderContextMenu(
+      { joinablePolylineIds: ["path-1", "path-2"], ids: ["path-1", "path-2"] },
+      { onJoinPolylines, onClose }
+    );
+
+    await user.click(screen.getByRole("button", { name: /join paths/i }));
+
+    expect(onJoinPolylines).toHaveBeenCalledWith(["path-1", "path-2"]);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  // ── Label / subtitle ───────────────────────────────────────────
+
+  it("shows 'Segment selected' subtitle when addWaypointSegmentIndex is set", () => {
+    renderContextMenu({
+      editablePolylineId: "path-1",
+      addWaypointSegmentIndex: 0,
+    });
+    expect(screen.getByText("Segment selected")).toBeDefined();
+  });
+
+  it("shows 'Waypoint selected' subtitle when deleteWaypointIndex is set", () => {
+    renderContextMenu({
+      editablePolylineId: "path-1",
+      deleteWaypointIndex: 1,
+    });
+    expect(screen.getByText("Waypoint selected")).toBeDefined();
+  });
+
+  it("shows item count subtitle for multi-selection without group label", () => {
+    renderContextMenu({ ids: ["a", "b", "c"] });
+    expect(screen.getByText("3 selected")).toBeDefined();
+  });
+
+  it("shows 'Quick actions' subtitle for single shape without path selection", () => {
+    renderContextMenu({ ids: ["gate-1"] });
+    expect(screen.getByText("Quick actions")).toBeDefined();
+  });
+
+  // ── Standard actions ───────────────────────────────────────────
+
+  it("clicking Duplicate calls onDuplicate with shape ids and closes", async () => {
+    const user = userEvent.setup();
+    const onDuplicate = vi.fn();
+    const onClose = vi.fn();
+
+    renderContextMenu({ ids: ["gate-1"] }, { onDuplicate, onClose });
+
+    await user.click(screen.getByRole("button", { name: /duplicate/i }));
+
+    expect(onDuplicate).toHaveBeenCalledWith(["gate-1"]);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("clicking Delete calls onDelete with shape ids and closes", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    const onClose = vi.fn();
+
+    renderContextMenu({ ids: ["gate-1"] }, { onDelete, onClose });
+
+    await user.click(screen.getByRole("button", { name: "Delete Del" }));
+
+    expect(onDelete).toHaveBeenCalledWith(["gate-1"]);
     expect(onClose).toHaveBeenCalledOnce();
   });
 });

--- a/tests/lib/canvas/polyline-targeting.test.ts
+++ b/tests/lib/canvas/polyline-targeting.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import {
+  findPolylineTarget,
+  resolveClosestPointOnPolyline,
+} from "@/lib/canvas/polyline-targeting";
+import { getPolylineSmoothSegmentPointsPx } from "@/lib/track/polyline-derived";
+import type { PolylineShape, Shape } from "@/lib/types";
+
+const designPpm = 10;
+
+function route(
+  id: string,
+  points: PolylineShape["points"],
+  options: Partial<PolylineShape> = {}
+): PolylineShape {
+  return {
+    id,
+    kind: "polyline",
+    x: 0,
+    y: 0,
+    rotation: 0,
+    points,
+    ...options,
+  };
+}
+
+describe("polyline targeting", () => {
+  it("projects a pointer to the closest point on a polyline", () => {
+    const result = resolveClosestPointOnPolyline([0, 0, 100, 0], {
+      x: 40,
+      y: 12,
+    });
+
+    expect(result.pointPx).toEqual({ x: 40, y: 0 });
+    expect(result.distanceSq).toBe(144);
+  });
+
+  it("returns the nearest route segment within the hit radius", () => {
+    const first = route("first", [
+      { x: 0, y: 0, z: 0 },
+      { x: 10, y: 0, z: 0 },
+    ]);
+    const second = route("second", [
+      { x: 0, y: 5, z: 0 },
+      { x: 10, y: 5, z: 0 },
+    ]);
+
+    const hit = findPolylineTarget({
+      designPpm,
+      maxDistancePx: 8,
+      pointer: { x: 42, y: 52 },
+      shapes: [first, second],
+    });
+
+    expect(hit?.shape.id).toBe("second");
+    expect(hit?.segmentIndex).toBe(0);
+    expect(hit?.pointPx.x).toBeCloseTo(42, 4);
+    expect(hit?.pointPx.y).toBeCloseTo(50, 4);
+  });
+
+  it("returns null outside the hit radius", () => {
+    const hit = findPolylineTarget({
+      designPpm,
+      maxDistancePx: 5,
+      pointer: { x: 50, y: 20 },
+      shapes: [
+        route("path", [
+          { x: 0, y: 0, z: 0 },
+          { x: 10, y: 0, z: 0 },
+        ]),
+      ],
+    });
+
+    expect(hit).toBeNull();
+  });
+
+  it("ignores locked paths, non-path shapes, and stub paths", () => {
+    const shapes: Shape[] = [
+      {
+        id: "gate",
+        kind: "gate",
+        x: 5,
+        y: 0,
+        rotation: 0,
+        width: 2,
+        height: 1.5,
+      },
+      route(
+        "locked",
+        [
+          { x: 0, y: 0, z: 0 },
+          { x: 10, y: 0, z: 0 },
+        ],
+        { locked: true }
+      ),
+      route("stub", [{ x: 5, y: 0, z: 0 }]),
+      route("target", [
+        { x: 0, y: 2, z: 0 },
+        { x: 10, y: 2, z: 0 },
+      ]),
+    ];
+
+    const hit = findPolylineTarget({
+      designPpm,
+      maxDistancePx: 8,
+      pointer: { x: 50, y: 20 },
+      shapes,
+    });
+
+    expect(hit?.shape.id).toBe("target");
+  });
+
+  it("targets the closing segment of a closed path", () => {
+    const closed = route(
+      "closed",
+      [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 0 },
+        { x: 10, y: 10, z: 0 },
+        { x: 0, y: 10, z: 0 },
+      ],
+      { closed: true }
+    );
+    const closingSegment = getPolylineSmoothSegmentPointsPx(
+      closed,
+      designPpm
+    )[3];
+    const pointOffset = Math.floor(closingSegment.length / 4) * 2;
+
+    const hit = findPolylineTarget({
+      designPpm,
+      maxDistancePx: 6,
+      pointer: {
+        x: closingSegment[pointOffset] + 1,
+        y: closingSegment[pointOffset + 1],
+      },
+      shapes: [closed],
+    });
+
+    expect(hit?.shape.id).toBe("closed");
+    expect(hit?.segmentIndex).toBe(3);
+    expect(hit?.distanceSq).toBeLessThanOrEqual(36);
+  });
+});

--- a/tests/lib/editor-tools.test.ts
+++ b/tests/lib/editor-tools.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
   buildGateCatalogTypePatch,
   createShapeForTool,
+  getShapeDisplayLabel,
   shapeKindLabels,
   toolLabels,
   toolShortcuts,
 } from "@/lib/editor-tools";
 import {
+  createTrackElementCatalogIdentity,
   createCatalogShapeDraft,
+  getTrackElementCatalogEntry,
   MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
   MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
   TRACKDRAW_FLAG_ELEMENT_ID,
@@ -134,6 +137,38 @@ describe("editor tool helpers", () => {
     expect(createShapeForTool("grab", { x: 1, y: 2 })).toBeNull();
     expect(createShapeForTool("preset", { x: 1, y: 2 })).toBeNull();
     expect(createShapeForTool("polyline", { x: 1, y: 2 })).toBeNull();
+  });
+
+  it("uses catalog-backed shape names for display labels", () => {
+    const shape = createShapeForTool(
+      "gate",
+      { x: 3, y: 4 },
+      {
+        activePlacementElementId: {
+          gate: MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+        },
+      }
+    );
+
+    expect(shape?.kind).toBe("gate");
+    expect(getShapeDisplayLabel({ ...shape!, id: "gate-1" })).toBe(
+      "MultiGP Standard Gate 5x5"
+    );
+  });
+
+  it("falls back to kind labels when catalog metadata does not match the shape", () => {
+    const flagEntry = getTrackElementCatalogEntry(TRACKDRAW_FLAG_ELEMENT_ID);
+    expect(flagEntry).not.toBeNull();
+
+    const gate = {
+      ...createCatalogShapeDraft(TRACKDRAW_GATE_ELEMENT_ID, { x: 1, y: 2 }),
+      id: "gate-2",
+      meta: {
+        catalog: createTrackElementCatalogIdentity(flagEntry!),
+      },
+    } as GateShape;
+
+    expect(getShapeDisplayLabel(gate)).toBe("Gate");
   });
 });
 

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -946,6 +946,47 @@ describe("editor store history", () => {
     ]);
   });
 
+  it("keeps a selected route segment when the same path is selected again", () => {
+    const state = useEditor.getState();
+    const routeId = state.addShape({
+      kind: "polyline",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      points: [
+        { x: 0, y: 0, z: 0 },
+        { x: 4, y: 0, z: 0 },
+      ],
+    });
+    const gateId = state.addShape({
+      kind: "gate",
+      x: 2,
+      y: 2,
+      rotation: 0,
+      width: 2,
+      height: 1.5,
+    });
+
+    state.setSelection([routeId]);
+    state.setSegmentSelection({
+      shapeId: routeId,
+      segmentIndex: 0,
+      point: { x: 2, y: 0 },
+    });
+
+    state.setSelection([routeId]);
+
+    expect(useEditor.getState().ui.segmentSelection).toEqual({
+      shapeId: routeId,
+      segmentIndex: 0,
+      point: { x: 2, y: 0 },
+    });
+
+    state.setSelection([gateId]);
+
+    expect(useEditor.getState().ui.segmentSelection).toBeNull();
+  });
+
   it("updates field and design metadata through explicit track actions", () => {
     const state = useEditor.getState();
     state.clearHistory();


### PR DESCRIPTION
Improve waypoint insertion on smooth paths across desktop and mobile. Right-clicking near a path on desktop should reliably open the context menu, and retapping a selected path on mobile should move the waypoint preview instead of clearing it.

## Changes

- Added a path hit-test fallback for desktop context menus when Konva misses the thin/smoothed line.
- Made mobile path retargeting more robust by handling touch taps before Konva can clear selection.
- Prevented reselecting the same path from clearing the selected segment preview.
- Updated context menu labels to show the specific gate/type label where available.
- Added regression coverage for preserving selected path segments.