### PR TITLE
fix: Refine path defaults and 3D elevation controls

### DIFF
--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -49,6 +49,7 @@ import {
   m2px,
   px2m,
 } from "@/lib/track/units";
+import { DEFAULT_POLYLINE_STROKE_WIDTH } from "@/lib/track/constants";
 import {
   buildSnapIndex,
   getNearbySnapCandidates as getNearbySnapCandidatesFromIndex,
@@ -1381,7 +1382,7 @@ const TrackCanvas = memo(
             rotation: 0,
             points,
             closed: nextClosed,
-            strokeWidth: 0.26,
+            strokeWidth: DEFAULT_POLYLINE_STROKE_WIDTH,
             showArrows: false,
             arrowSpacing: 15,
             smooth: true,

--- a/src/components/canvas/editor/TrackPreview3D.tsx
+++ b/src/components/canvas/editor/TrackPreview3D.tsx
@@ -332,7 +332,6 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
           {shapes.map((shape) => (
             <MemoShape3D
               key={shape.id}
-              isEditing={elevationDrag?.shapeId === shape.id}
               isPrimaryPolyline={primaryPolyline?.id === shape.id}
               isSelected={selectedIdSet.has(shape.id)}
               onSelect={handleShapeSelect}

--- a/src/components/canvas/editor/trackPreview3DEditSceneContent.tsx
+++ b/src/components/canvas/editor/trackPreview3DEditSceneContent.tsx
@@ -5,6 +5,10 @@ import { useFrame, type ThreeEvent } from "@react-three/fiber";
 import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import * as THREE from "three";
 import { getPreviewRotationGuideDegrees } from "@/lib/track/orientation";
+import {
+  DEFAULT_POLYLINE_STROKE_WIDTH,
+  POLYLINE_3D_HEIGHT_OFFSET,
+} from "@/lib/track/constants";
 import { getLadderVisualSpec } from "@/lib/track/elements/visual";
 import { getLadderRenderedHeight } from "@/lib/track/render3d-layout";
 import type {
@@ -133,10 +137,8 @@ export function PolylineElevationHandles3D({
     <group>
       {path.points.map((point, index) => {
         const pointHeight = Math.max(point.z ?? 0, 0);
-        const guideHeight = Math.max(0.4, pointHeight + 0.5);
         const isActive = activeIndex === index;
         const isHovered = hoveredIndex === index;
-        const handleY = pointHeight + 0.52;
         const guideColor = isActive
           ? "#f59e0b"
           : isHovered
@@ -156,6 +158,19 @@ export function PolylineElevationHandles3D({
           : isActive
             ? 0.18
             : 0.15;
+        const tubeRadius = Math.max(
+          0.02,
+          (path.strokeWidth ?? DEFAULT_POLYLINE_STROKE_WIDTH) / 2
+        );
+        const lineCenterY = pointHeight + POLYLINE_3D_HEIGHT_OFFSET;
+        const lineTopY = lineCenterY + tubeRadius;
+        const handleGap = isMobile ? 0.04 : 0.025;
+        const handleY = lineTopY + gripHeight / 2 + handleGap;
+        const guideHeight = Math.max(0.4, handleY);
+        const ringY = lineCenterY - tubeRadius * 0.25;
+        const ringInnerRadius = tubeRadius * 0.35;
+        const ringOuterRadius = tubeRadius * 0.72;
+        const hoverDiscRadius = tubeRadius * 0.82;
         const touchTargetRadius = isMobile ? 0.38 : gripRadius + 0.06;
         const touchTargetHeight = isMobile ? 0.58 : gripHeight;
         return (
@@ -169,10 +184,10 @@ export function PolylineElevationHandles3D({
               />
             </mesh>
             <mesh
-              position={[point.x, pointHeight + 0.03, point.y]}
+              position={[point.x, ringY, point.y]}
               rotation={[-Math.PI / 2, 0, 0]}
             >
-              <ringGeometry args={[0.13, 0.19, 40]} />
+              <ringGeometry args={[ringInnerRadius, ringOuterRadius, 40]} />
               <meshBasicMaterial
                 color={isActive ? "#fbbf24" : "#60a5fa"}
                 transparent
@@ -182,10 +197,10 @@ export function PolylineElevationHandles3D({
             </mesh>
             {(isActive || isHovered) && (
               <mesh
-                position={[point.x, pointHeight + 0.031, point.y]}
+                position={[point.x, ringY + 0.001, point.y]}
                 rotation={[-Math.PI / 2, 0, 0]}
               >
-                <circleGeometry args={[0.24, 36]} />
+                <circleGeometry args={[hoverDiscRadius, 36]} />
                 <meshBasicMaterial
                   color={isActive ? "#fbbf24" : "#93c5fd"}
                   transparent

--- a/src/components/canvas/editor/useTrackPreview3DInteractions.ts
+++ b/src/components/canvas/editor/useTrackPreview3DInteractions.ts
@@ -25,6 +25,40 @@ import {
   snapRotationDegrees,
 } from "@/components/canvas/trackPreview3DMath";
 
+function getVerticalDragPlaneY(
+  clientX: number,
+  clientY: number,
+  rect: DOMRect,
+  camera: THREE.Camera,
+  anchorX: number,
+  anchorZ: number
+): number | null {
+  const ndcX = ((clientX - rect.left) / rect.width) * 2 - 1;
+  const ndcY = -((clientY - rect.top) / rect.height) * 2 + 1;
+  const raycaster = new THREE.Raycaster();
+  raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
+
+  const cameraDirection = new THREE.Vector3();
+  camera.getWorldDirection(cameraDirection);
+  const planeNormal = new THREE.Vector3(
+    cameraDirection.x,
+    0,
+    cameraDirection.z
+  );
+  if (planeNormal.lengthSq() < 0.0001) {
+    return null;
+  }
+  planeNormal.normalize();
+
+  const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(
+    planeNormal,
+    new THREE.Vector3(anchorX, 0, anchorZ)
+  );
+  const hit = new THREE.Vector3();
+  if (!raycaster.ray.intersectPlane(plane, hit)) return null;
+  return hit.y;
+}
+
 interface UseTrackPreview3DInteractionsParams {
   beginInteraction: () => void;
   endInteraction: () => void;
@@ -61,9 +95,12 @@ export function useTrackPreview3DInteractions({
   updateShape,
 }: UseTrackPreview3DInteractionsParams) {
   const [elevationDrag, setElevationDrag] = useState<{
+    anchorX: number;
+    anchorZ: number;
     shapeId: string;
     idx: number;
     startClientY: number;
+    startPlaneY: number | null;
     startZ: number;
   } | null>(null);
   const [elevationPreviewPoints, setElevationPreviewPoints] = useState<
@@ -102,7 +139,9 @@ export function useTrackPreview3DInteractions({
   const rotationDragAnimationFrameRef = useRef<number | null>(null);
   const tiltDragAnimationFrameRef = useRef<number | null>(null);
   const ladderElevationDragAnimationFrameRef = useRef<number | null>(null);
-  const pendingClientYRef = useRef<number | null>(null);
+  const pendingElevationClientRef = useRef<{ x: number; y: number } | null>(
+    null
+  );
   const pendingRotationClientRef = useRef<{ x: number; y: number } | null>(
     null
   );
@@ -178,13 +217,30 @@ export function useTrackPreview3DInteractions({
       event.stopPropagation();
       const point = selectedPolyline?.points[index];
       if (!selectedPolyline || !point) return;
+      const camera = cameraRef.current;
+      const container = containerRef.current;
+      const rect = container?.getBoundingClientRect();
+      const startPlaneY =
+        camera && rect
+          ? getVerticalDragPlaneY(
+              event.nativeEvent.clientX,
+              event.nativeEvent.clientY,
+              rect,
+              camera,
+              point.x,
+              point.y
+            )
+          : null;
       if (!startSession()) return;
       setSelection([selectedPolyline.id]);
       setElevationPreviewPoints(selectedPolyline.points);
       setElevationDrag({
+        anchorX: point.x,
+        anchorZ: point.y,
         shapeId: selectedPolyline.id,
         idx: index,
         startClientY: event.nativeEvent.clientY,
+        startPlaneY,
         startZ: point.z ?? 0,
       });
     },
@@ -192,12 +248,29 @@ export function useTrackPreview3DInteractions({
   );
 
   const applyElevationDrag = useCallback(
-    (clientY: number) => {
+    (clientX: number, clientY: number) => {
       const drag = elevationDragRef.current;
       if (!drag) return;
       const shape = shapeById[drag.shapeId];
       if (!shape || shape.kind !== "polyline") return;
-      const deltaMeters = (drag.startClientY - clientY) * 0.035;
+      const camera = cameraRef.current;
+      const container = containerRef.current;
+      const rect = container?.getBoundingClientRect();
+      const planeY =
+        camera && rect && drag.startPlaneY !== null
+          ? getVerticalDragPlaneY(
+              clientX,
+              clientY,
+              rect,
+              camera,
+              drag.anchorX,
+              drag.anchorZ
+            )
+          : null;
+      const deltaMeters =
+        planeY !== null && drag.startPlaneY !== null
+          ? planeY - drag.startPlaneY
+          : (drag.startClientY - clientY) * 0.02;
       const nextZ = Math.max(0, +(drag.startZ + deltaMeters).toFixed(2));
       const currentPoint =
         elevationPreviewPointsRef.current?.[drag.idx] ?? shape.points[drag.idx];
@@ -245,12 +318,16 @@ export function useTrackPreview3DInteractions({
     };
 
     const handleMouseMove = (event: MouseEvent) => {
-      pendingClientYRef.current = event.clientY;
+      pendingElevationClientRef.current = {
+        x: event.clientX,
+        y: event.clientY,
+      };
       if (dragAnimationFrameRef.current !== null) return;
       dragAnimationFrameRef.current = window.requestAnimationFrame(() => {
         dragAnimationFrameRef.current = null;
-        if (pendingClientYRef.current !== null) {
-          applyElevationDrag(pendingClientYRef.current);
+        const client = pendingElevationClientRef.current;
+        if (client) {
+          applyElevationDrag(client.x, client.y);
         }
       });
     };
@@ -258,12 +335,16 @@ export function useTrackPreview3DInteractions({
     const handleTouchMove = (event: TouchEvent) => {
       if (!event.touches.length) return;
       event.preventDefault();
-      pendingClientYRef.current = event.touches[0].clientY;
+      pendingElevationClientRef.current = {
+        x: event.touches[0].clientX,
+        y: event.touches[0].clientY,
+      };
       if (dragAnimationFrameRef.current !== null) return;
       dragAnimationFrameRef.current = window.requestAnimationFrame(() => {
         dragAnimationFrameRef.current = null;
-        if (pendingClientYRef.current !== null) {
-          applyElevationDrag(pendingClientYRef.current);
+        const client = pendingElevationClientRef.current;
+        if (client) {
+          applyElevationDrag(client.x, client.y);
         }
       });
     };

--- a/src/components/canvas/editor/useTrackPreview3DInteractions.ts
+++ b/src/components/canvas/editor/useTrackPreview3DInteractions.ts
@@ -25,6 +25,13 @@ import {
   snapRotationDegrees,
 } from "@/components/canvas/trackPreview3DMath";
 
+const elevationDragRaycaster = new THREE.Raycaster();
+const elevationDragNdc = new THREE.Vector2();
+const elevationDragCameraDirection = new THREE.Vector3();
+const elevationDragPlaneNormal = new THREE.Vector3();
+const elevationDragPlane = new THREE.Plane();
+const elevationDragHit = new THREE.Vector3();
+
 function getVerticalDragPlaneY(
   clientX: number,
   clientY: number,
@@ -35,28 +42,33 @@ function getVerticalDragPlaneY(
 ): number | null {
   const ndcX = ((clientX - rect.left) / rect.width) * 2 - 1;
   const ndcY = -((clientY - rect.top) / rect.height) * 2 + 1;
-  const raycaster = new THREE.Raycaster();
-  raycaster.setFromCamera(new THREE.Vector2(ndcX, ndcY), camera);
+  elevationDragNdc.set(ndcX, ndcY);
+  elevationDragRaycaster.setFromCamera(elevationDragNdc, camera);
 
-  const cameraDirection = new THREE.Vector3();
-  camera.getWorldDirection(cameraDirection);
-  const planeNormal = new THREE.Vector3(
-    cameraDirection.x,
+  camera.getWorldDirection(elevationDragCameraDirection);
+  elevationDragPlaneNormal.set(
+    elevationDragCameraDirection.x,
     0,
-    cameraDirection.z
+    elevationDragCameraDirection.z
   );
-  if (planeNormal.lengthSq() < 0.0001) {
+  if (elevationDragPlaneNormal.lengthSq() < 0.0001) {
     return null;
   }
-  planeNormal.normalize();
+  elevationDragPlaneNormal.normalize();
 
-  const plane = new THREE.Plane().setFromNormalAndCoplanarPoint(
-    planeNormal,
-    new THREE.Vector3(anchorX, 0, anchorZ)
+  elevationDragPlane.setFromNormalAndCoplanarPoint(
+    elevationDragPlaneNormal,
+    elevationDragHit.set(anchorX, 0, anchorZ)
   );
-  const hit = new THREE.Vector3();
-  if (!raycaster.ray.intersectPlane(plane, hit)) return null;
-  return hit.y;
+  if (
+    !elevationDragRaycaster.ray.intersectPlane(
+      elevationDragPlane,
+      elevationDragHit
+    )
+  ) {
+    return null;
+  }
+  return elevationDragHit.y;
 }
 
 interface UseTrackPreview3DInteractionsParams {

--- a/src/components/canvas/renderers/polyline-shape.tsx
+++ b/src/components/canvas/renderers/polyline-shape.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/track/polyline-derived";
 import { isTouchLikeEvent } from "@/lib/canvas/shared";
 import { zToColor } from "@/lib/track/alt";
+import { DEFAULT_POLYLINE_STROKE_WIDTH } from "@/lib/track/constants";
 import { m2px, px2m } from "@/lib/track/units";
 import type { PolylinePoint, PolylineShape } from "@/lib/types";
 
@@ -105,7 +106,10 @@ export function PolylineShapeContent({
         : path,
     [path, previewPoints]
   );
-  const strokePx = m2px(displayPath.strokeWidth ?? 0.26, designPpm);
+  const strokePx = m2px(
+    displayPath.strokeWidth ?? DEFAULT_POLYLINE_STROKE_WIDTH,
+    designPpm
+  );
   const minSelectionStrokePx =
     (isMobile ? 44 : 30) / Math.max(viewportScale, 0.1);
   const selectionStrokePx = isMobile

--- a/src/components/canvas/share/PolylineShape.tsx
+++ b/src/components/canvas/share/PolylineShape.tsx
@@ -10,6 +10,7 @@ import {
   getRouteWarningSegmentColor,
 } from "@/lib/track/polyline-derived";
 import { zToColor } from "@/lib/track/alt";
+import { DEFAULT_POLYLINE_STROKE_WIDTH } from "@/lib/track/constants";
 import { m2px } from "@/lib/track/units";
 import type { PolylineShape as TrackPolylineShape } from "@/lib/types";
 
@@ -28,7 +29,10 @@ function SharePolylineShapeComponent({
   zmax,
   zmin,
 }: SharePolylineShapeProps) {
-  const strokePx = m2px(path.strokeWidth ?? 0.26, designPpm);
+  const strokePx = m2px(
+    path.strokeWidth ?? DEFAULT_POLYLINE_STROKE_WIDTH,
+    designPpm
+  );
   const polylineMetrics = useMemo(() => getPolyline2DDerived(path), [path]);
   const warningSegments = useMemo(
     () => getPolylineRouteWarningSegmentVisuals(path),

--- a/src/components/canvas/share/TrackPreview3D.tsx
+++ b/src/components/canvas/share/TrackPreview3D.tsx
@@ -109,7 +109,6 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
         shapes.map((shape) => (
           <MemoShape3D
             key={shape.id}
-            isEditing={false}
             isPrimaryPolyline={false}
             isSelected={false}
             onSelect={handleShapeSelect}

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { RoundedBox, Line as DreiLine, useTexture } from "@react-three/drei";
+import { RoundedBox, useTexture } from "@react-three/drei";
 import { useFrame, useThree, type ThreeEvent } from "@react-three/fiber";
 import type { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 import {
@@ -18,10 +18,7 @@ import {
   getRouteWarningSegmentColor,
   getPolylineSmoothSegmentPoints3D,
 } from "@/lib/track/polyline-derived";
-import {
-  getPolylineCurve3Derived,
-  getPolylinePreview3DPoints,
-} from "@/lib/track/polyline-derived-3d";
+import { getPolylineCurve3Derived } from "@/lib/track/polyline-derived-3d";
 import {
   getCornerFlagLayout,
   getLadderRenderedHeight,
@@ -34,6 +31,10 @@ import {
   getLadderVisualSpec,
 } from "@/lib/track/elements/visual";
 import { getShapeTimingMarker, getTimingMarkerColor } from "@/lib/track/timing";
+import {
+  DEFAULT_POLYLINE_STROKE_WIDTH,
+  POLYLINE_3D_HEIGHT_OFFSET,
+} from "@/lib/track/constants";
 import type {
   CornerMarkerFlagVisualSpec,
   GatePanelTextureVisualSpec,
@@ -701,7 +702,7 @@ function PanelFrameGate3D({
       </mesh>
 
       <PanelFrameGateTexturePlanes
-        frontZ={frontZ - 0.012}
+        frontZ={frontZ}
         h={h}
         leftPanelWidth={leftPanelWidth}
         leftPanelX={leftPanelX}
@@ -1425,7 +1426,7 @@ function PanelFrameLadder3D({
             <PanelFrameLadderSectionTexturePlanes
               bannerH={bannerH}
               bannerMidY={bannerMidY}
-              frontZ={frontZ - 0.012}
+              frontZ={frontZ}
               leftPanelWidth={leftPanelWidth}
               openingH={openingH}
               openingMidY={openingMidY}
@@ -1741,27 +1742,22 @@ function DiveGate3D({
   );
 }
 
-const POLYLINE_3D_HEIGHT_OFFSET = 0.3;
-
 function getPolylineTubeRadius(shape: PolylineShape) {
-  return Math.max(0.02, (shape.strokeWidth ?? 0.26) / 2);
+  return Math.max(
+    0.02,
+    (shape.strokeWidth ?? DEFAULT_POLYLINE_STROKE_WIDTH) / 2
+  );
 }
 
 function RaceLine3D({
-  editing = false,
   isPrimary = false,
   selected = false,
   shape,
 }: {
-  editing?: boolean;
   isPrimary?: boolean;
   selected?: boolean;
   shape: PolylineShape;
 }) {
-  const previewPoints = useMemo(
-    () => getPolylinePreview3DPoints(shape, POLYLINE_3D_HEIGHT_OFFSET),
-    [shape]
-  );
   const warningSegments = useMemo(
     () => getPolylineRouteWarningSegmentVisuals(shape),
     [shape]
@@ -1803,7 +1799,6 @@ function RaceLine3D({
     warningSegments.length,
   ]);
   const geometry = useMemo(() => {
-    if (editing) return null;
     const curveData = getPolylineCurve3Derived(shape, {
       heightOffset: POLYLINE_3D_HEIGHT_OFFSET,
       samplesPerSegment: 18,
@@ -1817,23 +1812,13 @@ function RaceLine3D({
       10,
       shape.closed ?? false
     );
-  }, [editing, shape, tubeRadius]);
+  }, [shape, tubeRadius]);
 
   useEffect(() => {
     return () => {
       segmentedGeometries?.forEach((geometry) => geometry?.dispose());
     };
   }, [segmentedGeometries]);
-
-  if (editing) {
-    return (
-      <DreiLine
-        points={previewPoints}
-        color={selected ? "#93c5fd" : (shape.color ?? "#3b82f6")}
-        lineWidth={Math.max(2, (shape.strokeWidth ?? 0.26) * 8)}
-      />
-    );
-  }
 
   if (!geometry) return null;
   return (
@@ -1964,7 +1949,6 @@ function SelectionMarker3D({ shape }: { shape: Shape }) {
 }
 
 function Shape3D({
-  isEditing,
   isPrimaryPolyline,
   isSelected,
   onSelect,
@@ -1973,7 +1957,6 @@ function Shape3D({
   tiltDragRef,
   elevationOverrideRef,
 }: {
-  isEditing: boolean;
   isPrimaryPolyline: boolean;
   isSelected: boolean;
   onSelect: (event: ThreeEvent<MouseEvent>, shapeId: string) => void;
@@ -2015,7 +1998,6 @@ function Shape3D({
       return (
         <group onClick={(event) => onSelect(event, shape.id)}>
           <RaceLine3D
-            editing={isEditing}
             isPrimary={isPrimaryPolyline}
             shape={shape}
             selected={isSelected}
@@ -2063,7 +2045,6 @@ export const MemoShape3D = memo(
   Shape3D,
   (prev, next) =>
     prev.shape === next.shape &&
-    prev.isEditing === next.isEditing &&
     prev.isPrimaryPolyline === next.isPrimaryPolyline &&
     prev.isSelected === next.isSelected &&
     prev.onSelect === next.onSelect &&

--- a/src/components/gallery/GalleryPreviewRenderer.tsx
+++ b/src/components/gallery/GalleryPreviewRenderer.tsx
@@ -38,7 +38,6 @@ export function GalleryPreviewRenderer({ onCapture }: Props) {
       shapes.map((shape) => (
         <MemoShape3D
           key={shape.id}
-          isEditing={false}
           isPrimaryPolyline={false}
           isSelected={false}
           onSelect={noop}

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -27,6 +27,7 @@ import {
   isTimingMarkerShape,
   type TimingRole,
 } from "@/lib/track/timing";
+import { DEFAULT_POLYLINE_STROKE_WIDTH } from "@/lib/track/constants";
 import type { PolylinePoint, Shape } from "@/lib/types";
 import {
   Copy,
@@ -900,7 +901,9 @@ export function SingleInspectorView({
             >
               <Row label={`Stroke width (${unitLabel})`}>
                 <MeasurementNum
-                  valueMeters={shape.strokeWidth ?? 0.26}
+                  valueMeters={
+                    shape.strokeWidth ?? DEFAULT_POLYLINE_STROKE_WIDTH
+                  }
                   unitSystem={unitSystem}
                   onChange={(value) =>
                     updateShape(shape.id, { strokeWidth: value })

--- a/src/lib/editor/shape-mutations.ts
+++ b/src/lib/editor/shape-mutations.ts
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import { DEFAULT_POLYLINE_STROKE_WIDTH } from "@/lib/track/constants";
 import { getShapeGroupId } from "@/lib/track/shape-groups";
 import type {
   PolylinePoint,
@@ -347,8 +348,8 @@ export function joinPolylineShapes(
         nextPath.arrowSpacing ?? 15
       ),
       strokeWidth: Math.max(
-        merged.strokeWidth ?? 0.26,
-        nextPath.strokeWidth ?? 0.26
+        merged.strokeWidth ?? DEFAULT_POLYLINE_STROKE_WIDTH,
+        nextPath.strokeWidth ?? DEFAULT_POLYLINE_STROKE_WIDTH
       ),
       closed: false,
       locked: false,

--- a/src/lib/export/exportFlythrough.ts
+++ b/src/lib/export/exportFlythrough.ts
@@ -159,8 +159,8 @@ function addPanelTexturePlane(
   );
   mesh.position.set(...position);
   mesh.rotation.y = Math.PI;
-  mesh.castShadow = true;
-  mesh.receiveShadow = true;
+  mesh.castShadow = false;
+  mesh.receiveShadow = false;
   group.add(mesh);
 }
 
@@ -275,19 +275,19 @@ async function createOfficialGateGroup(
     group,
     panelTextures.left,
     [leftPanelWidth, h],
-    [leftPanelX, h / 2, frontZ - 0.012]
+    [leftPanelX, h / 2, frontZ]
   );
   addPanelTexturePlane(
     group,
     panelTextures.right,
     [rightPanelWidth, h],
-    [rightPanelX, h / 2, frontZ - 0.012]
+    [rightPanelX, h / 2, frontZ]
   );
   addPanelTexturePlane(
     group,
     panelTextures.top,
     [topPanelW, topPanelHeight],
-    [0, topPanelY, frontZ - 0.012]
+    [0, topPanelY, frontZ]
   );
 
   return group;
@@ -304,6 +304,7 @@ async function createPanelFrameLadderGroup(
     baseY,
     frameTube,
     frameZ,
+    frontZ,
     gateH,
     leftPanelWidth,
     openingH,
@@ -428,19 +429,19 @@ async function createPanelFrameLadderGroup(
       group,
       panelTextures.left,
       [leftPanelWidth, openingH],
-      [-w / 2 - leftPanelWidth / 2, openingMidY, -panelDepth / 2 - 0.024]
+      [-w / 2 - leftPanelWidth / 2, openingMidY, frontZ]
     );
     addPanelTexturePlane(
       group,
       panelTextures.right,
       [rightPanelWidth, openingH],
-      [w / 2 + rightPanelWidth / 2, openingMidY, -panelDepth / 2 - 0.024]
+      [w / 2 + rightPanelWidth / 2, openingMidY, frontZ]
     );
     addPanelTexturePlane(
       group,
       panelTextures.top,
       [outerW, bannerH],
-      [0, bannerMidY, -panelDepth / 2 - 0.024]
+      [0, bannerMidY, frontZ]
     );
 
     const fill = new THREE.Mesh(new THREE.PlaneGeometry(w, openingH), fillMat);

--- a/src/lib/export/exportSvg.ts
+++ b/src/lib/export/exportSvg.ts
@@ -26,6 +26,7 @@ import {
   getPolylineRouteWarningSegmentVisuals,
   getPolylineSmoothSegmentPointsPx,
 } from "../track/polyline-derived";
+import { DEFAULT_POLYLINE_STROKE_WIDTH } from "../track/constants";
 import {
   getCone2DShape,
   getDiveGate2DShape,
@@ -121,7 +122,7 @@ function polylineToSvg(
   const d = pts
     .map((p, i) => `${i === 0 ? "M" : "L"}${m(p.x, ppm)},${m(p.y, ppm)}`)
     .join(" ");
-  const sw = m(s.strokeWidth ?? 0.26, ppm);
+  const sw = m(s.strokeWidth ?? DEFAULT_POLYLINE_STROKE_WIDTH, ppm);
   const color = s.color ?? "#3b82f6";
   const closed = s.closed ? " Z" : "";
   const warningSegments = showWarningVisuals

--- a/src/lib/track/constants.ts
+++ b/src/lib/track/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_POLYLINE_STROKE_WIDTH = 0.2;
+export const POLYLINE_3D_HEIGHT_OFFSET = 0.3;

--- a/src/lib/track/design.ts
+++ b/src/lib/track/design.ts
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import { normalizeMapReference } from "@/lib/map-reference/geometry";
 import { normalizeInventoryProfile } from "@/lib/planning/inventory";
+import { DEFAULT_POLYLINE_STROKE_WIDTH } from "@/lib/track/constants";
 import { normalizeShapeTimingMeta } from "@/lib/track/timing";
 import type {
   PolylineShape,
@@ -37,7 +38,7 @@ export function normalizeShape(shape: Shape): Shape {
       ...normalizePolylinePosition(shape),
       frontOffsetDeg: shape.frontOffsetDeg ?? 0,
       arrowSpacing: shape.arrowSpacing ?? 15,
-      strokeWidth: shape.strokeWidth ?? 0.26,
+      strokeWidth: shape.strokeWidth ?? DEFAULT_POLYLINE_STROKE_WIDTH,
       smooth: true,
     });
   }

--- a/src/lib/track/polyline-derived.ts
+++ b/src/lib/track/polyline-derived.ts
@@ -6,6 +6,7 @@ import {
 } from "./geometry";
 import { getDesignShapes } from "./design";
 import type { PolylinePoint, PolylineShape, TrackDesign } from "../types";
+import { DEFAULT_POLYLINE_STROKE_WIDTH } from "./constants";
 import { m2px } from "./units";
 
 const POLYLINE_2D_SAMPLES_PER_SEGMENT = 18;
@@ -153,7 +154,7 @@ export function getPolylineBounds(path: PolylineShape, ppm: number) {
     maxY = Math.max(maxY, y);
   }
 
-  const strokePx = m2px(path.strokeWidth ?? 0.26, ppm);
+  const strokePx = m2px(path.strokeWidth ?? DEFAULT_POLYLINE_STROKE_WIDTH, ppm);
   const bounds = {
     x: minX - strokePx,
     y: minY - strokePx,

--- a/src/lib/track/render3d-layout.ts
+++ b/src/lib/track/render3d-layout.ts
@@ -5,6 +5,7 @@ import type {
 import type { FlagShape, GateShape, LadderShape } from "@/lib/types";
 
 export const PANEL_FRAME_PANEL_DEPTH = 0.018;
+export const PANEL_FRAME_TEXTURE_SURFACE_OFFSET = 0.0015;
 export const TEXTURED_PANEL_FRAME_TUBE_SCALE = 0.58;
 const MULTIGP_FEATHER_FLAG_TEXTURE_ASPECT = 1134 / 5811;
 
@@ -21,7 +22,7 @@ export function getPanelFrameGateLayout(
   const frameTube =
     visual.frame.diameterMeters * TEXTURED_PANEL_FRAME_TUBE_SCALE;
   const frameZ = panelDepth * 0.1;
-  const frontZ = -(panelDepth / 2 + 0.012);
+  const frontZ = -(panelDepth / 2 + PANEL_FRAME_TEXTURE_SURFACE_OFFSET);
   const leftPanelX = -w / 2 - leftPanelWidth / 2;
   const rightPanelX = w / 2 + rightPanelWidth / 2;
   const topPanelY = h + topPanelHeight / 2;
@@ -72,7 +73,7 @@ export function getPanelFrameLadderLayout(
   const openingH = totalOpeningH / rungs;
   const gateH = openingH + bannerH;
   const totalH = gateH * rungs;
-  const frontZ = -(panelDepth / 2 + 0.012);
+  const frontZ = -(panelDepth / 2 + PANEL_FRAME_TEXTURE_SURFACE_OFFSET);
   const tJunctionRadius = frameTube * 0.8;
 
   return {

--- a/tests/lib/track/design.test.ts
+++ b/tests/lib/track/design.test.ts
@@ -46,7 +46,7 @@ describe("track design helpers", () => {
     ]);
     expect(normalized.frontOffsetDeg).toBe(0);
     expect(normalized.arrowSpacing).toBe(15);
-    expect(normalized.strokeWidth).toBe(0.26);
+    expect(normalized.strokeWidth).toBe(0.2);
     expect(normalized.smooth).toBe(true);
   });
 


### PR DESCRIPTION
This PR follows up on the 3D editing experience after the MultiGP texture work.

It centralizes the default path stroke width and lowers it from 0.26m to 0.20m. The shared constant is now used across path creation, normalization, 2D rendering, 3D preview, SVG export, inspector defaults, derived bounds, and path merge behavior so older or partial project data resolves consistently.

The 3D path elevation controls were adjusted for the thinner path line. The path now keeps rendering as a 3D tube while elevation editing, and the elevation drag uses camera/world projection instead of a fixed pixel multiplier. That should make vertical dragging feel less jumpy and closer to the mouse movement. The waypoint rings are still rendered as visible controls on the path surface, which keeps them easy to find and interact with.

This also tightens the panel-frame texture placement for gates and ladders by reducing the texture surface offset and removing extra per-renderer offsets, so the textures read more like decals on the panels instead of floating in front of them.