### PR TITLE
feat: add MultiGP Dive Gate 7x6 and Launch Gate 7x6 with texture placement

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -256,8 +256,6 @@ Current shipped foundation:
 
 Next catalog slices:
 
-- Dive Gate 7x6: add as a catalog-backed gate variant with official dimensions and a 3D rendering that reflects the low-profile dive orientation; shares the gate shape kind and inspector pipeline
-- Launch Gate 7x6: add as a catalog-backed gate variant used at the race start; shares the gate shape kind and pipeline, with official dimensions and appropriate 3D rendering
 - Double Gate Tower 5x5 and 7x6: introduce as a new shape kind with its own 2D representation, 3D rendering, catalog entries, and inspector pipeline; race-line behavior is gate-like (fly through) while the physical structure resembles a two-frame tower
 
 #### 3D Preview And Direct Manipulation
@@ -279,6 +277,8 @@ Feature tracks:
 Current shipped foundation:
 
 - Catalog-backed MultiGP-style gates, ladders, and corner flags now carry visual metadata for panel sizes, PVC frame placement, and texture-backed artwork; the live 3D preview and flythrough export consume shared layout helpers and extracted runtime textures while generic TrackDraw elements stay lightweight
+- MultiGP Dive Gate 7x6 and Launch Gate 7x6 are now catalog-backed with correct 3D arch and box-frame rendering respectively; banner panels cast and receive shadows correctly and texture orientations are accurate across all four panels
+- All MultiGP obstacle texture orientations (standard gate, championship gate, standard ladder, championship ladder, topless ladder, launch gate) are now correct and verified; the `ArchDiveGateVisualSpec` banner placement API mirrors the launch gate pattern so dive gate textures are fully configurable
 
 Important boundary:
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -26,14 +26,14 @@ The completed release-sized work is archived below. The next TrackDraw priority 
 
 ## Follow-up
 
-- [ ] MultiGP Dive Gate 7x6 (`No account required`)
-        Add as a catalog-backed gate variant with official dimensions and a 3D rendering that reflects the low-profile dive orientation. Shares the gate shape kind and inspector pipeline.
+- [x] MultiGP Dive Gate 7x6 (`No account required`)
+      Catalog-backed gate variant with official 7×6 ft dimensions and a 3D arch rendering. Shares the gate shape kind and inspector pipeline. Arch panels now cast and receive shadows correctly, and texture placement is fully configurable via the `ArchDiveGateVisualSpec` banner placement API.
 
-- [ ] MultiGP Launch Gate 7x6 (`No account required`)
-        Add as a catalog-backed gate variant used at the race start, with official dimensions and appropriate 3D rendering. Shares the gate shape kind and inspector pipeline.
+- [x] MultiGP Launch Gate 7x6 (`No account required`)
+      Catalog-backed gate variant with official 7×6 ft dimensions and a 3D box-frame rendering with four configurable banner panels. Shares the gate shape kind and inspector pipeline. Banner panels now cast and receive shadows correctly with correct texture orientations.
 
 - [ ] MultiGP Double Gate Tower 5x5 and 7x6 (`No account required`)
-        New shape kind with its own 2D representation, 3D rendering, catalog entries, and inspector pipeline. Race-line behavior is gate-like (fly through); physical structure is a two-frame tower.
+      New shape kind with its own 2D representation, 3D rendering, catalog entries, and inspector pipeline. Race-line behavior is gate-like (fly through); physical structure is a two-frame tower.
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -1947,6 +1947,8 @@ const TrackCanvas = memo(
       ]
     );
 
+    const shapeNodeViewportScale = isMobile ? stageTransform.scale : 1;
+
     // Memoize the shape nodes so that high-frequency local state changes
     // (cursor position, snap target, stage transform) do not trigger O(n)
     // JSX re-creation and React reconciliation for every shape on every frame.
@@ -1978,7 +1980,7 @@ const TrackCanvas = memo(
               effectiveVertexSel={effectiveVertexSel}
               hoveredWaypoint={hoveredWaypoint}
               isPrimaryPolyline={primaryPolylineId === shape.id}
-              viewportScale={stageTransform.scale}
+              viewportScale={shapeNodeViewportScale}
               isHovered={hoveredShapeId === shape.id}
               isMobile={isMobile}
               mobileMultiSelectEnabled={mobileMultiSelectEnabled}
@@ -2050,7 +2052,7 @@ const TrackCanvas = memo(
         resolveWaypointDragPosition,
         rotationSession,
         snapEnabled,
-        stageTransform.scale,
+        shapeNodeViewportScale,
         segmentSel,
         selectOnlyShape,
         selection.length,

--- a/src/components/canvas/editor/TrackPreview3D.tsx
+++ b/src/components/canvas/editor/TrackPreview3D.tsx
@@ -35,6 +35,7 @@ import {
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
 } from "@/lib/track/elements/catalog";
+import { getDiveGateVisualSpec } from "@/lib/track/elements/visual";
 import { useEditor } from "@/store/editor";
 import {
   useSessionActions,
@@ -177,10 +178,13 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
         ),
       [selectedIdSet, shapes]
     );
-    const hasSelectedDiveGate = useMemo(
+    const hasSelectedTiltableDiveGate = useMemo(
       () =>
         shapes.some(
-          (shape) => selectedIdSet.has(shape.id) && shape.kind === "divegate"
+          (shape) =>
+            selectedIdSet.has(shape.id) &&
+            shape.kind === "divegate" &&
+            getDiveGateVisualSpec(shape)?.variant !== "arch"
         ),
       [selectedIdSet, shapes]
     );
@@ -440,7 +444,8 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
               if (
                 !selectedIdSet.has(shape.id) ||
                 shape.locked ||
-                shape.kind !== "divegate"
+                shape.kind !== "divegate" ||
+                getDiveGateVisualSpec(shape)?.variant === "arch"
               )
                 return null;
               return (
@@ -563,7 +568,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
         <TrackPreview3DHintOverlays
           flyMode={flyMode}
           hasPath={hasPath}
-          hasSelectedDiveGate={hasSelectedDiveGate}
+          hasSelectedDiveGate={hasSelectedTiltableDiveGate}
           hasSelectedRotatable={hasSelectedRotatable}
           isMobile={isMobile}
           readOnly={readOnly}

--- a/src/components/canvas/editor/TrackPreview3D.tsx
+++ b/src/components/canvas/editor/TrackPreview3D.tsx
@@ -63,7 +63,20 @@ import {
   FlyThroughControlsOverlay,
   TrackPreview3DHintOverlays,
 } from "@/components/canvas/trackPreview3DOverlays";
+import {
+  EDGES,
+  generateExportConfigForCatalog,
+  getCurrentEdgeForPanel,
+  getEffectiveFlips,
+  getPanelsForCatalog,
+  setEdge,
+  toggleFlip,
+  useOverrideVersion,
+} from "@/components/canvas/textureDebugContext";
+import type { TexturePanelEdge } from "@/lib/track/elements/catalog";
+import { useDeveloperMode } from "@/hooks/useDeveloperMode";
 import { useTrackPreview3DInteractions } from "@/components/canvas/editor/useTrackPreview3DInteractions";
+import { motion, useReducedMotion } from "framer-motion";
 import dynamic from "next/dynamic";
 
 const DroneCamera = dynamic(
@@ -73,6 +86,154 @@ const DroneCamera = dynamic(
     })),
   { ssr: false }
 );
+
+const POPUP_TRANSITION = { duration: 0.16, ease: [0.22, 1, 0.36, 1] as const };
+
+function TextureDebugPopup({ catalogId }: { catalogId: string }) {
+  useOverrideVersion();
+  const theme = useTheme();
+  const prefersReducedMotion = useReducedMotion();
+  const panels = getPanelsForCatalog(catalogId);
+  const [copied, setCopied] = useState(false);
+  const isDark = theme === "dark";
+
+  function handleCopy() {
+    void navigator.clipboard.writeText(
+      generateExportConfigForCatalog(catalogId)
+    );
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1800);
+  }
+
+  const panelClass = isDark
+    ? "border-[#2b3443] bg-[#0f1726]/88 text-slate-50 shadow-[0_32px_96px_rgba(2,6,23,0.52)] backdrop-blur-md"
+    : "border-[#c8d4e5] bg-[#eef3f9]/88 text-slate-900 shadow-[0_28px_84px_rgba(15,23,42,0.22)] backdrop-blur-md";
+  const titleClass = isDark ? "text-sky-200/88" : "text-sky-700";
+  const bodyClass = isDark ? "text-white/54" : "text-slate-600";
+  const buttonClass = isDark
+    ? "border-white/10 bg-white/[0.05] text-white/76 hover:border-white/18 hover:bg-white/[0.08] hover:text-white"
+    : "border-slate-900/10 bg-white/72 text-slate-700 hover:border-slate-900/16 hover:bg-white hover:text-slate-950";
+  const rowClass = isDark ? "bg-white/[0.035]" : "bg-slate-900/[0.045]";
+  const segClass = isDark
+    ? "border-white/6 bg-white/[0.03]"
+    : "border-black/6 bg-black/[0.025]";
+  const segActive = isDark
+    ? "bg-white/12 text-white"
+    : "bg-white text-slate-900 shadow-sm";
+  const segIdle = isDark
+    ? "text-white/36 hover:bg-white/6 hover:text-white/70"
+    : "text-slate-400 hover:bg-black/5 hover:text-slate-700";
+  const flipActive = isDark
+    ? "border-sky-400/35 bg-sky-500/15 text-sky-300"
+    : "border-sky-500/30 bg-sky-500/10 text-sky-600";
+
+  return (
+    <motion.div
+      initial={
+        prefersReducedMotion ? false : { opacity: 0, y: -6, scale: 0.988 }
+      }
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={POPUP_TRANSITION}
+      className={`absolute top-3 right-3 z-20 w-74 max-w-[calc(100vw-1.5rem)] rounded-2xl border ${panelClass}`}
+    >
+      {/* Header — same structure as the Developer HUD */}
+      <div className="border-b border-current/8 px-3 py-2.5">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <p
+              className={`text-[9px] font-semibold tracking-[0.2em] uppercase ${titleClass}`}
+            >
+              Texture Debug
+            </p>
+            <p className={`mt-1 truncate text-[11px] ${bodyClass}`}>
+              {catalogId}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className={`shrink-0 rounded-md border px-2 py-1 text-[9px] font-medium tracking-[0.04em] transition-colors select-none ${
+              copied
+                ? "border-emerald-400/40 bg-emerald-500/15 text-emerald-400"
+                : buttonClass
+            }`}
+          >
+            {copied ? "✓ Copied" : "Copy config"}
+          </button>
+        </div>
+      </div>
+
+      {/* Panel rows */}
+      <div className="space-y-1.5 p-3">
+        {panels.length === 0 ? (
+          <p className={`py-1 text-center text-[11px] ${bodyClass}`}>
+            No panels registered yet
+          </p>
+        ) : (
+          panels.map((panel) => {
+            const current = getCurrentEdgeForPanel(catalogId, panel.panelName);
+            const flips = getEffectiveFlips(
+              catalogId,
+              panel.panelName,
+              panel.baseFlipX,
+              panel.baseFlipY
+            );
+            return (
+              <div
+                key={panel.panelName}
+                className={`rounded-lg px-2.5 py-2 ${rowClass}`}
+              >
+                {/* Row header: name + flip toggles */}
+                <div className="mb-1.5 flex items-center justify-between">
+                  <span className="text-[11px]">{panel.panelName}</span>
+                  <div className="flex items-center gap-1">
+                    <span className={`mr-0.5 text-[9px] ${bodyClass}`}>
+                      flip
+                    </span>
+                    {(["x", "y"] as const).map((axis) => {
+                      const active = axis === "x" ? flips.flipX : flips.flipY;
+                      return (
+                        <button
+                          key={axis}
+                          type="button"
+                          onClick={() =>
+                            toggleFlip(catalogId, panel.panelName, axis)
+                          }
+                          className={`rounded-md border px-2 py-0.5 text-[9px] font-medium tracking-[0.04em] transition-colors select-none ${
+                            active ? flipActive : buttonClass
+                          }`}
+                        >
+                          {axis.toUpperCase()}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+                {/* Edge segmented control */}
+                <div
+                  className={`flex gap-0.5 rounded-md border p-0.5 ${segClass}`}
+                >
+                  {(EDGES as TexturePanelEdge[]).map((edge) => (
+                    <button
+                      key={edge}
+                      type="button"
+                      onClick={() => setEdge(catalogId, panel.panelName, edge)}
+                      className={`flex-1 rounded py-1 text-[10px] font-medium transition-all select-none ${
+                        current === edge ? segActive : segIdle
+                      }`}
+                    >
+                      {edge}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+    </motion.div>
+  );
+}
 
 export interface TrackPreview3DHandle {
   screenshot: () => string;
@@ -116,6 +277,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
     const selectedPolyline = useEditor(selectSelectedPolyline);
     const theme = useTheme();
     const isMobile = useIsMobile();
+    const { enabled: devMode } = useDeveloperMode();
     const t = SCENE_3D_THEME[theme];
     const cx = field.width / 2;
     const cz = field.height / 2;
@@ -132,6 +294,12 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
     const orbitControlsRef = useRef<OrbitControlsImpl | null>(null);
     const selectionRef = useRef(selection);
     const selectedIdSet = useMemo(() => new Set(selection), [selection]);
+
+    const selectedDebugCatalogId = useMemo(() => {
+      if (!devMode || selection.length !== 1) return null;
+      const shape = shapeById[selection[0]];
+      return getTrackElementCatalogIdentity(shape?.meta)?.elementId ?? null;
+    }, [devMode, selection, shapeById]);
 
     const {
       containerRef,
@@ -184,7 +352,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
           (shape) =>
             selectedIdSet.has(shape.id) &&
             shape.kind === "divegate" &&
-            getDiveGateVisualSpec(shape)?.variant !== "arch"
+            !getDiveGateVisualSpec(shape)
         ),
       [selectedIdSet, shapes]
     );
@@ -445,7 +613,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
                 !selectedIdSet.has(shape.id) ||
                 shape.locked ||
                 shape.kind !== "divegate" ||
-                getDiveGateVisualSpec(shape)?.variant === "arch"
+                !!getDiveGateVisualSpec(shape)
               )
                 return null;
               return (
@@ -575,6 +743,10 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
           selectedPolyline={selectedPolyline}
           onStartFlyThrough={startFlyThrough}
         />
+
+        {devMode && selectedDebugCatalogId && (
+          <TextureDebugPopup catalogId={selectedDebugCatalogId} />
+        )}
       </div>
     );
   }

--- a/src/components/canvas/editor/trackPreview3DEditSceneContent.tsx
+++ b/src/components/canvas/editor/trackPreview3DEditSceneContent.tsx
@@ -302,7 +302,7 @@ export function GateRotateHandle3D({
         ? Math.max(((shape as FlagShape).poleHeight ?? 3.5) * 0.22, 1.45)
         : shape.kind === "ladder"
           ? ((shape as LadderShape).width ?? 2) / 2 + 0.85
-          : ((shape as DiveGateShape).size ?? 2.8) / 2 + 0.85,
+          : ((shape as DiveGateShape).width ?? 2.8) / 2 + 0.85,
     1.7
   );
   const yawRad = (-guideRotationDeg * Math.PI) / 180;
@@ -436,7 +436,7 @@ export function DiveGateTiltHandle3D({
   tiltOverrideRef: RefObject<number | null>;
 }) {
   const [hovered, setHovered] = useState(false);
-  const sz = shape.size ?? 2.8;
+  const sz = shape.width ?? 2.8;
   const tilt = shape.tilt ?? 0;
   const tiltRad = (tilt * Math.PI) / 180;
   const yawRad = (-shape.rotation * Math.PI) / 180;

--- a/src/components/canvas/editor/useTrackPreview3DInteractions.ts
+++ b/src/components/canvas/editor/useTrackPreview3DInteractions.ts
@@ -581,7 +581,7 @@ export function useTrackPreview3DInteractions({
       if (!camera || !container) return;
       const shape = shapeById[drag.shapeId];
       if (!shape || shape.kind !== "divegate") return;
-      if (getDiveGateVisualSpec(shape)?.variant === "arch") return;
+      if (getDiveGateVisualSpec(shape)) return;
       const dg = shape as DiveGateShape;
       const sz = dg.width ?? 2.8;
       const yawRad = (-dg.rotation * Math.PI) / 180;
@@ -624,7 +624,7 @@ export function useTrackPreview3DInteractions({
       event.stopPropagation();
       const shape = shapeById[shapeId];
       if (!shape || shape.kind !== "divegate" || shape.locked) return;
-      if (getDiveGateVisualSpec(shape)?.variant === "arch") return;
+      if (getDiveGateVisualSpec(shape)) return;
       if (!startSession()) return;
       setTiltDrag({ shapeId, startTilt: currentTilt });
     },

--- a/src/components/canvas/editor/useTrackPreview3DInteractions.ts
+++ b/src/components/canvas/editor/useTrackPreview3DInteractions.ts
@@ -12,6 +12,7 @@ import type { ThreeEvent } from "@react-three/fiber";
 import { useHistorySession } from "@/hooks/useHistorySession";
 import * as THREE from "three";
 import { normalizeRotationDegrees } from "@/lib/track/orientation";
+import { getDiveGateVisualSpec } from "@/lib/track/elements/visual";
 import type {
   DiveGateShape,
   LadderShape,
@@ -580,8 +581,9 @@ export function useTrackPreview3DInteractions({
       if (!camera || !container) return;
       const shape = shapeById[drag.shapeId];
       if (!shape || shape.kind !== "divegate") return;
+      if (getDiveGateVisualSpec(shape)?.variant === "arch") return;
       const dg = shape as DiveGateShape;
-      const sz = dg.size ?? 2.8;
+      const sz = dg.width ?? 2.8;
       const yawRad = (-dg.rotation * Math.PI) / 180;
       const centerY = dg.elevation ?? 3.0;
       const localX = sz / 2 + 0.6;
@@ -622,6 +624,7 @@ export function useTrackPreview3DInteractions({
       event.stopPropagation();
       const shape = shapeById[shapeId];
       if (!shape || shape.kind !== "divegate" || shape.locked) return;
+      if (getDiveGateVisualSpec(shape)?.variant === "arch") return;
       if (!startSession()) return;
       setTiltDrag({ shapeId, startTilt: currentTilt });
     },

--- a/src/components/canvas/renderers/shape-bounds.ts
+++ b/src/components/canvas/renderers/shape-bounds.ts
@@ -56,7 +56,9 @@ export function getShapeLocalBounds(shape: Shape, ppm: number) {
     }
     case "divegate": {
       const diveGate = getDiveGate2DShape(shape, ppm);
-      if (diveGate.variant === "arch") return diveGate.bounds;
+      if (diveGate.variant === "arch" || diveGate.variant === "launch") {
+        return diveGate.bounds;
+      }
 
       const { size, visibleDepth } = diveGate;
       return {

--- a/src/components/canvas/renderers/shape-bounds.ts
+++ b/src/components/canvas/renderers/shape-bounds.ts
@@ -55,7 +55,10 @@ export function getShapeLocalBounds(shape: Shape, ppm: number) {
       };
     }
     case "divegate": {
-      const { size, visibleDepth } = getDiveGate2DShape(shape, ppm);
+      const diveGate = getDiveGate2DShape(shape, ppm);
+      if (diveGate.variant === "arch") return diveGate.bounds;
+
+      const { size, visibleDepth } = diveGate;
       return {
         x: -size / 2,
         y: -visibleDepth / 2,

--- a/src/components/canvas/renderers/shape-node.tsx
+++ b/src/components/canvas/renderers/shape-node.tsx
@@ -409,7 +409,9 @@ export const TrackShapeNode = memo(TrackShapeNodeComponent, (prev, next) => {
     prev.allowInteraction === next.allowInteraction &&
     prev.designPpm === next.designPpm &&
     prev.isMobile === next.isMobile &&
-    prev.viewportScale === next.viewportScale &&
+    (!prev.isMobile ||
+      !next.isMobile ||
+      prev.viewportScale === next.viewportScale) &&
     prev.isHovered === next.isHovered &&
     prev.mobileMultiSelectEnabled === next.mobileMultiSelectEnabled &&
     prev.isSelected === next.isSelected &&

--- a/src/components/canvas/renderers/shape-renderers.tsx
+++ b/src/components/canvas/renderers/shape-renderers.tsx
@@ -12,6 +12,7 @@ import { useTheme } from "@/hooks/useTheme";
 import { m2px } from "@/lib/track/units";
 import {
   getCone2DShape,
+  getDiveGateArchPanelPath,
   getDiveGate2DShape,
   getFlag2DShape,
   getGate2DShape,
@@ -479,10 +480,144 @@ export function renderDiveGate(
   selected: boolean,
   ppm: number
 ) {
-  const { color, inset, postRadius, size, visibleDepth } = getDiveGate2DShape(
-    shape,
-    ppm
-  );
+  const diveGate = getDiveGate2DShape(shape, ppm);
+  if (diveGate.variant === "arch") {
+    const {
+      bounds,
+      color,
+      couplerPoints,
+      couplerRadius,
+      frameColor,
+      frameTube,
+      openingDepth,
+      openingW,
+      outerDepth,
+      outerW,
+      pipeSegments,
+    } = diveGate;
+    const panelOpacity = selected ? 0.95 : 0.88;
+    const panelPath = getDiveGateArchPanelPath(diveGate);
+
+    return (
+      <>
+        {selected && (
+          <Rect
+            x={bounds.x - m2px(0.15, ppm)}
+            y={bounds.y - m2px(0.15, ppm)}
+            width={bounds.width + m2px(0.3, ppm)}
+            height={bounds.height + m2px(0.3, ppm)}
+            stroke="#60a5fa"
+            strokeWidth={1}
+            opacity={0.85}
+            cornerRadius={4}
+            listening={false}
+          />
+        )}
+        <KonvaShape
+          fill={color}
+          opacity={panelOpacity}
+          sceneFunc={(context, shapeNode) => {
+            const { opening, outer } = panelPath;
+
+            context.beginPath();
+            context.moveTo(outer.x + outer.radius, outer.y);
+            context.lineTo(outer.x + outer.width - outer.radius, outer.y);
+            context.quadraticCurveTo(
+              outer.x + outer.width,
+              outer.y,
+              outer.x + outer.width,
+              outer.y + outer.radius
+            );
+            context.lineTo(
+              outer.x + outer.width,
+              outer.y + outer.height - outer.radius
+            );
+            context.quadraticCurveTo(
+              outer.x + outer.width,
+              outer.y + outer.height,
+              outer.x + outer.width - outer.radius,
+              outer.y + outer.height
+            );
+            context.lineTo(outer.x + outer.radius, outer.y + outer.height);
+            context.quadraticCurveTo(
+              outer.x,
+              outer.y + outer.height,
+              outer.x,
+              outer.y + outer.height - outer.radius
+            );
+            context.lineTo(outer.x, outer.y + outer.radius);
+            context.quadraticCurveTo(
+              outer.x,
+              outer.y,
+              outer.x + outer.radius,
+              outer.y
+            );
+            context.closePath();
+
+            context.moveTo(opening.x, opening.y);
+            context.lineTo(opening.x, opening.y + opening.height);
+            context.lineTo(
+              opening.x + opening.width,
+              opening.y + opening.height
+            );
+            context.lineTo(opening.x + opening.width, opening.y);
+            context.closePath();
+
+            context.fillShape(shapeNode);
+          }}
+        />
+        <Rect
+          width={outerW}
+          height={outerDepth}
+          offsetX={outerW / 2}
+          offsetY={outerDepth / 2}
+          stroke={frameColor}
+          strokeWidth={Math.max(1, frameTube * 0.55)}
+          fillEnabled={false}
+          cornerRadius={3}
+        />
+        <Rect
+          width={openingW}
+          height={openingDepth}
+          offsetX={openingW / 2}
+          offsetY={openingDepth / 2}
+          stroke={frameColor}
+          strokeWidth={Math.max(1, frameTube * 0.35)}
+          fillEnabled={false}
+          cornerRadius={2}
+        />
+        {pipeSegments.map((segment, index) => (
+          <Line
+            key={`pipe-${index}`}
+            points={[
+              segment.start.x,
+              segment.start.y,
+              segment.end.x,
+              segment.end.y,
+            ]}
+            stroke={frameColor}
+            strokeWidth={Math.max(1, frameTube * 0.58)}
+            lineCap="round"
+            lineJoin="round"
+            opacity={0.55}
+          />
+        ))}
+        {couplerPoints.map((point, index) => (
+          <Circle
+            key={`coupler-${index}`}
+            x={point.x}
+            y={point.y}
+            radius={couplerRadius}
+            fill="#d6d9de"
+            stroke={frameColor}
+            strokeWidth={Math.max(1, frameTube * 0.22)}
+          />
+        ))}
+      </>
+    );
+  }
+
+  const { color, inset, postRadius, size, visibleDepth } = diveGate;
   return (
     <>
       {selected && (

--- a/src/components/canvas/renderers/shape-renderers.tsx
+++ b/src/components/canvas/renderers/shape-renderers.tsx
@@ -481,7 +481,7 @@ export function renderDiveGate(
   ppm: number
 ) {
   const diveGate = getDiveGate2DShape(shape, ppm);
-  if (diveGate.variant === "arch") {
+  if (diveGate.variant === "arch" || diveGate.variant === "launch") {
     const {
       bounds,
       color,

--- a/src/components/canvas/textureDebugContext.tsx
+++ b/src/components/canvas/textureDebugContext.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import type { TexturePanelEdge } from "@/lib/track/elements/catalog";
+
+// ─── Override store ────────────────────────────────────────────────────────────
+
+export const EDGES: TexturePanelEdge[] = ["top", "right", "bottom", "left"];
+
+export const EDGE_ROTATIONS: Record<TexturePanelEdge, number> = {
+  top: 0,
+  right: Math.PI / 2,
+  bottom: Math.PI,
+  left: -Math.PI / 2,
+};
+
+export interface StoredPanel {
+  catalogId: string;
+  panelName: string;
+  source: string;
+  baseFlipX: boolean;
+  baseFlipY: boolean;
+  edgeIndex: number;
+  flipXOverride?: boolean;
+  flipYOverride?: boolean;
+}
+
+const overrideStore = new Map<string, StoredPanel>();
+let overrideVersion = 0;
+const overrideListeners = new Set<() => void>();
+
+function storeKey(catalogId: string, panelName: string) {
+  return `${catalogId}:${panelName}`;
+}
+
+function emitOverrideChange() {
+  overrideVersion++;
+  overrideListeners.forEach((fn) => fn());
+}
+
+export function registerPanel(
+  catalogId: string,
+  panelName: string,
+  source: string,
+  baseFlipX: boolean,
+  baseFlipY: boolean,
+  baseRotation: number
+) {
+  const key = storeKey(catalogId, panelName);
+  if (overrideStore.has(key)) return;
+  overrideStore.set(key, {
+    catalogId,
+    panelName,
+    source,
+    baseFlipX,
+    baseFlipY,
+    edgeIndex: snapToEdgeIndex(baseRotation),
+  });
+}
+
+export function setEdge(
+  catalogId: string,
+  panelName: string,
+  edge: TexturePanelEdge
+) {
+  const key = storeKey(catalogId, panelName);
+  const entry = overrideStore.get(key);
+  if (!entry) return;
+  overrideStore.set(key, { ...entry, edgeIndex: EDGES.indexOf(edge) });
+  emitOverrideChange();
+}
+
+export function getEffectiveRotation(
+  catalogId: string | undefined,
+  panelName: string,
+  baseRotation: number
+): number {
+  if (!catalogId) return baseRotation;
+  const entry = overrideStore.get(storeKey(catalogId, panelName));
+  if (!entry) return baseRotation;
+  return EDGE_ROTATIONS[EDGES[entry.edgeIndex]];
+}
+
+export function getEffectiveFlips(
+  catalogId: string | undefined,
+  panelName: string,
+  baseFlipX: boolean,
+  baseFlipY: boolean
+): { flipX: boolean; flipY: boolean } {
+  if (!catalogId) return { flipX: baseFlipX, flipY: baseFlipY };
+  const entry = overrideStore.get(storeKey(catalogId, panelName));
+  if (!entry) return { flipX: baseFlipX, flipY: baseFlipY };
+  return {
+    flipX: entry.flipXOverride ?? entry.baseFlipX,
+    flipY: entry.flipYOverride ?? entry.baseFlipY,
+  };
+}
+
+export function toggleFlip(
+  catalogId: string,
+  panelName: string,
+  axis: "x" | "y"
+) {
+  const key = storeKey(catalogId, panelName);
+  const entry = overrideStore.get(key);
+  if (!entry) return;
+  if (axis === "x") {
+    const current = entry.flipXOverride ?? entry.baseFlipX;
+    overrideStore.set(key, { ...entry, flipXOverride: !current });
+  } else {
+    const current = entry.flipYOverride ?? entry.baseFlipY;
+    overrideStore.set(key, { ...entry, flipYOverride: !current });
+  }
+  emitOverrideChange();
+}
+
+export function getPanelsForCatalog(catalogId: string): StoredPanel[] {
+  const result: StoredPanel[] = [];
+  for (const entry of overrideStore.values()) {
+    if (entry.catalogId === catalogId) result.push(entry);
+  }
+  return result;
+}
+
+export function getCurrentEdgeForPanel(
+  catalogId: string,
+  panelName: string
+): TexturePanelEdge {
+  const entry = overrideStore.get(storeKey(catalogId, panelName));
+  return entry ? EDGES[entry.edgeIndex] : "top";
+}
+
+export function generateExportConfig(): string {
+  if (overrideStore.size === 0)
+    return "(no panels registered — open dev mode while a track with textured elements is visible)";
+
+  const byCatalog = new Map<string, StoredPanel[]>();
+  for (const entry of overrideStore.values()) {
+    if (!byCatalog.has(entry.catalogId)) byCatalog.set(entry.catalogId, []);
+    byCatalog.get(entry.catalogId)!.push(entry);
+  }
+
+  const lines: string[] = [];
+  for (const [catalogId, panels] of byCatalog) {
+    lines.push(`// ${catalogId}`);
+    lines.push("placement: {");
+    for (const p of panels) {
+      lines.push(`  ${p.panelName}: { ${formatPanelConfig(p)} },`);
+    }
+    lines.push("},");
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export function generateExportConfigForCatalog(catalogId: string): string {
+  const panels = getPanelsForCatalog(catalogId);
+  if (panels.length === 0) return `// ${catalogId} — no panels registered`;
+
+  const lines: string[] = [`// ${catalogId}`, "placement: {"];
+  for (const p of panels) {
+    lines.push(`  ${p.panelName}: { ${formatPanelConfig(p)} },`);
+  }
+  lines.push("},");
+  return lines.join("\n");
+}
+
+function formatPanelConfig(p: StoredPanel): string {
+  const edge = EDGES[p.edgeIndex];
+  const flipX = p.flipXOverride ?? p.baseFlipX;
+  const flipY = p.flipYOverride ?? p.baseFlipY;
+  const orientParts: string[] = [`textureTopEdgeFaces: "${edge}"`];
+  if (flipX) orientParts.push("flipX: true");
+  if (flipY) orientParts.push("flipY: true");
+  return `source: "${p.source}", orientation: { ${orientParts.join(", ")} }`;
+}
+
+export function useOverrideVersion() {
+  return useSyncExternalStore(
+    (listener) => {
+      overrideListeners.add(listener);
+      return () => overrideListeners.delete(listener);
+    },
+    () => overrideVersion,
+    () => 0
+  );
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function snapToEdgeIndex(rotation: number): number {
+  let best = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < EDGES.length; i++) {
+    const r = EDGE_ROTATIONS[EDGES[i]];
+    const diff = ((rotation - r + Math.PI * 3) % (Math.PI * 2)) - Math.PI;
+    if (Math.abs(diff) < bestDist) {
+      bestDist = Math.abs(diff);
+      best = i;
+    }
+  }
+  return best;
+}

--- a/src/components/canvas/textureDebugContext.tsx
+++ b/src/components/canvas/textureDebugContext.tsx
@@ -56,6 +56,7 @@ export function registerPanel(
     baseFlipY,
     edgeIndex: snapToEdgeIndex(baseRotation),
   });
+  emitOverrideChange();
 }
 
 export function setEdge(

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -23,11 +23,14 @@ import { getPolylineCurve3Derived } from "@/lib/track/polyline-derived-3d";
 import {
   getCornerFlagLayout,
   getLadderRenderedHeight,
+  getMultiGpDiveGateArchLayout,
+  getMultiGpDiveGateArchTopY,
   getPanelFrameGateLayout,
   getPanelFrameLadderLayout,
   resolvePanelTextureMapping,
 } from "@/lib/track/render3d-layout";
 import {
+  getDiveGateVisualSpec,
   getFlagVisualSpec,
   getGateVisualSpec,
   getLadderVisualSpec,
@@ -38,6 +41,7 @@ import {
   POLYLINE_3D_HEIGHT_OFFSET,
 } from "@/lib/track/constants";
 import type {
+  ArchDiveGateVisualSpec,
   CornerMarkerFlagVisualSpec,
   GatePanelTextureVisualSpec,
   PanelFrameGateVisualSpec,
@@ -1648,6 +1652,205 @@ function Ladder3D({
   );
 }
 
+function PipeBetween({
+  color,
+  emissive,
+  emissiveIntensity,
+  end,
+  radius,
+  start,
+}: {
+  color: string;
+  emissive: string;
+  emissiveIntensity: number;
+  end: [number, number, number];
+  radius: number;
+  start: [number, number, number];
+}) {
+  const { length, midpoint, quaternion } = useMemo(() => {
+    const from = new THREE.Vector3(...start);
+    const to = new THREE.Vector3(...end);
+    const direction = to.clone().sub(from);
+    const pipeLength = direction.length();
+    return {
+      length: pipeLength,
+      midpoint: from.add(to).multiplyScalar(0.5),
+      quaternion: new THREE.Quaternion().setFromUnitVectors(
+        new THREE.Vector3(0, 1, 0),
+        direction.normalize()
+      ),
+    };
+  }, [end, start]);
+
+  return (
+    <mesh position={midpoint} quaternion={quaternion} castShadow>
+      <cylinderGeometry args={[radius, radius, length, 16]} />
+      <meshStandardMaterial
+        color={color}
+        emissive={emissive}
+        emissiveIntensity={emissiveIntensity}
+        roughness={0.48}
+        metalness={0.05}
+      />
+    </mesh>
+  );
+}
+
+function ArchDiveGate3D({
+  selected,
+  shape,
+  outerRef,
+  visual,
+}: {
+  selected: boolean;
+  shape: DiveGateShape;
+  outerRef?: Ref<THREE.Group>;
+  visual: ArchDiveGateVisualSpec;
+}) {
+  const yawRad = (-shape.rotation * Math.PI) / 180;
+  const tube = visual.frame.diameterMeters;
+  const pipeRadius = tube / 2;
+  const frameColor = visual.frame.color;
+  const [sideTexture, topTexture] = useTexture([
+    visual.banner.sideTexture,
+    visual.banner.topTexture,
+  ]) as THREE.Texture[];
+
+  for (const texture of [sideTexture, topTexture]) {
+    if (texture.colorSpace !== THREE.SRGBColorSpace) {
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.anisotropy = 4;
+      texture.needsUpdate = true;
+    }
+  }
+
+  const layout = getMultiGpDiveGateArchLayout(shape);
+
+  const sel = selected;
+  const emissive = sel ? "#60a5fa" : frameColor;
+  const emissiveIntensity = sel ? 0.55 : 0.08;
+
+  return (
+    <group
+      ref={outerRef}
+      position={[shape.x, 0, shape.y]}
+      rotation={[0, yawRad, 0]}
+    >
+      {layout.pipeSegments.map(({ end, start }, index) => (
+        <PipeBetween
+          key={`pipe-${index}`}
+          start={start}
+          end={end}
+          radius={pipeRadius}
+          color={frameColor}
+          emissive={emissive}
+          emissiveIntensity={emissiveIntensity}
+        />
+      ))}
+      {layout.couplerPoints.map(({ height, postH, x, z }, index) => {
+        if (height >= postH) return null;
+
+        return (
+          <mesh key={`coupler-${index}`} position={[x, height, z]} castShadow>
+            <cylinderGeometry
+              args={[tube * 0.75, tube * 0.75, tube * 1.8, 16]}
+            />
+            <meshStandardMaterial
+              color="#d6d9de"
+              emissive={sel ? "#60a5fa" : "#d6d9de"}
+              emissiveIntensity={sel ? 0.35 : 0.04}
+              roughness={0.54}
+              metalness={0.08}
+            />
+          </mesh>
+        );
+      })}
+
+      <group
+        position={[0, layout.centerY, 0]}
+        rotation={[layout.tiltRad, 0, 0]}
+      >
+        <mesh position={[-layout.halfOpening - layout.sidePanelW / 2, 0, 0]}>
+          <planeGeometry args={[layout.sidePanelW, layout.openingH]} />
+          <meshStandardMaterial
+            color="#ffffff"
+            map={sideTexture}
+            roughness={0.72}
+            metalness={0.01}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+        <mesh
+          position={[layout.halfOpening + layout.sidePanelW / 2, 0, 0]}
+          rotation={[0, 0, Math.PI]}
+        >
+          <planeGeometry args={[layout.sidePanelW, layout.openingH]} />
+          <meshStandardMaterial
+            color="#ffffff"
+            map={sideTexture}
+            roughness={0.72}
+            metalness={0.01}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+        <mesh position={[0, layout.openingH / 2 + layout.bannerH / 2, 0]}>
+          <planeGeometry args={[layout.outerW, layout.bannerH]} />
+          <meshStandardMaterial
+            color="#ffffff"
+            map={topTexture}
+            roughness={0.68}
+            metalness={0.02}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+        <mesh position={[0, -layout.openingH / 2 - layout.bannerH / 2, 0]}>
+          <planeGeometry args={[layout.outerW, layout.bannerH]} />
+          <meshStandardMaterial
+            color="#ffffff"
+            map={topTexture}
+            roughness={0.68}
+            metalness={0.02}
+            side={THREE.DoubleSide}
+          />
+        </mesh>
+
+        <mesh position={[0, layout.halfOuterH, 0]} castShadow>
+          <boxGeometry args={[layout.outerW, tube, tube]} />
+          <meshStandardMaterial
+            color={frameColor}
+            emissive={emissive}
+            emissiveIntensity={emissiveIntensity}
+          />
+        </mesh>
+        <mesh position={[0, -layout.halfOuterH, 0]} castShadow>
+          <boxGeometry args={[layout.outerW, tube, tube]} />
+          <meshStandardMaterial
+            color={frameColor}
+            emissive={emissive}
+            emissiveIntensity={emissiveIntensity}
+          />
+        </mesh>
+        <mesh position={[-layout.halfOuterW, 0, 0]} castShadow>
+          <boxGeometry args={[tube, layout.outerH, tube]} />
+          <meshStandardMaterial
+            color={frameColor}
+            emissive={emissive}
+            emissiveIntensity={emissiveIntensity}
+          />
+        </mesh>
+        <mesh position={[layout.halfOuterW, 0, 0]} castShadow>
+          <boxGeometry args={[tube, layout.outerH, tube]} />
+          <meshStandardMaterial
+            color={frameColor}
+            emissive={emissive}
+            emissiveIntensity={emissiveIntensity}
+          />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
 function DiveGate3D({
   selected = false,
   shape,
@@ -1659,8 +1862,11 @@ function DiveGate3D({
   outerRef?: Ref<THREE.Group>;
   tiltDragRef?: RefObject<number | null>;
 }) {
+  const visual = getDiveGateVisualSpec(shape);
+  const isArch = visual?.variant === "arch";
+
   const color = shape.color ?? "#f97316";
-  const sz = shape.size ?? 2.8;
+  const sz = shape.width ?? 2.8;
   const thick = shape.thick ?? 0.2;
   const tilt = shape.tilt ?? 0;
   const tiltRad = (tilt * Math.PI) / 180;
@@ -1677,7 +1883,7 @@ function DiveGate3D({
   const postMeshesRef = useRef<Array<THREE.Mesh | null>>([]);
 
   useFrame(() => {
-    if (!tiltDragRef || tiltDragRef.current === null) return;
+    if (isArch || !tiltDragRef || tiltDragRef.current === null) return;
     const liveTiltRad = (tiltDragRef.current * Math.PI) / 180;
 
     if (frameGroupRef.current) {
@@ -1707,6 +1913,17 @@ function DiveGate3D({
       }
     }
   });
+
+  if (isArch) {
+    return (
+      <ArchDiveGate3D
+        selected={selected}
+        shape={shape}
+        outerRef={outerRef}
+        visual={visual as ArchDiveGateVisualSpec}
+      />
+    );
+  }
 
   return (
     <group
@@ -1923,8 +2140,15 @@ function getPolylineTopY(shape: PolylineShape): number {
 }
 
 function getDiveGateTopY(shape: DiveGateShape): number {
+  const visual = getDiveGateVisualSpec(shape);
+  if (visual?.variant === "arch") {
+    return getMultiGpDiveGateArchTopY();
+  }
+
   const tiltRad = ((shape.tilt ?? 0) * Math.PI) / 180;
-  return (shape.elevation ?? 3) + ((shape.size ?? 2.8) / 2) * Math.sin(tiltRad);
+  return (
+    (shape.elevation ?? 3) + ((shape.width ?? 2.8) / 2) * Math.sin(tiltRad)
+  );
 }
 
 function getShapeTopY(shape: Shape): number {

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -107,6 +107,8 @@ function cloneTextureForPanel(
 ) {
   const clone = texture.clone();
   clone.center.set(0.5, 0.5);
+  clone.wrapS = THREE.RepeatWrapping;
+  clone.wrapT = THREE.RepeatWrapping;
   clone.rotation = rotation;
   clone.repeat.set(flipX ? -1 : 1, flipY ? -1 : 1);
   clone.offset.set(0, 0);

--- a/src/components/canvas/trackPreview3DSharedSceneContent.tsx
+++ b/src/components/canvas/trackPreview3DSharedSceneContent.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { RoundedBox, useTexture } from "@react-three/drei";
+import {
+  getEffectiveFlips,
+  getEffectiveRotation,
+  registerPanel,
+  useOverrideVersion,
+} from "@/components/canvas/textureDebugContext";
 import { useFrame, useThree, type ThreeEvent } from "@react-three/fiber";
 import type { OrbitControls as OrbitControlsImpl } from "three-stdlib";
 import {
@@ -25,9 +31,13 @@ import {
   getLadderRenderedHeight,
   getMultiGpDiveGateArchLayout,
   getMultiGpDiveGateArchTopY,
+  getMultiGpLaunchGateLayout,
+  getMultiGpLaunchGateTopY,
   getPanelFrameGateLayout,
   getPanelFrameLadderLayout,
-  resolvePanelTextureMapping,
+  resolveArchDiveGateBannerTextureMapping,
+  resolveLaunchGateBannerTextureMapping,
+  resolvePanelFrameTextureMapping,
 } from "@/lib/track/render3d-layout";
 import {
   getDiveGateVisualSpec,
@@ -44,10 +54,14 @@ import type {
   ArchDiveGateVisualSpec,
   CornerMarkerFlagVisualSpec,
   GatePanelTextureVisualSpec,
+  LaunchGateVisualSpec,
   PanelFrameGateVisualSpec,
   PanelFrameLadderVisualSpec,
 } from "@/lib/track/elements/catalog";
-import { getTrackElementCatalogTexturePaths } from "@/lib/track/elements/catalog";
+import {
+  getTrackElementCatalogIdentity,
+  getTrackElementCatalogTexturePaths,
+} from "@/lib/track/elements/catalog";
 import type {
   ConeShape,
   DiveGateShape,
@@ -81,6 +95,23 @@ function assignGroupRef(
     return;
   }
   ref.current = node;
+}
+
+function cloneTextureForPanel(
+  texture: THREE.Texture,
+  {
+    flipX = false,
+    flipY = false,
+    rotation = 0,
+  }: { flipX?: boolean; flipY?: boolean; rotation?: number }
+) {
+  const clone = texture.clone();
+  clone.center.set(0.5, 0.5);
+  clone.rotation = rotation;
+  clone.repeat.set(flipX ? -1 : 1, flipY ? -1 : 1);
+  clone.offset.set(0, 0);
+  clone.needsUpdate = true;
+  return clone;
 }
 
 export function CameraCapture({
@@ -460,6 +491,7 @@ function useTextTexture(
 }
 
 function PanelFrameGateTexturePlanes({
+  catalogId,
   frontZ,
   h,
   leftPanelWidth,
@@ -471,6 +503,7 @@ function PanelFrameGateTexturePlanes({
   topPanelW,
   topPanelY,
 }: {
+  catalogId?: string;
   frontZ: number;
   h: number;
   leftPanelWidth: number;
@@ -487,10 +520,6 @@ function PanelFrameGateTexturePlanes({
     textures.right,
     textures.top ?? textures.left,
   ]) as THREE.Texture[];
-  const { leftPanel, rightPanel, leftRotationZ } = resolvePanelTextureMapping(
-    textures,
-    [leftTexture, rightTexture]
-  );
 
   for (const texture of [leftTexture, rightTexture, topTexture]) {
     if (texture.colorSpace !== THREE.SRGBColorSpace) {
@@ -499,39 +528,156 @@ function PanelFrameGateTexturePlanes({
       texture.needsUpdate = true;
     }
   }
+  const overrideVersion = useOverrideVersion();
+  const panelTextures = useMemo(() => {
+    const mapping = resolvePanelFrameTextureMapping(textures, {
+      left: leftTexture,
+      right: rightTexture,
+      top: topTexture,
+    });
+    const leftFlips = getEffectiveFlips(
+      catalogId,
+      "left",
+      mapping.left.flipX,
+      mapping.left.flipY
+    );
+    const rightFlips = getEffectiveFlips(
+      catalogId,
+      "right",
+      mapping.right.flipX,
+      mapping.right.flipY
+    );
+    const topFlips = mapping.top
+      ? getEffectiveFlips(
+          catalogId,
+          "top",
+          mapping.top.flipX,
+          mapping.top.flipY
+        )
+      : null;
+    return {
+      left: {
+        texture: cloneTextureForPanel(mapping.left.texture, {
+          rotation: getEffectiveRotation(
+            catalogId,
+            "left",
+            mapping.left.rotation
+          ),
+          ...leftFlips,
+        }),
+        rotation: mapping.left.rotation,
+        source: mapping.left.source,
+        flipX: mapping.left.flipX,
+        flipY: mapping.left.flipY,
+      },
+      right: {
+        texture: cloneTextureForPanel(mapping.right.texture, {
+          rotation: getEffectiveRotation(
+            catalogId,
+            "right",
+            mapping.right.rotation
+          ),
+          ...rightFlips,
+        }),
+        rotation: mapping.right.rotation,
+        source: mapping.right.source,
+        flipX: mapping.right.flipX,
+        flipY: mapping.right.flipY,
+      },
+      top:
+        mapping.top && topFlips
+          ? {
+              texture: cloneTextureForPanel(mapping.top.texture, {
+                rotation: getEffectiveRotation(
+                  catalogId,
+                  "top",
+                  mapping.top.rotation
+                ),
+                ...topFlips,
+              }),
+              rotation: mapping.top.rotation,
+              source: mapping.top.source,
+              flipX: mapping.top.flipX,
+              flipY: mapping.top.flipY,
+            }
+          : null,
+    };
+    // overrideVersion is intentionally included to trigger re-clone on cycle
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    leftTexture,
+    rightTexture,
+    textures,
+    topTexture,
+    overrideVersion,
+    catalogId,
+  ]);
+
+  useEffect(() => {
+    if (!catalogId) return;
+    registerPanel(
+      catalogId,
+      "left",
+      panelTextures.left.source,
+      panelTextures.left.flipX,
+      panelTextures.left.flipY,
+      panelTextures.left.rotation
+    );
+    registerPanel(
+      catalogId,
+      "right",
+      panelTextures.right.source,
+      panelTextures.right.flipX,
+      panelTextures.right.flipY,
+      panelTextures.right.rotation
+    );
+    if (panelTextures.top)
+      registerPanel(
+        catalogId,
+        "top",
+        panelTextures.top.source,
+        panelTextures.top.flipX,
+        panelTextures.top.flipY,
+        panelTextures.top.rotation
+      );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogId]);
 
   return (
     <>
-      <mesh
-        position={[leftPanelX, h / 2, frontZ]}
-        rotation={[0, Math.PI, leftRotationZ]}
-      >
-        <planeGeometry args={[leftPanelWidth, h]} />
-        <meshStandardMaterial
-          map={leftPanel}
-          roughness={0.72}
-          metalness={0.01}
-          side={THREE.FrontSide}
-        />
-      </mesh>
-      <mesh position={[rightPanelX, h / 2, frontZ]} rotation={[0, Math.PI, 0]}>
-        <planeGeometry args={[rightPanelWidth, h]} />
-        <meshStandardMaterial
-          map={rightPanel}
-          roughness={0.72}
-          metalness={0.01}
-          side={THREE.FrontSide}
-        />
-      </mesh>
-      <mesh position={[0, topPanelY, frontZ]} rotation={[0, Math.PI, 0]}>
-        <planeGeometry args={[topPanelW, topPanelHeight]} />
-        <meshStandardMaterial
-          map={topTexture}
-          roughness={0.68}
-          metalness={0.02}
-          side={THREE.FrontSide}
-        />
-      </mesh>
+      <group position={[leftPanelX, h / 2, frontZ]} rotation={[0, Math.PI, 0]}>
+        <mesh>
+          <planeGeometry args={[leftPanelWidth, h]} />
+          <meshStandardMaterial
+            map={panelTextures.left.texture}
+            roughness={0.72}
+            metalness={0.01}
+            side={THREE.FrontSide}
+          />
+        </mesh>
+      </group>
+      <group position={[rightPanelX, h / 2, frontZ]} rotation={[0, Math.PI, 0]}>
+        <mesh>
+          <planeGeometry args={[rightPanelWidth, h]} />
+          <meshStandardMaterial
+            map={panelTextures.right.texture}
+            roughness={0.72}
+            metalness={0.01}
+            side={THREE.FrontSide}
+          />
+        </mesh>
+      </group>
+      <group position={[0, topPanelY, frontZ]} rotation={[0, Math.PI, 0]}>
+        <mesh>
+          <planeGeometry args={[topPanelW, topPanelHeight]} />
+          <meshStandardMaterial
+            map={panelTextures.top?.texture ?? null}
+            roughness={0.68}
+            metalness={0.02}
+            side={THREE.FrontSide}
+          />
+        </mesh>
+      </group>
     </>
   );
 }
@@ -539,6 +685,7 @@ function PanelFrameGateTexturePlanes({
 function PanelFrameLadderSectionTexturePlanes({
   bannerH,
   bannerMidY,
+  catalogId,
   frontZ,
   hasTopPanel,
   leftPanelWidth,
@@ -551,6 +698,7 @@ function PanelFrameLadderSectionTexturePlanes({
 }: {
   bannerH: number;
   bannerMidY: number;
+  catalogId?: string;
   frontZ: number;
   hasTopPanel: boolean;
   leftPanelWidth: number;
@@ -571,10 +719,6 @@ function PanelFrameLadderSectionTexturePlanes({
     textures.right,
     textures.top ?? textures.left,
   ]) as THREE.Texture[];
-  const { leftPanel, rightPanel, leftRotationZ } = resolvePanelTextureMapping(
-    textures,
-    [leftTexture, rightTexture]
-  );
 
   for (const texture of [leftTexture, rightTexture, topTexture]) {
     if (texture.colorSpace !== THREE.SRGBColorSpace) {
@@ -583,43 +727,162 @@ function PanelFrameLadderSectionTexturePlanes({
       texture.needsUpdate = true;
     }
   }
+  const overrideVersion = useOverrideVersion();
+  const panelTextures = useMemo(() => {
+    const mapping = resolvePanelFrameTextureMapping(textures, {
+      left: leftTexture,
+      right: rightTexture,
+      top: textures.top ? topTexture : null,
+    });
+    const leftFlips = getEffectiveFlips(
+      catalogId,
+      "left",
+      mapping.left.flipX,
+      mapping.left.flipY
+    );
+    const rightFlips = getEffectiveFlips(
+      catalogId,
+      "right",
+      mapping.right.flipX,
+      mapping.right.flipY
+    );
+    const topFlips = mapping.top
+      ? getEffectiveFlips(
+          catalogId,
+          "top",
+          mapping.top.flipX,
+          mapping.top.flipY
+        )
+      : null;
+    return {
+      left: {
+        texture: cloneTextureForPanel(mapping.left.texture, {
+          rotation: getEffectiveRotation(
+            catalogId,
+            "left",
+            mapping.left.rotation
+          ),
+          ...leftFlips,
+        }),
+        rotation: mapping.left.rotation,
+        source: mapping.left.source,
+        flipX: mapping.left.flipX,
+        flipY: mapping.left.flipY,
+      },
+      right: {
+        texture: cloneTextureForPanel(mapping.right.texture, {
+          rotation: getEffectiveRotation(
+            catalogId,
+            "right",
+            mapping.right.rotation
+          ),
+          ...rightFlips,
+        }),
+        rotation: mapping.right.rotation,
+        source: mapping.right.source,
+        flipX: mapping.right.flipX,
+        flipY: mapping.right.flipY,
+      },
+      top:
+        mapping.top && topFlips
+          ? {
+              texture: cloneTextureForPanel(mapping.top.texture, {
+                rotation: getEffectiveRotation(
+                  catalogId,
+                  "top",
+                  mapping.top.rotation
+                ),
+                ...topFlips,
+              }),
+              rotation: mapping.top.rotation,
+              source: mapping.top.source,
+              flipX: mapping.top.flipX,
+              flipY: mapping.top.flipY,
+            }
+          : null,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    leftTexture,
+    rightTexture,
+    textures,
+    topTexture,
+    overrideVersion,
+    catalogId,
+  ]);
+
+  useEffect(() => {
+    if (!catalogId) return;
+    registerPanel(
+      catalogId,
+      "left",
+      panelTextures.left.source,
+      panelTextures.left.flipX,
+      panelTextures.left.flipY,
+      panelTextures.left.rotation
+    );
+    registerPanel(
+      catalogId,
+      "right",
+      panelTextures.right.source,
+      panelTextures.right.flipX,
+      panelTextures.right.flipY,
+      panelTextures.right.rotation
+    );
+    if (panelTextures.top)
+      registerPanel(
+        catalogId,
+        "top",
+        panelTextures.top.source,
+        panelTextures.top.flipX,
+        panelTextures.top.flipY,
+        panelTextures.top.rotation
+      );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogId]);
 
   return (
     <>
-      <mesh
+      <group
         position={[leftPanelX, openingMidY, frontZ]}
-        rotation={[0, Math.PI, leftRotationZ]}
-      >
-        <planeGeometry args={[leftPanelWidth, openingH]} />
-        <meshStandardMaterial
-          map={leftPanel}
-          roughness={0.72}
-          metalness={0.01}
-          side={THREE.FrontSide}
-        />
-      </mesh>
-      <mesh
-        position={[rightPanelX, openingMidY, frontZ]}
         rotation={[0, Math.PI, 0]}
       >
-        <planeGeometry args={[rightPanelWidth, openingH]} />
-        <meshStandardMaterial
-          map={rightPanel}
-          roughness={0.72}
-          metalness={0.01}
-          side={THREE.FrontSide}
-        />
-      </mesh>
-      {shouldRenderTopTexture ? (
-        <mesh position={[0, bannerMidY, frontZ]} rotation={[0, Math.PI, 0]}>
-          <planeGeometry args={[topPanelW, bannerH]} />
+        <mesh>
+          <planeGeometry args={[leftPanelWidth, openingH]} />
           <meshStandardMaterial
-            map={topTexture}
-            roughness={0.68}
-            metalness={0.02}
+            map={panelTextures.left.texture}
+            roughness={0.72}
+            metalness={0.01}
             side={THREE.FrontSide}
           />
         </mesh>
+      </group>
+      <group
+        position={[rightPanelX, openingMidY, frontZ]}
+        rotation={[0, Math.PI, 0]}
+      >
+        <mesh>
+          <planeGeometry args={[rightPanelWidth, openingH]} />
+          <meshStandardMaterial
+            map={panelTextures.right.texture}
+            roughness={0.72}
+            metalness={0.01}
+            side={THREE.FrontSide}
+          />
+        </mesh>
+      </group>
+      {shouldRenderTopTexture ? (
+        <group position={[0, bannerMidY, frontZ]} rotation={[0, Math.PI, 0]}>
+          <mesh>
+            <planeGeometry args={[topPanelW, bannerH]} />
+            <meshStandardMaterial
+              map={panelTextures.top?.texture ?? null}
+              roughness={0.68}
+              metalness={0.02}
+              side={THREE.FrontSide}
+            />
+          </mesh>
+        </group>
       ) : null}
     </>
   );
@@ -638,6 +901,7 @@ function PanelFrameGate3D({
   visual: PanelFrameGateVisualSpec;
   rot: [number, number, number];
 }) {
+  const catalogId = getTrackElementCatalogIdentity(shape.meta)?.elementId;
   const { frame, panels } = visual;
   const h = shape.height ?? 2;
   const {
@@ -741,6 +1005,7 @@ function PanelFrameGate3D({
 
       <Suspense fallback={null}>
         <PanelFrameGateTexturePlanes
+          catalogId={catalogId}
           frontZ={frontZ}
           h={h}
           leftPanelWidth={leftPanelWidth}
@@ -1307,12 +1572,14 @@ function StartFinish3D({
 }
 
 function PanelFrameLadder3D({
+  catalogId,
   selected = false,
   shape,
   outerRef,
   elevationOverrideRef,
   visual,
 }: {
+  catalogId?: string;
   selected?: boolean;
   shape: LadderShape;
   outerRef?: Ref<THREE.Group>;
@@ -1476,6 +1743,7 @@ function PanelFrameLadder3D({
               <PanelFrameLadderSectionTexturePlanes
                 bannerH={bannerH}
                 bannerMidY={section.bannerMidY}
+                catalogId={catalogId}
                 frontZ={frontZ}
                 hasTopPanel={section.hasTopPanel}
                 leftPanelWidth={leftPanelWidth}
@@ -1545,6 +1813,7 @@ function Ladder3D({
   outerRef?: Ref<THREE.Group>;
   elevationOverrideRef?: RefObject<number | null>;
 }) {
+  const catalogId = getTrackElementCatalogIdentity(shape.meta)?.elementId;
   const ladderVisual = getLadderVisualSpec(shape);
   const color = shape.color ?? "#3b82f6";
   const w = shape.width ?? 1.5;
@@ -1581,6 +1850,7 @@ function Ladder3D({
   if (ladderVisual?.variant === "panel-frame") {
     return (
       <PanelFrameLadder3D
+        catalogId={catalogId}
         shape={shape}
         selected={selected}
         outerRef={outerRef}
@@ -1707,6 +1977,7 @@ function ArchDiveGate3D({
   outerRef?: Ref<THREE.Group>;
   visual: ArchDiveGateVisualSpec;
 }) {
+  const catalogId = getTrackElementCatalogIdentity(shape.meta)?.elementId;
   const yawRad = (-shape.rotation * Math.PI) / 180;
   const tube = visual.frame.diameterMeters;
   const pipeRadius = tube / 2;
@@ -1723,6 +1994,134 @@ function ArchDiveGate3D({
       texture.needsUpdate = true;
     }
   }
+
+  const overrideVersion = useOverrideVersion();
+  const panelTextures = useMemo(() => {
+    const mapping = resolveArchDiveGateBannerTextureMapping(visual.banner, {
+      side: sideTexture,
+      top: topTexture,
+    });
+    const leftFlips = getEffectiveFlips(
+      catalogId,
+      "left",
+      mapping.left.flipX,
+      mapping.left.flipY
+    );
+    const rightFlips = getEffectiveFlips(
+      catalogId,
+      "right",
+      mapping.right.flipX,
+      mapping.right.flipY
+    );
+    const topFlips = getEffectiveFlips(
+      catalogId,
+      "top",
+      mapping.top.flipX,
+      mapping.top.flipY
+    );
+    const bottomFlips = getEffectiveFlips(
+      catalogId,
+      "bottom",
+      mapping.bottom.flipX,
+      mapping.bottom.flipY
+    );
+    return {
+      left: {
+        texture: cloneTextureForPanel(mapping.left.texture, {
+          rotation: getEffectiveRotation(
+            catalogId,
+            "left",
+            mapping.left.rotation
+          ),
+          ...leftFlips,
+        }),
+        rotation: mapping.left.rotation,
+        source: mapping.left.source,
+        flipX: mapping.left.flipX,
+        flipY: mapping.left.flipY,
+      },
+      right: {
+        texture: cloneTextureForPanel(mapping.right.texture, {
+          rotation: getEffectiveRotation(
+            catalogId,
+            "right",
+            mapping.right.rotation
+          ),
+          ...rightFlips,
+        }),
+        rotation: mapping.right.rotation,
+        source: mapping.right.source,
+        flipX: mapping.right.flipX,
+        flipY: mapping.right.flipY,
+      },
+      top: {
+        texture: cloneTextureForPanel(mapping.top.texture, {
+          rotation: getEffectiveRotation(
+            catalogId,
+            "top",
+            mapping.top.rotation
+          ),
+          ...topFlips,
+        }),
+        rotation: mapping.top.rotation,
+        source: mapping.top.source,
+        flipX: mapping.top.flipX,
+        flipY: mapping.top.flipY,
+      },
+      bottom: {
+        texture: cloneTextureForPanel(mapping.bottom.texture, {
+          rotation: getEffectiveRotation(
+            catalogId,
+            "bottom",
+            mapping.bottom.rotation
+          ),
+          ...bottomFlips,
+        }),
+        rotation: mapping.bottom.rotation,
+        source: mapping.bottom.source,
+        flipX: mapping.bottom.flipX,
+        flipY: mapping.bottom.flipY,
+      },
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sideTexture, topTexture, visual.banner, overrideVersion, catalogId]);
+
+  useEffect(() => {
+    if (!catalogId) return;
+    registerPanel(
+      catalogId,
+      "left",
+      panelTextures.left.source,
+      panelTextures.left.flipX,
+      panelTextures.left.flipY,
+      panelTextures.left.rotation
+    );
+    registerPanel(
+      catalogId,
+      "right",
+      panelTextures.right.source,
+      panelTextures.right.flipX,
+      panelTextures.right.flipY,
+      panelTextures.right.rotation
+    );
+    registerPanel(
+      catalogId,
+      "top",
+      panelTextures.top.source,
+      panelTextures.top.flipX,
+      panelTextures.top.flipY,
+      panelTextures.top.rotation
+    );
+    registerPanel(
+      catalogId,
+      "bottom",
+      panelTextures.bottom.source,
+      panelTextures.bottom.flipX,
+      panelTextures.bottom.flipY,
+      panelTextures.bottom.rotation
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogId]);
 
   const layout = getMultiGpDiveGateArchLayout(shape);
 
@@ -1770,11 +2169,15 @@ function ArchDiveGate3D({
         position={[0, layout.centerY, 0]}
         rotation={[layout.tiltRad, 0, 0]}
       >
-        <mesh position={[-layout.halfOpening - layout.sidePanelW / 2, 0, 0]}>
+        <mesh
+          position={[-layout.halfOpening - layout.sidePanelW / 2, 0, 0]}
+          castShadow
+          receiveShadow
+        >
           <planeGeometry args={[layout.sidePanelW, layout.openingH]} />
           <meshStandardMaterial
             color="#ffffff"
-            map={sideTexture}
+            map={panelTextures.left.texture}
             roughness={0.72}
             metalness={0.01}
             side={THREE.DoubleSide}
@@ -1783,31 +2186,41 @@ function ArchDiveGate3D({
         <mesh
           position={[layout.halfOpening + layout.sidePanelW / 2, 0, 0]}
           rotation={[0, 0, Math.PI]}
+          castShadow
+          receiveShadow
         >
           <planeGeometry args={[layout.sidePanelW, layout.openingH]} />
           <meshStandardMaterial
             color="#ffffff"
-            map={sideTexture}
+            map={panelTextures.right.texture}
             roughness={0.72}
             metalness={0.01}
             side={THREE.DoubleSide}
           />
         </mesh>
-        <mesh position={[0, layout.openingH / 2 + layout.bannerH / 2, 0]}>
+        <mesh
+          position={[0, layout.openingH / 2 + layout.bannerH / 2, 0]}
+          castShadow
+          receiveShadow
+        >
           <planeGeometry args={[layout.outerW, layout.bannerH]} />
           <meshStandardMaterial
             color="#ffffff"
-            map={topTexture}
+            map={panelTextures.top.texture}
             roughness={0.68}
             metalness={0.02}
             side={THREE.DoubleSide}
           />
         </mesh>
-        <mesh position={[0, -layout.openingH / 2 - layout.bannerH / 2, 0]}>
+        <mesh
+          position={[0, -layout.openingH / 2 - layout.bannerH / 2, 0]}
+          castShadow
+          receiveShadow
+        >
           <planeGeometry args={[layout.outerW, layout.bannerH]} />
           <meshStandardMaterial
             color="#ffffff"
-            map={topTexture}
+            map={panelTextures.bottom.texture}
             roughness={0.68}
             metalness={0.02}
             side={THREE.DoubleSide}
@@ -1851,6 +2264,269 @@ function ArchDiveGate3D({
   );
 }
 
+function LaunchGate3D({
+  selected,
+  shape,
+  outerRef,
+  visual,
+}: {
+  selected: boolean;
+  shape: DiveGateShape;
+  outerRef?: Ref<THREE.Group>;
+  visual: LaunchGateVisualSpec;
+}) {
+  const catalogId = getTrackElementCatalogIdentity(shape.meta)?.elementId;
+  const yawRad = (-shape.rotation * Math.PI) / 180;
+  const tube = visual.frame.diameterMeters;
+  const pipeRadius = tube / 2;
+  const frameColor = visual.frame.color;
+  const [sideTexture, topTexture] = useTexture([
+    visual.banner.sideTexture,
+    visual.banner.topTexture,
+  ]) as THREE.Texture[];
+
+  for (const texture of [sideTexture, topTexture]) {
+    if (texture.colorSpace !== THREE.SRGBColorSpace) {
+      texture.colorSpace = THREE.SRGBColorSpace;
+      texture.anisotropy = 4;
+      texture.needsUpdate = true;
+    }
+  }
+  const overrideVersion = useOverrideVersion();
+  const panelTextures = useMemo(
+    () => {
+      const mapping = resolveLaunchGateBannerTextureMapping(visual.banner, {
+        side: sideTexture,
+        top: topTexture,
+      });
+      const frontFlips = getEffectiveFlips(
+        catalogId,
+        "front",
+        mapping.front.flipX,
+        mapping.front.flipY
+      );
+      const rearFlips = getEffectiveFlips(
+        catalogId,
+        "rear",
+        mapping.rear.flipX,
+        mapping.rear.flipY
+      );
+      const leftFlips = getEffectiveFlips(
+        catalogId,
+        "left",
+        mapping.left.flipX,
+        mapping.left.flipY
+      );
+      const rightFlips = getEffectiveFlips(
+        catalogId,
+        "right",
+        mapping.right.flipX,
+        mapping.right.flipY
+      );
+      return {
+        front: {
+          texture: cloneTextureForPanel(mapping.front.texture, {
+            rotation: getEffectiveRotation(
+              catalogId,
+              "front",
+              mapping.front.rotation
+            ),
+            ...frontFlips,
+          }),
+          rotation: mapping.front.rotation,
+          source: mapping.front.source,
+          flipX: mapping.front.flipX,
+          flipY: mapping.front.flipY,
+        },
+        rear: {
+          texture: cloneTextureForPanel(mapping.rear.texture, {
+            rotation: getEffectiveRotation(
+              catalogId,
+              "rear",
+              mapping.rear.rotation
+            ),
+            ...rearFlips,
+          }),
+          rotation: mapping.rear.rotation,
+          source: mapping.rear.source,
+          flipX: mapping.rear.flipX,
+          flipY: mapping.rear.flipY,
+        },
+        left: {
+          texture: cloneTextureForPanel(mapping.left.texture, {
+            rotation: getEffectiveRotation(
+              catalogId,
+              "left",
+              mapping.left.rotation
+            ),
+            ...leftFlips,
+          }),
+          rotation: mapping.left.rotation,
+          source: mapping.left.source,
+          flipX: mapping.left.flipX,
+          flipY: mapping.left.flipY,
+        },
+        right: {
+          texture: cloneTextureForPanel(mapping.right.texture, {
+            rotation: getEffectiveRotation(
+              catalogId,
+              "right",
+              mapping.right.rotation
+            ),
+            ...rightFlips,
+          }),
+          rotation: mapping.right.rotation,
+          source: mapping.right.source,
+          flipX: mapping.right.flipX,
+          flipY: mapping.right.flipY,
+        },
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sideTexture, topTexture, visual.banner, overrideVersion, catalogId]
+  );
+  const layout = getMultiGpLaunchGateLayout(shape);
+  const sel = selected;
+  const emissive = sel ? "#60a5fa" : frameColor;
+  const emissiveIntensity = sel ? 0.55 : 0.08;
+  const banners = [
+    {
+      x: 0,
+      z: -layout.halfOpeningD - layout.endPanelD / 2,
+      width: layout.outerW,
+      depth: layout.endPanelD,
+      rotZ: 0,
+      panel: panelTextures.front,
+      panelName: "front",
+    },
+    {
+      x: 0,
+      z: layout.halfOpeningD + layout.endPanelD / 2,
+      width: layout.outerW,
+      depth: layout.endPanelD,
+      rotZ: Math.PI,
+      panel: panelTextures.rear,
+      panelName: "rear",
+    },
+    {
+      x: -layout.halfOpeningW - layout.sidePanelW / 2,
+      z: 0,
+      width: layout.sidePanelW,
+      depth: layout.openingD,
+      rotZ: 0,
+      panel: panelTextures.left,
+      panelName: "left",
+    },
+    {
+      x: layout.halfOpeningW + layout.sidePanelW / 2,
+      z: 0,
+      width: layout.sidePanelW,
+      depth: layout.openingD,
+      rotZ: 0,
+      panel: panelTextures.right,
+      panelName: "right",
+    },
+  ];
+
+  useEffect(() => {
+    if (!catalogId) return;
+    registerPanel(
+      catalogId,
+      "front",
+      panelTextures.front.source,
+      panelTextures.front.flipX,
+      panelTextures.front.flipY,
+      panelTextures.front.rotation
+    );
+    registerPanel(
+      catalogId,
+      "rear",
+      panelTextures.rear.source,
+      panelTextures.rear.flipX,
+      panelTextures.rear.flipY,
+      panelTextures.rear.rotation
+    );
+    registerPanel(
+      catalogId,
+      "left",
+      panelTextures.left.source,
+      panelTextures.left.flipX,
+      panelTextures.left.flipY,
+      panelTextures.left.rotation
+    );
+    registerPanel(
+      catalogId,
+      "right",
+      panelTextures.right.source,
+      panelTextures.right.flipX,
+      panelTextures.right.flipY,
+      panelTextures.right.rotation
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogId]);
+
+  return (
+    <group
+      ref={outerRef}
+      position={[shape.x, 0, shape.y]}
+      rotation={[0, yawRad, 0]}
+    >
+      {layout.pipeSegments.map(({ end, start }, index) => (
+        <PipeBetween
+          key={`pipe-${index}`}
+          start={start}
+          end={end}
+          radius={pipeRadius}
+          color={frameColor}
+          emissive={emissive}
+          emissiveIntensity={emissiveIntensity}
+        />
+      ))}
+      {layout.couplerPoints.map(({ height, postH, x, z }, index) => {
+        if (height >= postH) return null;
+
+        return (
+          <mesh key={`coupler-${index}`} position={[x, height, z]} castShadow>
+            <cylinderGeometry
+              args={[tube * 0.75, tube * 0.75, tube * 1.8, 16]}
+            />
+            <meshStandardMaterial
+              color="#d6d9de"
+              emissive={sel ? "#60a5fa" : "#d6d9de"}
+              emissiveIntensity={sel ? 0.35 : 0.04}
+              roughness={0.54}
+              metalness={0.08}
+            />
+          </mesh>
+        );
+      })}
+
+      <group position={[0, layout.topY - tube * 0.12, 0]}>
+        {banners.map(({ depth, panel, rotZ, width, x, z }, index) => {
+          return (
+            <group
+              key={`banner-${index}`}
+              position={[x, 0, z]}
+              rotation={[Math.PI / 2, 0, rotZ]}
+            >
+              <mesh castShadow receiveShadow>
+                <planeGeometry args={[width, depth]} />
+                <meshStandardMaterial
+                  color="#ffffff"
+                  map={panel.texture}
+                  roughness={0.68}
+                  metalness={0.02}
+                  side={THREE.DoubleSide}
+                />
+              </mesh>
+            </group>
+          );
+        })}
+      </group>
+    </group>
+  );
+}
+
 function DiveGate3D({
   selected = false,
   shape,
@@ -1864,6 +2540,7 @@ function DiveGate3D({
 }) {
   const visual = getDiveGateVisualSpec(shape);
   const isArch = visual?.variant === "arch";
+  const isLaunch = visual?.variant === "launch";
 
   const color = shape.color ?? "#f97316";
   const sz = shape.width ?? 2.8;
@@ -1883,7 +2560,9 @@ function DiveGate3D({
   const postMeshesRef = useRef<Array<THREE.Mesh | null>>([]);
 
   useFrame(() => {
-    if (isArch || !tiltDragRef || tiltDragRef.current === null) return;
+    if (isArch || isLaunch || !tiltDragRef || tiltDragRef.current === null) {
+      return;
+    }
     const liveTiltRad = (tiltDragRef.current * Math.PI) / 180;
 
     if (frameGroupRef.current) {
@@ -1921,6 +2600,17 @@ function DiveGate3D({
         shape={shape}
         outerRef={outerRef}
         visual={visual as ArchDiveGateVisualSpec}
+      />
+    );
+  }
+
+  if (isLaunch) {
+    return (
+      <LaunchGate3D
+        selected={selected}
+        shape={shape}
+        outerRef={outerRef}
+        visual={visual as LaunchGateVisualSpec}
       />
     );
   }
@@ -2143,6 +2833,9 @@ function getDiveGateTopY(shape: DiveGateShape): number {
   const visual = getDiveGateVisualSpec(shape);
   if (visual?.variant === "arch") {
     return getMultiGpDiveGateArchTopY();
+  }
+  if (visual?.variant === "launch") {
+    return getMultiGpLaunchGateTopY();
   }
 
   const tiltRad = ((shape.tilt ?? 0) * Math.PI) / 180;

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -816,7 +816,12 @@ export default function EditorShell({
               setMobilePathBuilderPinnedOpen(tool === "polyline");
               setActiveTool(tool);
               // Keep drawer open for catalog tools so the type list stays visible
-              const catalogTools: EditorTool[] = ["gate", "flag", "ladder"];
+              const catalogTools: EditorTool[] = [
+                "gate",
+                "flag",
+                "ladder",
+                "divegate",
+              ];
               if (!catalogTools.includes(tool)) {
                 setMobileToolsOpen(false);
               }

--- a/src/components/editor/ElementPlacementControl.tsx
+++ b/src/components/editor/ElementPlacementControl.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/popover";
 import {
   getCatalogEntriesByKind,
+  TRACKDRAW_DIVE_GATE_ELEMENT_ID,
   TRACKDRAW_FLAG_ELEMENT_ID,
   TRACKDRAW_GATE_ELEMENT_ID,
   TRACKDRAW_LADDER_ELEMENT_ID,
@@ -26,26 +27,28 @@ const catalogEntriesByTool: Partial<
   gate: getCatalogEntriesByKind("gate"),
   flag: getCatalogEntriesByKind("flag"),
   ladder: getCatalogEntriesByKind("ladder"),
+  divegate: getCatalogEntriesByKind("divegate"),
 };
 
 const defaultIdByTool: Partial<Record<EditorTool, TrackElementCatalogId>> = {
   gate: TRACKDRAW_GATE_ELEMENT_ID,
   flag: TRACKDRAW_FLAG_ELEMENT_ID,
   ladder: TRACKDRAW_LADDER_ELEMENT_ID,
+  divegate: TRACKDRAW_DIVE_GATE_ELEMENT_ID,
 };
 
 const labelByTool: Partial<Record<EditorTool, string>> = {
   gate: "Gate",
   flag: "Flag",
   ladder: "Ladder",
+  divegate: "Dive Gate",
 };
 
-function getControlWidthCh(entries: { name: string }[]) {
-  return Math.max(
-    22,
-    Math.min(32, Math.max(...entries.map((e) => e.name.length)) + 5)
-  );
-}
+const allEntries = Object.values(catalogEntriesByTool).flat();
+const controlWidthCh = Math.max(
+  28,
+  Math.min(42, Math.max(...allEntries.map((e) => e.name.length)) + 8)
+);
 
 export function ElementPlacementControl() {
   const [open, setOpen] = useState(false);
@@ -66,9 +69,7 @@ export function ElementPlacementControl() {
     : undefined;
   const toolLabel = labelByTool[activeTool] ?? activeTool;
   const controlWidthStyle = {
-    width: visible
-      ? `min(${getControlWidthCh(entries!)}ch, calc(100vw - 2rem))`
-      : "auto",
+    width: visible ? `min(${controlWidthCh}ch, calc(100vw - 2rem))` : "auto",
   } satisfies CSSProperties;
 
   return (
@@ -76,7 +77,7 @@ export function ElementPlacementControl() {
       <AnimatePresence>
         {visible && activeEntry && (
           <motion.div
-            key={activeTool}
+            key="placement-control"
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 10 }}
@@ -88,23 +89,43 @@ export function ElementPlacementControl() {
                 style={controlWidthStyle}
                 className="group border-border/55 bg-sidebar/96 hover:border-border/80 hover:bg-sidebar grid h-12 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2.5 rounded-xl border px-3 text-left shadow-[0_8px_32px_rgba(15,23,42,0.18)] backdrop-blur-md transition-all"
               >
-                <span className="border-border/40 text-muted-foreground rounded-md border px-2 py-1 text-[9px] leading-none font-semibold tracking-widest uppercase">
-                  {toolLabel}
-                </span>
-                <span className="min-w-0">
-                  <span className="text-foreground block truncate text-[13px] leading-none font-semibold">
-                    {activeEntry.name}
-                  </span>
-                  <span className="mt-1.5 flex min-w-0 items-center gap-1.5">
-                    <span className="text-muted-foreground/70 truncate text-[11px] leading-none">
-                      {activeEntry.dimensions.display.label}
-                    </span>
-                    {activeEntry.official ? (
-                      <span className="bg-brand-primary/14 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-[0.06em] uppercase">
-                        Official
+                <AnimatePresence initial={false} mode="popLayout">
+                  <motion.span
+                    key={activeTool}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.12 }}
+                    className="border-border/40 text-muted-foreground rounded-md border px-2 py-1 text-[9px] leading-none font-semibold tracking-widest uppercase"
+                  >
+                    {toolLabel}
+                  </motion.span>
+                </AnimatePresence>
+                <span className="relative min-w-0 overflow-hidden">
+                  <AnimatePresence initial={false} mode="popLayout">
+                    <motion.span
+                      key={activeEntry.id}
+                      initial={{ opacity: 0, y: 5 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      exit={{ opacity: 0, y: -5 }}
+                      transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
+                      className="block min-w-0"
+                    >
+                      <span className="text-foreground block truncate text-[13px] leading-none font-semibold">
+                        {activeEntry.name}
                       </span>
-                    ) : null}
-                  </span>
+                      <span className="mt-1.5 flex min-w-0 items-center gap-1.5">
+                        <span className="text-muted-foreground/70 truncate text-[11px] leading-none">
+                          {activeEntry.dimensions.display.label}
+                        </span>
+                        {activeEntry.official ? (
+                          <span className="bg-brand-primary/14 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-[0.06em] uppercase">
+                            Official
+                          </span>
+                        ) : null}
+                      </span>
+                    </motion.span>
+                  </AnimatePresence>
                 </span>
                 <ChevronDown
                   className={cn(

--- a/src/components/editor/mobile/ToolsControls.tsx
+++ b/src/components/editor/mobile/ToolsControls.tsx
@@ -5,6 +5,7 @@ import { Check, Redo2, Undo2 } from "lucide-react";
 import { mobileToolEntries } from "@/components/editor/tool-icons";
 import {
   getCatalogEntriesByKind,
+  TRACKDRAW_DIVE_GATE_ELEMENT_ID,
   TRACKDRAW_FLAG_ELEMENT_ID,
   TRACKDRAW_GATE_ELEMENT_ID,
   TRACKDRAW_LADDER_ELEMENT_ID,
@@ -18,12 +19,14 @@ const catalogEntriesByTool = {
   gate: getCatalogEntriesByKind("gate"),
   flag: getCatalogEntriesByKind("flag"),
   ladder: getCatalogEntriesByKind("ladder"),
+  divegate: getCatalogEntriesByKind("divegate"),
 } as const;
 
 const defaultIdByTool: Partial<Record<EditorTool, TrackElementCatalogId>> = {
   gate: TRACKDRAW_GATE_ELEMENT_ID,
   flag: TRACKDRAW_FLAG_ELEMENT_ID,
   ladder: TRACKDRAW_LADDER_ELEMENT_ID,
+  divegate: TRACKDRAW_DIVE_GATE_ELEMENT_ID,
 };
 
 const catalogToolIds = Object.keys(catalogEntriesByTool) as EditorTool[];

--- a/src/components/inspector/views/single.tsx
+++ b/src/components/inspector/views/single.tsx
@@ -11,12 +11,14 @@ import {
   getCatalogEntriesByKind,
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
+  TRACKDRAW_DIVE_GATE_ELEMENT_ID,
   TRACKDRAW_FLAG_ELEMENT_ID,
   TRACKDRAW_GATE_ELEMENT_ID,
   TRACKDRAW_LADDER_ELEMENT_ID,
   type TrackElementCatalogId,
 } from "@/lib/track/elements/catalog";
 import {
+  buildDiveGateCatalogTypePatch,
   buildFlagCatalogTypePatch,
   buildGateCatalogTypePatch,
   buildLadderCatalogTypePatch,
@@ -175,6 +177,19 @@ export function SingleInspectorView({
   const hasFixedLadderDimensions =
     selectedLadderShape &&
     catalogEntry?.kind === "ladder" &&
+    catalogEntry.editable?.dimensions === false;
+
+  const selectedDiveGateShape = shape.kind === "divegate" ? shape : null;
+  const diveGateCatalogEntries = selectedDiveGateShape
+    ? getCatalogEntriesByKind("divegate")
+    : null;
+  const activeDiveGateEntryId: TrackElementCatalogId =
+    catalogEntry?.kind === "divegate"
+      ? (catalogIdentity!.elementId as TrackElementCatalogId)
+      : TRACKDRAW_DIVE_GATE_ELEMENT_ID;
+  const hasFixedDiveGateDimensions =
+    selectedDiveGateShape &&
+    catalogEntry?.kind === "divegate" &&
     catalogEntry.editable?.dimensions === false;
 
   const hasFixedCatalogColor =
@@ -506,6 +521,65 @@ export function SingleInspectorView({
             </Section>
           ) : null}
 
+          {diveGateCatalogEntries ? (
+            <Section title="Catalog" defaultOpen>
+              <Row label="Type">
+                <Select
+                  value={activeDiveGateEntryId}
+                  disabled={shape.locked}
+                  onValueChange={(value) => {
+                    const patch = buildDiveGateCatalogTypePatch(
+                      selectedDiveGateShape!,
+                      value as TrackElementCatalogId
+                    );
+                    if (patch)
+                      updateShape(shape.id, patch as Partial<typeof shape>);
+                  }}
+                >
+                  <SelectTrigger className="border-border/40 bg-muted/40 h-9 w-full text-xs shadow-none lg:h-7 lg:text-[11px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {diveGateCatalogEntries.map((entry) => (
+                      <SelectItem
+                        key={entry.id}
+                        value={entry.id}
+                        className="text-xs lg:text-[11px]"
+                      >
+                        {entry.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </Row>
+              {catalogIdentity?.snapshot.organization ? (
+                <Row label="Source">
+                  {catalogEntry?.sources?.[0]?.url ? (
+                    <a
+                      href={catalogEntry.sources[0].url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-foreground hover:text-foreground/70 text-[12px] underline underline-offset-2 transition-colors"
+                    >
+                      {catalogIdentity.snapshot.organization}
+                    </a>
+                  ) : (
+                    <span className="text-foreground text-[12px]">
+                      {catalogIdentity.snapshot.organization}
+                    </span>
+                  )}
+                </Row>
+              ) : null}
+              {catalogIdentity ? (
+                <Row label="Official size">
+                  <span className="text-foreground text-[12px]">
+                    {catalogIdentity.snapshot.dimensionsLabel}
+                  </span>
+                </Row>
+              ) : null}
+            </Section>
+          ) : null}
+
           {canSetTimingMarker && (
             <Section title="Race timing" defaultOpen={timingSectionDefaultOpen}>
               <Row label="Role">
@@ -794,13 +868,15 @@ export function SingleInspectorView({
                 )}
               </>
             )}
-            {shape.kind === "divegate" && (
+            {shape.kind === "divegate" && !hasFixedDiveGateDimensions && (
               <>
                 <Row label={`Size (${unitLabel})`}>
                   <MeasurementNum
-                    valueMeters={shape.size}
+                    valueMeters={shape.width}
                     unitSystem={unitSystem}
-                    onChange={(value) => updateShape(shape.id, { size: value })}
+                    onChange={(value) =>
+                      updateShape(shape.id, { width: value })
+                    }
                     minMeters={0.5}
                   />
                 </Row>

--- a/src/lib/canvas/interaction-helpers.ts
+++ b/src/lib/canvas/interaction-helpers.ts
@@ -194,7 +194,7 @@ export function getWheelZoomTarget(options: {
   currentTargetScale: number;
   deltaY: number;
 }) {
-  const zoomIntensity = options.ctrlKey ? 0.006 : 0.0025;
+  const zoomIntensity = options.ctrlKey ? 0.006 : 0.003;
   const zoomFactor = Math.exp(-options.deltaY * zoomIntensity);
   return clampZoom(options.currentTargetScale * zoomFactor);
 }

--- a/src/lib/editor-tools.ts
+++ b/src/lib/editor-tools.ts
@@ -14,6 +14,7 @@ import {
   type TrackElementCatalogEntry,
 } from "@/lib/track/elements/catalog";
 import type {
+  DiveGateShape,
   FlagShape,
   GateShape,
   LadderShape,
@@ -126,7 +127,7 @@ export function createShapeForTool(
 }
 
 function buildCatalogTypePatchInner<
-  S extends GateShape | FlagShape | LadderShape,
+  S extends GateShape | FlagShape | LadderShape | DiveGateShape,
 >(shape: S, entry: TrackElementCatalogEntry): Partial<S> {
   const draft = createCatalogShapeDraft(entry.id, {
     x: shape.x,
@@ -176,5 +177,14 @@ export function buildLadderCatalogTypePatch(
 ): Partial<LadderShape> | null {
   const entry = getTrackElementCatalogEntry(targetEntryId);
   if (!entry || entry.kind !== "ladder") return null;
+  return buildCatalogTypePatchInner(shape, entry);
+}
+
+export function buildDiveGateCatalogTypePatch(
+  shape: DiveGateShape,
+  targetEntryId: TrackElementCatalogId
+): Partial<DiveGateShape> | null {
+  const entry = getTrackElementCatalogEntry(targetEntryId);
+  if (!entry || entry.kind !== "divegate") return null;
   return buildCatalogTypePatchInner(shape, entry);
 }

--- a/src/lib/export/exportFlythrough.ts
+++ b/src/lib/export/exportFlythrough.ts
@@ -2,974 +2,28 @@
 
 import * as THREE from "three";
 import {
-  Output,
-  WebMOutputFormat,
   BufferTarget,
   CanvasSource,
+  Output,
+  WebMOutputFormat,
 } from "mediabunny";
+import { addFlythroughShapes } from "@/lib/export/flythroughSceneShapes";
+import type { FlythroughProgress, FlythroughTheme } from "@/lib/export/shared";
 import {
   createCurveSampler,
   FPV_CAMERA_FOV,
   getFpvCameraPose,
   getInitialFpvCameraPose,
 } from "@/lib/track/fpvCamera";
-import {
-  getGateVisualSpec,
-  getFlagVisualSpec,
-  getLadderVisualSpec,
-} from "@/lib/track/elements/visual";
-import {
-  getCornerFlagLayout,
-  getPanelFrameGateLayout,
-  getPanelFrameLadderLayout,
-  resolvePanelTextureMapping,
-} from "@/lib/track/render3d-layout";
 import { getPolylineCurve3Derived } from "@/lib/track/polyline-derived-3d";
-import type {
-  GatePanelTextureVisualSpec,
-  PanelFrameGateVisualSpec,
-  PanelFrameLadderVisualSpec,
-  FlagVisualSpec,
-} from "@/lib/track/elements/catalog";
-import type {
-  GateShape,
-  TrackDesign,
-  Shape,
-  PolylineShape,
-  LadderShape,
-} from "@/lib/types";
-import type { FlythroughProgress, FlythroughTheme } from "@/lib/export/shared";
+import type { PolylineShape, Shape, TrackDesign } from "@/lib/types";
 
 const FPS = 60;
 const BITRATE = 8_000_000;
 const WIDTH = 1280;
 const HEIGHT = 720;
-// Target drone speed in m/s — determines video duration from track length
+// Target drone speed in m/s: determines video duration from track length.
 const TARGET_SPEED_MS = 7;
-
-function getOrderedShapes(design: TrackDesign): Shape[] {
-  return design.shapeOrder
-    .map((id) => design.shapeById[id])
-    .filter((s): s is Shape => Boolean(s));
-}
-
-function makeMat(color: string, emissiveIntensity = 0.08) {
-  return new THREE.MeshStandardMaterial({
-    color,
-    emissive: color,
-    emissiveIntensity,
-    roughness: 0.4,
-    metalness: 0.05,
-  });
-}
-
-function addBox(
-  group: THREE.Group,
-  size: [number, number, number],
-  position: [number, number, number],
-  material: THREE.Material
-) {
-  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), material);
-  mesh.position.set(...position);
-  mesh.castShadow = true;
-  mesh.receiveShadow = true;
-  group.add(mesh);
-}
-
-function addCylinder(
-  group: THREE.Group,
-  radius: number,
-  length: number,
-  position: [number, number, number],
-  rotation: [number, number, number],
-  material: THREE.Material
-) {
-  const mesh = new THREE.Mesh(
-    new THREE.CylinderGeometry(radius, radius, length, 16),
-    material
-  );
-  mesh.position.set(...position);
-  mesh.rotation.set(...rotation);
-  mesh.castShadow = true;
-  mesh.receiveShadow = true;
-  group.add(mesh);
-}
-
-function getGateLadderYawRadians(rotation: number) {
-  return (-(rotation + 180) * Math.PI) / 180;
-}
-
-const textureLoader = new THREE.TextureLoader();
-const textureCache = new Map<string, Promise<THREE.Texture>>();
-
-function loadTexture(path: string): Promise<THREE.Texture> {
-  const cached = textureCache.get(path);
-  if (cached) return cached;
-
-  const promise = new Promise<THREE.Texture>((resolve, reject) => {
-    textureLoader.load(
-      path,
-      (texture) => {
-        texture.colorSpace = THREE.SRGBColorSpace;
-        texture.anisotropy = 4;
-        resolve(texture);
-      },
-      undefined,
-      (error) => {
-        textureCache.delete(path);
-        reject(error);
-      }
-    );
-  });
-  textureCache.set(path, promise);
-  return promise;
-}
-
-async function loadFlagTextures(visual: FlagVisualSpec | null) {
-  if (!visual?.textures) return null;
-  const [front, back] = await Promise.all([
-    loadTexture(visual.textures.front),
-    loadTexture(visual.textures.back),
-  ]);
-  return { front, back };
-}
-
-async function loadPanelTextures(textures: GatePanelTextureVisualSpec) {
-  const [left, right, top] = await Promise.all([
-    loadTexture(textures.left),
-    loadTexture(textures.right),
-    textures.top ? loadTexture(textures.top) : Promise.resolve(null),
-  ]);
-  return { left, right, top };
-}
-
-function addPanelTexturePlane(
-  group: THREE.Group,
-  texture: THREE.Texture,
-  size: [number, number],
-  position: [number, number, number],
-  textureRotationZ = 0
-) {
-  const mesh = new THREE.Mesh(
-    new THREE.PlaneGeometry(...size),
-    new THREE.MeshStandardMaterial({
-      map: texture,
-      roughness: 0.72,
-      metalness: 0.01,
-      side: THREE.FrontSide,
-    })
-  );
-  mesh.position.set(...position);
-  mesh.rotation.y = Math.PI;
-  mesh.rotation.z = textureRotationZ;
-  mesh.castShadow = false;
-  mesh.receiveShadow = false;
-  group.add(mesh);
-}
-
-async function createOfficialGateGroup(
-  shape: GateShape,
-  visual: PanelFrameGateVisualSpec
-): Promise<THREE.Group> {
-  const { panels } = visual;
-  const panelTextures = await loadPanelTextures(visual.textures);
-  const {
-    frameTube,
-    frameZ,
-    frontZ,
-    h,
-    leftPanelWidth,
-    leftPanelX,
-    outerLeftX,
-    outerRightX,
-    outerTopY,
-    panelDepth,
-    rightPanelWidth,
-    rightPanelX,
-    topPanelHeight,
-    topPanelW,
-    topPanelY,
-  } = getPanelFrameGateLayout(shape, visual);
-  const yaw = getGateLadderYawRadians(shape.rotation);
-  const {
-    leftPanel: leftSideTexture,
-    rightPanel: rightSideTexture,
-    leftRotationZ: leftSideTextureRotationZ,
-  } = resolvePanelTextureMapping(visual.textures, [
-    panelTextures.left,
-    panelTextures.right,
-  ]);
-
-  const group = new THREE.Group();
-  group.position.set(shape.x, 0, shape.y);
-  group.rotation.y = yaw;
-
-  const frameMat = new THREE.MeshStandardMaterial({
-    color: "#e5e7eb",
-    roughness: 0.82,
-    metalness: 0.02,
-  });
-  const leftPanelMat = new THREE.MeshStandardMaterial({
-    color: panels.left.color,
-    emissive: panels.left.color,
-    emissiveIntensity: 0.02,
-    roughness: 0.7,
-    metalness: 0.01,
-  });
-  const rightPanelMat = new THREE.MeshStandardMaterial({
-    color: panels.right.color,
-    emissive: panels.right.color,
-    emissiveIntensity: 0.02,
-    roughness: 0.7,
-    metalness: 0.01,
-  });
-  const topMat = new THREE.MeshStandardMaterial({
-    color: panels.top.color,
-    emissive: panels.top.color,
-    emissiveIntensity: 0.04,
-    roughness: 0.64,
-    metalness: 0.03,
-  });
-  addCylinder(
-    group,
-    frameTube / 2,
-    outerTopY,
-    [outerLeftX, outerTopY / 2, frameZ],
-    [0, 0, 0],
-    frameMat
-  );
-  addCylinder(
-    group,
-    frameTube / 2,
-    outerTopY,
-    [outerRightX, outerTopY / 2, frameZ],
-    [0, 0, 0],
-    frameMat
-  );
-  addCylinder(
-    group,
-    frameTube / 2,
-    outerRightX - outerLeftX,
-    [0, outerTopY, frameZ],
-    [0, 0, Math.PI / 2],
-    frameMat
-  );
-  for (const x of [outerLeftX, outerRightX]) {
-    const elbow = new THREE.Mesh(
-      new THREE.SphereGeometry(frameTube * 0.66, 16, 12),
-      frameMat
-    );
-    elbow.position.set(x, outerTopY, frameZ);
-    elbow.castShadow = true;
-    group.add(elbow);
-  }
-  addBox(
-    group,
-    [leftPanelWidth, h, panelDepth],
-    [leftPanelX, h / 2, 0],
-    leftPanelMat
-  );
-  addBox(
-    group,
-    [rightPanelWidth, h, panelDepth],
-    [rightPanelX, h / 2, 0],
-    rightPanelMat
-  );
-  addBox(
-    group,
-    [topPanelW, topPanelHeight, panelDepth],
-    [0, topPanelY, 0],
-    topMat
-  );
-
-  addPanelTexturePlane(
-    group,
-    leftSideTexture,
-    [leftPanelWidth, h],
-    [leftPanelX, h / 2, frontZ],
-    leftSideTextureRotationZ
-  );
-  addPanelTexturePlane(
-    group,
-    rightSideTexture,
-    [rightPanelWidth, h],
-    [rightPanelX, h / 2, frontZ]
-  );
-  if (panelTextures.top) {
-    addPanelTexturePlane(
-      group,
-      panelTextures.top,
-      [topPanelW, topPanelHeight],
-      [0, topPanelY, frontZ]
-    );
-  }
-
-  return group;
-}
-
-async function createPanelFrameLadderGroup(
-  shape: LadderShape,
-  visual: PanelFrameLadderVisualSpec
-): Promise<THREE.Group> {
-  const { frame, panels } = visual;
-  const topPanel = panels.top;
-  const panelTextures = await loadPanelTextures(visual.textures);
-  const {
-    bannerH,
-    baseY,
-    frameTube,
-    frameZ,
-    frontZ,
-    leftPanelWidth,
-    openingH,
-    outerLeftX,
-    outerRightX,
-    outerW,
-    panelDepth,
-    rightPanelWidth,
-    sections,
-    totalH,
-    w,
-  } = getPanelFrameLadderLayout(shape, visual);
-  const yaw = getGateLadderYawRadians(shape.rotation);
-  const {
-    leftPanel: leftSideTexture,
-    rightPanel: rightSideTexture,
-    leftRotationZ: leftSideTextureRotationZ,
-  } = resolvePanelTextureMapping(visual.textures, [
-    panelTextures.left,
-    panelTextures.right,
-  ]);
-
-  const group = new THREE.Group();
-  group.position.set(shape.x, baseY, shape.y);
-  group.rotation.y = yaw;
-
-  const frameMat = new THREE.MeshStandardMaterial({
-    color: "#e5e7eb",
-    roughness: 0.82,
-    metalness: 0.02,
-  });
-  const leftPanelMat = new THREE.MeshStandardMaterial({
-    color: panels.left.color,
-    emissive: panels.left.color,
-    emissiveIntensity: 0.02,
-    roughness: 0.7,
-    metalness: 0.01,
-  });
-  const rightPanelMat = new THREE.MeshStandardMaterial({
-    color: panels.right.color,
-    emissive: panels.right.color,
-    emissiveIntensity: 0.02,
-    roughness: 0.7,
-    metalness: 0.01,
-  });
-  const topPanelMat = topPanel
-    ? new THREE.MeshStandardMaterial({
-        color: topPanel.color,
-        emissive: topPanel.color,
-        emissiveIntensity: 0.04,
-        roughness: 0.64,
-        metalness: 0.03,
-      })
-    : null;
-  const fillMat = new THREE.MeshBasicMaterial({
-    color: frame.color,
-    transparent: true,
-    opacity: 0.045,
-    side: THREE.DoubleSide,
-  });
-
-  addCylinder(
-    group,
-    frameTube / 2,
-    totalH,
-    [outerLeftX, totalH / 2, frameZ],
-    [0, 0, 0],
-    frameMat
-  );
-  addCylinder(
-    group,
-    frameTube / 2,
-    totalH,
-    [outerRightX, totalH / 2, frameZ],
-    [0, 0, 0],
-    frameMat
-  );
-  if (baseY > 0) {
-    addCylinder(
-      group,
-      frameTube / 2,
-      outerW,
-      [0, 0, frameZ],
-      [0, 0, Math.PI / 2],
-      frameMat
-    );
-  }
-
-  if (sections.at(-1)?.hasTopPanel ?? true) {
-    for (const x of [outerLeftX, outerRightX]) {
-      const elbow = new THREE.Mesh(
-        new THREE.SphereGeometry(frameTube * 0.66, 16, 12),
-        frameMat
-      );
-      elbow.position.set(x, totalH, frameZ);
-      elbow.castShadow = true;
-      group.add(elbow);
-    }
-  }
-
-  for (const section of sections) {
-    if (section.hasTopPanel) {
-      addCylinder(
-        group,
-        frameTube / 2,
-        outerW,
-        [0, section.barY, frameZ],
-        [0, 0, Math.PI / 2],
-        frameMat
-      );
-    }
-    if (section.hasTopPanel && topPanelMat && bannerH > 0) {
-      addBox(
-        group,
-        [outerW, bannerH, panelDepth],
-        [0, section.bannerMidY, 0],
-        topPanelMat
-      );
-    }
-    addBox(
-      group,
-      [leftPanelWidth, openingH, panelDepth],
-      [-w / 2 - leftPanelWidth / 2, section.openingMidY, 0],
-      leftPanelMat
-    );
-    addBox(
-      group,
-      [rightPanelWidth, openingH, panelDepth],
-      [w / 2 + rightPanelWidth / 2, section.openingMidY, 0],
-      rightPanelMat
-    );
-    addPanelTexturePlane(
-      group,
-      leftSideTexture,
-      [leftPanelWidth, openingH],
-      [-w / 2 - leftPanelWidth / 2, section.openingMidY, frontZ],
-      leftSideTextureRotationZ
-    );
-    addPanelTexturePlane(
-      group,
-      rightSideTexture,
-      [rightPanelWidth, openingH],
-      [w / 2 + rightPanelWidth / 2, section.openingMidY, frontZ]
-    );
-    if (section.hasTopPanel && panelTextures.top && bannerH > 0) {
-      addPanelTexturePlane(
-        group,
-        panelTextures.top,
-        [outerW, bannerH],
-        [0, section.bannerMidY, frontZ]
-      );
-    }
-
-    const fill = new THREE.Mesh(new THREE.PlaneGeometry(w, openingH), fillMat);
-    fill.position.set(0, section.openingMidY, -panelDepth / 2 - 0.004);
-    group.add(fill);
-  }
-
-  return group;
-}
-
-async function addShapes(scene: THREE.Scene, shapes: Shape[]): Promise<void> {
-  for (const shape of shapes) {
-    if (shape.kind === "gate") {
-      const visual = getGateVisualSpec(shape);
-      if (visual.variant === "panel-frame") {
-        scene.add(await createOfficialGateGroup(shape, visual));
-        continue;
-      }
-
-      const color = shape.color ?? "#3b82f6";
-      const thick = shape.thick ?? 0.2;
-      const h = shape.height ?? 2;
-      const w = shape.width ?? 3;
-      const yaw = getGateLadderYawRadians(shape.rotation);
-      const mat = makeMat(color);
-
-      const group = new THREE.Group();
-      group.position.set(shape.x, 0, shape.y);
-      group.rotation.y = yaw;
-
-      const lp = new THREE.Mesh(new THREE.BoxGeometry(thick, h, thick), mat);
-      lp.position.set(-(w / 2), h / 2, 0);
-      group.add(lp);
-
-      const rp = new THREE.Mesh(new THREE.BoxGeometry(thick, h, thick), mat);
-      rp.position.set(w / 2, h / 2, 0);
-      group.add(rp);
-
-      const top = new THREE.Mesh(
-        new THREE.BoxGeometry(w + thick, thick, thick),
-        mat
-      );
-      top.position.set(0, h, 0);
-      group.add(top);
-
-      scene.add(group);
-    } else if (shape.kind === "ladder") {
-      const ladderVisual = getLadderVisualSpec(shape);
-      if (ladderVisual?.variant === "panel-frame") {
-        scene.add(await createPanelFrameLadderGroup(shape, ladderVisual));
-        continue;
-      }
-
-      const color = shape.color ?? "#3b82f6";
-      const w = shape.width ?? 1.5;
-      const totalH = shape.height ?? 4.5;
-      const rungs = Math.max(1, shape.rungs ?? 3);
-      const baseY = Math.max(shape.elevation ?? 0, 0);
-      const thick = 0.2;
-      const gateH = totalH / rungs;
-      const yaw = getGateLadderYawRadians(shape.rotation);
-      const mat = makeMat(color);
-      const fillMat = new THREE.MeshBasicMaterial({
-        color,
-        transparent: true,
-        opacity: 0.06,
-        side: THREE.DoubleSide,
-      });
-
-      const group = new THREE.Group();
-      group.position.set(shape.x, baseY, shape.y);
-      group.rotation.y = yaw;
-
-      for (let i = 0; i < rungs; i++) {
-        const rungGroup = new THREE.Group();
-        rungGroup.position.y = i * gateH;
-
-        const lp = new THREE.Mesh(
-          new THREE.BoxGeometry(thick, gateH, thick),
-          mat
-        );
-        lp.position.set(-(w / 2), gateH / 2, 0);
-        rungGroup.add(lp);
-
-        const rp = new THREE.Mesh(
-          new THREE.BoxGeometry(thick, gateH, thick),
-          mat
-        );
-        rp.position.set(w / 2, gateH / 2, 0);
-        rungGroup.add(rp);
-
-        const topBar = new THREE.Mesh(
-          new THREE.BoxGeometry(w + thick, thick, thick),
-          mat
-        );
-        topBar.position.set(0, gateH, 0);
-        rungGroup.add(topBar);
-
-        // Lower bar (only on first rung, visible only when elevated)
-        if (i === 0 && baseY > 0) {
-          const lowerBar = new THREE.Mesh(
-            new THREE.BoxGeometry(w + thick, thick, thick),
-            mat
-          );
-          lowerBar.position.set(0, 0, 0);
-          rungGroup.add(lowerBar);
-        }
-
-        const fill = new THREE.Mesh(new THREE.PlaneGeometry(w, gateH), fillMat);
-        fill.position.set(0, gateH / 2, 0);
-        rungGroup.add(fill);
-
-        group.add(rungGroup);
-      }
-
-      scene.add(group);
-    } else if (shape.kind === "startfinish") {
-      // Match StartFinish3D exactly (minus RoundedBox rounding which is minor)
-      const color = shape.color ?? "#f59e0b";
-      const totalW = shape.width ?? 3.0;
-      const spacing = totalW / 4;
-      const podW = spacing * 0.72;
-      const podD = podW * 1.5;
-      const podH = 0.08;
-      const topInset = 0.08;
-      const stripeW = 0.1;
-      const gap = spacing - podW;
-      const yaw = (-shape.rotation * Math.PI) / 180;
-
-      const baseMat = new THREE.MeshStandardMaterial({
-        color: "#111a26",
-        roughness: 0.88,
-        metalness: 0.08,
-      });
-
-      const group = new THREE.Group();
-      group.position.set(shape.x, 0, shape.y);
-      group.rotation.y = yaw;
-
-      for (let i = 0; i < 4; i++) {
-        const px = -totalW / 2 + spacing * i + spacing / 2;
-        const emissiveIntensity = 0.08 + i * 0.025;
-
-        const podGroup = new THREE.Group();
-        podGroup.position.x = px;
-
-        const base = new THREE.Mesh(
-          new THREE.BoxGeometry(podW, podH, podD),
-          baseMat
-        );
-        base.position.set(0, podH / 2, 0);
-        podGroup.add(base);
-
-        const topMat = new THREE.MeshStandardMaterial({
-          color,
-          emissive: color,
-          emissiveIntensity,
-          roughness: 0.34,
-          metalness: 0.18,
-        });
-        const top = new THREE.Mesh(
-          new THREE.BoxGeometry(podW - topInset, 0.018, podD - topInset),
-          topMat
-        );
-        top.position.set(0, podH + 0.012, 0);
-        podGroup.add(top);
-
-        // Stripe
-        const stripe = new THREE.Mesh(
-          new THREE.PlaneGeometry(podW - topInset * 1.2, stripeW),
-          new THREE.MeshBasicMaterial({
-            color: "#ffffff",
-            transparent: true,
-            opacity: 0.16,
-            side: THREE.DoubleSide,
-          })
-        );
-        stripe.rotation.x = -Math.PI / 2;
-        stripe.position.set(0, podH + 0.022, -(podD / 2) + 0.16);
-        podGroup.add(stripe);
-
-        // Glow plane
-        const glow = new THREE.Mesh(
-          new THREE.PlaneGeometry(podW + 0.08, podD + 0.08),
-          new THREE.MeshBasicMaterial({
-            color,
-            transparent: true,
-            opacity: 0.05,
-            side: THREE.DoubleSide,
-          })
-        );
-        glow.rotation.x = -Math.PI / 2;
-        glow.position.set(0, 0.004, 0);
-        podGroup.add(glow);
-
-        group.add(podGroup);
-      }
-
-      // Bridge connectors between pod pairs
-      for (const dir of [-1, 1]) {
-        const bridge = new THREE.Mesh(
-          new THREE.BoxGeometry(gap + 0.02, 0.015, 0.1),
-          new THREE.MeshStandardMaterial({
-            color: "#1c2634",
-            roughness: 0.9,
-            metalness: 0.04,
-          })
-        );
-        bridge.position.set(dir * spacing, 0.01, 0);
-        group.add(bridge);
-      }
-
-      scene.add(group);
-    } else if (shape.kind === "divegate") {
-      const color = shape.color ?? "#f97316";
-      const sz = shape.size ?? 2.8;
-      const thick = shape.thick ?? 0.2;
-      const tilt = shape.tilt ?? 0;
-      const tiltRad = (tilt * Math.PI) / 180;
-      const yawRad = (-shape.rotation * Math.PI) / 180;
-      const centerY = shape.elevation ?? 3.0;
-      const mat = makeMat(color);
-      const fillMat = new THREE.MeshBasicMaterial({
-        color,
-        transparent: true,
-        opacity: 0.07,
-        side: THREE.DoubleSide,
-      });
-
-      const outer = new THREE.Group();
-      outer.position.set(shape.x, 0, shape.y);
-      outer.rotation.y = yawRad;
-
-      const frame = new THREE.Group();
-      frame.position.set(0, centerY, 0);
-      frame.rotation.x = -Math.PI / 2 + tiltRad;
-
-      const topBar = new THREE.Mesh(
-        new THREE.BoxGeometry(sz, thick, thick),
-        mat
-      );
-      topBar.position.set(0, sz / 2, 0);
-      frame.add(topBar);
-
-      const botBar = new THREE.Mesh(
-        new THREE.BoxGeometry(sz, thick, thick),
-        mat
-      );
-      botBar.position.set(0, -sz / 2, 0);
-      frame.add(botBar);
-
-      const leftBar = new THREE.Mesh(
-        new THREE.BoxGeometry(thick, sz, thick),
-        mat
-      );
-      leftBar.position.set(-sz / 2, 0, 0);
-      frame.add(leftBar);
-
-      const rightBar = new THREE.Mesh(
-        new THREE.BoxGeometry(thick, sz, thick),
-        mat
-      );
-      rightBar.position.set(sz / 2, 0, 0);
-      frame.add(rightBar);
-
-      const fill = new THREE.Mesh(
-        new THREE.PlaneGeometry(sz - thick * 2, sz - thick * 2),
-        fillMat
-      );
-      frame.add(fill);
-
-      outer.add(frame);
-
-      // Ground posts — corners of the frame projected down to y=0
-      const bottomY = centerY - (sz / 2) * Math.sin(tiltRad);
-      const topY2 = centerY + (sz / 2) * Math.sin(tiltRad);
-      const bottomZ = (sz / 2) * Math.cos(tiltRad);
-      const topZ = -(sz / 2) * Math.cos(tiltRad);
-      const postW = thick;
-
-      const corners = [
-        { x: -sz / 2, py: bottomY, pz: bottomZ },
-        { x: sz / 2, py: bottomY, pz: bottomZ },
-        { x: -sz / 2, py: topY2, pz: topZ },
-        { x: sz / 2, py: topY2, pz: topZ },
-      ];
-      for (const { x, py, pz } of corners) {
-        if (py > 0.05) {
-          const post = new THREE.Mesh(
-            new THREE.BoxGeometry(postW, 1, postW),
-            mat
-          );
-          post.position.set(x, py / 2, pz);
-          post.scale.y = py;
-          outer.add(post);
-        }
-      }
-
-      scene.add(outer);
-    } else if (shape.kind === "flag") {
-      const color = shape.color ?? "#a855f7";
-      const yaw = (-shape.rotation * Math.PI) / 180;
-      const flagVisual = getFlagVisualSpec(shape);
-      const flagTextures = await loadFlagTextures(flagVisual);
-      const {
-        bannerCenterY,
-        bannerHeight,
-        bannerTextureWidth,
-        bannerTextureX,
-        panelDepth,
-        ph,
-        poleCapRadius,
-        polePoints,
-        poleRadius,
-        poleTipX,
-        poleTipY,
-      } = getCornerFlagLayout(shape, Boolean(flagTextures));
-
-      const mastCurve = new THREE.CatmullRomCurve3(
-        polePoints.map(([x, y]) => new THREE.Vector3(x, y, 0)),
-        false,
-        "centripetal",
-        0.5
-      );
-
-      const mastMat = new THREE.MeshStandardMaterial({
-        color: "#d7dde8",
-        metalness: 0.3,
-        roughness: 0.42,
-      });
-      const bannerMat = new THREE.MeshStandardMaterial(
-        flagTextures
-          ? {
-              color: "#ffffff",
-              transparent: true,
-              roughness: 0.78,
-              side: THREE.DoubleSide,
-              map: flagTextures.front,
-            }
-          : {
-              color,
-              emissive: color,
-              emissiveIntensity: 0.08,
-              roughness: 0.68,
-              side: THREE.DoubleSide,
-            }
-      );
-
-      const group = new THREE.Group();
-      group.position.set(shape.x, 0, shape.y);
-      group.rotation.y = yaw;
-
-      // Base ring
-      const ringGeo = new THREE.RingGeometry(0.06, 0.14, 24);
-      const ringMat = new THREE.MeshBasicMaterial({
-        color,
-        transparent: true,
-        opacity: 0.14,
-        side: THREE.DoubleSide,
-      });
-      const ring = new THREE.Mesh(ringGeo, ringMat);
-      ring.rotation.x = -Math.PI / 2;
-      ring.position.set(0, 0.025, 0);
-      group.add(ring);
-
-      const mast = new THREE.Mesh(
-        new THREE.TubeGeometry(mastCurve, 40, poleRadius, 10, false),
-        mastMat
-      );
-      group.add(mast);
-      const mastCap = new THREE.Mesh(
-        new THREE.SphereGeometry(poleCapRadius, 18, 12),
-        mastMat
-      );
-      mastCap.position.set(poleTipX, poleTipY, 0);
-      mastCap.castShadow = true;
-      mastCap.receiveShadow = true;
-      group.add(mastCap);
-
-      // Extruded bezier banner — matches Flag3D fallback.
-      const bannerTop = ph * 0.96;
-      const bannerBottom = ph * 0.18;
-      const bannerWidth = Math.max(ph * 0.18, 0.62);
-      const bannerShape = new THREE.Shape();
-      bannerShape.moveTo(0.03, bannerBottom);
-      bannerShape.bezierCurveTo(
-        0.02,
-        ph * 0.34,
-        0.01,
-        ph * 0.72,
-        0.08,
-        bannerTop
-      );
-      bannerShape.bezierCurveTo(
-        bannerWidth * 0.24,
-        ph * 1.01,
-        bannerWidth * 0.72,
-        ph * 0.96,
-        bannerWidth * 0.94,
-        ph * 0.78
-      );
-      bannerShape.bezierCurveTo(
-        bannerWidth * 1.02,
-        ph * 0.6,
-        bannerWidth * 0.82,
-        ph * 0.34,
-        bannerWidth * 0.22,
-        bannerBottom + ph * 0.02
-      );
-      bannerShape.bezierCurveTo(
-        bannerWidth * 0.1,
-        bannerBottom - ph * 0.005,
-        0.05,
-        bannerBottom - ph * 0.002,
-        0.03,
-        bannerBottom
-      );
-
-      const banner = new THREE.Mesh(
-        new THREE.ExtrudeGeometry(bannerShape, {
-          depth: 0.018,
-          bevelEnabled: false,
-        }),
-        bannerMat
-      );
-      banner.position.set(0.01, 0, 0);
-      if (flagTextures) {
-        const frontPanel = new THREE.Mesh(
-          new THREE.PlaneGeometry(bannerTextureWidth, bannerHeight),
-          new THREE.MeshStandardMaterial({
-            map: flagTextures.front,
-            transparent: true,
-            roughness: 0.78,
-            side: THREE.FrontSide,
-          })
-        );
-        frontPanel.position.set(
-          bannerTextureX,
-          bannerCenterY,
-          panelDepth * 0.65
-        );
-        group.add(frontPanel);
-
-        const backPanel = new THREE.Mesh(
-          new THREE.PlaneGeometry(bannerTextureWidth, bannerHeight),
-          new THREE.MeshStandardMaterial({
-            map: flagTextures.back,
-            transparent: true,
-            roughness: 0.78,
-            side: THREE.FrontSide,
-          })
-        );
-        backPanel.position.set(
-          bannerTextureX,
-          bannerCenterY,
-          -panelDepth * 0.35
-        );
-        backPanel.rotation.y = Math.PI;
-        group.add(backPanel);
-      } else {
-        group.add(banner);
-      }
-
-      scene.add(group);
-    } else if (shape.kind === "cone") {
-      const color = shape.color ?? "#f97316";
-      const r = shape.radius ?? 0.2;
-      const h = Math.max(r * 1.15, 0.11);
-      const baseRadius = Math.max(r * 1.18, 0.12);
-      const topRadius = Math.max(baseRadius * 0.6, 0.075);
-      const mat = makeMat(color, 0.06);
-
-      const coneGroup = new THREE.Group();
-      coneGroup.position.set(shape.x, 0, shape.y);
-
-      const cone = new THREE.Mesh(
-        new THREE.CylinderGeometry(topRadius, baseRadius, h, 24),
-        mat
-      );
-      cone.position.set(0, h / 2, 0);
-      coneGroup.add(cone);
-
-      // Ring on top — matches Cone3D
-      const topRing = new THREE.Mesh(
-        new THREE.RingGeometry(topRadius * 0.28, topRadius * 0.86, 24),
-        new THREE.MeshBasicMaterial({
-          color: "#fed7aa",
-          transparent: true,
-          opacity: 0.85,
-          side: THREE.DoubleSide,
-        })
-      );
-      topRing.rotation.x = -Math.PI / 2;
-      topRing.position.set(0, h + 0.004, 0);
-      coneGroup.add(topRing);
-
-      scene.add(coneGroup);
-    }
-  }
-}
 
 const THEME = {
   dark: {
@@ -992,6 +46,12 @@ const THEME = {
   },
 } as const;
 
+function getOrderedShapes(design: TrackDesign): Shape[] {
+  return design.shapeOrder
+    .map((id) => design.shapeById[id])
+    .filter((shape): shape is Shape => Boolean(shape));
+}
+
 function loadWatermarkTexture(
   isDark: boolean
 ): Promise<THREE.CanvasTexture | null> {
@@ -1011,7 +71,9 @@ function loadWatermarkTexture(
       resolve(new THREE.CanvasTexture(c));
     };
     img.onerror = () => resolve(null);
-    img.src = `/assets/brand/trackdraw-logo-mono-${isDark ? "darkbg" : "lightbg"}.svg`;
+    img.src = `/assets/brand/trackdraw-logo-mono-${
+      isDark ? "darkbg" : "lightbg"
+    }.svg`;
   });
 }
 
@@ -1024,7 +86,8 @@ export function exportFlythrough(
   return new Promise((resolve, reject) => {
     const shapes = getOrderedShapes(design);
     const polyline = shapes.find(
-      (s): s is PolylineShape => s.kind === "polyline" && s.points.length >= 2
+      (shape): shape is PolylineShape =>
+        shape.kind === "polyline" && shape.points.length >= 2
     );
     if (!polyline) {
       return reject(new Error("No track path to fly through"));
@@ -1048,7 +111,6 @@ export function exportFlythrough(
     const t = THEME[themeName];
     const isDark = themeName === "dark";
 
-    // Hidden canvas — off-screen but in the DOM for WebGL rendering
     const canvas = document.createElement("canvas");
     canvas.width = WIDTH;
     canvas.height = HEIGHT;
@@ -1109,7 +171,6 @@ export function exportFlythrough(
     );
     scene.add(tube);
 
-    // Grid matching the actual 3D view
     const gridStep = design.field.gridStep;
     const gridSize = Math.max(fw, fh) * 1.5;
     const gridDivisions = Math.round(gridSize / gridStep);
@@ -1127,7 +188,6 @@ export function exportFlythrough(
       if (document.body.contains(canvas)) document.body.removeChild(canvas);
     };
 
-    // Duration from track length at realistic FPV speed
     const trackLengthM = curve.getLength();
     const loopDurationS = trackLengthM / TARGET_SPEED_MS;
     const totalFrames = Math.max(1, Math.round(loopDurationS * FPS));
@@ -1161,13 +221,10 @@ export function exportFlythrough(
       URL.revokeObjectURL(url);
     };
 
-    // mediabunny: frame-accurate WebM encoding via CanvasSource.
-    // Timestamps are in seconds; frames are rendered off-screen and captured directly.
     void (async () => {
       try {
-        await addShapes(scene, shapes);
+        await addFlythroughShapes(scene, shapes);
 
-        // Watermark logo on the ground — same as FieldWatermark in the actual 3D view
         const wmTex = await loadWatermarkTexture(isDark);
         if (wmTex) {
           const aspect = wmTex.image.width / wmTex.image.height;
@@ -1186,7 +243,6 @@ export function exportFlythrough(
           scene.add(wm);
         }
 
-        // Prime camera at t=0 after all async scene assets are loaded.
         const initialPose = getInitialFpvCameraPose(samplePoint);
         camera.position.copy(initialPose.position);
         camera.lookAt(initialPose.lookTarget);
@@ -1201,7 +257,7 @@ export function exportFlythrough(
         const videoSource = new CanvasSource(canvas, {
           codec: "vp9",
           bitrate: BITRATE,
-          keyFrameInterval: 1, // keyframe every second
+          keyFrameInterval: 1,
         });
         output.addVideoTrack(videoSource);
 
@@ -1213,12 +269,8 @@ export function exportFlythrough(
           tickCamera(i);
           renderer.render(scene, camera);
 
-          await videoSource.add(
-            (i - 1) * frameDuration, // timestamp in seconds
-            frameDuration
-          );
+          await videoSource.add((i - 1) * frameDuration, frameDuration);
 
-          // Yield periodically to report progress and keep the UI responsive
           if (i % 10 === 0) {
             reportProgress(i);
             await new Promise<void>((r) => setTimeout(r, 0));

--- a/src/lib/export/exportSvg.ts
+++ b/src/lib/export/exportSvg.ts
@@ -203,7 +203,7 @@ function diveGateToSvg(s: DiveGateShape, ppm: number): string {
   const cx = m(s.x, ppm);
   const cy = m(s.y, ppm);
   const diveGate = getDiveGate2DShape(s, ppm);
-  if (diveGate.variant === "arch") {
+  if (diveGate.variant === "arch" || diveGate.variant === "launch") {
     const {
       color,
       couplerPoints,
@@ -289,7 +289,9 @@ function getNumberedShapeBounds(shape: Shape, ppm: number) {
     }
     case "divegate": {
       const diveGate = getDiveGate2DShape(shape, ppm);
-      if (diveGate.variant === "arch") return diveGate.bounds;
+      if (diveGate.variant === "arch" || diveGate.variant === "launch") {
+        return diveGate.bounds;
+      }
 
       const { size, visibleDepth } = diveGate;
       return {

--- a/src/lib/export/exportSvg.ts
+++ b/src/lib/export/exportSvg.ts
@@ -29,6 +29,7 @@ import {
 import { DEFAULT_POLYLINE_STROKE_WIDTH } from "../track/constants";
 import {
   getCone2DShape,
+  getDiveGateArchPanelPath,
   getDiveGate2DShape,
   getFlag2DShape,
   getGate2DShape,
@@ -201,10 +202,44 @@ function ladderToSvg(s: LadderShape, ppm: number): string {
 function diveGateToSvg(s: DiveGateShape, ppm: number): string {
   const cx = m(s.x, ppm);
   const cy = m(s.y, ppm);
-  const { color, inset, postRadius, size, visibleDepth } = getDiveGate2DShape(
-    s,
-    ppm
-  );
+  const diveGate = getDiveGate2DShape(s, ppm);
+  if (diveGate.variant === "arch") {
+    const {
+      color,
+      couplerPoints,
+      couplerRadius,
+      frameColor,
+      frameTube,
+      openingDepth,
+      openingW,
+      outerDepth,
+      outerW,
+      pipeSegments,
+    } = diveGate;
+    const pipes = pipeSegments
+      .map(
+        (segment) =>
+          `<line x1="${segment.start.x}" y1="${segment.start.y}" x2="${segment.end.x}" y2="${segment.end.y}" stroke="${frameColor}" stroke-width="${Math.max(1, frameTube * 0.58)}" stroke-linecap="round" opacity="0.55"/>`
+      )
+      .join("");
+    const couplers = couplerPoints
+      .map(
+        (point) =>
+          `<circle cx="${point.x}" cy="${point.y}" r="${couplerRadius}" fill="#d6d9de" stroke="${frameColor}" stroke-width="${Math.max(1, frameTube * 0.22)}"/>`
+      )
+      .join("");
+    const panelPath = getDiveGateArchPanelPath(diveGate);
+
+    return `<g transform="translate(${cx},${cy}) rotate(${s.rotation})">
+      <path d="${panelPath.svgPath}" fill="${color}" fill-opacity="0.88" fill-rule="evenodd"/>
+      <rect x="${-outerW / 2}" y="${-outerDepth / 2}" width="${outerW}" height="${outerDepth}" fill="none" stroke="${frameColor}" stroke-width="${Math.max(1, frameTube * 0.55)}" rx="3"/>
+      <rect x="${-openingW / 2}" y="${-openingDepth / 2}" width="${openingW}" height="${openingDepth}" fill="none" stroke="${frameColor}" stroke-width="${Math.max(1, frameTube * 0.35)}" rx="2"/>
+      ${pipes}
+      ${couplers}
+    </g>`;
+  }
+
+  const { color, inset, postRadius, size, visibleDepth } = diveGate;
   return `<g transform="rotate(${s.rotation},${cx},${cy})">
     <rect x="${cx - size / 2}" y="${cy - visibleDepth / 2}" width="${size}" height="${visibleDepth}" fill="${color}" fill-opacity="0.03" rx="4"/>
     <rect x="${cx - size / 2}" y="${cy - visibleDepth / 2}" width="${size}" height="${visibleDepth}" stroke="${color}" stroke-width="2" fill="none" rx="4" opacity="0.95"/>
@@ -253,7 +288,10 @@ function getNumberedShapeBounds(shape: Shape, ppm: number) {
       return { x: -width / 2, y: -depth / 2, width, height: depth };
     }
     case "divegate": {
-      const { size, visibleDepth } = getDiveGate2DShape(shape, ppm);
+      const diveGate = getDiveGate2DShape(shape, ppm);
+      if (diveGate.variant === "arch") return diveGate.bounds;
+
+      const { size, visibleDepth } = diveGate;
       return {
         x: -size / 2,
         y: -visibleDepth / 2,

--- a/src/lib/export/flythroughSceneShapes.ts
+++ b/src/lib/export/flythroughSceneShapes.ts
@@ -8,14 +8,17 @@ import {
 import {
   getCornerFlagLayout,
   getMultiGpDiveGateArchLayout,
+  getMultiGpLaunchGateLayout,
   getPanelFrameGateLayout,
   getPanelFrameLadderLayout,
-  resolvePanelTextureMapping,
+  resolveLaunchGateBannerTextureMapping,
+  resolvePanelFrameTextureMapping,
 } from "@/lib/track/render3d-layout";
 import type {
   ArchDiveGateVisualSpec,
   FlagVisualSpec,
   GatePanelTextureVisualSpec,
+  LaunchGateVisualSpec,
   PanelFrameGateVisualSpec,
   PanelFrameLadderVisualSpec,
 } from "@/lib/track/elements/catalog";
@@ -118,6 +121,23 @@ function loadTexture(path: string): Promise<THREE.Texture> {
   return promise;
 }
 
+function cloneTextureForPanel(
+  texture: THREE.Texture,
+  {
+    flipX = false,
+    flipY = false,
+    rotation = 0,
+  }: { flipX?: boolean; flipY?: boolean; rotation?: number }
+) {
+  const clone = texture.clone();
+  clone.center.set(0.5, 0.5);
+  clone.rotation = rotation;
+  clone.repeat.set(flipX ? -1 : 1, flipY ? -1 : 1);
+  clone.offset.set(0, 0);
+  clone.needsUpdate = true;
+  return clone;
+}
+
 async function loadFlagTextures(visual: FlagVisualSpec | null) {
   if (!visual?.textures) return null;
   const [front, back] = await Promise.all([
@@ -140,8 +160,7 @@ function addPanelTexturePlane(
   group: THREE.Group,
   texture: THREE.Texture,
   size: [number, number],
-  position: [number, number, number],
-  textureRotationZ = 0
+  position: [number, number, number]
 ) {
   const mesh = new THREE.Mesh(
     new THREE.PlaneGeometry(...size),
@@ -154,7 +173,6 @@ function addPanelTexturePlane(
   );
   mesh.position.set(...position);
   mesh.rotation.y = Math.PI;
-  mesh.rotation.z = textureRotationZ;
   mesh.castShadow = false;
   mesh.receiveShadow = false;
   group.add(mesh);
@@ -184,14 +202,11 @@ async function createOfficialGateGroup(
     topPanelY,
   } = getPanelFrameGateLayout(shape, visual);
   const yaw = getGateLadderYawRadians(shape.rotation);
-  const {
-    leftPanel: leftSideTexture,
-    rightPanel: rightSideTexture,
-    leftRotationZ: leftSideTextureRotationZ,
-  } = resolvePanelTextureMapping(visual.textures, [
-    panelTextures.left,
-    panelTextures.right,
-  ]);
+  const textureMapping = resolvePanelFrameTextureMapping(visual.textures, {
+    left: panelTextures.left,
+    right: panelTextures.right,
+    top: panelTextures.top,
+  });
 
   const group = new THREE.Group();
   group.position.set(shape.x, 0, shape.y);
@@ -277,21 +292,20 @@ async function createOfficialGateGroup(
 
   addPanelTexturePlane(
     group,
-    leftSideTexture,
+    cloneTextureForPanel(textureMapping.left.texture, textureMapping.left),
     [leftPanelWidth, h],
-    [leftPanelX, h / 2, frontZ],
-    leftSideTextureRotationZ
+    [leftPanelX, h / 2, frontZ]
   );
   addPanelTexturePlane(
     group,
-    rightSideTexture,
+    cloneTextureForPanel(textureMapping.right.texture, textureMapping.right),
     [rightPanelWidth, h],
     [rightPanelX, h / 2, frontZ]
   );
-  if (panelTextures.top) {
+  if (textureMapping.top) {
     addPanelTexturePlane(
       group,
-      panelTextures.top,
+      cloneTextureForPanel(textureMapping.top.texture, textureMapping.top),
       [topPanelW, topPanelHeight],
       [0, topPanelY, frontZ]
     );
@@ -325,14 +339,11 @@ async function createPanelFrameLadderGroup(
     w,
   } = getPanelFrameLadderLayout(shape, visual);
   const yaw = getGateLadderYawRadians(shape.rotation);
-  const {
-    leftPanel: leftSideTexture,
-    rightPanel: rightSideTexture,
-    leftRotationZ: leftSideTextureRotationZ,
-  } = resolvePanelTextureMapping(visual.textures, [
-    panelTextures.left,
-    panelTextures.right,
-  ]);
+  const textureMapping = resolvePanelFrameTextureMapping(visual.textures, {
+    left: panelTextures.left,
+    right: panelTextures.right,
+    top: panelTextures.top,
+  });
 
   const group = new THREE.Group();
   group.position.set(shape.x, baseY, shape.y);
@@ -445,21 +456,20 @@ async function createPanelFrameLadderGroup(
     );
     addPanelTexturePlane(
       group,
-      leftSideTexture,
+      cloneTextureForPanel(textureMapping.left.texture, textureMapping.left),
       [leftPanelWidth, openingH],
-      [-w / 2 - leftPanelWidth / 2, section.openingMidY, frontZ],
-      leftSideTextureRotationZ
+      [-w / 2 - leftPanelWidth / 2, section.openingMidY, frontZ]
     );
     addPanelTexturePlane(
       group,
-      rightSideTexture,
+      cloneTextureForPanel(textureMapping.right.texture, textureMapping.right),
       [rightPanelWidth, openingH],
       [w / 2 + rightPanelWidth / 2, section.openingMidY, frontZ]
     );
-    if (section.hasTopPanel && panelTextures.top && bannerH > 0) {
+    if (section.hasTopPanel && textureMapping.top && bannerH > 0) {
       addPanelTexturePlane(
         group,
-        panelTextures.top,
+        cloneTextureForPanel(textureMapping.top.texture, textureMapping.top),
         [outerW, bannerH],
         [0, section.bannerMidY, frontZ]
       );
@@ -580,6 +590,128 @@ async function createArchDiveGateGroup(
     panel.add(banner);
   }
 
+  group.add(panel);
+
+  return group;
+}
+
+async function createLaunchGateGroup(
+  shape: DiveGateShape,
+  visual: LaunchGateVisualSpec
+): Promise<THREE.Group> {
+  const [sideTexture, topTexture] = await Promise.all([
+    loadTexture(visual.banner.sideTexture),
+    loadTexture(visual.banner.topTexture),
+  ]);
+  const tube = visual.frame.diameterMeters;
+  const pipeRadius = tube / 2;
+  const layout = getMultiGpLaunchGateLayout(shape);
+
+  const group = new THREE.Group();
+  group.position.set(shape.x, 0, shape.y);
+  group.rotation.y = (-shape.rotation * Math.PI) / 180;
+
+  const frameMat = makeMat(visual.frame.color);
+  const makeBannerMat = (texture: THREE.Texture) =>
+    new THREE.MeshStandardMaterial({
+      color: "#ffffff",
+      map: texture,
+      roughness: 0.68,
+      metalness: 0.02,
+      side: THREE.DoubleSide,
+    });
+  const textureMapping = resolveLaunchGateBannerTextureMapping(visual.banner, {
+    side: sideTexture,
+    top: topTexture,
+  });
+  const bannerMats = {
+    front: makeBannerMat(
+      cloneTextureForPanel(textureMapping.front.texture, textureMapping.front)
+    ),
+    rear: makeBannerMat(
+      cloneTextureForPanel(textureMapping.rear.texture, textureMapping.rear)
+    ),
+    left: makeBannerMat(
+      cloneTextureForPanel(textureMapping.left.texture, textureMapping.left)
+    ),
+    right: makeBannerMat(
+      cloneTextureForPanel(textureMapping.right.texture, textureMapping.right)
+    ),
+  };
+  const couplerMat = new THREE.MeshStandardMaterial({
+    color: "#d6d9de",
+    roughness: 0.54,
+    metalness: 0.08,
+  });
+
+  for (const { end, start } of layout.pipeSegments) {
+    addPipeBetween(group, start, end, pipeRadius, frameMat);
+  }
+  for (const { height, postH, x, z } of layout.couplerPoints) {
+    if (height < postH) {
+      addCylinder(
+        group,
+        tube * 0.75,
+        tube * 1.8,
+        [x, height, z],
+        [0, 0, 0],
+        couplerMat
+      );
+    }
+  }
+
+  const panel = new THREE.Group();
+  panel.position.y = layout.topY - tube * 0.12;
+  const banners: Array<{
+    depth: number;
+    material: THREE.Material;
+    rotZ: number;
+    width: number;
+    x: number;
+    z: number;
+  }> = [
+    {
+      x: 0,
+      z: -layout.halfOpeningD - layout.endPanelD / 2,
+      width: layout.outerW,
+      depth: layout.endPanelD,
+      rotZ: 0,
+      material: bannerMats.front,
+    },
+    {
+      x: 0,
+      z: layout.halfOpeningD + layout.endPanelD / 2,
+      width: layout.outerW,
+      depth: layout.endPanelD,
+      rotZ: Math.PI,
+      material: bannerMats.rear,
+    },
+    {
+      x: -layout.halfOpeningW - layout.sidePanelW / 2,
+      z: 0,
+      width: layout.sidePanelW,
+      depth: layout.openingD,
+      rotZ: 0,
+      material: bannerMats.left,
+    },
+    {
+      x: layout.halfOpeningW + layout.sidePanelW / 2,
+      z: 0,
+      width: layout.sidePanelW,
+      depth: layout.openingD,
+      rotZ: 0,
+      material: bannerMats.right,
+    },
+  ];
+  for (const { depth, material, rotZ, width, x, z } of banners) {
+    const banner = new THREE.Mesh(
+      new THREE.PlaneGeometry(width, depth),
+      material
+    );
+    banner.position.set(x, 0, z);
+    banner.rotation.set(Math.PI / 2, 0, rotZ);
+    panel.add(banner);
+  }
   group.add(panel);
 
   return group;
@@ -790,6 +922,10 @@ export async function addFlythroughShapes(
       const diveGateVisual = getDiveGateVisualSpec(shape);
       if (diveGateVisual?.variant === "arch") {
         scene.add(await createArchDiveGateGroup(shape, diveGateVisual));
+        continue;
+      }
+      if (diveGateVisual?.variant === "launch") {
+        scene.add(await createLaunchGateGroup(shape, diveGateVisual));
         continue;
       }
 

--- a/src/lib/export/flythroughSceneShapes.ts
+++ b/src/lib/export/flythroughSceneShapes.ts
@@ -131,6 +131,8 @@ function cloneTextureForPanel(
 ) {
   const clone = texture.clone();
   clone.center.set(0.5, 0.5);
+  clone.wrapS = THREE.RepeatWrapping;
+  clone.wrapT = THREE.RepeatWrapping;
   clone.rotation = rotation;
   clone.repeat.set(flipX ? -1 : 1, flipY ? -1 : 1);
   clone.offset.set(0, 0);

--- a/src/lib/export/flythroughSceneShapes.ts
+++ b/src/lib/export/flythroughSceneShapes.ts
@@ -1,0 +1,1077 @@
+import * as THREE from "three";
+import {
+  getDiveGateVisualSpec,
+  getFlagVisualSpec,
+  getGateVisualSpec,
+  getLadderVisualSpec,
+} from "@/lib/track/elements/visual";
+import {
+  getCornerFlagLayout,
+  getMultiGpDiveGateArchLayout,
+  getPanelFrameGateLayout,
+  getPanelFrameLadderLayout,
+  resolvePanelTextureMapping,
+} from "@/lib/track/render3d-layout";
+import type {
+  ArchDiveGateVisualSpec,
+  FlagVisualSpec,
+  GatePanelTextureVisualSpec,
+  PanelFrameGateVisualSpec,
+  PanelFrameLadderVisualSpec,
+} from "@/lib/track/elements/catalog";
+import type { DiveGateShape, GateShape, LadderShape, Shape } from "@/lib/types";
+
+function makeMat(color: string, emissiveIntensity = 0.08) {
+  return new THREE.MeshStandardMaterial({
+    color,
+    emissive: color,
+    emissiveIntensity,
+    roughness: 0.4,
+    metalness: 0.05,
+  });
+}
+
+function addBox(
+  group: THREE.Group,
+  size: [number, number, number],
+  position: [number, number, number],
+  material: THREE.Material
+) {
+  const mesh = new THREE.Mesh(new THREE.BoxGeometry(...size), material);
+  mesh.position.set(...position);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  group.add(mesh);
+}
+
+function addCylinder(
+  group: THREE.Group,
+  radius: number,
+  length: number,
+  position: [number, number, number],
+  rotation: [number, number, number],
+  material: THREE.Material
+) {
+  const mesh = new THREE.Mesh(
+    new THREE.CylinderGeometry(radius, radius, length, 16),
+    material
+  );
+  mesh.position.set(...position);
+  mesh.rotation.set(...rotation);
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  group.add(mesh);
+}
+
+function addPipeBetween(
+  group: THREE.Group,
+  start: [number, number, number],
+  end: [number, number, number],
+  radius: number,
+  material: THREE.Material
+) {
+  const from = new THREE.Vector3(...start);
+  const to = new THREE.Vector3(...end);
+  const direction = to.clone().sub(from);
+  const length = direction.length();
+  const mesh = new THREE.Mesh(
+    new THREE.CylinderGeometry(radius, radius, length, 16),
+    material
+  );
+  mesh.position.copy(from.add(to).multiplyScalar(0.5));
+  mesh.quaternion.setFromUnitVectors(
+    new THREE.Vector3(0, 1, 0),
+    direction.normalize()
+  );
+  mesh.castShadow = true;
+  mesh.receiveShadow = true;
+  group.add(mesh);
+}
+
+function getGateLadderYawRadians(rotation: number) {
+  return (-(rotation + 180) * Math.PI) / 180;
+}
+
+const textureLoader = new THREE.TextureLoader();
+const textureCache = new Map<string, Promise<THREE.Texture>>();
+
+function loadTexture(path: string): Promise<THREE.Texture> {
+  const cached = textureCache.get(path);
+  if (cached) return cached;
+
+  const promise = new Promise<THREE.Texture>((resolve, reject) => {
+    textureLoader.load(
+      path,
+      (texture) => {
+        texture.colorSpace = THREE.SRGBColorSpace;
+        texture.anisotropy = 4;
+        resolve(texture);
+      },
+      undefined,
+      (error) => {
+        textureCache.delete(path);
+        reject(error);
+      }
+    );
+  });
+  textureCache.set(path, promise);
+  return promise;
+}
+
+async function loadFlagTextures(visual: FlagVisualSpec | null) {
+  if (!visual?.textures) return null;
+  const [front, back] = await Promise.all([
+    loadTexture(visual.textures.front),
+    loadTexture(visual.textures.back),
+  ]);
+  return { front, back };
+}
+
+async function loadPanelTextures(textures: GatePanelTextureVisualSpec) {
+  const [left, right, top] = await Promise.all([
+    loadTexture(textures.left),
+    loadTexture(textures.right),
+    textures.top ? loadTexture(textures.top) : Promise.resolve(null),
+  ]);
+  return { left, right, top };
+}
+
+function addPanelTexturePlane(
+  group: THREE.Group,
+  texture: THREE.Texture,
+  size: [number, number],
+  position: [number, number, number],
+  textureRotationZ = 0
+) {
+  const mesh = new THREE.Mesh(
+    new THREE.PlaneGeometry(...size),
+    new THREE.MeshStandardMaterial({
+      map: texture,
+      roughness: 0.72,
+      metalness: 0.01,
+      side: THREE.FrontSide,
+    })
+  );
+  mesh.position.set(...position);
+  mesh.rotation.y = Math.PI;
+  mesh.rotation.z = textureRotationZ;
+  mesh.castShadow = false;
+  mesh.receiveShadow = false;
+  group.add(mesh);
+}
+
+async function createOfficialGateGroup(
+  shape: GateShape,
+  visual: PanelFrameGateVisualSpec
+): Promise<THREE.Group> {
+  const { panels } = visual;
+  const panelTextures = await loadPanelTextures(visual.textures);
+  const {
+    frameTube,
+    frameZ,
+    frontZ,
+    h,
+    leftPanelWidth,
+    leftPanelX,
+    outerLeftX,
+    outerRightX,
+    outerTopY,
+    panelDepth,
+    rightPanelWidth,
+    rightPanelX,
+    topPanelHeight,
+    topPanelW,
+    topPanelY,
+  } = getPanelFrameGateLayout(shape, visual);
+  const yaw = getGateLadderYawRadians(shape.rotation);
+  const {
+    leftPanel: leftSideTexture,
+    rightPanel: rightSideTexture,
+    leftRotationZ: leftSideTextureRotationZ,
+  } = resolvePanelTextureMapping(visual.textures, [
+    panelTextures.left,
+    panelTextures.right,
+  ]);
+
+  const group = new THREE.Group();
+  group.position.set(shape.x, 0, shape.y);
+  group.rotation.y = yaw;
+
+  const frameMat = new THREE.MeshStandardMaterial({
+    color: "#e5e7eb",
+    roughness: 0.82,
+    metalness: 0.02,
+  });
+  const leftPanelMat = new THREE.MeshStandardMaterial({
+    color: panels.left.color,
+    emissive: panels.left.color,
+    emissiveIntensity: 0.02,
+    roughness: 0.7,
+    metalness: 0.01,
+  });
+  const rightPanelMat = new THREE.MeshStandardMaterial({
+    color: panels.right.color,
+    emissive: panels.right.color,
+    emissiveIntensity: 0.02,
+    roughness: 0.7,
+    metalness: 0.01,
+  });
+  const topMat = new THREE.MeshStandardMaterial({
+    color: panels.top.color,
+    emissive: panels.top.color,
+    emissiveIntensity: 0.04,
+    roughness: 0.64,
+    metalness: 0.03,
+  });
+  addCylinder(
+    group,
+    frameTube / 2,
+    outerTopY,
+    [outerLeftX, outerTopY / 2, frameZ],
+    [0, 0, 0],
+    frameMat
+  );
+  addCylinder(
+    group,
+    frameTube / 2,
+    outerTopY,
+    [outerRightX, outerTopY / 2, frameZ],
+    [0, 0, 0],
+    frameMat
+  );
+  addCylinder(
+    group,
+    frameTube / 2,
+    outerRightX - outerLeftX,
+    [0, outerTopY, frameZ],
+    [0, 0, Math.PI / 2],
+    frameMat
+  );
+  for (const x of [outerLeftX, outerRightX]) {
+    const elbow = new THREE.Mesh(
+      new THREE.SphereGeometry(frameTube * 0.66, 16, 12),
+      frameMat
+    );
+    elbow.position.set(x, outerTopY, frameZ);
+    elbow.castShadow = true;
+    group.add(elbow);
+  }
+  addBox(
+    group,
+    [leftPanelWidth, h, panelDepth],
+    [leftPanelX, h / 2, 0],
+    leftPanelMat
+  );
+  addBox(
+    group,
+    [rightPanelWidth, h, panelDepth],
+    [rightPanelX, h / 2, 0],
+    rightPanelMat
+  );
+  addBox(
+    group,
+    [topPanelW, topPanelHeight, panelDepth],
+    [0, topPanelY, 0],
+    topMat
+  );
+
+  addPanelTexturePlane(
+    group,
+    leftSideTexture,
+    [leftPanelWidth, h],
+    [leftPanelX, h / 2, frontZ],
+    leftSideTextureRotationZ
+  );
+  addPanelTexturePlane(
+    group,
+    rightSideTexture,
+    [rightPanelWidth, h],
+    [rightPanelX, h / 2, frontZ]
+  );
+  if (panelTextures.top) {
+    addPanelTexturePlane(
+      group,
+      panelTextures.top,
+      [topPanelW, topPanelHeight],
+      [0, topPanelY, frontZ]
+    );
+  }
+
+  return group;
+}
+
+async function createPanelFrameLadderGroup(
+  shape: LadderShape,
+  visual: PanelFrameLadderVisualSpec
+): Promise<THREE.Group> {
+  const { frame, panels } = visual;
+  const topPanel = panels.top;
+  const panelTextures = await loadPanelTextures(visual.textures);
+  const {
+    bannerH,
+    baseY,
+    frameTube,
+    frameZ,
+    frontZ,
+    leftPanelWidth,
+    openingH,
+    outerLeftX,
+    outerRightX,
+    outerW,
+    panelDepth,
+    rightPanelWidth,
+    sections,
+    totalH,
+    w,
+  } = getPanelFrameLadderLayout(shape, visual);
+  const yaw = getGateLadderYawRadians(shape.rotation);
+  const {
+    leftPanel: leftSideTexture,
+    rightPanel: rightSideTexture,
+    leftRotationZ: leftSideTextureRotationZ,
+  } = resolvePanelTextureMapping(visual.textures, [
+    panelTextures.left,
+    panelTextures.right,
+  ]);
+
+  const group = new THREE.Group();
+  group.position.set(shape.x, baseY, shape.y);
+  group.rotation.y = yaw;
+
+  const frameMat = new THREE.MeshStandardMaterial({
+    color: "#e5e7eb",
+    roughness: 0.82,
+    metalness: 0.02,
+  });
+  const leftPanelMat = new THREE.MeshStandardMaterial({
+    color: panels.left.color,
+    emissive: panels.left.color,
+    emissiveIntensity: 0.02,
+    roughness: 0.7,
+    metalness: 0.01,
+  });
+  const rightPanelMat = new THREE.MeshStandardMaterial({
+    color: panels.right.color,
+    emissive: panels.right.color,
+    emissiveIntensity: 0.02,
+    roughness: 0.7,
+    metalness: 0.01,
+  });
+  const topPanelMat = topPanel
+    ? new THREE.MeshStandardMaterial({
+        color: topPanel.color,
+        emissive: topPanel.color,
+        emissiveIntensity: 0.04,
+        roughness: 0.64,
+        metalness: 0.03,
+      })
+    : null;
+  const fillMat = new THREE.MeshBasicMaterial({
+    color: frame.color,
+    transparent: true,
+    opacity: 0.045,
+    side: THREE.DoubleSide,
+  });
+
+  addCylinder(
+    group,
+    frameTube / 2,
+    totalH,
+    [outerLeftX, totalH / 2, frameZ],
+    [0, 0, 0],
+    frameMat
+  );
+  addCylinder(
+    group,
+    frameTube / 2,
+    totalH,
+    [outerRightX, totalH / 2, frameZ],
+    [0, 0, 0],
+    frameMat
+  );
+  if (baseY > 0) {
+    addCylinder(
+      group,
+      frameTube / 2,
+      outerW,
+      [0, 0, frameZ],
+      [0, 0, Math.PI / 2],
+      frameMat
+    );
+  }
+
+  if (sections.at(-1)?.hasTopPanel ?? true) {
+    for (const x of [outerLeftX, outerRightX]) {
+      const elbow = new THREE.Mesh(
+        new THREE.SphereGeometry(frameTube * 0.66, 16, 12),
+        frameMat
+      );
+      elbow.position.set(x, totalH, frameZ);
+      elbow.castShadow = true;
+      group.add(elbow);
+    }
+  }
+
+  for (const section of sections) {
+    if (section.hasTopPanel) {
+      addCylinder(
+        group,
+        frameTube / 2,
+        outerW,
+        [0, section.barY, frameZ],
+        [0, 0, Math.PI / 2],
+        frameMat
+      );
+    }
+    if (section.hasTopPanel && topPanelMat && bannerH > 0) {
+      addBox(
+        group,
+        [outerW, bannerH, panelDepth],
+        [0, section.bannerMidY, 0],
+        topPanelMat
+      );
+    }
+    addBox(
+      group,
+      [leftPanelWidth, openingH, panelDepth],
+      [-w / 2 - leftPanelWidth / 2, section.openingMidY, 0],
+      leftPanelMat
+    );
+    addBox(
+      group,
+      [rightPanelWidth, openingH, panelDepth],
+      [w / 2 + rightPanelWidth / 2, section.openingMidY, 0],
+      rightPanelMat
+    );
+    addPanelTexturePlane(
+      group,
+      leftSideTexture,
+      [leftPanelWidth, openingH],
+      [-w / 2 - leftPanelWidth / 2, section.openingMidY, frontZ],
+      leftSideTextureRotationZ
+    );
+    addPanelTexturePlane(
+      group,
+      rightSideTexture,
+      [rightPanelWidth, openingH],
+      [w / 2 + rightPanelWidth / 2, section.openingMidY, frontZ]
+    );
+    if (section.hasTopPanel && panelTextures.top && bannerH > 0) {
+      addPanelTexturePlane(
+        group,
+        panelTextures.top,
+        [outerW, bannerH],
+        [0, section.bannerMidY, frontZ]
+      );
+    }
+
+    const fill = new THREE.Mesh(new THREE.PlaneGeometry(w, openingH), fillMat);
+    fill.position.set(0, section.openingMidY, -panelDepth / 2 - 0.004);
+    group.add(fill);
+  }
+
+  return group;
+}
+
+async function createArchDiveGateGroup(
+  shape: DiveGateShape,
+  visual: ArchDiveGateVisualSpec
+): Promise<THREE.Group> {
+  const [sideTexture, topTexture] = await Promise.all([
+    loadTexture(visual.banner.sideTexture),
+    loadTexture(visual.banner.topTexture),
+  ]);
+  const tube = visual.frame.diameterMeters;
+  const pipeRadius = tube / 2;
+  const layout = getMultiGpDiveGateArchLayout(shape);
+
+  const group = new THREE.Group();
+  group.position.set(shape.x, 0, shape.y);
+  group.rotation.y = (-shape.rotation * Math.PI) / 180;
+
+  const frameMat = makeMat(visual.frame.color);
+  const sideMat = new THREE.MeshStandardMaterial({
+    color: "#ffffff",
+    map: sideTexture,
+    roughness: 0.72,
+    metalness: 0.01,
+    side: THREE.DoubleSide,
+  });
+  const topMat = new THREE.MeshStandardMaterial({
+    color: "#ffffff",
+    map: topTexture,
+    roughness: 0.68,
+    metalness: 0.02,
+    side: THREE.DoubleSide,
+  });
+  const couplerMat = new THREE.MeshStandardMaterial({
+    color: "#d6d9de",
+    roughness: 0.54,
+    metalness: 0.08,
+  });
+
+  for (const { end, start } of layout.pipeSegments) {
+    addPipeBetween(group, start, end, pipeRadius, frameMat);
+  }
+  for (const { height, postH, x, z } of layout.couplerPoints) {
+    if (height < postH) {
+      addCylinder(
+        group,
+        tube * 0.75,
+        tube * 1.8,
+        [x, height, z],
+        [0, 0, 0],
+        couplerMat
+      );
+    }
+  }
+
+  const panel = new THREE.Group();
+  panel.position.set(0, layout.centerY, 0);
+  panel.rotation.x = layout.tiltRad;
+
+  addBox(
+    panel,
+    [layout.outerW, tube, tube],
+    [0, layout.halfOuterH, 0],
+    frameMat
+  );
+  addBox(
+    panel,
+    [layout.outerW, tube, tube],
+    [0, -layout.halfOuterH, 0],
+    frameMat
+  );
+  addBox(
+    panel,
+    [tube, layout.outerH, tube],
+    [-layout.halfOuterW, 0, 0],
+    frameMat
+  );
+  addBox(
+    panel,
+    [tube, layout.outerH, tube],
+    [layout.halfOuterW, 0, 0],
+    frameMat
+  );
+
+  for (const x of [
+    -layout.halfOpening - layout.sidePanelW / 2,
+    layout.halfOpening + layout.sidePanelW / 2,
+  ]) {
+    const side = new THREE.Mesh(
+      new THREE.PlaneGeometry(layout.sidePanelW, layout.openingH),
+      sideMat
+    );
+    side.position.set(x, 0, 0);
+    if (x > 0) side.rotation.z = Math.PI;
+    panel.add(side);
+  }
+
+  for (const y of [
+    layout.openingH / 2 + layout.bannerH / 2,
+    -layout.openingH / 2 - layout.bannerH / 2,
+  ]) {
+    const banner = new THREE.Mesh(
+      new THREE.PlaneGeometry(layout.outerW, layout.bannerH),
+      topMat
+    );
+    banner.position.set(0, y, 0);
+    panel.add(banner);
+  }
+
+  group.add(panel);
+
+  return group;
+}
+
+export async function addFlythroughShapes(
+  scene: THREE.Scene,
+  shapes: Shape[]
+): Promise<void> {
+  for (const shape of shapes) {
+    if (shape.kind === "gate") {
+      const visual = getGateVisualSpec(shape);
+      if (visual.variant === "panel-frame") {
+        scene.add(await createOfficialGateGroup(shape, visual));
+        continue;
+      }
+
+      const color = shape.color ?? "#3b82f6";
+      const thick = shape.thick ?? 0.2;
+      const h = shape.height ?? 2;
+      const w = shape.width ?? 3;
+      const yaw = getGateLadderYawRadians(shape.rotation);
+      const mat = makeMat(color);
+
+      const group = new THREE.Group();
+      group.position.set(shape.x, 0, shape.y);
+      group.rotation.y = yaw;
+
+      const lp = new THREE.Mesh(new THREE.BoxGeometry(thick, h, thick), mat);
+      lp.position.set(-(w / 2), h / 2, 0);
+      group.add(lp);
+
+      const rp = new THREE.Mesh(new THREE.BoxGeometry(thick, h, thick), mat);
+      rp.position.set(w / 2, h / 2, 0);
+      group.add(rp);
+
+      const top = new THREE.Mesh(
+        new THREE.BoxGeometry(w + thick, thick, thick),
+        mat
+      );
+      top.position.set(0, h, 0);
+      group.add(top);
+
+      scene.add(group);
+    } else if (shape.kind === "ladder") {
+      const ladderVisual = getLadderVisualSpec(shape);
+      if (ladderVisual?.variant === "panel-frame") {
+        scene.add(await createPanelFrameLadderGroup(shape, ladderVisual));
+        continue;
+      }
+
+      const color = shape.color ?? "#3b82f6";
+      const w = shape.width ?? 1.5;
+      const totalH = shape.height ?? 4.5;
+      const rungs = Math.max(1, shape.rungs ?? 3);
+      const baseY = Math.max(shape.elevation ?? 0, 0);
+      const thick = 0.2;
+      const gateH = totalH / rungs;
+      const yaw = getGateLadderYawRadians(shape.rotation);
+      const mat = makeMat(color);
+      const fillMat = new THREE.MeshBasicMaterial({
+        color,
+        transparent: true,
+        opacity: 0.06,
+        side: THREE.DoubleSide,
+      });
+
+      const group = new THREE.Group();
+      group.position.set(shape.x, baseY, shape.y);
+      group.rotation.y = yaw;
+
+      for (let i = 0; i < rungs; i++) {
+        const rungGroup = new THREE.Group();
+        rungGroup.position.y = i * gateH;
+
+        const lp = new THREE.Mesh(
+          new THREE.BoxGeometry(thick, gateH, thick),
+          mat
+        );
+        lp.position.set(-(w / 2), gateH / 2, 0);
+        rungGroup.add(lp);
+
+        const rp = new THREE.Mesh(
+          new THREE.BoxGeometry(thick, gateH, thick),
+          mat
+        );
+        rp.position.set(w / 2, gateH / 2, 0);
+        rungGroup.add(rp);
+
+        const topBar = new THREE.Mesh(
+          new THREE.BoxGeometry(w + thick, thick, thick),
+          mat
+        );
+        topBar.position.set(0, gateH, 0);
+        rungGroup.add(topBar);
+
+        if (i === 0 && baseY > 0) {
+          const lowerBar = new THREE.Mesh(
+            new THREE.BoxGeometry(w + thick, thick, thick),
+            mat
+          );
+          lowerBar.position.set(0, 0, 0);
+          rungGroup.add(lowerBar);
+        }
+
+        const fill = new THREE.Mesh(new THREE.PlaneGeometry(w, gateH), fillMat);
+        fill.position.set(0, gateH / 2, 0);
+        rungGroup.add(fill);
+
+        group.add(rungGroup);
+      }
+
+      scene.add(group);
+    } else if (shape.kind === "startfinish") {
+      const color = shape.color ?? "#f59e0b";
+      const totalW = shape.width ?? 3.0;
+      const spacing = totalW / 4;
+      const podW = spacing * 0.72;
+      const podD = podW * 1.5;
+      const podH = 0.08;
+      const topInset = 0.08;
+      const stripeW = 0.1;
+      const gap = spacing - podW;
+      const yaw = (-shape.rotation * Math.PI) / 180;
+
+      const baseMat = new THREE.MeshStandardMaterial({
+        color: "#111a26",
+        roughness: 0.88,
+        metalness: 0.08,
+      });
+
+      const group = new THREE.Group();
+      group.position.set(shape.x, 0, shape.y);
+      group.rotation.y = yaw;
+
+      for (let i = 0; i < 4; i++) {
+        const px = -totalW / 2 + spacing * i + spacing / 2;
+        const emissiveIntensity = 0.08 + i * 0.025;
+
+        const podGroup = new THREE.Group();
+        podGroup.position.x = px;
+
+        const base = new THREE.Mesh(
+          new THREE.BoxGeometry(podW, podH, podD),
+          baseMat
+        );
+        base.position.set(0, podH / 2, 0);
+        podGroup.add(base);
+
+        const topMat = new THREE.MeshStandardMaterial({
+          color,
+          emissive: color,
+          emissiveIntensity,
+          roughness: 0.34,
+          metalness: 0.18,
+        });
+        const top = new THREE.Mesh(
+          new THREE.BoxGeometry(podW - topInset, 0.018, podD - topInset),
+          topMat
+        );
+        top.position.set(0, podH + 0.012, 0);
+        podGroup.add(top);
+
+        const stripe = new THREE.Mesh(
+          new THREE.PlaneGeometry(podW - topInset * 1.2, stripeW),
+          new THREE.MeshBasicMaterial({
+            color: "#ffffff",
+            transparent: true,
+            opacity: 0.16,
+            side: THREE.DoubleSide,
+          })
+        );
+        stripe.rotation.x = -Math.PI / 2;
+        stripe.position.set(0, podH + 0.022, -(podD / 2) + 0.16);
+        podGroup.add(stripe);
+
+        const glow = new THREE.Mesh(
+          new THREE.PlaneGeometry(podW + 0.08, podD + 0.08),
+          new THREE.MeshBasicMaterial({
+            color,
+            transparent: true,
+            opacity: 0.05,
+            side: THREE.DoubleSide,
+          })
+        );
+        glow.rotation.x = -Math.PI / 2;
+        glow.position.set(0, 0.004, 0);
+        podGroup.add(glow);
+
+        group.add(podGroup);
+      }
+
+      for (const dir of [-1, 1]) {
+        const bridge = new THREE.Mesh(
+          new THREE.BoxGeometry(gap + 0.02, 0.015, 0.1),
+          new THREE.MeshStandardMaterial({
+            color: "#1c2634",
+            roughness: 0.9,
+            metalness: 0.04,
+          })
+        );
+        bridge.position.set(dir * spacing, 0.01, 0);
+        group.add(bridge);
+      }
+
+      scene.add(group);
+    } else if (shape.kind === "divegate") {
+      const diveGateVisual = getDiveGateVisualSpec(shape);
+      if (diveGateVisual?.variant === "arch") {
+        scene.add(await createArchDiveGateGroup(shape, diveGateVisual));
+        continue;
+      }
+
+      const color = shape.color ?? "#f97316";
+      const sz = shape.width ?? 2.8;
+      const thick = shape.thick ?? 0.2;
+      const tilt = shape.tilt ?? 0;
+      const tiltRad = (tilt * Math.PI) / 180;
+      const yawRad = (-shape.rotation * Math.PI) / 180;
+      const centerY = shape.elevation ?? 3.0;
+      const mat = makeMat(color);
+      const fillMat = new THREE.MeshBasicMaterial({
+        color,
+        transparent: true,
+        opacity: 0.07,
+        side: THREE.DoubleSide,
+      });
+
+      const outer = new THREE.Group();
+      outer.position.set(shape.x, 0, shape.y);
+      outer.rotation.y = yawRad;
+
+      const frame = new THREE.Group();
+      frame.position.set(0, centerY, 0);
+      frame.rotation.x = -Math.PI / 2 + tiltRad;
+
+      const topBar = new THREE.Mesh(
+        new THREE.BoxGeometry(sz, thick, thick),
+        mat
+      );
+      topBar.position.set(0, sz / 2, 0);
+      frame.add(topBar);
+
+      const botBar = new THREE.Mesh(
+        new THREE.BoxGeometry(sz, thick, thick),
+        mat
+      );
+      botBar.position.set(0, -sz / 2, 0);
+      frame.add(botBar);
+
+      const leftBar = new THREE.Mesh(
+        new THREE.BoxGeometry(thick, sz, thick),
+        mat
+      );
+      leftBar.position.set(-sz / 2, 0, 0);
+      frame.add(leftBar);
+
+      const rightBar = new THREE.Mesh(
+        new THREE.BoxGeometry(thick, sz, thick),
+        mat
+      );
+      rightBar.position.set(sz / 2, 0, 0);
+      frame.add(rightBar);
+
+      const fill = new THREE.Mesh(
+        new THREE.PlaneGeometry(sz - thick * 2, sz - thick * 2),
+        fillMat
+      );
+      frame.add(fill);
+
+      outer.add(frame);
+
+      const bottomY = centerY - (sz / 2) * Math.sin(tiltRad);
+      const topY2 = centerY + (sz / 2) * Math.sin(tiltRad);
+      const bottomZ = (sz / 2) * Math.cos(tiltRad);
+      const topZ = -(sz / 2) * Math.cos(tiltRad);
+      const postW = thick;
+
+      const corners = [
+        { x: -sz / 2, py: bottomY, pz: bottomZ },
+        { x: sz / 2, py: bottomY, pz: bottomZ },
+        { x: -sz / 2, py: topY2, pz: topZ },
+        { x: sz / 2, py: topY2, pz: topZ },
+      ];
+      for (const { x, py, pz } of corners) {
+        if (py > 0.05) {
+          const post = new THREE.Mesh(
+            new THREE.BoxGeometry(postW, 1, postW),
+            mat
+          );
+          post.position.set(x, py / 2, pz);
+          post.scale.y = py;
+          outer.add(post);
+        }
+      }
+
+      scene.add(outer);
+    } else if (shape.kind === "flag") {
+      const color = shape.color ?? "#a855f7";
+      const yaw = (-shape.rotation * Math.PI) / 180;
+      const flagVisual = getFlagVisualSpec(shape);
+      const flagTextures = await loadFlagTextures(flagVisual);
+      const {
+        bannerCenterY,
+        bannerHeight,
+        bannerTextureWidth,
+        bannerTextureX,
+        panelDepth,
+        ph,
+        poleCapRadius,
+        polePoints,
+        poleRadius,
+        poleTipX,
+        poleTipY,
+      } = getCornerFlagLayout(shape, Boolean(flagTextures));
+
+      const mastCurve = new THREE.CatmullRomCurve3(
+        polePoints.map(([x, y]) => new THREE.Vector3(x, y, 0)),
+        false,
+        "centripetal",
+        0.5
+      );
+
+      const mastMat = new THREE.MeshStandardMaterial({
+        color: "#d7dde8",
+        metalness: 0.3,
+        roughness: 0.42,
+      });
+      const bannerMat = new THREE.MeshStandardMaterial(
+        flagTextures
+          ? {
+              color: "#ffffff",
+              transparent: true,
+              roughness: 0.78,
+              side: THREE.DoubleSide,
+              map: flagTextures.front,
+            }
+          : {
+              color,
+              emissive: color,
+              emissiveIntensity: 0.08,
+              roughness: 0.68,
+              side: THREE.DoubleSide,
+            }
+      );
+
+      const group = new THREE.Group();
+      group.position.set(shape.x, 0, shape.y);
+      group.rotation.y = yaw;
+
+      const ringGeo = new THREE.RingGeometry(0.06, 0.14, 24);
+      const ringMat = new THREE.MeshBasicMaterial({
+        color,
+        transparent: true,
+        opacity: 0.14,
+        side: THREE.DoubleSide,
+      });
+      const ring = new THREE.Mesh(ringGeo, ringMat);
+      ring.rotation.x = -Math.PI / 2;
+      ring.position.set(0, 0.025, 0);
+      group.add(ring);
+
+      const mast = new THREE.Mesh(
+        new THREE.TubeGeometry(mastCurve, 40, poleRadius, 10, false),
+        mastMat
+      );
+      group.add(mast);
+      const mastCap = new THREE.Mesh(
+        new THREE.SphereGeometry(poleCapRadius, 18, 12),
+        mastMat
+      );
+      mastCap.position.set(poleTipX, poleTipY, 0);
+      mastCap.castShadow = true;
+      mastCap.receiveShadow = true;
+      group.add(mastCap);
+
+      const bannerTop = ph * 0.96;
+      const bannerBottom = ph * 0.18;
+      const bannerWidth = Math.max(ph * 0.18, 0.62);
+      const bannerShape = new THREE.Shape();
+      bannerShape.moveTo(0.03, bannerBottom);
+      bannerShape.bezierCurveTo(
+        0.02,
+        ph * 0.34,
+        0.01,
+        ph * 0.72,
+        0.08,
+        bannerTop
+      );
+      bannerShape.bezierCurveTo(
+        bannerWidth * 0.24,
+        ph * 1.01,
+        bannerWidth * 0.72,
+        ph * 0.96,
+        bannerWidth * 0.94,
+        ph * 0.78
+      );
+      bannerShape.bezierCurveTo(
+        bannerWidth * 1.02,
+        ph * 0.6,
+        bannerWidth * 0.82,
+        ph * 0.34,
+        bannerWidth * 0.22,
+        bannerBottom + ph * 0.02
+      );
+      bannerShape.bezierCurveTo(
+        bannerWidth * 0.1,
+        bannerBottom - ph * 0.005,
+        0.05,
+        bannerBottom - ph * 0.002,
+        0.03,
+        bannerBottom
+      );
+
+      const banner = new THREE.Mesh(
+        new THREE.ExtrudeGeometry(bannerShape, {
+          depth: 0.018,
+          bevelEnabled: false,
+        }),
+        bannerMat
+      );
+      banner.position.set(0.01, 0, 0);
+      if (flagTextures) {
+        const frontPanel = new THREE.Mesh(
+          new THREE.PlaneGeometry(bannerTextureWidth, bannerHeight),
+          new THREE.MeshStandardMaterial({
+            map: flagTextures.front,
+            transparent: true,
+            roughness: 0.78,
+            side: THREE.FrontSide,
+          })
+        );
+        frontPanel.position.set(
+          bannerTextureX,
+          bannerCenterY,
+          panelDepth * 0.65
+        );
+        group.add(frontPanel);
+
+        const backPanel = new THREE.Mesh(
+          new THREE.PlaneGeometry(bannerTextureWidth, bannerHeight),
+          new THREE.MeshStandardMaterial({
+            map: flagTextures.back,
+            transparent: true,
+            roughness: 0.78,
+            side: THREE.FrontSide,
+          })
+        );
+        backPanel.position.set(
+          bannerTextureX,
+          bannerCenterY,
+          -panelDepth * 0.35
+        );
+        backPanel.rotation.y = Math.PI;
+        group.add(backPanel);
+      } else {
+        group.add(banner);
+      }
+
+      scene.add(group);
+    } else if (shape.kind === "cone") {
+      const color = shape.color ?? "#f97316";
+      const r = shape.radius ?? 0.2;
+      const h = Math.max(r * 1.15, 0.11);
+      const baseRadius = Math.max(r * 1.18, 0.12);
+      const topRadius = Math.max(baseRadius * 0.6, 0.075);
+      const mat = makeMat(color, 0.06);
+
+      const coneGroup = new THREE.Group();
+      coneGroup.position.set(shape.x, 0, shape.y);
+
+      const cone = new THREE.Mesh(
+        new THREE.CylinderGeometry(topRadius, baseRadius, h, 24),
+        mat
+      );
+      cone.position.set(0, h / 2, 0);
+      coneGroup.add(cone);
+
+      const topRing = new THREE.Mesh(
+        new THREE.RingGeometry(topRadius * 0.28, topRadius * 0.86, 24),
+        new THREE.MeshBasicMaterial({
+          color: "#fed7aa",
+          transparent: true,
+          opacity: 0.85,
+          side: THREE.DoubleSide,
+        })
+      );
+      topRing.rotation.x = -Math.PI / 2;
+      topRing.position.set(0, h + 0.004, 0);
+      coneGroup.add(topRing);
+
+      scene.add(coneGroup);
+    }
+  }
+}

--- a/src/lib/server/api-projects.ts
+++ b/src/lib/server/api-projects.ts
@@ -234,7 +234,7 @@ function toOverlayObstacle(
     case "divegate":
       return {
         ...base,
-        size: shape.size,
+        width: shape.width,
         tilt: shape.tilt ?? 0,
         elevation: shape.elevation ?? 3,
       };

--- a/src/lib/track/design.ts
+++ b/src/lib/track/design.ts
@@ -4,6 +4,7 @@ import { normalizeInventoryProfile } from "@/lib/planning/inventory";
 import { DEFAULT_POLYLINE_STROKE_WIDTH } from "@/lib/track/constants";
 import { normalizeShapeTimingMeta } from "@/lib/track/timing";
 import type {
+  DiveGateShape,
   PolylineShape,
   SerializedTrackDesign,
   Shape,
@@ -48,6 +49,17 @@ export function normalizeShape(shape: Shape): Shape {
       ...shape,
       frontOffsetDeg: shape.frontOffsetDeg ?? 0,
       elevation: shape.elevation ?? 0,
+    });
+  }
+
+  if (shape.kind === "divegate") {
+    const { size: legacySize, ...rest } = shape as DiveGateShape & {
+      size?: number;
+    };
+    return normalizeShapeTimingMeta({
+      ...rest,
+      width: shape.width ?? legacySize ?? 2.8,
+      frontOffsetDeg: shape.frontOffsetDeg ?? 0,
     });
   }
 

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -21,6 +21,7 @@ export const MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID =
 export const MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID =
   "multigp-topless-ladder-7x6";
 export const MULTIGP_DIVE_GATE_7X6_ELEMENT_ID = "multigp-dive-gate-7x6";
+export const MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID = "multigp-launch-gate-7x6";
 
 export type TrackElementCatalogId =
   | typeof TRACKDRAW_GATE_ELEMENT_ID
@@ -36,7 +37,8 @@ export type TrackElementCatalogId =
   | typeof MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID
   | typeof MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID
   | typeof MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID
-  | typeof MULTIGP_DIVE_GATE_7X6_ELEMENT_ID;
+  | typeof MULTIGP_DIVE_GATE_7X6_ELEMENT_ID
+  | typeof MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID;
 
 type PlaceableCatalogShape = Exclude<Shape, PolylineShape>;
 export type TrackElementShapeDraft = ShapeDraft<PlaceableCatalogShape>;
@@ -77,10 +79,28 @@ export interface GateFrameVisualSpec {
   diameterMeters: number;
 }
 
+export type TexturePanelEdge = "top" | "right" | "bottom" | "left";
+
+export interface TextureOrientationSpec {
+  textureTopEdgeFaces?: TexturePanelEdge;
+  flipX?: boolean;
+  flipY?: boolean;
+}
+
+export interface PanelTexturePlacementSpec<TSource extends string> {
+  source: TSource;
+  orientation?: TextureOrientationSpec;
+}
+
 export interface GatePanelTextureVisualSpec {
   left: string;
   right: string;
   top?: string;
+  placement?: {
+    left?: PanelTexturePlacementSpec<"left" | "right" | "top">;
+    right?: PanelTexturePlacementSpec<"left" | "right" | "top">;
+    top?: PanelTexturePlacementSpec<"left" | "right" | "top">;
+  };
 }
 
 export interface FrameOnlyGateVisualSpec {
@@ -138,10 +158,33 @@ export interface ArchDiveGateVisualSpec {
     color: string;
     sideTexture: string;
     topTexture: string;
+    placement?: {
+      left?: PanelTexturePlacementSpec<"side" | "top">;
+      right?: PanelTexturePlacementSpec<"side" | "top">;
+      top?: PanelTexturePlacementSpec<"side" | "top">;
+      bottom?: PanelTexturePlacementSpec<"side" | "top">;
+    };
   };
 }
 
-export type DiveGateVisualSpec = ArchDiveGateVisualSpec;
+export interface LaunchGateVisualSpec {
+  kind: "divegate";
+  variant: "launch";
+  frame: GateFrameVisualSpec;
+  banner: {
+    color: string;
+    sideTexture: string;
+    topTexture: string;
+    placement?: {
+      front?: PanelTexturePlacementSpec<"side" | "top">;
+      rear?: PanelTexturePlacementSpec<"side" | "top">;
+      left?: PanelTexturePlacementSpec<"side" | "top">;
+      right?: PanelTexturePlacementSpec<"side" | "top">;
+    };
+  };
+}
+
+export type DiveGateVisualSpec = ArchDiveGateVisualSpec | LaunchGateVisualSpec;
 
 export type TrackElementVisualSpec =
   | GateVisualSpec
@@ -276,6 +319,11 @@ const panelFrameGateVisual = {
     right:
       "/assets/models/textures/multigp-obstacles/MultiGP-2017-Airgate-right-panel-regular-50-percent.webp",
     top: "/assets/models/textures/multigp-obstacles/MultiGP-2017-Airgate-top-regular-50-percent.webp",
+    placement: {
+      left: { source: "right", orientation: { textureTopEdgeFaces: "top" } },
+      right: { source: "left", orientation: { textureTopEdgeFaces: "top" } },
+      top: { source: "top", orientation: { textureTopEdgeFaces: "top" } },
+    },
   },
 } satisfies GateVisualSpec;
 
@@ -291,6 +339,11 @@ const panelFrameChampionshipGateVisual = {
     right:
       "/assets/models/textures/multigp-obstacles/large-side-panel-multigp.webp",
     top: "/assets/models/textures/multigp-obstacles/large-top-multigp.webp",
+    placement: {
+      left: { source: "left", orientation: { flipX: true } },
+      right: { source: "left", orientation: { flipX: true } },
+      top: { source: "top", orientation: { flipX: true } },
+    },
   },
 } satisfies GateVisualSpec;
 
@@ -569,6 +622,17 @@ export const trackElementCatalog = [
         right:
           "/assets/models/textures/multigp-obstacles/MultiGP-2017-Airgate-right-panel-regular-50-percent.webp",
         top: "/assets/models/textures/multigp-obstacles/MultiGP-2017-Airgate-top-regular-50-percent.webp",
+        placement: {
+          left: {
+            source: "right",
+            orientation: { textureTopEdgeFaces: "top" },
+          },
+          right: {
+            source: "left",
+            orientation: { textureTopEdgeFaces: "top" },
+          },
+          top: { source: "top", orientation: { textureTopEdgeFaces: "top" } },
+        },
       },
     } satisfies LadderVisualSpec,
     exportHints: { simulatorFriendly: true },
@@ -627,6 +691,17 @@ export const trackElementCatalog = [
         right:
           "/assets/models/textures/multigp-obstacles/large-side-panel-multigp.webp",
         top: "/assets/models/textures/multigp-obstacles/large-top-multigp.webp",
+        placement: {
+          left: {
+            source: "left",
+            orientation: { textureTopEdgeFaces: "bottom" },
+          },
+          right: {
+            source: "left",
+            orientation: { textureTopEdgeFaces: "top" },
+          },
+          top: { source: "top", orientation: { textureTopEdgeFaces: "top" } },
+        },
       },
     } satisfies LadderVisualSpec,
     exportHints: { simulatorFriendly: true },
@@ -685,6 +760,24 @@ export const trackElementCatalog = [
         right:
           "/assets/models/textures/multigp-obstacles/large-side-panel-multigp.webp",
         top: "/assets/models/textures/multigp-obstacles/large-top-multigp.webp",
+        placement: {
+          left: {
+            source: "left",
+            orientation: { textureTopEdgeFaces: "bottom" },
+          },
+          right: {
+            source: "left",
+            orientation: { textureTopEdgeFaces: "top" },
+          },
+          top: {
+            source: "top",
+            orientation: {
+              textureTopEdgeFaces: "bottom",
+              flipX: true,
+              flipY: true,
+            },
+          },
+        },
       },
       topPanelPlacement: "lower-sections",
     } satisfies LadderVisualSpec,
@@ -763,6 +856,79 @@ export const trackElementCatalog = [
           "/assets/models/textures/multigp-obstacles/large-side-panel-multigp.webp",
         topTexture:
           "/assets/models/textures/multigp-obstacles/large-top-multigp.webp",
+      },
+    } satisfies DiveGateVisualSpec,
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID,
+    name: "MultiGP Launch Gate 7x6",
+    organization: "MultiGP",
+    kind: "divegate",
+    official: true,
+    editable: { color: false, dimensions: false },
+    dimensions: {
+      widthMeters: feetToMeters(7),
+      heightMeters: feetToMeters(6),
+      display: {
+        unitSystem: "imperial",
+        label: "7 ft x 6 ft",
+      },
+    },
+    defaultShape: {
+      kind: "divegate",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: feetToMeters(7),
+      height: feetToMeters(6),
+      thick: 0.055,
+      tilt: 0,
+      elevation: 0,
+      color: "#f8fafc",
+    } satisfies TrackElementShapeDraft,
+    tags: ["launch", "race", "multigp", "technical"],
+    sources: [
+      {
+        label: "MultiGP Drone Race Course Obstacles",
+        url: "https://www.multigp.com/multigp-drone-race-course-obstacles/",
+      },
+    ],
+    render2d: { icon: "divegate" },
+    render3d: { modelHint: "launch-gate" },
+    visual: {
+      kind: "divegate",
+      variant: "launch",
+      frame: {
+        placement: "outer",
+        material: "pvc",
+        color: "#f8fafc",
+        diameterMeters: 0.055,
+      },
+      banner: {
+        color: "#202e5d",
+        sideTexture:
+          "/assets/models/textures/multigp-obstacles/large-side-panel-multigp.webp",
+        topTexture:
+          "/assets/models/textures/multigp-obstacles/large-top-multigp.webp",
+        placement: {
+          front: {
+            source: "top",
+            orientation: { textureTopEdgeFaces: "bottom", flipX: true },
+          },
+          rear: {
+            source: "top",
+            orientation: { textureTopEdgeFaces: "bottom", flipX: true },
+          },
+          left: {
+            source: "side",
+            orientation: { textureTopEdgeFaces: "top", flipY: true },
+          },
+          right: {
+            source: "side",
+            orientation: { textureTopEdgeFaces: "bottom", flipY: true },
+          },
+        },
       },
     } satisfies DiveGateVisualSpec,
     exportHints: { simulatorFriendly: true },

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -20,6 +20,7 @@ export const MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID =
   "multigp-championship-ladder-7x6";
 export const MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID =
   "multigp-topless-ladder-7x6";
+export const MULTIGP_DIVE_GATE_7X6_ELEMENT_ID = "multigp-dive-gate-7x6";
 
 export type TrackElementCatalogId =
   | typeof TRACKDRAW_GATE_ELEMENT_ID
@@ -34,7 +35,8 @@ export type TrackElementCatalogId =
   | typeof MULTIGP_CORNER_FLAG_ELEMENT_ID
   | typeof MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID
   | typeof MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID
-  | typeof MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID;
+  | typeof MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID
+  | typeof MULTIGP_DIVE_GATE_7X6_ELEMENT_ID;
 
 type PlaceableCatalogShape = Exclude<Shape, PolylineShape>;
 export type TrackElementShapeDraft = ShapeDraft<PlaceableCatalogShape>;
@@ -127,10 +129,25 @@ export interface PanelFrameLadderVisualSpec {
 }
 
 export type LadderVisualSpec = PanelFrameLadderVisualSpec;
+
+export interface ArchDiveGateVisualSpec {
+  kind: "divegate";
+  variant: "arch";
+  frame: GateFrameVisualSpec;
+  banner: {
+    color: string;
+    sideTexture: string;
+    topTexture: string;
+  };
+}
+
+export type DiveGateVisualSpec = ArchDiveGateVisualSpec;
+
 export type TrackElementVisualSpec =
   | GateVisualSpec
   | FlagVisualSpec
-  | LadderVisualSpec;
+  | LadderVisualSpec
+  | DiveGateVisualSpec;
 
 export interface TrackElementCatalogEntry {
   id: TrackElementCatalogId;
@@ -687,7 +704,7 @@ export const trackElementCatalog = [
       x: 0,
       y: 0,
       rotation: 0,
-      size: 2.8,
+      width: 2.8,
       thick: 0.2,
       tilt: 0,
       elevation: 3,
@@ -696,6 +713,58 @@ export const trackElementCatalog = [
     tags: ["technical", "practice"],
     render2d: { icon: "divegate" },
     render3d: { modelHint: "dive-gate" },
+    exportHints: { simulatorFriendly: true },
+  },
+  {
+    id: MULTIGP_DIVE_GATE_7X6_ELEMENT_ID,
+    name: "MultiGP Dive Gate 7x6",
+    organization: "MultiGP",
+    kind: "divegate",
+    official: true,
+    editable: { color: false, dimensions: false },
+    dimensions: {
+      widthMeters: feetToMeters(7),
+      heightMeters: feetToMeters(6),
+      display: { unitSystem: "imperial", label: "7 ft x 6 ft" },
+    },
+    defaultShape: {
+      kind: "divegate",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: feetToMeters(7),
+      height: feetToMeters(6),
+      thick: 0.055,
+      tilt: 0,
+      elevation: 0,
+      color: "#f8fafc",
+    } satisfies TrackElementShapeDraft,
+    tags: ["championship", "race", "multigp", "technical"],
+    sources: [
+      {
+        label: "MultiGP Drone Race Course Obstacles",
+        url: "https://www.multigp.com/multigp-drone-race-course-obstacles/",
+      },
+    ],
+    render2d: { icon: "divegate" },
+    render3d: { modelHint: "dive-gate" },
+    visual: {
+      kind: "divegate",
+      variant: "arch",
+      frame: {
+        placement: "outer",
+        material: "pvc",
+        color: "#f8fafc",
+        diameterMeters: 0.055,
+      },
+      banner: {
+        color: "#202e5d",
+        sideTexture:
+          "/assets/models/textures/multigp-obstacles/large-side-panel-multigp.webp",
+        topTexture:
+          "/assets/models/textures/multigp-obstacles/large-top-multigp.webp",
+      },
+    } satisfies DiveGateVisualSpec,
     exportHints: { simulatorFriendly: true },
   },
 ] satisfies TrackElementCatalogEntry[];
@@ -724,6 +793,12 @@ export function getTrackElementCatalogTexturePaths(): string[] {
     if (visual.kind === "flag") {
       paths.add(visual.textures.front);
       paths.add(visual.textures.back);
+      continue;
+    }
+
+    if (visual.kind === "divegate") {
+      paths.add(visual.banner.sideTexture);
+      paths.add(visual.banner.topTexture);
     }
   }
 

--- a/src/lib/track/elements/visual.ts
+++ b/src/lib/track/elements/visual.ts
@@ -1,7 +1,14 @@
-import type { FlagShape, GateShape, LadderShape, Shape } from "@/lib/types";
+import type {
+  DiveGateShape,
+  FlagShape,
+  GateShape,
+  LadderShape,
+  Shape,
+} from "@/lib/types";
 import {
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
+  type DiveGateVisualSpec,
   type FrameOnlyGateVisualSpec,
   type FlagVisualSpec,
   type GateVisualSpec,
@@ -45,6 +52,14 @@ export function getLadderVisualSpec(
 ): LadderVisualSpec | null {
   const visual = getTrackElementVisualSpec(shape);
   if (visual?.kind === "ladder") return visual;
+  return null;
+}
+
+export function getDiveGateVisualSpec(
+  shape: DiveGateShape
+): DiveGateVisualSpec | null {
+  const visual = getTrackElementVisualSpec(shape);
+  if (visual?.kind === "divegate") return visual;
   return null;
 }
 

--- a/src/lib/track/obstacleNumbering.ts
+++ b/src/lib/track/obstacleNumbering.ts
@@ -73,7 +73,7 @@ function getObstaclePathTolerance(shape: Shape) {
     case "ladder":
       return Math.max(shape.width * 0.42, 1.15);
     case "divegate":
-      return Math.max(shape.size * 0.38, 1.15);
+      return Math.max(shape.width * 0.38, 1.15);
     default:
       return 1.1;
   }

--- a/src/lib/track/render3d-layout.ts
+++ b/src/lib/track/render3d-layout.ts
@@ -1,6 +1,12 @@
 import type {
+  ArchDiveGateVisualSpec,
+  GatePanelTextureVisualSpec,
+  LaunchGateVisualSpec,
   PanelFrameGateVisualSpec,
   PanelFrameLadderVisualSpec,
+  PanelTexturePlacementSpec,
+  TextureOrientationSpec,
+  TexturePanelEdge,
 } from "@/lib/track/elements/catalog";
 import { feetToMeters } from "@/lib/track/units";
 import type {
@@ -16,6 +22,37 @@ export const TEXTURED_PANEL_FRAME_TUBE_SCALE = 0.58;
 const MULTIGP_FEATHER_FLAG_TEXTURE_ASPECT = 1134 / 5811;
 
 export type Point3Tuple = [number, number, number];
+
+export interface TexturePanelTransform {
+  flipX: boolean;
+  flipY: boolean;
+  rotation: number;
+}
+
+export interface ResolvedTexturePanel<T> extends TexturePanelTransform {
+  texture: T;
+  source: string;
+}
+
+export interface PanelFrameTextureMapping<T> {
+  left: ResolvedTexturePanel<T>;
+  right: ResolvedTexturePanel<T>;
+  top: ResolvedTexturePanel<T> | null;
+}
+
+export interface LaunchGateBannerTextureMapping<T> {
+  front: ResolvedTexturePanel<T>;
+  rear: ResolvedTexturePanel<T>;
+  left: ResolvedTexturePanel<T>;
+  right: ResolvedTexturePanel<T>;
+}
+
+export interface ArchDiveGateBannerTextureMapping<T> {
+  left: ResolvedTexturePanel<T>;
+  right: ResolvedTexturePanel<T>;
+  top: ResolvedTexturePanel<T>;
+  bottom: ResolvedTexturePanel<T>;
+}
 
 export interface MultiGpDiveGateArchLayout {
   bannerH: number;
@@ -43,6 +80,30 @@ export interface MultiGpDiveGateArchLayout {
   topY: number;
 }
 
+export interface MultiGpLaunchGateLayout {
+  couplerPoints: {
+    height: number;
+    postH: number;
+    x: number;
+    z: number;
+  }[];
+  halfOpeningD: number;
+  halfOpeningW: number;
+  halfOuterD: number;
+  halfOuterW: number;
+  openingD: number;
+  openingW: number;
+  outerD: number;
+  outerW: number;
+  pipeSegments: {
+    end: Point3Tuple;
+    start: Point3Tuple;
+  }[];
+  sidePanelW: number;
+  endPanelD: number;
+  topY: number;
+}
+
 const MULTIGP_DIVE_GATE_OPENING_W = feetToMeters(7);
 const MULTIGP_DIVE_GATE_OPENING_H = feetToMeters(6);
 const MULTIGP_DIVE_GATE_BANNER_H = feetToMeters(2);
@@ -52,25 +113,134 @@ const MULTIGP_DIVE_GATE_REAR_EDGE_H = feetToMeters(15);
 const MULTIGP_DIVE_GATE_FRONT_COUPLER_H = feetToMeters(2);
 const MULTIGP_DIVE_GATE_REAR_COUPLER_H = feetToMeters(5);
 const MULTIGP_DIVE_GATE_REAR_LEG_OUTSET_W = feetToMeters(2);
+const MULTIGP_LAUNCH_GATE_OPENING_W = feetToMeters(7);
+const MULTIGP_LAUNCH_GATE_OPENING_D = feetToMeters(6);
+const MULTIGP_LAUNCH_GATE_OUTER_W = feetToMeters(10);
+const MULTIGP_LAUNCH_GATE_OUTER_D = feetToMeters(10);
+const MULTIGP_LAUNCH_GATE_TOP_Y = feetToMeters(15);
+const MULTIGP_LAUNCH_GATE_COUPLER_H = feetToMeters(5);
 
-/**
- * When a gate uses the same texture URL for both panels (symmetric), the right
- * panel texture is mirrored by rotating 180° around Z so the branding faces the
- * correct direction on each side.
- *
- * Pass `loaded` as `[leftLoaded, rightLoaded]` (the first two entries from
- * `useTexture` or `loadPanelTextures`). Returns the resolved panel textures and
- * the Z-rotation to apply to the left-panel mesh.
- */
-export function resolvePanelTextureMapping<T>(
-  textureUrls: { left: string; right: string },
-  loaded: readonly [T, T]
-): { leftPanel: T; rightPanel: T; leftRotationZ: number } {
-  const symmetric = textureUrls.left === textureUrls.right;
+const TEXTURE_TOP_EDGE_ROTATIONS: Record<TexturePanelEdge, number> = {
+  top: 0,
+  right: Math.PI / 2,
+  bottom: Math.PI,
+  left: -Math.PI / 2,
+};
+
+export function resolveTexturePanelTransform(
+  orientation?: TextureOrientationSpec
+): TexturePanelTransform {
   return {
-    leftPanel: symmetric ? loaded[0] : loaded[1],
-    rightPanel: loaded[0],
-    leftRotationZ: symmetric ? Math.PI : 0,
+    flipX: Boolean(orientation?.flipX),
+    flipY: Boolean(orientation?.flipY),
+    rotation:
+      TEXTURE_TOP_EDGE_ROTATIONS[orientation?.textureTopEdgeFaces ?? "top"],
+  };
+}
+
+function resolvePanelTexture<T, TSource extends string>(
+  placement: PanelTexturePlacementSpec<TSource> | undefined,
+  fallback: PanelTexturePlacementSpec<TSource>,
+  textures: Record<TSource, T>
+): ResolvedTexturePanel<T> {
+  const resolvedPlacement = placement ?? fallback;
+  return {
+    texture: textures[resolvedPlacement.source],
+    source: resolvedPlacement.source as string,
+    ...resolveTexturePanelTransform(resolvedPlacement.orientation),
+  };
+}
+
+export function resolvePanelFrameTextureMapping<T>(
+  textureSpec: GatePanelTextureVisualSpec,
+  loaded: { left: T; right: T; top: T | null }
+): PanelFrameTextureMapping<T> {
+  const symmetric = textureSpec.left === textureSpec.right;
+  const topSource = textureSpec.top ? "top" : "left";
+  const leftFallback: PanelTexturePlacementSpec<"left" | "right" | "top"> =
+    symmetric
+      ? {
+          source: "left",
+          orientation: { textureTopEdgeFaces: "bottom" },
+        }
+      : { source: "right" };
+  const rightFallback: PanelTexturePlacementSpec<"left" | "right" | "top"> = {
+    source: "left",
+  };
+
+  return {
+    left: resolvePanelTexture(
+      textureSpec.placement?.left,
+      leftFallback,
+      loaded as Record<"left" | "right" | "top", T>
+    ),
+    right: resolvePanelTexture(
+      textureSpec.placement?.right,
+      rightFallback,
+      loaded as Record<"left" | "right" | "top", T>
+    ),
+    top: loaded.top
+      ? resolvePanelTexture(
+          textureSpec.placement?.top,
+          { source: topSource },
+          loaded as Record<"left" | "right" | "top", T>
+        )
+      : null,
+  };
+}
+
+export function resolveLaunchGateBannerTextureMapping<T>(
+  banner: LaunchGateVisualSpec["banner"],
+  loaded: { side: T; top: T }
+): LaunchGateBannerTextureMapping<T> {
+  return {
+    front: resolvePanelTexture(
+      banner.placement?.front,
+      { source: "top", orientation: { flipX: true } },
+      loaded
+    ),
+    rear: resolvePanelTexture(
+      banner.placement?.rear,
+      {
+        source: "top",
+        orientation: { textureTopEdgeFaces: "bottom", flipX: true },
+      },
+      loaded
+    ),
+    left: resolvePanelTexture(
+      banner.placement?.left,
+      { source: "side", orientation: { flipX: true } },
+      loaded
+    ),
+    right: resolvePanelTexture(
+      banner.placement?.right,
+      { source: "side", orientation: { flipY: true } },
+      loaded
+    ),
+  };
+}
+
+export function resolveArchDiveGateBannerTextureMapping<T>(
+  banner: ArchDiveGateVisualSpec["banner"],
+  loaded: { side: T; top: T }
+): ArchDiveGateBannerTextureMapping<T> {
+  return {
+    left: resolvePanelTexture(
+      banner.placement?.left,
+      { source: "side" },
+      loaded
+    ),
+    right: resolvePanelTexture(
+      banner.placement?.right,
+      { source: "side" },
+      loaded
+    ),
+    top: resolvePanelTexture(banner.placement?.top, { source: "top" }, loaded),
+    bottom: resolvePanelTexture(
+      banner.placement?.bottom,
+      { source: "top" },
+      loaded
+    ),
   };
 }
 
@@ -315,6 +485,95 @@ export function getMultiGpDiveGateArchLayout(
     sidePanelW: MULTIGP_DIVE_GATE_SIDE_PANEL_W,
     tiltRad,
     topY: MULTIGP_DIVE_GATE_REAR_EDGE_H,
+  };
+}
+
+export function getMultiGpLaunchGateTopY() {
+  return MULTIGP_LAUNCH_GATE_TOP_Y;
+}
+
+export function getMultiGpLaunchGateLayout(
+  shape: Pick<DiveGateShape, "width" | "height">
+): MultiGpLaunchGateLayout {
+  const openingW = shape.width ?? MULTIGP_LAUNCH_GATE_OPENING_W;
+  const openingD = shape.height ?? MULTIGP_LAUNCH_GATE_OPENING_D;
+  const outerW = MULTIGP_LAUNCH_GATE_OUTER_W;
+  const outerD = MULTIGP_LAUNCH_GATE_OUTER_D;
+  const sidePanelW = (outerW - openingW) / 2;
+  const endPanelD = (outerD - openingD) / 2;
+  const halfOpeningW = openingW / 2;
+  const halfOpeningD = openingD / 2;
+  const halfOuterW = outerW / 2;
+  const halfOuterD = outerD / 2;
+  const topY = MULTIGP_LAUNCH_GATE_TOP_Y;
+  const legTops: Point3Tuple[] = [
+    [-halfOuterW, topY, -halfOuterD],
+    [halfOuterW, topY, -halfOuterD],
+    [halfOuterW, topY, halfOuterD],
+    [-halfOuterW, topY, halfOuterD],
+  ];
+  const topSegments: Array<[Point3Tuple, Point3Tuple]> = [
+    [
+      [-halfOuterW, topY, -halfOuterD],
+      [halfOuterW, topY, -halfOuterD],
+    ],
+    [
+      [halfOuterW, topY, -halfOuterD],
+      [halfOuterW, topY, halfOuterD],
+    ],
+    [
+      [halfOuterW, topY, halfOuterD],
+      [-halfOuterW, topY, halfOuterD],
+    ],
+    [
+      [-halfOuterW, topY, halfOuterD],
+      [-halfOuterW, topY, -halfOuterD],
+    ],
+    [
+      [-halfOpeningW, topY, -halfOpeningD],
+      [halfOpeningW, topY, -halfOpeningD],
+    ],
+    [
+      [halfOpeningW, topY, -halfOpeningD],
+      [halfOpeningW, topY, halfOpeningD],
+    ],
+    [
+      [halfOpeningW, topY, halfOpeningD],
+      [-halfOpeningW, topY, halfOpeningD],
+    ],
+    [
+      [-halfOpeningW, topY, halfOpeningD],
+      [-halfOpeningW, topY, -halfOpeningD],
+    ],
+  ];
+  const pipeSegments = [
+    ...legTops.map((end) => ({
+      start: [end[0], 0, end[2]] as Point3Tuple,
+      end,
+    })),
+    ...topSegments.map(([start, end]) => ({ start, end })),
+  ];
+  const couplerPoints = legTops.map(([x, , z]) => ({
+    height: MULTIGP_LAUNCH_GATE_COUPLER_H,
+    postH: topY,
+    x,
+    z,
+  }));
+
+  return {
+    couplerPoints,
+    halfOpeningD,
+    halfOpeningW,
+    halfOuterD,
+    halfOuterW,
+    openingD,
+    openingW,
+    outerD,
+    outerW,
+    pipeSegments,
+    sidePanelW,
+    endPanelD,
+    topY,
   };
 }
 

--- a/src/lib/track/render3d-layout.ts
+++ b/src/lib/track/render3d-layout.ts
@@ -2,12 +2,56 @@ import type {
   PanelFrameGateVisualSpec,
   PanelFrameLadderVisualSpec,
 } from "@/lib/track/elements/catalog";
-import type { FlagShape, GateShape, LadderShape } from "@/lib/types";
+import { feetToMeters } from "@/lib/track/units";
+import type {
+  DiveGateShape,
+  FlagShape,
+  GateShape,
+  LadderShape,
+} from "@/lib/types";
 
 export const PANEL_FRAME_PANEL_DEPTH = 0.018;
 export const PANEL_FRAME_TEXTURE_SURFACE_OFFSET = 0.0015;
 export const TEXTURED_PANEL_FRAME_TUBE_SCALE = 0.58;
 const MULTIGP_FEATHER_FLAG_TEXTURE_ASPECT = 1134 / 5811;
+
+export type Point3Tuple = [number, number, number];
+
+export interface MultiGpDiveGateArchLayout {
+  bannerH: number;
+  centerY: number;
+  cornerPoints: Point3Tuple[];
+  couplerPoints: {
+    height: number;
+    postH: number;
+    x: number;
+    z: number;
+  }[];
+  pipeSegments: {
+    end: Point3Tuple;
+    start: Point3Tuple;
+  }[];
+  halfOpening: number;
+  halfOuterH: number;
+  halfOuterW: number;
+  openingH: number;
+  openingW: number;
+  outerH: number;
+  outerW: number;
+  sidePanelW: number;
+  tiltRad: number;
+  topY: number;
+}
+
+const MULTIGP_DIVE_GATE_OPENING_W = feetToMeters(7);
+const MULTIGP_DIVE_GATE_OPENING_H = feetToMeters(6);
+const MULTIGP_DIVE_GATE_BANNER_H = feetToMeters(2);
+const MULTIGP_DIVE_GATE_SIDE_PANEL_W = feetToMeters(2);
+const MULTIGP_DIVE_GATE_FRONT_EDGE_H = feetToMeters(12);
+const MULTIGP_DIVE_GATE_REAR_EDGE_H = feetToMeters(15);
+const MULTIGP_DIVE_GATE_FRONT_COUPLER_H = feetToMeters(2);
+const MULTIGP_DIVE_GATE_REAR_COUPLER_H = feetToMeters(5);
+const MULTIGP_DIVE_GATE_REAR_LEG_OUTSET_W = feetToMeters(2);
 
 /**
  * When a gate uses the same texture URL for both panels (symmetric), the right
@@ -159,6 +203,119 @@ export function getLadderRenderedHeight(
   const height = shape.height ?? 4.5;
   if (!visual) return height;
   return getPanelFrameLadderLayout(shape, visual).totalH;
+}
+
+export function getMultiGpDiveGateArchTopY() {
+  return MULTIGP_DIVE_GATE_REAR_EDGE_H;
+}
+
+export function getMultiGpDiveGateArchLayout(
+  shape: Pick<DiveGateShape, "width" | "height">
+): MultiGpDiveGateArchLayout {
+  const openingW = shape.width ?? MULTIGP_DIVE_GATE_OPENING_W;
+  const openingH = shape.height ?? MULTIGP_DIVE_GATE_OPENING_H;
+  const halfOpening = openingW / 2;
+  const outerW = openingW + MULTIGP_DIVE_GATE_SIDE_PANEL_W * 2;
+  const outerH = openingH + MULTIGP_DIVE_GATE_BANNER_H * 2;
+  const halfOuterW = outerW / 2;
+  const halfOuterH = outerH / 2;
+  const verticalSpan =
+    MULTIGP_DIVE_GATE_REAR_EDGE_H - MULTIGP_DIVE_GATE_FRONT_EDGE_H;
+  const tiltRad = -Math.acos(Math.min(1, verticalSpan / outerH));
+  const centerY =
+    (MULTIGP_DIVE_GATE_FRONT_EDGE_H + MULTIGP_DIVE_GATE_REAR_EDGE_H) / 2;
+
+  const panelPoint = (x: number, y: number): Point3Tuple => [
+    x,
+    centerY + y * Math.cos(tiltRad),
+    y * Math.sin(tiltRad),
+  ];
+  const cornerPoints = [
+    panelPoint(-halfOuterW, -halfOuterH),
+    panelPoint(halfOuterW, -halfOuterH),
+    panelPoint(-halfOuterW, halfOuterH),
+    panelPoint(halfOuterW, halfOuterH),
+  ];
+  const rearLeftSupportTop: Point3Tuple = [
+    cornerPoints[2][0] - MULTIGP_DIVE_GATE_REAR_LEG_OUTSET_W,
+    cornerPoints[2][1],
+    cornerPoints[2][2],
+  ];
+  const rearRightSupportTop: Point3Tuple = [
+    cornerPoints[3][0] + MULTIGP_DIVE_GATE_REAR_LEG_OUTSET_W,
+    cornerPoints[3][1],
+    cornerPoints[3][2],
+  ];
+  const pipeSegments = [
+    {
+      start: [cornerPoints[0][0], 0, cornerPoints[0][2]] as Point3Tuple,
+      end: cornerPoints[0],
+    },
+    {
+      start: [cornerPoints[1][0], 0, cornerPoints[1][2]] as Point3Tuple,
+      end: cornerPoints[1],
+    },
+    {
+      start: cornerPoints[2],
+      end: rearLeftSupportTop,
+    },
+    {
+      start: [rearLeftSupportTop[0], 0, rearLeftSupportTop[2]] as Point3Tuple,
+      end: rearLeftSupportTop,
+    },
+    {
+      start: cornerPoints[3],
+      end: rearRightSupportTop,
+    },
+    {
+      start: [rearRightSupportTop[0], 0, rearRightSupportTop[2]] as Point3Tuple,
+      end: rearRightSupportTop,
+    },
+  ];
+  const couplerPoints = [
+    {
+      height: MULTIGP_DIVE_GATE_FRONT_COUPLER_H,
+      postH: cornerPoints[0][1],
+      x: cornerPoints[0][0],
+      z: cornerPoints[0][2],
+    },
+    {
+      height: MULTIGP_DIVE_GATE_FRONT_COUPLER_H,
+      postH: cornerPoints[1][1],
+      x: cornerPoints[1][0],
+      z: cornerPoints[1][2],
+    },
+    {
+      height: MULTIGP_DIVE_GATE_REAR_COUPLER_H,
+      postH: rearLeftSupportTop[1],
+      x: rearLeftSupportTop[0],
+      z: rearLeftSupportTop[2],
+    },
+    {
+      height: MULTIGP_DIVE_GATE_REAR_COUPLER_H,
+      postH: rearRightSupportTop[1],
+      x: rearRightSupportTop[0],
+      z: rearRightSupportTop[2],
+    },
+  ];
+
+  return {
+    bannerH: MULTIGP_DIVE_GATE_BANNER_H,
+    centerY,
+    cornerPoints,
+    couplerPoints,
+    halfOpening,
+    halfOuterH,
+    halfOuterW,
+    openingH,
+    openingW,
+    outerH,
+    outerW,
+    pipeSegments,
+    sidePanelW: MULTIGP_DIVE_GATE_SIDE_PANEL_W,
+    tiltRad,
+    topY: MULTIGP_DIVE_GATE_REAR_EDGE_H,
+  };
 }
 
 export function getCornerFlagLayout(shape: FlagShape, hasTextures = false) {

--- a/src/lib/track/shape2d.ts
+++ b/src/lib/track/shape2d.ts
@@ -1,8 +1,10 @@
 import { m2px } from "@/lib/track/units";
 import {
+  getDiveGateVisualSpec,
   getGateVisualSpec,
   getLadderVisualSpec,
 } from "@/lib/track/elements/visual";
+import { getMultiGpDiveGateArchLayout } from "@/lib/track/render3d-layout";
 import type {
   ConeShape,
   DiveGateShape,
@@ -11,6 +13,8 @@ import type {
   LadderShape,
   StartFinishShape,
 } from "@/lib/types";
+
+const DIVE_GATE_2D_BANNER_VISUAL_SCALE = 0.82;
 
 export function getGate2DShape(shape: GateShape, ppm: number) {
   const visual = getGateVisualSpec(shape);
@@ -148,8 +152,123 @@ export function getLadder2DShape(shape: LadderShape, ppm: number) {
   };
 }
 
+export function getDiveGateArchPanelPath(options: {
+  openingDepth: number;
+  openingW: number;
+  outerDepth: number;
+  outerW: number;
+}) {
+  const { openingDepth, openingW, outerDepth, outerW } = options;
+  const outerRadius = Math.min(3, outerW / 2, outerDepth / 2);
+  const outer = {
+    height: outerDepth,
+    radius: outerRadius,
+    width: outerW,
+    x: -outerW / 2,
+    y: -outerDepth / 2,
+  };
+  const opening = {
+    height: openingDepth,
+    width: openingW,
+    x: -openingW / 2,
+    y: -openingDepth / 2,
+  };
+  const outerPath = [
+    `M ${outer.x + outer.radius} ${outer.y}`,
+    `H ${outer.x + outer.width - outer.radius}`,
+    `Q ${outer.x + outer.width} ${outer.y} ${outer.x + outer.width} ${outer.y + outer.radius}`,
+    `V ${outer.y + outer.height - outer.radius}`,
+    `Q ${outer.x + outer.width} ${outer.y + outer.height} ${outer.x + outer.width - outer.radius} ${outer.y + outer.height}`,
+    `H ${outer.x + outer.radius}`,
+    `Q ${outer.x} ${outer.y + outer.height} ${outer.x} ${outer.y + outer.height - outer.radius}`,
+    `V ${outer.y + outer.radius}`,
+    `Q ${outer.x} ${outer.y} ${outer.x + outer.radius} ${outer.y}`,
+    "Z",
+  ].join(" ");
+  const openingPath = [
+    `M ${opening.x} ${opening.y}`,
+    `H ${opening.x + opening.width}`,
+    `V ${opening.y + opening.height}`,
+    `H ${opening.x}`,
+    "Z",
+  ].join(" ");
+
+  return {
+    opening,
+    outer,
+    svgPath: `${outerPath} ${openingPath}`,
+  };
+}
+
 export function getDiveGate2DShape(shape: DiveGateShape, ppm: number) {
-  const size = m2px(shape.size ?? 2.8, ppm);
+  const visual = getDiveGateVisualSpec(shape);
+  if (visual?.variant === "arch") {
+    const layout = getMultiGpDiveGateArchLayout(shape);
+    const toPoint = ([x, , z]: [number, number, number]) => ({
+      x: m2px(x, ppm),
+      y: m2px(z, ppm),
+    });
+    const pipeSegments = layout.pipeSegments.map(({ end, start }) => ({
+      end: toPoint(end),
+      start: toPoint(start),
+    }));
+    const couplerPoints = layout.couplerPoints.map(({ x, z }) => ({
+      x: m2px(x, ppm),
+      y: m2px(z, ppm),
+    }));
+    const projectedDepthScale = Math.abs(Math.sin(layout.tiltRad));
+    const sidePanelW = m2px(layout.sidePanelW, ppm);
+    const sidePanelVisualW = sidePanelW * DIVE_GATE_2D_BANNER_VISUAL_SCALE;
+    const openingW = m2px(layout.openingW, ppm);
+    const openingDepth = Math.max(
+      m2px(0.18, ppm),
+      m2px(layout.openingH * projectedDepthScale, ppm)
+    );
+    const bannerDepth = Math.max(
+      m2px(0.16, ppm),
+      m2px(
+        layout.bannerH * projectedDepthScale * DIVE_GATE_2D_BANNER_VISUAL_SCALE,
+        ppm
+      )
+    );
+    const outerDepth = openingDepth + bannerDepth * 2;
+    const outerW = openingW + sidePanelVisualW * 2;
+    const frameTube = Math.max(2, m2px(shape.thick ?? 0.055, ppm));
+    const allPoints = [
+      ...pipeSegments.flatMap((segment) => [segment.start, segment.end]),
+      ...couplerPoints,
+      { x: -outerW / 2, y: -outerDepth / 2 },
+      { x: outerW / 2, y: outerDepth / 2 },
+    ];
+    const minX = Math.min(...allPoints.map((point) => point.x)) - frameTube;
+    const maxX = Math.max(...allPoints.map((point) => point.x)) + frameTube;
+    const minY = Math.min(...allPoints.map((point) => point.y)) - frameTube;
+    const maxY = Math.max(...allPoints.map((point) => point.y)) + frameTube;
+
+    return {
+      bounds: {
+        height: maxY - minY,
+        width: maxX - minX,
+        x: minX,
+        y: minY,
+      },
+      color: visual.banner.color,
+      bannerDepth,
+      couplerRadius: Math.max(2.5, frameTube * 0.75),
+      couplerPoints,
+      frameColor: visual.frame.color,
+      frameTube,
+      openingDepth,
+      openingW,
+      outerDepth,
+      outerW,
+      pipeSegments,
+      sidePanelW,
+      variant: "arch" as const,
+    };
+  }
+
+  const size = m2px(shape.width ?? 2.8, ppm);
   const thick = m2px(shape.thick ?? 0.2, ppm);
   const tilt = shape.tilt ?? 0;
   const visibleDepth = Math.max(
@@ -164,6 +283,7 @@ export function getDiveGate2DShape(shape: DiveGateShape, ppm: number) {
     inset,
     postRadius,
     size,
+    variant: "frame-only" as const,
     visibleDepth,
   };
 }

--- a/src/lib/track/shape2d.ts
+++ b/src/lib/track/shape2d.ts
@@ -4,7 +4,10 @@ import {
   getGateVisualSpec,
   getLadderVisualSpec,
 } from "@/lib/track/elements/visual";
-import { getMultiGpDiveGateArchLayout } from "@/lib/track/render3d-layout";
+import {
+  getMultiGpDiveGateArchLayout,
+  getMultiGpLaunchGateLayout,
+} from "@/lib/track/render3d-layout";
 import type {
   ConeShape,
   DiveGateShape,
@@ -202,6 +205,57 @@ export function getDiveGateArchPanelPath(options: {
 
 export function getDiveGate2DShape(shape: DiveGateShape, ppm: number) {
   const visual = getDiveGateVisualSpec(shape);
+  if (visual?.variant === "launch") {
+    const layout = getMultiGpLaunchGateLayout(shape);
+    const toPoint = ([x, , z]: [number, number, number]) => ({
+      x: m2px(x, ppm),
+      y: m2px(z, ppm),
+    });
+    const pipeSegments = layout.pipeSegments.map(({ end, start }) => ({
+      end: toPoint(end),
+      start: toPoint(start),
+    }));
+    const couplerPoints = layout.couplerPoints.map(({ x, z }) => ({
+      x: m2px(x, ppm),
+      y: m2px(z, ppm),
+    }));
+    const outerW = m2px(layout.outerW, ppm);
+    const outerDepth = m2px(layout.outerD, ppm);
+    const openingW = m2px(layout.openingW, ppm);
+    const openingDepth = m2px(layout.openingD, ppm);
+    const frameTube = Math.max(2, m2px(shape.thick ?? 0.055, ppm));
+    const allPoints = [
+      ...pipeSegments.flatMap((segment) => [segment.start, segment.end]),
+      ...couplerPoints,
+      { x: -outerW / 2, y: -outerDepth / 2 },
+      { x: outerW / 2, y: outerDepth / 2 },
+    ];
+    const minX = Math.min(...allPoints.map((point) => point.x)) - frameTube;
+    const maxX = Math.max(...allPoints.map((point) => point.x)) + frameTube;
+    const minY = Math.min(...allPoints.map((point) => point.y)) - frameTube;
+    const maxY = Math.max(...allPoints.map((point) => point.y)) + frameTube;
+
+    return {
+      bounds: {
+        height: maxY - minY,
+        width: maxX - minX,
+        x: minX,
+        y: minY,
+      },
+      color: visual.banner.color,
+      couplerRadius: Math.max(2.5, frameTube * 0.75),
+      couplerPoints,
+      frameColor: visual.frame.color,
+      frameTube,
+      openingDepth,
+      openingW,
+      outerDepth,
+      outerW,
+      pipeSegments,
+      variant: "launch" as const,
+    };
+  }
+
   if (visual?.variant === "arch") {
     const layout = getMultiGpDiveGateArchLayout(shape);
     const toPoint = ([x, , z]: [number, number, number]) => ({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,7 +71,7 @@ export interface LadderShape extends BaseShape {
 export interface DiveGateShape extends BaseShape {
   kind: "divegate";
   width: number; // m width of flying opening (or square frame side for generic variant)
-  height?: number; // m height of flying opening (defaults to width for square frame)
+  height?: number; // m secondary opening/footprint span, depending on variant (defaults to width for square frame)
   thick?: number; // m frame/panel width (default 0.20)
   tilt?: number; // degrees from vertical: 0=vertical wall, 90=flat/horizontal (generic only)
   elevation?: number; // m height of frame center above ground (generic variant, default 3.0)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,10 +70,11 @@ export interface LadderShape extends BaseShape {
 
 export interface DiveGateShape extends BaseShape {
   kind: "divegate";
-  size: number; // m outer dimension (square frame)
+  width: number; // m width of flying opening (or square frame side for generic variant)
+  height?: number; // m height of flying opening (defaults to width for square frame)
   thick?: number; // m frame/panel width (default 0.20)
-  tilt?: number; // degrees from vertical: 0=vertical wall, 90=flat/horizontal
-  elevation?: number; // m height of frame center above ground (default 3.0)
+  tilt?: number; // degrees from vertical: 0=vertical wall, 90=flat/horizontal (generic only)
+  elevation?: number; // m height of frame center above ground (generic variant, default 3.0)
 }
 
 export interface PolylinePoint {

--- a/tests/lib/canvas/interaction-helpers.test.ts
+++ b/tests/lib/canvas/interaction-helpers.test.ts
@@ -171,7 +171,7 @@ describe("canvas interaction helpers", () => {
         currentTargetScale: 1,
         deltaY: -100,
       })
-    ).toBeGreaterThan(1);
+    ).toBeCloseTo(Math.exp(0.3));
 
     expect(
       getZoomedStagePosition({

--- a/tests/lib/editor-tools.test.ts
+++ b/tests/lib/editor-tools.test.ts
@@ -59,7 +59,7 @@ describe("editor tool helpers", () => {
     });
     expect(createShapeForTool("divegate", point)).toMatchObject({
       kind: "divegate",
-      size: 2.8,
+      width: 2.8,
       thick: 0.2,
       tilt: 0,
       elevation: 3,

--- a/tests/lib/planning/setup-estimate.test.ts
+++ b/tests/lib/planning/setup-estimate.test.ts
@@ -55,7 +55,7 @@ describe("setup estimate helpers", () => {
           x: 14,
           y: 18,
           rotation: 0,
-          size: 2.8,
+          width: 2.8,
           tilt: 30,
           elevation: 4,
         },

--- a/tests/lib/track/design.test.ts
+++ b/tests/lib/track/design.test.ts
@@ -81,6 +81,41 @@ describe("track design helpers", () => {
     expect(normalized.shapeById["gate-1"]?.kind).toBe("gate");
   });
 
+  it("migrates legacy dive gate size storage to width", () => {
+    const normalized = normalizeDesign({
+      id: "design-legacy-divegate",
+      version: 2,
+      title: "Layout",
+      description: "",
+      tags: [],
+      authorName: "",
+      inventory,
+      field: { width: 60, height: 40, origin: "tl", gridStep: 1, ppm: 20 },
+      shapes: [
+        {
+          id: "dive-1",
+          kind: "divegate",
+          x: 10,
+          y: 8,
+          rotation: 0,
+          size: 2.8,
+          tilt: 30,
+          elevation: 3,
+        },
+      ],
+      createdAt: "2026-04-13T10:00:00.000Z",
+      updatedAt: "2026-04-13T10:00:00.000Z",
+    } as unknown as SerializedTrackDesign);
+
+    expect(normalized.shapeById["dive-1"]).toMatchObject({
+      kind: "divegate",
+      width: 2.8,
+      tilt: 30,
+      elevation: 3,
+    });
+    expect("size" in normalized.shapeById["dive-1"]!).toBe(false);
+  });
+
   it("normalizes timing marker metadata on supported shapes", () => {
     const design = normalizeDesign({
       id: "design-timing",

--- a/tests/lib/track/elements/catalog.test.ts
+++ b/tests/lib/track/elements/catalog.test.ts
@@ -9,6 +9,7 @@ import {
   MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
   MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID,
   MULTIGP_DIVE_GATE_7X6_ELEMENT_ID,
+  MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID,
   MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
   MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID,
   MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID,
@@ -53,6 +54,7 @@ describe("track element catalog", () => {
     ).toEqual([
       TRACKDRAW_DIVE_GATE_ELEMENT_ID,
       MULTIGP_DIVE_GATE_7X6_ELEMENT_ID,
+      MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID,
     ]);
   });
 
@@ -179,6 +181,37 @@ describe("track element catalog", () => {
     });
     expect(diveGate?.dimensions.widthMeters).toBeCloseTo(feetToMeters(7));
     expect(diveGate?.dimensions.heightMeters).toBeCloseTo(feetToMeters(6));
+  });
+
+  it("documents the official MultiGP launch gate and texture", () => {
+    const launchGate = getTrackElementCatalogEntry(
+      MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID
+    );
+
+    expect(launchGate).toMatchObject({
+      name: "MultiGP Launch Gate 7x6",
+      organization: "MultiGP",
+      kind: "divegate",
+      official: true,
+      dimensions: {
+        display: {
+          unitSystem: "imperial",
+          label: "7 ft x 6 ft",
+        },
+      },
+      visual: {
+        kind: "divegate",
+        variant: "launch",
+        banner: {
+          sideTexture:
+            "/assets/models/textures/multigp-obstacles/large-side-panel-multigp.webp",
+          topTexture:
+            "/assets/models/textures/multigp-obstacles/large-top-multigp.webp",
+        },
+      },
+    });
+    expect(launchGate?.dimensions.widthMeters).toBeCloseTo(feetToMeters(7));
+    expect(launchGate?.dimensions.heightMeters).toBeCloseTo(feetToMeters(6));
   });
 
   it("can stamp catalog identity metadata when a placement flow asks for it", () => {

--- a/tests/lib/track/elements/catalog.test.ts
+++ b/tests/lib/track/elements/catalog.test.ts
@@ -8,9 +8,11 @@ import {
   getTrackElementCatalogIdentity,
   MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
   MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID,
+  MULTIGP_DIVE_GATE_7X6_ELEMENT_ID,
   MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
   MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID,
   MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID,
+  TRACKDRAW_DIVE_GATE_ELEMENT_ID,
   TRACKDRAW_GATE_ELEMENT_ID,
   TRACKDRAW_LADDER_ELEMENT_ID,
   trackElementCatalog,
@@ -42,6 +44,15 @@ describe("track element catalog", () => {
       MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID,
       MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID,
       MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID,
+    ]);
+  });
+
+  it("exposes dive gate entries for placement controls", () => {
+    expect(
+      getCatalogEntriesByKind("divegate").map((entry) => entry.id)
+    ).toEqual([
+      TRACKDRAW_DIVE_GATE_ELEMENT_ID,
+      MULTIGP_DIVE_GATE_7X6_ELEMENT_ID,
     ]);
   });
 
@@ -140,6 +151,34 @@ describe("track element catalog", () => {
     expect(toplessLadder?.dimensions.heightMeters).toBeCloseTo(
       feetToMeters(6) * 3
     );
+  });
+
+  it("documents the official MultiGP dive gate opening and textures", () => {
+    const diveGate = getTrackElementCatalogEntry(
+      MULTIGP_DIVE_GATE_7X6_ELEMENT_ID
+    );
+
+    expect(diveGate).toMatchObject({
+      name: "MultiGP Dive Gate 7x6",
+      organization: "MultiGP",
+      kind: "divegate",
+      official: true,
+      dimensions: {
+        display: { unitSystem: "imperial", label: "7 ft x 6 ft" },
+      },
+      visual: {
+        kind: "divegate",
+        variant: "arch",
+        banner: {
+          sideTexture:
+            "/assets/models/textures/multigp-obstacles/large-side-panel-multigp.webp",
+          topTexture:
+            "/assets/models/textures/multigp-obstacles/large-top-multigp.webp",
+        },
+      },
+    });
+    expect(diveGate?.dimensions.widthMeters).toBeCloseTo(feetToMeters(7));
+    expect(diveGate?.dimensions.heightMeters).toBeCloseTo(feetToMeters(6));
   });
 
   it("can stamp catalog identity metadata when a placement flow asks for it", () => {

--- a/tests/lib/track/orientation.test.ts
+++ b/tests/lib/track/orientation.test.ts
@@ -61,7 +61,7 @@ describe("track orientation helpers", () => {
       x: 0,
       y: 0,
       rotation: 30,
-      size: 2.8,
+      width: 2.8,
     };
 
     expect(getShapeFacingDegrees(diveGate)).toBe(120);

--- a/tests/lib/track/render3d-layout.test.ts
+++ b/tests/lib/track/render3d-layout.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  getMultiGpDiveGateArchLayout,
+  getMultiGpDiveGateArchTopY,
+} from "@/lib/track/render3d-layout";
+import { feetToMeters } from "@/lib/track/units";
+
+describe("track 3D layout helpers", () => {
+  it("derives the official MultiGP dive gate sloped plane and coupler heights", () => {
+    const layout = getMultiGpDiveGateArchLayout({
+      width: feetToMeters(7),
+      height: feetToMeters(6),
+    });
+
+    expect(layout.topY).toBeCloseTo(feetToMeters(15));
+    expect(getMultiGpDiveGateArchTopY()).toBeCloseTo(feetToMeters(15));
+    expect(layout.cornerPoints[0]?.[1]).toBeCloseTo(feetToMeters(12));
+    expect(layout.cornerPoints[2]?.[1]).toBeCloseTo(feetToMeters(15));
+    expect(layout.pipeSegments).toHaveLength(6);
+    expect(layout.pipeSegments[2]?.start[0]).toBeCloseTo(
+      layout.cornerPoints[2]?.[0] ?? 0
+    );
+    expect(layout.pipeSegments[2]?.end[0]).toBeCloseTo(
+      (layout.cornerPoints[2]?.[0] ?? 0) - feetToMeters(2)
+    );
+    expect(layout.pipeSegments[4]?.end[0]).toBeCloseTo(
+      (layout.cornerPoints[3]?.[0] ?? 0) + feetToMeters(2)
+    );
+    expect(layout.couplerPoints.map((point) => point.height)).toEqual([
+      feetToMeters(2),
+      feetToMeters(2),
+      feetToMeters(5),
+      feetToMeters(5),
+    ]);
+  });
+});

--- a/tests/lib/track/render3d-layout.test.ts
+++ b/tests/lib/track/render3d-layout.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   getMultiGpDiveGateArchLayout,
   getMultiGpDiveGateArchTopY,
+  getMultiGpLaunchGateLayout,
+  getMultiGpLaunchGateTopY,
 } from "@/lib/track/render3d-layout";
 import { feetToMeters } from "@/lib/track/units";
 
@@ -29,6 +31,30 @@ describe("track 3D layout helpers", () => {
     expect(layout.couplerPoints.map((point) => point.height)).toEqual([
       feetToMeters(2),
       feetToMeters(2),
+      feetToMeters(5),
+      feetToMeters(5),
+    ]);
+  });
+
+  it("derives the official MultiGP launch gate overhead layout", () => {
+    const layout = getMultiGpLaunchGateLayout({
+      width: feetToMeters(7),
+      height: feetToMeters(6),
+    });
+
+    expect(layout.topY).toBeCloseTo(feetToMeters(15));
+    expect(getMultiGpLaunchGateTopY()).toBeCloseTo(feetToMeters(15));
+    expect(layout.openingW).toBeCloseTo(feetToMeters(7));
+    expect(layout.openingD).toBeCloseTo(feetToMeters(6));
+    expect(layout.outerW).toBeCloseTo(feetToMeters(10));
+    expect(layout.outerD).toBeCloseTo(feetToMeters(10));
+    expect(layout.sidePanelW).toBeCloseTo(feetToMeters(1.5));
+    expect(layout.endPanelD).toBeCloseTo(feetToMeters(2));
+    expect(layout.pipeSegments).toHaveLength(12);
+    expect(layout.couplerPoints).toHaveLength(4);
+    expect(layout.couplerPoints.map((point) => point.height)).toEqual([
+      feetToMeters(5),
+      feetToMeters(5),
       feetToMeters(5),
       feetToMeters(5),
     ]);

--- a/tests/lib/track/shape2d.test.ts
+++ b/tests/lib/track/shape2d.test.ts
@@ -10,9 +10,10 @@ import {
 import { feetToMeters } from "@/lib/track/units";
 import {
   createCatalogShapeDraft,
+  MULTIGP_DIVE_GATE_7X6_ELEMENT_ID,
   MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
 } from "@/lib/track/elements/catalog";
-import type { GateShape } from "@/lib/types";
+import type { DiveGateShape, GateShape } from "@/lib/types";
 
 describe("track 2d shape helpers", () => {
   const ppm = 20;
@@ -108,7 +109,7 @@ describe("track 2d shape helpers", () => {
         x: 0,
         y: 0,
         rotation: 0,
-        size: 2.8,
+        width: 2.8,
         tilt: 60,
       },
       ppm
@@ -142,5 +143,25 @@ describe("track 2d shape helpers", () => {
     expect(gate.panels.rightWidth).toBeCloseTo(feetToMeters(1) * ppm);
     expect(gate.panels.topColor).toBe("#202e5d");
     expect(gate.frame.placement).toBe("outer");
+  });
+
+  it("uses a top-down footprint for the official MultiGP dive gate", () => {
+    const shape = createCatalogShapeDraft(MULTIGP_DIVE_GATE_7X6_ELEMENT_ID, {
+      x: 0,
+      y: 0,
+      includeCatalogMetadata: true,
+    }) as DiveGateShape;
+    const diveGate = getDiveGate2DShape(shape, ppm);
+
+    expect(diveGate.variant).toBe("arch");
+    if (diveGate.variant !== "arch") {
+      throw new Error("expected arch dive gate metrics");
+    }
+    expect(diveGate.openingW).toBeCloseTo(feetToMeters(7) * ppm);
+    expect(diveGate.sidePanelW).toBeCloseTo(feetToMeters(2) * ppm);
+    expect(diveGate.pipeSegments).toHaveLength(6);
+    expect(diveGate.couplerPoints).toHaveLength(4);
+    expect(diveGate.bounds.width).toBeGreaterThan(diveGate.openingW);
+    expect(diveGate.bounds.height).toBeGreaterThan(diveGate.openingDepth);
   });
 });

--- a/tests/lib/track/shape2d.test.ts
+++ b/tests/lib/track/shape2d.test.ts
@@ -11,6 +11,7 @@ import { feetToMeters } from "@/lib/track/units";
 import {
   createCatalogShapeDraft,
   MULTIGP_DIVE_GATE_7X6_ELEMENT_ID,
+  MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID,
   MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
 } from "@/lib/track/elements/catalog";
 import type { DiveGateShape, GateShape } from "@/lib/types";
@@ -163,5 +164,27 @@ describe("track 2d shape helpers", () => {
     expect(diveGate.couplerPoints).toHaveLength(4);
     expect(diveGate.bounds.width).toBeGreaterThan(diveGate.openingW);
     expect(diveGate.bounds.height).toBeGreaterThan(diveGate.openingDepth);
+  });
+
+  it("uses a top-down square footprint for the official MultiGP launch gate", () => {
+    const shape = createCatalogShapeDraft(MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID, {
+      x: 0,
+      y: 0,
+      includeCatalogMetadata: true,
+    }) as DiveGateShape;
+    const launchGate = getDiveGate2DShape(shape, ppm);
+
+    expect(launchGate.variant).toBe("launch");
+    if (launchGate.variant !== "launch") {
+      throw new Error("expected launch gate metrics");
+    }
+    expect(launchGate.openingW).toBeCloseTo(feetToMeters(7) * ppm);
+    expect(launchGate.openingDepth).toBeCloseTo(feetToMeters(6) * ppm);
+    expect(launchGate.outerW).toBeCloseTo(feetToMeters(10) * ppm);
+    expect(launchGate.outerDepth).toBeCloseTo(feetToMeters(10) * ppm);
+    expect(launchGate.pipeSegments).toHaveLength(12);
+    expect(launchGate.couplerPoints).toHaveLength(4);
+    expect(launchGate.bounds.width).toBeGreaterThan(launchGate.openingW);
+    expect(launchGate.bounds.height).toBeGreaterThan(launchGate.openingDepth);
   });
 });


### PR DESCRIPTION
## Summary

- **Dive Gate 7x6**: new arch-style element with configurable banner panels (left, right, top, bottom); added `placement` to `ArchDiveGateVisualSpec` matching the same pattern as `LaunchGateVisualSpec`; added `resolveArchDiveGateBannerTextureMapping` to `render3d-layout.ts`; wired `ArchDiveGate3D` up with `catalogId`, `useOverrideVersion`, `registerPanel`, and `getEffectiveFlips`/`getEffectiveRotation`
- **Launch Gate 7x6**: new tall gate with four configurable banner panels; full 3D rendering with panel texture support and size variants
- **Texture orientations**: corrected placements for all MultiGP panel-frame elements using explicit `textureTopEdgeFaces` configs (standard gate 5x5, championship gate 7x6, standard ladder 5x5, championship ladder 7x6, topless ladder 7x6)
- **Shadow fix**: added `castShadow receiveShadow` to arch dive gate and launch gate banner planes — light was passing through thin planes as if they were transparent
- **Texture color fix**: all banner planes now use `color="#ffffff"` so the texture map is not darkened by the element's navy panel color (`#202e5d`)
- **TextureDebugPopup**: redesigned to match `PerformanceHud` exactly — framer-motion entry animation, dark/light HUD color tokens, `w-74 rounded-2xl`, two-line row layout with X/Y flip toggles and a full-width edge segmented control per panel
