### PR TITLE
test: Expand meaningful TrackDraw coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ AI agents are expected to keep this file current. When a change introduces a dur
 - `src/lib`: design normalization, geometry, sharing, export, and helpers
 - `src/types`: shared TypeScript types
 - `tests`: unit, regression, and component coverage grouped by product area or module
+- `tests/helpers`: shared test fixtures, browser storage fakes, D1 statement mocks, and editor-store builders; reuse these before adding per-file mock factories
 - `migrations`: D1 database migrations
 - `public`: static assets and generated public media references
 - `docs`: roadmap and planning docs; keep product language aligned with shipped behavior

--- a/tests/app/api/account/session.route.test.ts
+++ b/tests/app/api/account/session.route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/server/auth-session", () => ({
+  getCurrentUserFromHeaders: vi.fn(),
+}));
+
+import { GET } from "@/app/api/account/session/route";
+import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
+import { testUser } from "../../../helpers/api-routes";
+
+describe("account session API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns the resolved user when a valid browser session exists", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(testUser);
+
+    const response = await GET(
+      new Request("http://localhost/api/account/session", {
+        headers: { cookie: "better-auth.session_token=signed" },
+      })
+    );
+
+    expect(getCurrentUserFromHeaders).toHaveBeenCalledWith(expect.any(Headers));
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      user: testUser,
+    });
+  });
+
+  it("returns a null user for anonymous browser sessions", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
+
+    const response = await GET(
+      new Request("http://localhost/api/account/session")
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      user: null,
+    });
+  });
+
+  it("surfaces session resolver failures as a 500 response", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockRejectedValue(
+      new Error("D1 unavailable")
+    );
+
+    const response = await GET(
+      new Request("http://localhost/api/account/session")
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "D1 unavailable",
+    });
+  });
+});

--- a/tests/app/api/dashboard/gallery.route.test.ts
+++ b/tests/app/api/dashboard/gallery.route.test.ts
@@ -39,53 +39,20 @@ import {
   moveGalleryEntryToListed,
 } from "@/lib/server/gallery";
 import { resolveStoredShare } from "@/lib/server/shares";
-import type { StoredShare } from "@/lib/server/shares";
+import {
+  createGalleryEntryFixture,
+  createStoredShareFixture,
+  moderatorActor,
+  routeContext,
+} from "../../../helpers/api-routes";
 
-const actor = {
-  id: "mod-1",
-  email: "mod@trackdraw.local",
-  name: "Moderator",
-  image: null,
-  role: "moderator" as const,
-};
-
-const entry = {
-  id: "entry-1",
-  shareToken: "share-token",
-  ownerUserId: "owner-1",
-  galleryState: "listed" as const,
-  galleryTitle: "Track",
-  galleryDescription: "Public description",
-  galleryPreviewImage: "gallery/previews/entry-1.webp",
-  galleryPublishedAt: "2026-04-20T10:00:00.000Z",
-  moderationHiddenAt: null,
-  createdAt: "2026-04-20T09:00:00.000Z",
-  updatedAt: "2026-04-20T10:00:00.000Z",
-};
-
-const storedShare = {
-  id: "share-id",
-  token: "share-token",
-  design: {
-    title: "Track",
-    description: "Description",
-    field: { width: 30, height: 20, gridStep: 5 },
-    shapes: [],
-  },
-  title: "Track",
-  description: "Description",
-  shapeCount: 0,
-  fieldWidth: 30,
-  fieldHeight: 20,
-  createdAt: "2026-04-20T10:00:00.000Z",
-  updatedAt: "2026-04-20T10:00:00.000Z",
-  publishedAt: "2026-04-20T10:00:00.000Z",
+const entry = createGalleryEntryFixture();
+const storedShare = createStoredShareFixture({
   expiresAt: null,
-  revokedAt: null,
   ownerUserId: "owner-1",
   projectId: "project-1",
   shareType: "published",
-} as unknown as StoredShare;
+});
 
 function patchRequest(action: string) {
   return new Request("http://localhost/api/dashboard/gallery/share-token", {
@@ -102,13 +69,13 @@ function deleteRequest() {
 }
 
 function context() {
-  return { params: Promise.resolve({ shareToken: "share-token" }) };
+  return routeContext({ shareToken: "share-token" });
 }
 
 describe("dashboard gallery API route", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(actor);
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(moderatorActor);
     vi.mocked(hasCapability).mockReturnValue(true);
     vi.mocked(getGalleryEntryByShareToken)
       .mockResolvedValueOnce(entry)
@@ -150,7 +117,7 @@ describe("dashboard gallery API route", () => {
     expect(resolveStoredShare).toHaveBeenCalledWith("share-token");
     expect(moveGalleryEntryToFeatured).toHaveBeenCalledWith("share-token");
     expect(createAuditEvent).toHaveBeenCalledWith({
-      actorUserId: actor.id,
+      actorUserId: moderatorActor.id,
       targetUserId: entry.ownerUserId,
       eventType: "gallery.entry.featured",
       entityType: "gallery_entry",
@@ -213,7 +180,7 @@ describe("dashboard gallery API route", () => {
     await expect(response.json()).resolves.toEqual({ ok: true });
     expect(deleteGalleryEntry).toHaveBeenCalledWith("share-token");
     expect(createAuditEvent).toHaveBeenCalledWith({
-      actorUserId: actor.id,
+      actorUserId: moderatorActor.id,
       targetUserId: entry.ownerUserId,
       eventType: "gallery.entry.deleted",
       entityType: "gallery_entry",

--- a/tests/app/api/dashboard/users.route.test.ts
+++ b/tests/app/api/dashboard/users.route.test.ts
@@ -25,7 +25,6 @@ vi.mock("@/lib/server/audit", () => ({
 
 import { GET } from "@/app/api/dashboard/users/route";
 import { PATCH } from "@/app/api/dashboard/users/[userId]/route";
-import type { AdminUser } from "@/lib/admin-users";
 import { createAuditEvent } from "@/lib/server/audit";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 import {
@@ -38,32 +37,25 @@ import {
   listUsersForAdmin,
   updateUserRole,
 } from "@/lib/server/users";
+import {
+  adminActor,
+  createAdminUserFixture,
+  jsonRequest,
+  moderatorActor,
+  routeContext,
+} from "../../../helpers/api-routes";
 
-const adminActor = {
-  id: "admin-1",
-  email: "admin@trackdraw.local",
-  name: "Admin",
-  image: null,
-  role: "admin" as const,
-};
+const targetUser = createAdminUserFixture();
 
-const moderatorActor = {
-  id: "mod-1",
-  email: "mod@trackdraw.local",
-  name: "Moderator",
-  image: null,
-  role: "moderator" as const,
-};
+function patchRoleRequest(role: string) {
+  return jsonRequest("http://localhost/api/dashboard/users/user-2", "PATCH", {
+    role,
+  });
+}
 
-const targetUser: AdminUser = {
-  id: "user-2",
-  name: "Target User",
-  email: "target@trackdraw.local",
-  image: null,
-  role: "user",
-  createdAt: "2026-01-01T00:00:00.000Z",
-  updatedAt: "2026-01-01T00:00:00.000Z",
-};
+function userContext() {
+  return routeContext({ userId: "user-2" });
+}
 
 describe("dashboard users API routes", () => {
   beforeEach(() => {
@@ -123,11 +115,8 @@ describe("dashboard users API routes", () => {
       vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
 
       const response = await PATCH(
-        new Request("http://localhost/api/dashboard/users/user-2", {
-          method: "PATCH",
-          body: JSON.stringify({ role: "moderator" }),
-        }),
-        { params: Promise.resolve({ userId: "user-2" }) }
+        patchRoleRequest("moderator"),
+        userContext()
       );
 
       expect(response.status).toBe(401);
@@ -142,11 +131,8 @@ describe("dashboard users API routes", () => {
       vi.mocked(canAssignAccountRole).mockReturnValue(false);
 
       const response = await PATCH(
-        new Request("http://localhost/api/dashboard/users/user-2", {
-          method: "PATCH",
-          body: JSON.stringify({ role: "moderator" }),
-        }),
-        { params: Promise.resolve({ userId: "user-2" }) }
+        patchRoleRequest("moderator"),
+        userContext()
       );
 
       expect(response.status).toBe(403);
@@ -157,20 +143,14 @@ describe("dashboard users API routes", () => {
     });
 
     it("prevents demoting the last admin", async () => {
-      const loneAdminUser: AdminUser = { ...targetUser, role: "admin" };
+      const loneAdminUser = createAdminUserFixture({ role: "admin" });
 
       vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
       vi.mocked(canAssignAccountRole).mockReturnValue(true);
       vi.mocked(getAdminUserById).mockResolvedValue(loneAdminUser);
       vi.mocked(countUsersByRole).mockResolvedValue(1);
 
-      const response = await PATCH(
-        new Request("http://localhost/api/dashboard/users/user-2", {
-          method: "PATCH",
-          body: JSON.stringify({ role: "user" }),
-        }),
-        { params: Promise.resolve({ userId: "user-2" }) }
-      );
+      const response = await PATCH(patchRoleRequest("user"), userContext());
 
       expect(response.status).toBe(400);
       await expect(response.json()).resolves.toEqual({
@@ -182,18 +162,15 @@ describe("dashboard users API routes", () => {
     });
 
     it("returns early without writing when the role does not change", async () => {
-      const existingModerator: AdminUser = { ...targetUser, role: "moderator" };
+      const existingModerator = createAdminUserFixture({ role: "moderator" });
 
       vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
       vi.mocked(canAssignAccountRole).mockReturnValue(true);
       vi.mocked(getAdminUserById).mockResolvedValue(existingModerator);
 
       const response = await PATCH(
-        new Request("http://localhost/api/dashboard/users/user-2", {
-          method: "PATCH",
-          body: JSON.stringify({ role: "moderator" }),
-        }),
-        { params: Promise.resolve({ userId: "user-2" }) }
+        patchRoleRequest("moderator"),
+        userContext()
       );
 
       expect(response.status).toBe(200);
@@ -206,7 +183,7 @@ describe("dashboard users API routes", () => {
     });
 
     it("updates the role and writes an audit event", async () => {
-      const updatedUser: AdminUser = { ...targetUser, role: "moderator" };
+      const updatedUser = createAdminUserFixture({ role: "moderator" });
 
       vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
       vi.mocked(canAssignAccountRole).mockReturnValue(true);
@@ -214,11 +191,8 @@ describe("dashboard users API routes", () => {
       vi.mocked(updateUserRole).mockResolvedValue(updatedUser);
 
       const response = await PATCH(
-        new Request("http://localhost/api/dashboard/users/user-2", {
-          method: "PATCH",
-          body: JSON.stringify({ role: "moderator" }),
-        }),
-        { params: Promise.resolve({ userId: "user-2" }) }
+        patchRoleRequest("moderator"),
+        userContext()
       );
 
       expect(response.status).toBe(200);

--- a/tests/app/api/media.route.test.ts
+++ b/tests/app/api/media.route.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockMediaBucket,
+  createR2ObjectBody,
+  installCloudflareMediaBucket,
+} from "../../helpers/cloudflare";
+import { routeContext } from "../../helpers/api-routes";
+
+const mocks = vi.hoisted(() => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: mocks.getCloudflareContext,
+}));
+
+import { GET } from "@/app/api/media/[...key]/route";
+
+function mediaContext(key: string[]) {
+  return routeContext({ key });
+}
+
+describe("media API route", () => {
+  beforeEach(() => {
+    mocks.getCloudflareContext.mockReset();
+  });
+
+  it("rejects empty media keys before reading R2", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/media"),
+      mediaContext([""])
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe("Missing media key");
+    expect(mocks.getCloudflareContext).not.toHaveBeenCalled();
+  });
+
+  it("returns a server error when the media bucket binding is missing", async () => {
+    installCloudflareMediaBucket(mocks.getCloudflareContext, null);
+
+    const response = await GET(
+      new Request("http://localhost/api/media/gallery/previews/entry-1.webp"),
+      mediaContext(["gallery", "previews", "entry-1.webp"])
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.text()).resolves.toBe("Missing media bucket binding");
+  });
+
+  it("returns 404 when the R2 object does not exist", async () => {
+    const bucket = createMockMediaBucket();
+    installCloudflareMediaBucket(mocks.getCloudflareContext, bucket);
+
+    const response = await GET(
+      new Request("http://localhost/api/media/gallery/previews/missing.webp"),
+      mediaContext(["gallery", "previews", "missing.webp"])
+    );
+
+    expect(bucket.get).toHaveBeenCalledWith("gallery/previews/missing.webp");
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Media object not found");
+  });
+
+  it("serves media objects with R2 metadata, etag, and cache headers", async () => {
+    const bucket = createMockMediaBucket({
+      get: vi.fn(async () =>
+        createR2ObjectBody({
+          body: "webp-body",
+          etag: '"etag-1"',
+          cacheControl: "public, max-age=60",
+          contentType: "image/webp",
+        })
+      ),
+    });
+    installCloudflareMediaBucket(mocks.getCloudflareContext, bucket);
+
+    const response = await GET(
+      new Request("http://localhost/api/media/gallery/previews/entry-1.webp"),
+      mediaContext(["gallery", "", "previews", "entry-1.webp"])
+    );
+
+    expect(response.status).toBe(200);
+    expect(bucket.get).toHaveBeenCalledWith("gallery/previews/entry-1.webp");
+    expect(response.headers.get("content-type")).toBe("image/webp");
+    expect(response.headers.get("etag")).toBe('"etag-1"');
+    expect(response.headers.get("cache-control")).toBe("public, max-age=60");
+    await expect(response.text()).resolves.toBe("webp-body");
+  });
+
+  it("falls back to octet-stream content type and immutable caching", async () => {
+    const bucket = createMockMediaBucket({
+      get: vi.fn(async () =>
+        createR2ObjectBody({
+          body: "asset-body",
+          etag: '"etag-2"',
+        })
+      ),
+    });
+    installCloudflareMediaBucket(mocks.getCloudflareContext, bucket);
+
+    const response = await GET(
+      new Request("http://localhost/api/media/gallery/previews/entry-2.webp"),
+      mediaContext(["gallery", "previews", "entry-2.webp"])
+    );
+
+    expect(response.headers.get("content-type")).toBe(
+      "application/octet-stream"
+    );
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable"
+    );
+  });
+});

--- a/tests/app/api/project.route.test.ts
+++ b/tests/app/api/project.route.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createStoredProjectFixture,
+  routeContext,
+  testUser,
+} from "../../helpers/api-routes";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/server/auth-session", () => ({
+  getCurrentUserFromHeaders: vi.fn(),
+}));
+
+vi.mock("@/lib/server/csrf", () => ({
+  isTrustedRequest: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/server/projects", () => ({
+  archiveProjectForUser: vi.fn(),
+  getProjectForUser: vi.fn(),
+}));
+
+import { DELETE, GET } from "@/app/api/projects/[projectId]/route";
+import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
+import { isTrustedRequest } from "@/lib/server/csrf";
+import {
+  archiveProjectForUser,
+  getProjectForUser,
+} from "@/lib/server/projects";
+
+function projectRequest(method = "GET") {
+  return new Request("http://localhost/api/projects/project-1", { method });
+}
+
+function projectContext(projectId = "project-1") {
+  return routeContext({ projectId });
+}
+
+describe("project API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(testUser);
+    vi.mocked(isTrustedRequest).mockReturnValue(true);
+  });
+
+  it("requires an authenticated user before loading a project", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
+
+    const response = await GET(projectRequest(), projectContext());
+
+    expect(response.status).toBe(401);
+    expect(getProjectForUser).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error:
+        "Authenticated cloud project access is not available for this request.",
+    });
+  });
+
+  it("returns 404 when the project is not owned by the user", async () => {
+    vi.mocked(getProjectForUser).mockResolvedValue(null);
+
+    const response = await GET(projectRequest(), projectContext());
+
+    expect(response.status).toBe(404);
+    expect(getProjectForUser).toHaveBeenCalledWith("project-1", testUser.id);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Project not found",
+    });
+  });
+
+  it("returns the stored project for the authenticated owner", async () => {
+    const project = createStoredProjectFixture();
+    vi.mocked(getProjectForUser).mockResolvedValue(project);
+
+    const response = await GET(projectRequest(), projectContext());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, project });
+  });
+
+  it("blocks archive requests that fail the trusted-request guard", async () => {
+    vi.mocked(isTrustedRequest).mockReturnValue(false);
+
+    const response = await DELETE(projectRequest("DELETE"), projectContext());
+
+    expect(response.status).toBe(403);
+    expect(getCurrentUserFromHeaders).not.toHaveBeenCalled();
+    expect(archiveProjectForUser).not.toHaveBeenCalled();
+  });
+
+  it("archives the project for the authenticated owner", async () => {
+    const response = await DELETE(projectRequest("DELETE"), projectContext());
+
+    expect(response.status).toBe(200);
+    expect(archiveProjectForUser).toHaveBeenCalledWith(
+      "project-1",
+      testUser.id
+    );
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+});

--- a/tests/app/api/projects.route.test.ts
+++ b/tests/app/api/projects.route.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultDesign } from "@/lib/track/design";
 import type { StoredProject } from "@/lib/server/projects";
+import {
+  createStoredProjectFixture,
+  jsonRequest,
+  testUser,
+} from "../../helpers/api-routes";
 
 vi.mock("server-only", () => ({}));
 
@@ -60,49 +65,18 @@ import {
   saveProjectForUser,
 } from "@/lib/server/projects";
 
-const user = {
-  id: "user-1",
-  email: "pilot@trackdraw.local",
-  name: "Pilot",
-  image: null,
-  role: "user" as const,
-};
-
-function makeStoredProject(overrides: Partial<StoredProject> = {}) {
-  const design = createDefaultDesign();
-  return {
-    id: "project-1",
-    ownerUserId: user.id,
-    title: "Race layout",
-    description: "",
-    design,
-    designUpdatedAt: design.updatedAt,
-    fieldWidth: design.field.width,
-    fieldHeight: design.field.height,
-    shapeCount: 0,
-    createdAt: "2026-04-20T10:00:00.000Z",
-    updatedAt: "2026-04-20T10:00:00.000Z",
-    archivedAt: null,
-    ...overrides,
-  } satisfies StoredProject;
-}
-
 function postRequest(body: unknown) {
-  return new Request("http://localhost/api/projects", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  return jsonRequest("http://localhost/api/projects", "POST", body);
 }
 
 describe("projects API route", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(user);
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(testUser);
   });
 
   it("lists account projects with design version metadata", async () => {
-    const project = makeStoredProject({
+    const project = createStoredProjectFixture({
       updatedAt: "2026-04-20T12:00:00.000Z",
     });
     vi.mocked(listProjectsForUser).mockResolvedValue([project]);
@@ -110,7 +84,7 @@ describe("projects API route", () => {
     const response = await GET(new Request("http://localhost/api/projects"));
 
     expect(response.status).toBe(200);
-    expect(listProjectsForUser).toHaveBeenCalledWith(user.id);
+    expect(listProjectsForUser).toHaveBeenCalledWith(testUser.id);
     await expect(response.json()).resolves.toEqual({
       ok: true,
       projects: [
@@ -127,7 +101,7 @@ describe("projects API route", () => {
 
   it("passes the known account design version when saving", async () => {
     const design = createDefaultDesign();
-    const project = makeStoredProject({ design });
+    const project = createStoredProjectFixture({ design });
     vi.mocked(saveProjectForUser).mockResolvedValue(project);
 
     const response = await POST(
@@ -140,7 +114,7 @@ describe("projects API route", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(saveProjectForUser).toHaveBeenCalledWith(user.id, design, {
+    expect(saveProjectForUser).toHaveBeenCalledWith(testUser.id, design, {
       projectId: "project-1",
       title: "Race layout",
       description: undefined,
@@ -154,7 +128,7 @@ describe("projects API route", () => {
     localDesign.updatedAt = "2026-04-20T10:05:00.000Z";
     const cloudDesign = createDefaultDesign();
     cloudDesign.updatedAt = "2026-04-20T10:10:00.000Z";
-    const cloudProject = makeStoredProject({
+    const cloudProject = createStoredProjectFixture({
       design: cloudDesign,
       designUpdatedAt: cloudDesign.updatedAt,
       updatedAt: "2026-04-20T10:11:00.000Z",

--- a/tests/app/api/shares.gallery.route.test.ts
+++ b/tests/app/api/shares.gallery.route.test.ts
@@ -29,9 +29,10 @@ vi.mock("@/lib/server/shares", () => ({
   revokeShare: vi.fn(),
 }));
 
-import { PATCH } from "@/app/api/shares/[token]/route";
+import { DELETE, PATCH } from "@/app/api/shares/[token]/route";
 import { uploadGalleryPreviewImage } from "@/lib/server/gallery-media";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
+import { isTrustedRequest } from "@/lib/server/csrf";
 import { isResourceOwner } from "@/lib/server/authorization";
 import {
   deleteGalleryEntry,
@@ -43,65 +44,42 @@ import {
 import {
   getOrCreateGalleryEntryForShare,
   resolveStoredShare,
+  revokeShare,
 } from "@/lib/server/shares";
-import type { StoredShare } from "@/lib/server/shares";
+import {
+  createGalleryEntryFixture,
+  createStoredShareFixture,
+  jsonRequest,
+  routeContext,
+  testUser,
+} from "../../helpers/api-routes";
 
-const owner = {
-  id: "user-1",
-  email: "owner@trackdraw.local",
-  name: "Owner",
-  image: null,
-  role: "user" as const,
-};
-
-const share = {
-  id: "share-id-1",
-  token: "share-token",
-  design: {
-    title: "Track",
-    description: "Description",
-    field: { width: 30, height: 20, gridStep: 5 },
-    shapes: [],
-  },
-  title: "Track",
-  description: "Description",
-  shapeCount: 0,
-  fieldWidth: 30,
-  fieldHeight: 20,
-  createdAt: "2026-04-20T10:00:00.000Z",
-  updatedAt: "2026-04-20T10:00:00.000Z",
-  publishedAt: "2026-04-20T10:00:00.000Z",
-  expiresAt: "2026-05-20T10:00:00.000Z",
-  revokedAt: null,
-  ownerUserId: owner.id,
+const share = createStoredShareFixture({
+  ownerUserId: testUser.id,
   projectId: "project-1",
   shareType: "published",
-} as unknown as StoredShare;
+});
 
-const entry = {
-  id: "entry-1",
+const entry = createGalleryEntryFixture({
   shareToken: share.token,
-  ownerUserId: owner.id,
-  galleryState: "unlisted" as const,
-  galleryTitle: "Track",
+  ownerUserId: testUser.id,
+  galleryState: "unlisted",
   galleryDescription: "Description",
   galleryPreviewImage: null,
   galleryPublishedAt: null,
-  moderationHiddenAt: null,
   createdAt: "2026-04-20T10:00:00.000Z",
-  updatedAt: "2026-04-20T10:00:00.000Z",
-};
+});
 
 function patchRequest(body: unknown) {
-  return new Request(`http://localhost/api/shares/${share.token}`, {
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  return jsonRequest(
+    `http://localhost/api/shares/${share.token}`,
+    "PATCH",
+    body
+  );
 }
 
 function context() {
-  return { params: Promise.resolve({ token: share.token }) };
+  return routeContext({ token: share.token });
 }
 
 describe("owner share gallery API route", () => {
@@ -111,7 +89,7 @@ describe("owner share gallery API route", () => {
       status: "available",
       share,
     });
-    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(owner);
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(testUser);
     vi.mocked(isResourceOwner).mockReturnValue(true);
     vi.mocked(getOrCreateGalleryEntryForShare).mockResolvedValue(entry);
     vi.mocked(getGalleryEntryByShareToken).mockResolvedValue({
@@ -165,6 +143,35 @@ describe("owner share gallery API route", () => {
     expect(moveGalleryEntryToListed).toHaveBeenCalledWith(share.token);
   });
 
+  it("blocks share revocation before ownership checks when the request is not trusted", async () => {
+    vi.mocked(isTrustedRequest).mockReturnValue(false);
+
+    const response = (await DELETE(
+      new Request(`http://localhost/api/shares/${share.token}`, {
+        method: "DELETE",
+      }),
+      context()
+    )) as Response;
+
+    expect(response.status).toBe(403);
+    expect(resolveStoredShare).not.toHaveBeenCalled();
+    expect(revokeShare).not.toHaveBeenCalled();
+  });
+
+  it("revokes an owned share without touching gallery metadata", async () => {
+    const response = (await DELETE(
+      new Request(`http://localhost/api/shares/${share.token}`, {
+        method: "DELETE",
+      }),
+      context()
+    )) as Response;
+
+    expect(response.status).toBe(200);
+    expect(revokeShare).toHaveBeenCalledWith(share.token);
+    expect(updateGalleryEntryMetadata).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
   it("blocks gallery changes for expired or revoked shares", async () => {
     vi.mocked(resolveStoredShare).mockResolvedValue({
       status: "expired",
@@ -212,6 +219,30 @@ describe("owner share gallery API route", () => {
     expect(moveGalleryEntryToListed).not.toHaveBeenCalled();
   });
 
+  it("requires an account display name before listing in the gallery", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue({
+      ...testUser,
+      name: "  ",
+    });
+
+    const response = (await PATCH(
+      patchRequest({
+        action: "list",
+        title: "Public title",
+        description: "Public description",
+      }),
+      context()
+    )) as Response;
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Set a display name on your account before listing in the gallery",
+    });
+    expect(updateGalleryEntryMetadata).not.toHaveBeenCalled();
+    expect(moveGalleryEntryToListed).not.toHaveBeenCalled();
+  });
+
   it("updates metadata only for listed or featured entries", async () => {
     vi.mocked(getOrCreateGalleryEntryForShare).mockResolvedValue({
       ...entry,
@@ -234,6 +265,29 @@ describe("owner share gallery API route", () => {
       description: "Updated public description",
     });
     expect(moveGalleryEntryToListed).not.toHaveBeenCalled();
+  });
+
+  it("rejects metadata updates while an entry is still unlisted", async () => {
+    vi.mocked(getOrCreateGalleryEntryForShare).mockResolvedValue({
+      ...entry,
+      galleryState: "unlisted",
+    });
+
+    const response = (await PATCH(
+      patchRequest({
+        action: "update",
+        title: "Updated title",
+        description: "Updated public description",
+      }),
+      context()
+    )) as Response;
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Only listed gallery items can update their metadata",
+    });
+    expect(updateGalleryEntryMetadata).not.toHaveBeenCalled();
   });
 
   it("removes a gallery entry without revoking the share", async () => {

--- a/tests/app/api/shares.route.test.ts
+++ b/tests/app/api/shares.route.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultDesign } from "@/lib/track/design";
-import type { StoredShare, UserShare } from "@/lib/server/shares";
+import type { UserShare } from "@/lib/server/shares";
+import {
+  createStoredProjectFixture,
+  createStoredShareFixture,
+  jsonRequest,
+  testUser,
+} from "../../helpers/api-routes";
 
 vi.mock("server-only", () => ({}));
 vi.mock("@/lib/server/csrf", () => ({ isTrustedRequest: vi.fn(() => true) }));
@@ -28,43 +34,8 @@ import {
   getSharesByUserId,
 } from "@/lib/server/shares";
 
-const user = {
-  id: "user-1",
-  email: "pilot@trackdraw.local",
-  name: "Pilot",
-  image: null,
-  role: "user" as const,
-};
-
-function createStoredShare(overrides: Partial<StoredShare> = {}): StoredShare {
-  const design = createDefaultDesign();
-  return {
-    id: "share-id",
-    token: "share-token",
-    design,
-    title: design.title,
-    description: "Read-only TrackDraw plan.",
-    shapeCount: 0,
-    fieldWidth: design.field.width,
-    fieldHeight: design.field.height,
-    createdAt: "2026-04-20T10:00:00.000Z",
-    updatedAt: "2026-04-20T10:00:00.000Z",
-    publishedAt: "2026-04-20T10:00:00.000Z",
-    expiresAt: "2026-05-20T10:00:00.000Z",
-    revokedAt: null,
-    ownerUserId: null,
-    projectId: null,
-    shareType: "temporary",
-    ...overrides,
-  };
-}
-
 function postRequest(body: unknown) {
-  return new Request("http://localhost/api/shares", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+  return jsonRequest("http://localhost/api/shares", "POST", body);
 }
 
 describe("shares API route", () => {
@@ -78,7 +49,9 @@ describe("shares API route", () => {
 
   it("creates anonymous temporary shares with requested expiry", async () => {
     const design = createDefaultDesign();
-    const share = createStoredShare({ expiresAt: "2026-05-02T12:00:00.000Z" });
+    const share = createStoredShareFixture({
+      expiresAt: "2026-05-02T12:00:00.000Z",
+    });
     vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
     vi.mocked(createShare).mockResolvedValue(share);
 
@@ -110,27 +83,19 @@ describe("shares API route", () => {
 
   it("creates authenticated project shares as published links and ignores expiry input", async () => {
     const design = createDefaultDesign();
-    const share = createStoredShare({
+    const share = createStoredShareFixture({
       expiresAt: null,
-      ownerUserId: user.id,
+      ownerUserId: testUser.id,
       projectId: "project-1",
       shareType: "published",
     });
-    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(user);
-    vi.mocked(getProjectForUser).mockResolvedValue({
-      id: "project-1",
-      ownerUserId: user.id,
-      title: "Project",
-      description: "",
-      design,
-      designUpdatedAt: design.updatedAt,
-      fieldWidth: design.field.width,
-      fieldHeight: design.field.height,
-      shapeCount: 0,
-      createdAt: "2026-04-20T10:00:00.000Z",
-      updatedAt: "2026-04-20T10:00:00.000Z",
-      archivedAt: null,
-    });
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(testUser);
+    vi.mocked(getProjectForUser).mockResolvedValue(
+      createStoredProjectFixture({
+        title: "Project",
+        design,
+      })
+    );
     vi.mocked(createShare).mockResolvedValue(share);
 
     const response = await POST(
@@ -149,7 +114,7 @@ describe("shares API route", () => {
         token: "share-token",
         path: "/share/share-token?view=2d",
         expiresAt: null,
-        ownerUserId: user.id,
+        ownerUserId: testUser.id,
         projectId: "project-1",
         shareType: "published",
       },
@@ -158,7 +123,7 @@ describe("shares API route", () => {
       expect.objectContaining({ id: design.id }),
       {
         expiresInDays: undefined,
-        ownerUserId: user.id,
+        ownerUserId: testUser.id,
         projectId: "project-1",
       }
     );
@@ -215,7 +180,7 @@ describe("shares API route", () => {
       galleryTitle: null,
       galleryDescription: null,
     };
-    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(user);
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(testUser);
     vi.mocked(getShareByProjectIdForUser).mockResolvedValue(share);
 
     const response = await GET(
@@ -225,7 +190,7 @@ describe("shares API route", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true, share });
     expect(getShareByProjectIdForUser).toHaveBeenCalledWith(
-      user.id,
+      testUser.id,
       "project-1"
     );
     expect(getSharesByUserId).not.toHaveBeenCalled();

--- a/tests/app/api/v1/me.route.test.ts
+++ b/tests/app/api/v1/me.route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/server/api-v1", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/server/api-v1")>();
+  return {
+    ...actual,
+    authenticateApiRequest: vi.fn(),
+  };
+});
+
+import { GET } from "@/app/api/v1/me/route";
+import { authenticateApiRequest } from "@/lib/server/api-v1";
+
+describe("v1 me API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("passes through API authentication failures", async () => {
+    const response = NextResponse.json(
+      {
+        title: "Unauthorized",
+        status: 401,
+        detail: "Missing bearer token.",
+        code: "unauthorized",
+      },
+      { status: 401 }
+    );
+    vi.mocked(authenticateApiRequest).mockResolvedValue({
+      ok: false,
+      response,
+    });
+
+    const result = await GET(new Request("http://localhost/api/v1/me"));
+
+    expect(result).toBe(response);
+  });
+
+  it("returns the authenticated API identity with normalized permissions", async () => {
+    vi.mocked(authenticateApiRequest).mockResolvedValue({
+      ok: true,
+      identity: {
+        user: {
+          id: "user-1",
+          email: "pilot@example.com",
+          name: "Race Director",
+        },
+        key: {
+          permissions: {
+            tracks: ["read", 123],
+            admin: "invalid",
+          },
+          expiresAt: new Date("2026-06-09T12:00:00.000Z"),
+        },
+      },
+    } as never);
+
+    const response = await GET(new Request("http://localhost/api/v1/me"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        type: "api_identity",
+        account: {
+          id: "user-1",
+          name: "Race Director",
+        },
+        permissions: {
+          tracks: ["read"],
+        },
+        expires_at: "2026-06-09T12:00:00.000Z",
+      },
+      meta: { api_version: "v1" },
+    });
+  });
+});

--- a/tests/app/api/v1/projects.route.test.ts
+++ b/tests/app/api/v1/projects.route.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextResponse } from "next/server";
-import { createDefaultDesign } from "@/lib/track/design";
 import type {
   StoredProject,
   StoredProjectSummary,
 } from "@/lib/server/projects";
+import {
+  createStoredProjectFixture,
+  createStoredProjectSummaryFixture,
+  routeContext,
+} from "../../../helpers/api-routes";
 
 vi.mock("@/lib/server/api-keys", () => ({
   trackReadPermission: { tracks: ["read"] },
@@ -51,6 +55,12 @@ vi.mock("@/lib/server/api-projects", () => ({
     id: project.id,
     title: project.title,
   })),
+  toApiProjectSummary: vi.fn((project: StoredProject) => ({
+    type: "project",
+    id: project.id,
+    title: project.title,
+    shape_count: project.shapeCount,
+  })),
   toApiTrackPackage: vi.fn((project: StoredProject) => ({
     type: "track",
     source: { type: "project", id: project.id },
@@ -65,6 +75,7 @@ import * as projectRoute from "@/app/api/v1/projects/[projectId]/route";
 import * as trackRoute from "@/app/api/v1/projects/[projectId]/track/route";
 import * as overlayRoute from "@/app/api/v1/projects/[projectId]/overlay/route";
 import * as projectsRoute from "@/app/api/v1/projects/route";
+import * as openApiRoute from "@/app/api/v1/openapi.json/route";
 import { authenticateApiRequest } from "@/lib/server/api-v1";
 import { trackReadPermission } from "@/lib/server/api-keys";
 import {
@@ -73,6 +84,7 @@ import {
 } from "@/lib/server/projects";
 import {
   toApiOverlayPackage,
+  toApiProjectSummary,
   toApiProjectSummaryLight,
   toApiTrackPackage,
 } from "@/lib/server/api-projects";
@@ -83,38 +95,21 @@ const apiIdentity = {
 };
 
 function makeProject(id = "project-1"): StoredProject {
-  const design = createDefaultDesign();
-  return {
+  return createStoredProjectFixture({
     id,
-    ownerUserId: "user-1",
-    title: "Race layout",
-    description: "",
-    design,
-    designUpdatedAt: design.updatedAt,
-    fieldWidth: design.field.width,
-    fieldHeight: design.field.height,
-    shapeCount: 0,
     createdAt: "2026-04-28T09:00:00.000Z",
     updatedAt: "2026-04-28T12:30:00.000Z",
-    archivedAt: null,
-  };
+  });
 }
 
 function makeProjectSummary(id = "project-1"): StoredProjectSummary {
-  return {
+  return createStoredProjectSummaryFixture({
     id,
-    ownerUserId: "user-1",
-    title: "Race layout",
-    fieldWidth: 60,
-    fieldHeight: 40,
-    shapeCount: 0,
-    createdAt: "2026-04-28T09:00:00.000Z",
-    updatedAt: "2026-04-28T12:30:00.000Z",
-  };
+  });
 }
 
 function projectContext(projectId: string) {
-  return { params: Promise.resolve({ projectId }) };
+  return routeContext({ projectId });
 }
 
 describe("v1 project API routes", () => {
@@ -160,6 +155,67 @@ describe("v1 project API routes", () => {
 
     expect(response.status).toBe(400);
     expect(listProjectSummariesForUser).not.toHaveBeenCalled();
+  });
+
+  it("marks pagination when more projects exist than the requested limit", async () => {
+    vi.mocked(listProjectSummariesForUser).mockResolvedValue([
+      makeProjectSummary("project-1"),
+      makeProjectSummary("project-2"),
+      makeProjectSummary("project-3"),
+    ]);
+
+    const response = await projectsRoute.GET(
+      new Request("http://localhost/api/v1/projects?limit=2")
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      data: [
+        { id: "project-1", title: "Race layout" },
+        { id: "project-2", title: "Race layout" },
+      ],
+      pagination: {
+        limit: 2,
+        next_cursor: null,
+        has_more: true,
+      },
+    });
+  });
+
+  it("returns project metadata through the public API serializer", async () => {
+    const project = makeProject();
+    vi.mocked(getProjectForUser).mockResolvedValue(project);
+
+    const response = await projectRoute.GET(
+      new Request("http://localhost/api/v1/projects/project-1"),
+      projectContext("project-1")
+    );
+
+    expect(getProjectForUser).toHaveBeenCalledWith("project-1", "user-1");
+    expect(toApiProjectSummary).toHaveBeenCalledWith(project);
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        type: "project",
+        id: "project-1",
+        title: "Race layout",
+        shape_count: 0,
+      },
+      meta: { api_version: "v1" },
+    });
+  });
+
+  it("rejects blank project ids before reading project metadata", async () => {
+    const response = await projectRoute.GET(
+      new Request("http://localhost/api/v1/projects/%20"),
+      projectContext(" ")
+    );
+
+    expect(response.status).toBe(400);
+    expect(getProjectForUser).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      title: "Bad Request",
+      detail: "Missing project id.",
+      code: "bad_request",
+    });
   });
 
   it("returns 404 for project metadata when the project is not owned by the key owner", async () => {
@@ -216,6 +272,17 @@ describe("v1 project API routes", () => {
     expect(response.status).toBe(404);
   });
 
+  it("rejects blank project ids before building track packages", async () => {
+    const response = await trackRoute.GET(
+      new Request("http://localhost/api/v1/projects/%20/track"),
+      projectContext(" ")
+    );
+
+    expect(response.status).toBe(400);
+    expect(getProjectForUser).not.toHaveBeenCalled();
+    expect(toApiTrackPackage).not.toHaveBeenCalled();
+  });
+
   it("returns overlay data only after loading a project for the API key owner", async () => {
     const project = makeProject();
     vi.mocked(getProjectForUser).mockResolvedValue(project);
@@ -262,5 +329,17 @@ describe("v1 project API routes", () => {
 
     expect(response.status).toBe(401);
     expect(getProjectForUser).not.toHaveBeenCalled();
+  });
+
+  it("serves the OpenAPI schema with short public caching", async () => {
+    const response = openApiRoute.GET();
+
+    expect(response.headers.get("cache-control")).toBe("public, max-age=300");
+    await expect(response.json()).resolves.toMatchObject({
+      openapi: "3.1.0",
+      info: {
+        title: "TrackDraw REST API",
+      },
+    });
   });
 });

--- a/tests/app/robots.test.ts
+++ b/tests/app/robots.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import robots from "@/app/robots";
+
+describe("robots metadata", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("allows public crawling and points at the configured sitemap", () => {
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://preview.trackdraw.app");
+
+    expect(robots()).toEqual({
+      rules: [
+        {
+          userAgent: "*",
+          allow: "/",
+        },
+      ],
+      sitemap: "https://preview.trackdraw.app/sitemap.xml",
+      host: "https://preview.trackdraw.app",
+    });
+  });
+});

--- a/tests/app/sitemap.test.ts
+++ b/tests/app/sitemap.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/server/gallery", () => ({
+  listPublicGalleryEntries: vi.fn(),
+}));
+
+import sitemap from "@/app/sitemap";
+import { listPublicGalleryEntries } from "@/lib/server/gallery";
+
+describe("sitemap metadata", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T12:00:00.000Z"));
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://trackdraw.test");
+    vi.mocked(listPublicGalleryEntries).mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it("includes core public routes and canonical gallery share links", async () => {
+    vi.mocked(listPublicGalleryEntries).mockResolvedValue([
+      {
+        id: "entry-1",
+        shareToken: "share token",
+        ownerUserId: "user-1",
+        galleryState: "featured",
+        galleryTitle: "Featured track",
+        galleryDescription: "Description",
+        galleryPreviewImage: null,
+        galleryPublishedAt: "2026-06-08T10:00:00.000Z",
+        moderationHiddenAt: null,
+        createdAt: "2026-06-07T10:00:00.000Z",
+        updatedAt: "2026-06-08T11:00:00.000Z",
+        ownerName: "Pilot",
+        shareTitle: "Featured share",
+        fieldWidth: 60,
+        fieldHeight: 40,
+        shapeCount: 12,
+      },
+    ]);
+
+    const entries = await sitemap();
+
+    expect(listPublicGalleryEntries).toHaveBeenCalledWith(100);
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          url: "https://trackdraw.test",
+          priority: 1,
+        }),
+        expect.objectContaining({
+          url: "https://trackdraw.test/gallery",
+          changeFrequency: "daily",
+        }),
+        expect.objectContaining({
+          url: "https://trackdraw.test/share/share%20token",
+          lastModified: new Date("2026-06-08T10:00:00.000Z"),
+          priority: 0.75,
+        }),
+      ])
+    );
+  });
+
+  it("still returns core routes when gallery lookup fails", async () => {
+    vi.mocked(listPublicGalleryEntries).mockRejectedValue(new Error("D1 down"));
+
+    const entries = await sitemap();
+
+    expect(entries.map((entry) => entry.url)).toEqual([
+      "https://trackdraw.test",
+      "https://trackdraw.test/gallery",
+      "https://trackdraw.test/studio",
+      "https://trackdraw.test/privacy",
+      "https://trackdraw.test/terms",
+    ]);
+  });
+});

--- a/tests/components/canvas/useTrackCanvasViewport.test.tsx
+++ b/tests/components/canvas/useTrackCanvasViewport.test.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  vi,
+} from "vitest";
+import { useRef } from "react";
+import { useTrackCanvasViewport } from "@/components/canvas/useTrackCanvasViewport";
+import type { Stage as KonvaStage } from "konva/lib/Stage";
+
+type StageMock = {
+  batchDraw: Mock;
+  off: Mock;
+  on: Mock;
+  position: Mock;
+  x: Mock;
+  y: Mock;
+};
+
+class ResizeObserverMock {
+  static instances: ResizeObserverMock[] = [];
+
+  callback: ResizeObserverCallback;
+  disconnect = vi.fn();
+  observe = vi.fn();
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    ResizeObserverMock.instances.push(this);
+  }
+}
+
+function createStageMock(): StageMock {
+  let position = { x: 100, y: 200 };
+
+  return {
+    batchDraw: vi.fn(),
+    off: vi.fn(),
+    on: vi.fn(),
+    position: vi.fn((nextPosition: { x: number; y: number }) => {
+      position = nextPosition;
+    }),
+    x: vi.fn(() => position.x),
+    y: vi.fn(() => position.y),
+  };
+}
+
+function asKonvaStage(stage: StageMock): KonvaStage {
+  return stage as unknown as KonvaStage;
+}
+
+function Harness({
+  contentDragActive = false,
+  hasManualView = false,
+  stage = createStageMock(),
+  fitFieldToViewport = vi.fn(),
+  setManualView = vi.fn(),
+  setViewportSize = vi.fn(),
+  syncTransform = vi.fn(),
+}: {
+  contentDragActive?: boolean;
+  fitFieldToViewport?: () => void;
+  hasManualView?: boolean;
+  setManualView?: (value: boolean) => void;
+  setViewportSize?: (size: { width: number; height: number }) => void;
+  stage?: StageMock;
+  syncTransform?: () => void;
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const contentDragActiveRef = useRef(contentDragActive);
+  const hasManualViewRef = useRef(hasManualView);
+  const stageInstance = asKonvaStage(stage);
+  const stageRef = useRef<KonvaStage | null>(stageInstance);
+
+  useTrackCanvasViewport({
+    containerRef,
+    contentDragActiveRef,
+    fitFieldToViewport,
+    hasManualViewRef,
+    setManualView,
+    setViewportSize,
+    stageRef,
+    stageInstance,
+    syncTransform,
+  });
+
+  return <div ref={containerRef} data-testid="canvas-container" />;
+}
+
+describe("useTrackCanvasViewport", () => {
+  beforeEach(() => {
+    ResizeObserverMock.instances = [];
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("subscribes to stage transform changes and fits new canvases", () => {
+    const stage = createStageMock();
+    const fitFieldToViewport = vi.fn();
+    const syncTransform = vi.fn();
+    const { unmount } = render(
+      <Harness
+        fitFieldToViewport={fitFieldToViewport}
+        stage={stage}
+        syncTransform={syncTransform}
+      />
+    );
+
+    expect(stage.on).toHaveBeenCalledWith(
+      "xChange yChange scaleXChange scaleYChange dragmove",
+      expect.any(Function)
+    );
+    expect(syncTransform).toHaveBeenCalledTimes(1);
+    expect(fitFieldToViewport).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(stage.off).toHaveBeenCalledWith(
+      "xChange yChange scaleXChange scaleYChange dragmove",
+      expect.any(Function)
+    );
+  });
+
+  it("reports clamped viewport dimensions from ResizeObserver", () => {
+    const setViewportSize = vi.fn();
+    render(<Harness setViewportSize={setViewportSize} />);
+    const observer = ResizeObserverMock.instances.at(-1)!;
+
+    act(() => {
+      observer.callback(
+        [
+          {
+            contentRect: {
+              width: 249.8,
+              height: 0,
+            },
+          } as ResizeObserverEntry,
+        ],
+        observer as unknown as ResizeObserver
+      );
+    });
+
+    expect(setViewportSize).toHaveBeenCalledWith({ width: 249, height: 1 });
+  });
+
+  it("pans the stage with the middle mouse button when content is not being dragged", () => {
+    const stage = createStageMock();
+    const setManualView = vi.fn();
+    const syncTransform = vi.fn();
+    render(
+      <Harness
+        setManualView={setManualView}
+        stage={stage}
+        syncTransform={syncTransform}
+      />
+    );
+    syncTransform.mockClear();
+    const container = screen.getByTestId("canvas-container");
+
+    act(() => {
+      container.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          button: 1,
+          clientX: 10,
+          clientY: 20,
+        })
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: 18,
+          clientY: 15,
+        })
+      );
+      window.dispatchEvent(
+        new MouseEvent("mouseup", {
+          bubbles: true,
+          button: 1,
+        })
+      );
+    });
+
+    expect(setManualView).toHaveBeenCalledWith(true);
+    expect(stage.position).toHaveBeenCalledWith({ x: 108, y: 195 });
+    expect(stage.batchDraw).toHaveBeenCalledTimes(1);
+    expect(syncTransform).toHaveBeenCalledTimes(1);
+    expect(container.style.cursor).toBe("");
+  });
+
+  it("ignores middle mouse panning while canvas content is already dragged", () => {
+    const stage = createStageMock();
+    const setManualView = vi.fn();
+    render(
+      <Harness contentDragActive setManualView={setManualView} stage={stage} />
+    );
+    const container = screen.getByTestId("canvas-container");
+
+    act(() => {
+      container.dispatchEvent(
+        new MouseEvent("mousedown", {
+          bubbles: true,
+          button: 1,
+          clientX: 10,
+          clientY: 20,
+        })
+      );
+      container.dispatchEvent(
+        new MouseEvent("mousemove", {
+          bubbles: true,
+          clientX: 18,
+          clientY: 15,
+        })
+      );
+    });
+
+    expect(setManualView).not.toHaveBeenCalled();
+    expect(stage.position).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/dialogs/CompleteProfileDialog.test.tsx
+++ b/tests/components/dialogs/CompleteProfileDialog.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import CompleteProfileDialog from "@/components/dialogs/CompleteProfileDialog";
+
+const mobileState = vi.hoisted(() => ({
+  isMobile: false,
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mobileState.isMobile,
+}));
+
+vi.mock("@/components/MobileDrawer", () => ({
+  MobileDrawer: ({
+    children,
+    open,
+    title,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    title: string;
+  }) =>
+    open ? (
+      <section aria-label={title} data-testid="mobile-drawer">
+        {children}
+      </section>
+    ) : null,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+  },
+}));
+
+function renderCompleteProfile(
+  overrides: Partial<React.ComponentProps<typeof CompleteProfileDialog>> = {}
+) {
+  const props: React.ComponentProps<typeof CompleteProfileDialog> = {
+    open: true,
+    onOpenChange: vi.fn(),
+    email: "pilot@example.com",
+    currentName: null,
+    onSave: vi.fn(async () => undefined),
+    ...overrides,
+  };
+
+  render(<CompleteProfileDialog {...props} />);
+  return props;
+}
+
+describe("CompleteProfileDialog", () => {
+  afterEach(() => {
+    cleanup();
+    mobileState.isMobile = false;
+    vi.clearAllMocks();
+  });
+
+  it("saves a trimmed display name and closes the dialog", async () => {
+    const user = userEvent.setup();
+    const props = renderCompleteProfile();
+
+    await user.type(screen.getByLabelText("Display name"), "  Race Pilot  ");
+    await user.click(screen.getByRole("button", { name: "Save name" }));
+
+    await waitFor(() => {
+      expect(props.onSave).toHaveBeenCalledWith("Race Pilot");
+    });
+    expect(toast.success).toHaveBeenCalledWith("Profile updated");
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps saving disabled until a visible name is entered", async () => {
+    const user = userEvent.setup();
+    renderCompleteProfile();
+    const input = screen.getByLabelText("Display name");
+    const saveButton = screen.getByRole("button", { name: "Save name" });
+
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+
+    await user.type(input, "   ");
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
+
+    await user.type(input, "Pilot");
+    expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("shows account update failures without closing", async () => {
+    const user = userEvent.setup();
+    const props = renderCompleteProfile({
+      onSave: vi.fn(async () => {
+        throw new Error("Name update failed");
+      }),
+    });
+
+    await user.type(screen.getByLabelText("Display name"), "Race Pilot");
+    await user.click(screen.getByRole("button", { name: "Save name" }));
+
+    expect(await screen.findByText("Name update failed")).toBeTruthy();
+    expect(props.onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("uses the mobile drawer shell on small screens", () => {
+    mobileState.isMobile = true;
+
+    renderCompleteProfile({ currentName: "Mobile Pilot" });
+
+    expect(screen.getByTestId("mobile-drawer")).toBeTruthy();
+    expect(screen.getByDisplayValue("Mobile Pilot")).toBeTruthy();
+  });
+});

--- a/tests/components/dialogs/ExportDialog.test.tsx
+++ b/tests/components/dialogs/ExportDialog.test.tsx
@@ -5,16 +5,22 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import ExportDialog from "@/components/dialogs/ExportDialog";
+import type { TrackCanvasHandle } from "@/components/canvas/editor/TrackCanvas";
 import { useEditor } from "@/store/editor";
 
 const mocks = vi.hoisted(() => ({
   downloadJsonFile: vi.fn(),
+  exportPdf: vi.fn(),
   toastError: vi.fn(),
   toastSuccess: vi.fn(),
 }));
 
+const viewport = vi.hoisted(() => ({
+  isMobile: true,
+}));
+
 vi.mock("@/hooks/use-mobile", () => ({
-  useIsMobile: () => true,
+  useIsMobile: () => viewport.isMobile,
 }));
 
 vi.mock("@/hooks/useTheme", () => ({
@@ -41,8 +47,24 @@ vi.mock("@/components/MobileDrawer", () => ({
     ) : null,
 }));
 
+vi.mock("@/components/DesktopModal", () => ({
+  DesktopModal: ({
+    children,
+    open,
+    title,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    title: string;
+  }) => (open ? <section aria-label={title}>{children}</section> : null),
+}));
+
 vi.mock("@/lib/export/download-json", () => ({
   downloadJsonFile: mocks.downloadJsonFile,
+}));
+
+vi.mock("@/lib/export/exportPdf", () => ({
+  exportPdf: mocks.exportPdf,
 }));
 
 vi.mock("sonner", () => ({
@@ -56,7 +78,9 @@ describe("ExportDialog mobile workflow", () => {
   beforeEach(() => {
     useEditor.getState().newProject();
     useEditor.getState().clearHistory();
+    viewport.isMobile = true;
     mocks.downloadJsonFile.mockReset();
+    mocks.exportPdf.mockReset();
     mocks.toastError.mockReset();
     mocks.toastSuccess.mockReset();
   });
@@ -161,5 +185,87 @@ describe("ExportDialog mobile workflow", () => {
       );
     });
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("exports a desktop JSON project with a sanitized custom filename", async () => {
+    viewport.isMobile = false;
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    render(
+      <ExportDialog
+        activeTab="3d"
+        canvasRef={React.createRef()}
+        onOpenChange={onOpenChange}
+        open
+      />
+    );
+
+    await user.type(screen.getByPlaceholderText("New Track"), "Race Day #1");
+    await user.click(screen.getByRole("button", { name: /Project File/ }));
+
+    await waitFor(() => {
+      expect(mocks.downloadJsonFile).toHaveBeenCalledWith(
+        "Race_Day_1.json",
+        expect.objectContaining({ version: 2 })
+      );
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Exported", undefined);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("passes an account-published share URL into desktop Race Pack exports", async () => {
+    viewport.isMobile = false;
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const stage = { id: "stage-1" };
+    const canvasRef = {
+      current: {
+        getStage: () => stage,
+      } as unknown as TrackCanvasHandle,
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === "/api/shares?projectId=project-1") {
+          return Response.json({
+            ok: true,
+            share: {
+              shareType: "published",
+              token: "published-token",
+            },
+          });
+        }
+
+        throw new Error(`Unexpected request: ${String(input)}`);
+      })
+    );
+
+    render(
+      <ExportDialog
+        activeTab="3d"
+        canvasRef={canvasRef}
+        onOpenChange={onOpenChange}
+        open
+        projectId="project-1"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Race Pack/ }));
+
+    await waitFor(() => {
+      expect(mocks.exportPdf).toHaveBeenCalledWith(
+        stage,
+        expect.objectContaining({ version: 2 }),
+        "New_Track_race_pack.pdf",
+        "dark",
+        expect.objectContaining({
+          preset: "race-day",
+          shareUrl: expect.stringMatching(/\/share\/published-token\?view=2d$/),
+        })
+      );
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith("Exported", undefined);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/tests/components/dialogs/KeyboardShortcutsDialog.test.tsx
+++ b/tests/components/dialogs/KeyboardShortcutsDialog.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import KeyboardShortcutsDialog from "@/components/dialogs/KeyboardShortcutsDialog";
+
+const mobileState = vi.hoisted(() => ({
+  isMobile: false,
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({
+  useIsMobile: () => mobileState.isMobile,
+}));
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.HTMLAttributes<HTMLDivElement> & {
+      children?: React.ReactNode;
+    }) => <div {...props}>{children}</div>,
+  },
+}));
+
+vi.mock("@/components/MobileDrawer", () => ({
+  MobileDrawer: ({
+    children,
+    open,
+    title,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    title: string;
+  }) =>
+    open ? (
+      <section aria-label={title} data-testid="mobile-drawer">
+        {children}
+      </section>
+    ) : null,
+}));
+
+describe("KeyboardShortcutsDialog", () => {
+  afterEach(() => {
+    cleanup();
+    mobileState.isMobile = false;
+  });
+
+  it("opens with tools shortcuts and expands another section on desktop", async () => {
+    const user = userEvent.setup();
+
+    render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText("Keyboard Shortcuts")).toBeTruthy();
+    expect(screen.getByText("Gate")).toBeTruthy();
+    expect(screen.getByText("G")).toBeTruthy();
+    expect(screen.queryByText("Save snapshot")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Project" }));
+
+    expect(screen.getByText("Save snapshot")).toBeTruthy();
+    expect(screen.getByText("Ctrl/Cmd")).toBeTruthy();
+    expect(screen.getByText("S")).toBeTruthy();
+  });
+
+  it("collapses the open shortcuts section when clicked again", async () => {
+    const user = userEvent.setup();
+
+    render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText("Select")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Tools" }));
+
+    expect(screen.queryByText("Select")).toBeNull();
+  });
+
+  it("uses the mobile drawer shell on small screens", () => {
+    mobileState.isMobile = true;
+
+    render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByTestId("mobile-drawer")).toBeTruthy();
+    expect(
+      screen.getByRole("region", { name: "Keyboard Shortcuts" })
+    ).toBeTruthy();
+  });
+});

--- a/tests/components/dialogs/ShareDialog.test.tsx
+++ b/tests/components/dialogs/ShareDialog.test.tsx
@@ -1,10 +1,16 @@
 // @vitest-environment happy-dom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 import ShareDialog from "@/components/dialogs/ShareDialog";
 import { createDefaultDesign } from "@/lib/track/design";
 import { useEditor } from "@/store/editor";
+import {
+  createMemoryStorage,
+  installWindowStorage,
+} from "../../helpers/storage";
 
 const authState = vi.hoisted(() => ({
   session: null as {
@@ -25,36 +31,29 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams("view=2d"),
 }));
 
-const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
-  window,
-  "localStorage"
-);
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
 
-function createMemoryStorage(): Storage {
-  const store = new Map<string, string>();
+let restoreStorage: (() => void) | null = null;
 
-  return {
-    get length() {
-      return store.size;
-    },
-    clear: vi.fn(() => {
-      store.clear();
-    }),
-    getItem: vi.fn((key: string) => store.get(key) ?? null),
-    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
-    removeItem: vi.fn((key: string) => {
-      store.delete(key);
-    }),
-    setItem: vi.fn((key: string, value: string) => {
-      store.set(key, value);
-    }),
-  };
-}
-
-function renderShareDialog(projectId: string | null = null) {
+function renderShareDialog(
+  projectId: string | null = null,
+  onSharePublished = vi.fn()
+) {
   render(
-    <ShareDialog open onOpenChange={vi.fn()} hasPath projectId={projectId} />
+    <ShareDialog
+      open
+      onOpenChange={vi.fn()}
+      hasPath
+      projectId={projectId}
+      onSharePublished={onSharePublished}
+    />
   );
+  return { onSharePublished };
 }
 
 describe("ShareDialog", () => {
@@ -67,10 +66,7 @@ describe("ShareDialog", () => {
         name: "Klaas",
       },
     };
-    Object.defineProperty(window, "localStorage", {
-      configurable: true,
-      value: createMemoryStorage(),
-    });
+    restoreStorage = installWindowStorage(createMemoryStorage());
     vi.stubGlobal(
       "matchMedia",
       vi.fn(() => ({
@@ -102,15 +98,8 @@ describe("ShareDialog", () => {
     cleanup();
     useEditor.getState().newProject();
     useEditor.getState().clearHistory();
-    if (originalLocalStorageDescriptor) {
-      Object.defineProperty(
-        window,
-        "localStorage",
-        originalLocalStorageDescriptor
-      );
-    } else {
-      Reflect.deleteProperty(window, "localStorage");
-    }
+    restoreStorage?.();
+    restoreStorage = null;
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -139,5 +128,116 @@ describe("ShareDialog", () => {
       )
     ).toBeTruthy();
     expect(screen.getByRole("button", { name: /Create link/i })).toBeTruthy();
+  });
+
+  it("creates a separate published link for authenticated local or copied tracks", async () => {
+    const user = userEvent.setup();
+    const onSharePublished = vi.fn();
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      Response.json({
+        ok: true,
+        share: {
+          token: "published-token",
+          path: "/share/published-token?view=2d",
+          expiresAt: null,
+          shareType: "published",
+        },
+      })
+    );
+
+    renderShareDialog(null, onSharePublished);
+
+    await user.click(screen.getByRole("button", { name: /Create new link/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue(/\/share\/published-token\?view=2d/)
+      ).toBeTruthy();
+    });
+
+    const [, request] = fetchMock.mock.calls.find(
+      ([url, init]) => url === "/api/shares" && init?.method === "POST"
+    )!;
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      view: "2d",
+      design: expect.objectContaining({ title: "Shared copy" }),
+    });
+    expect(JSON.parse(String(request?.body))).not.toHaveProperty("projectId");
+    expect(JSON.parse(String(request?.body))).not.toHaveProperty(
+      "expiresInDays"
+    );
+    expect(localStorage.getItem("trackdraw-anon-share")).toContain(
+      "published-token"
+    );
+    expect(onSharePublished).toHaveBeenCalledOnce();
+    expect(toast.success).toHaveBeenCalledWith("Link created");
+  });
+
+  it("creates an account project link with the project id and no expiry", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockImplementation(async (input, init) => {
+      if (String(input).startsWith("/api/shares?projectId=")) {
+        return Response.json({ ok: true, share: null });
+      }
+
+      if (input === "/api/shares" && init?.method === "POST") {
+        return Response.json({
+          ok: true,
+          share: {
+            token: "project-share",
+            path: "/share/project-share?view=2d",
+            expiresAt: null,
+            shareType: "published",
+          },
+        });
+      }
+
+      throw new Error(`Unexpected request: ${String(input)}`);
+    });
+
+    renderShareDialog("project-1");
+
+    await user.click(screen.getByRole("button", { name: /^Create link$/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue(/\/share\/project-share\?view=2d/)
+      ).toBeTruthy();
+    });
+
+    const [, request] = fetchMock.mock.calls.find(
+      ([url, init]) => url === "/api/shares" && init?.method === "POST"
+    )!;
+    const body = JSON.parse(String(request?.body));
+    expect(body).toMatchObject({
+      projectId: "project-1",
+      view: "2d",
+      design: expect.objectContaining({ title: "Shared copy" }),
+    });
+    expect(body).not.toHaveProperty("expiresInDays");
+    expect(toast.success).toHaveBeenCalledWith("Link created");
+  });
+
+  it("surfaces share creation failures without storing a stale local link", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.mocked(fetch);
+    fetchMock.mockResolvedValue(
+      Response.json(
+        { ok: false, error: "Failed to publish share" },
+        { status: 500 }
+      )
+    );
+
+    renderShareDialog();
+
+    await user.click(screen.getByRole("button", { name: /Create new link/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to publish share");
+    });
+    expect(screen.queryByLabelText("share-url-input")).toBeNull();
+    expect(localStorage.getItem("trackdraw-anon-share")).toBeNull();
   });
 });

--- a/tests/components/editor/AccountMenu.test.tsx
+++ b/tests/components/editor/AccountMenu.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AccountMenu from "@/components/editor/AccountMenu";
+import { authClient } from "@/lib/auth-client";
+
+const sessionState = vi.hoisted(() => ({
+  session: {
+    data: null as
+      | {
+          user?: {
+            email?: string | null;
+            name?: string | null;
+            role?: string | null;
+          } | null;
+        }
+      | null,
+    isPending: false,
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => sessionState.session,
+    signOut: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock("@/components/dialogs/AccountDialog", () => ({
+  default: ({
+    open,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  }) => (open ? <div data-testid="account-dialog" /> : null),
+}));
+
+vi.mock("@/components/UserAvatar", () => ({
+  default: ({
+    email,
+    name,
+  }: {
+    email?: string | null;
+    name?: string | null;
+  }) => <span>{name ?? email ?? "avatar"}</span>,
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverTrigger: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    children: React.ReactNode;
+  }) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+describe("AccountMenu", () => {
+  afterEach(() => {
+    cleanup();
+    sessionState.session = { data: null, isPending: false };
+    vi.clearAllMocks();
+  });
+
+  it("shows pending and signed-out states", () => {
+    sessionState.session = { data: null, isPending: true };
+    const { rerender } = render(<AccountMenu />);
+
+    expect(screen.getByText("Checking auth…")).toBeTruthy();
+
+    sessionState.session = { data: null, isPending: false };
+    rerender(<AccountMenu />);
+
+    expect(screen.getByRole("link", { name: /Sign in/ }).getAttribute("href")).toBe(
+      "/login"
+    );
+  });
+
+  it("shows account metadata and dashboard access for moderators and admins only", () => {
+    sessionState.session = {
+      isPending: false,
+      data: {
+        user: {
+          email: "pilot@example.com",
+          name: "",
+          role: "moderator",
+        },
+      },
+    };
+
+    const { rerender } = render(<AccountMenu />);
+
+    expect(screen.getAllByText("pilot@example.com").length).toBeGreaterThan(0);
+    expect(screen.getByText("No display name set")).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Dashboard/ }).getAttribute("href")).toBe(
+      "/dashboard"
+    );
+
+    sessionState.session = {
+      isPending: false,
+      data: {
+        user: {
+          email: "pilot@example.com",
+          name: "Race Pilot",
+          role: "user",
+        },
+      },
+    };
+    rerender(<AccountMenu />);
+
+    expect(screen.queryByRole("link", { name: /Dashboard/ })).toBeNull();
+    expect(screen.getAllByText("Race Pilot").length).toBeGreaterThan(0);
+    expect(screen.getByText("TrackDraw account")).toBeTruthy();
+  });
+
+  it("opens profile after closing the popover and signs out", async () => {
+    const user = userEvent.setup();
+    sessionState.session = {
+      isPending: false,
+      data: {
+        user: {
+          email: "pilot@example.com",
+          name: "Race Pilot",
+          role: "admin",
+        },
+      },
+    };
+
+    render(<AccountMenu />);
+
+    await user.click(screen.getByRole("button", { name: "Profile" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("account-dialog")).toBeTruthy();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Sign out" }));
+
+    expect(authClient.signOut).toHaveBeenCalledWith({
+      fetchOptions: {
+        onSuccess: expect.any(Function),
+      },
+    });
+  });
+});

--- a/tests/components/editor/AccountMenu.test.tsx
+++ b/tests/components/editor/AccountMenu.test.tsx
@@ -9,15 +9,13 @@ import { authClient } from "@/lib/auth-client";
 
 const sessionState = vi.hoisted(() => ({
   session: {
-    data: null as
-      | {
-          user?: {
-            email?: string | null;
-            name?: string | null;
-            role?: string | null;
-          } | null;
-        }
-      | null,
+    data: null as {
+      user?: {
+        email?: string | null;
+        name?: string | null;
+        role?: string | null;
+      } | null;
+    } | null,
     isPending: false,
   },
 }));
@@ -95,9 +93,9 @@ describe("AccountMenu", () => {
     sessionState.session = { data: null, isPending: false };
     rerender(<AccountMenu />);
 
-    expect(screen.getByRole("link", { name: /Sign in/ }).getAttribute("href")).toBe(
-      "/login"
-    );
+    expect(
+      screen.getByRole("link", { name: /Sign in/ }).getAttribute("href")
+    ).toBe("/login");
   });
 
   it("shows account metadata and dashboard access for moderators and admins only", () => {
@@ -116,9 +114,9 @@ describe("AccountMenu", () => {
 
     expect(screen.getAllByText("pilot@example.com").length).toBeGreaterThan(0);
     expect(screen.getByText("No display name set")).toBeTruthy();
-    expect(screen.getByRole("link", { name: /Dashboard/ }).getAttribute("href")).toBe(
-      "/dashboard"
-    );
+    expect(
+      screen.getByRole("link", { name: /Dashboard/ }).getAttribute("href")
+    ).toBe("/dashboard");
 
     sessionState.session = {
       isPending: false,

--- a/tests/components/editor/LayoutPresetPicker.test.tsx
+++ b/tests/components/editor/LayoutPresetPicker.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LayoutPresetPicker } from "@/components/editor/LayoutPresetPicker";
+import { layoutPresets } from "@/lib/planning/layout-presets";
+
+vi.mock("@/components/MobileDrawer", () => ({
+  MobileDrawer: ({
+    children,
+    open,
+    pinnedContent,
+    title,
+  }: {
+    children: React.ReactNode;
+    open: boolean;
+    pinnedContent?: React.ReactNode;
+    title: string;
+  }) =>
+    open ? (
+      <section aria-label={title} data-testid="mobile-drawer">
+        {pinnedContent}
+        {children}
+      </section>
+    ) : null,
+}));
+
+function getPresetButton(presetName: string) {
+  const button = screen
+    .getAllByRole("button")
+    .find((element) => element.textContent?.includes(presetName));
+
+  if (!button) {
+    throw new Error(`Preset button not found: ${presetName}`);
+  }
+
+  return button;
+}
+
+describe("LayoutPresetPicker", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does not mount the desktop picker while closed", () => {
+    render(
+      <LayoutPresetPicker
+        open={false}
+        onOpenChange={vi.fn()}
+        selectedPresetId={null}
+        onSelectPreset={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("Layout presets")).toBeNull();
+  });
+
+  it("shows the selected desktop preset and returns the chosen preset id", async () => {
+    const user = userEvent.setup();
+    const onSelectPreset = vi.fn();
+    const selectedPreset = layoutPresets[0];
+    const nextPreset = layoutPresets[1];
+
+    render(
+      <LayoutPresetPicker
+        open
+        onOpenChange={vi.fn()}
+        selectedPresetId={selectedPreset.id}
+        onSelectPreset={onSelectPreset}
+      />
+    );
+
+    expect(
+      screen.getByText(`Current preset: ${selectedPreset.name}`)
+    ).toBeTruthy();
+
+    await user.click(getPresetButton(nextPreset.name));
+
+    expect(onSelectPreset).toHaveBeenCalledWith(nextPreset.id);
+  });
+
+  it("keeps selected preset context visible in the mobile drawer", async () => {
+    const user = userEvent.setup();
+    const onSelectPreset = vi.fn();
+    const selectedPreset = layoutPresets[0];
+    const nextPreset = layoutPresets[1];
+
+    render(
+      <LayoutPresetPicker
+        mobile
+        open
+        onOpenChange={vi.fn()}
+        selectedPresetId={selectedPreset.id}
+        onSelectPreset={onSelectPreset}
+      />
+    );
+
+    expect(screen.getByTestId("mobile-drawer")).toBeTruthy();
+    expect(
+      screen.getByText(`Current preset: ${selectedPreset.name}`)
+    ).toBeTruthy();
+
+    await user.click(getPresetButton(nextPreset.name));
+
+    expect(onSelectPreset).toHaveBeenCalledWith(nextPreset.id);
+  });
+});

--- a/tests/components/editor/PerformanceHud.test.tsx
+++ b/tests/components/editor/PerformanceHud.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import PerformanceHud from "@/components/editor/PerformanceHud";
+import { resetPerfMetrics } from "@/lib/perf";
+
+const developerModeState = vi.hoisted(() => ({
+  enabled: true,
+  setEnabled: vi.fn(),
+}));
+
+const perfState = vi.hoisted(() => ({
+  metrics: {} as Record<
+    string,
+    {
+      avgMs: number;
+      count: number;
+      lastMs: number;
+      maxMs: number;
+      minMs: number;
+      totalMs: number;
+    }
+  >,
+}));
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    aside: ({
+      children,
+      ...props
+    }: React.HTMLAttributes<HTMLElement> & {
+      children: React.ReactNode;
+    }) => <aside {...props}>{children}</aside>,
+  },
+  useReducedMotion: () => false,
+}));
+
+vi.mock("@/hooks/useDeveloperMode", () => ({
+  useDeveloperMode: () => developerModeState,
+}));
+
+vi.mock("@/hooks/useTheme", () => ({
+  useTheme: () => "dark",
+}));
+
+vi.mock("@/lib/perf", () => ({
+  getPerfSnapshot: () => perfState.metrics,
+  resetPerfMetrics: vi.fn(),
+  subscribePerf: () => () => undefined,
+}));
+
+vi.mock("@/store/editor", () => ({
+  useEditor: (selector: (state: unknown) => unknown) =>
+    selector({
+      ui: { activeTool: "gate" },
+      session: { selection: ["gate-1", "gate-2"] },
+    }),
+}));
+
+function metric(lastMs: number) {
+  return {
+    avgMs: lastMs,
+    count: 1,
+    lastMs,
+    maxMs: lastMs,
+    minMs: lastMs,
+    totalMs: lastMs,
+  };
+}
+
+describe("PerformanceHud", () => {
+  afterEach(() => {
+    cleanup();
+    developerModeState.enabled = true;
+    developerModeState.setEnabled.mockClear();
+    perfState.metrics = {};
+    vi.clearAllMocks();
+  });
+
+  it("stays hidden when developer mode is disabled", () => {
+    developerModeState.enabled = false;
+
+    render(<PerformanceHud />);
+
+    expect(screen.queryByText("Developer HUD")).toBeNull();
+  });
+
+  it("shows editor context and performance levels", () => {
+    perfState.metrics = {
+      "render:TrackCanvas": metric(12),
+      "render:TrackPreview3D": metric(40),
+      "render:Inspector": metric(90),
+    };
+
+    render(<PerformanceHud />);
+
+    expect(screen.getByText("Developer HUD")).toBeTruthy();
+    expect(screen.getByText("Tool gate · 2 selected")).toBeTruthy();
+    expect(screen.getByText("OK")).toBeTruthy();
+    expect(screen.getByText("Busy")).toBeTruthy();
+    expect(screen.getByText("Heavy")).toBeTruthy();
+    expect(screen.getByText("12.0ms")).toBeTruthy();
+  });
+
+  it("resets metrics and closes the HUD from its controls", async () => {
+    const user = userEvent.setup();
+    render(<PerformanceHud />);
+
+    await user.click(screen.getByRole("button", { name: "Reset" }));
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(resetPerfMetrics).toHaveBeenCalledOnce();
+    expect(developerModeState.setEnabled).toHaveBeenCalledWith(false);
+  });
+});

--- a/tests/components/editor/StatusBar.test.tsx
+++ b/tests/components/editor/StatusBar.test.tsx
@@ -4,10 +4,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import StatusBar from "@/components/editor/StatusBar";
 import { useEditor } from "@/store/editor";
-import {
-  gateDraft,
-  resetEditorStore,
-} from "../../helpers/editor-store";
+import { gateDraft, resetEditorStore } from "../../helpers/editor-store";
 
 const developerModeState = vi.hoisted(() => ({
   enabled: false,

--- a/tests/components/editor/StatusBar.test.tsx
+++ b/tests/components/editor/StatusBar.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import StatusBar from "@/components/editor/StatusBar";
+import { useEditor } from "@/store/editor";
+import {
+  gateDraft,
+  resetEditorStore,
+} from "../../helpers/editor-store";
+
+const developerModeState = vi.hoisted(() => ({
+  enabled: false,
+  toggle: vi.fn(),
+}));
+
+vi.mock("@/hooks/useDeveloperMode", () => ({
+  useDeveloperMode: () => developerModeState,
+}));
+
+vi.mock("@/hooks/useMeasurementUnitSystem", () => ({
+  useMeasurementUnitSystem: () => ({ unitSystem: "metric" }),
+}));
+
+vi.mock("@/components/AppTooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@/components/VersionTag", () => ({
+  default: () => <span>v-test</span>,
+}));
+
+describe("StatusBar", () => {
+  beforeEach(() => {
+    resetEditorStore();
+    developerModeState.enabled = false;
+    developerModeState.toggle.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("summarizes active tool, zoom, cursor, field size, and selection", () => {
+    const state = useEditor.getState();
+    const gateId = state.addShape(gateDraft());
+    useEditor.getState().setActiveTool("gate");
+    useEditor.getState().setZoom(1.5);
+    useEditor.getState().updateField({ width: 42, height: 28, gridStep: 0.5 });
+    useEditor.getState().setSelection([gateId]);
+
+    render(<StatusBar cursorPos={{ x: 12.25, y: 6.75 }} snapActive />);
+
+    expect(screen.getByRole("status").textContent).toContain("Gate");
+    expect(screen.getByRole("status").textContent).toContain("150%");
+    expect(screen.getByRole("status").textContent).toContain("0.5 m");
+    expect(screen.getByRole("status").textContent).toContain("12.3 m, 6.8 m");
+    expect(screen.getByRole("status").textContent).toContain("1 selected");
+    expect(screen.getByRole("status").textContent).toContain("42 x 28 m");
+  });
+
+  it("toggles snap from the status bar control", () => {
+    useEditor.getState().setSnapEnabled(true);
+
+    render(<StatusBar />);
+
+    const snapButton = screen.getByRole("button", { name: /Snap On/ });
+    expect(snapButton.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(snapButton);
+
+    expect(useEditor.getState().ui.snapEnabled).toBe(false);
+    expect(screen.getByRole("button", { name: /Snap Off/ })).toBeTruthy();
+  });
+
+  it("toggles developer mode from the development control", () => {
+    developerModeState.enabled = true;
+
+    render(<StatusBar />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Dev On" }));
+
+    expect(developerModeState.toggle).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/components/editor/useAccountProjectSync.test.tsx
+++ b/tests/components/editor/useAccountProjectSync.test.tsx
@@ -1,9 +1,19 @@
 // @vitest-environment happy-dom
 
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultDesign } from "@/lib/track/design";
-import { useAccountProjectSync } from "@/components/editor/useAccountProjectSync";
+import {
+  AccountProjectSyncConflictError,
+  useAccountProjectSync,
+} from "@/components/editor/useAccountProjectSync";
+import { saveProject } from "@/lib/projects";
+import type { TrackDesign } from "@/lib/types";
+import { createMemoryStorage } from "../../helpers/storage";
+
+vi.mock("nanoid", () => ({
+  nanoid: () => "local-copy-id",
+}));
 
 vi.mock("@/lib/auth-client", () => ({
   isDevAuthShimEnabled: () => false,
@@ -17,23 +27,27 @@ vi.mock("sonner", () => ({
   },
 }));
 
-function createMemoryStorage(): Storage {
-  const store = new Map<string, string>();
+type HookOptions = Parameters<typeof useAccountProjectSync>[0];
 
-  return {
-    get length() {
-      return store.size;
-    },
-    clear: vi.fn(() => store.clear()),
-    getItem: vi.fn((key: string) => store.get(key) ?? null),
-    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
-    removeItem: vi.fn((key: string) => {
-      store.delete(key);
-    }),
-    setItem: vi.fn((key: string, value: string) => {
-      store.set(key, value);
-    }),
+function renderAccountProjectSync(overrides: Partial<HookOptions> = {}) {
+  const design = overrides.design ?? createDefaultDesign();
+  const options: HookOptions = {
+    authUserId: null,
+    readOnly: false,
+    design,
+    projectManagerOpen: false,
+    historyPaused: false,
+    interactionSessionDepth: 0,
+    snapshotCurrentDesign: vi.fn(),
+    replaceDesign: vi.fn(),
+    setProjects: vi.fn(),
+    setRestorePoints: vi.fn(),
+    setActiveRestorePointId: vi.fn(),
+    setSaveStatusLabel: vi.fn(),
+    ...overrides,
   };
+
+  return renderHook(() => useAccountProjectSync(options));
 }
 
 describe("useAccountProjectSync", () => {
@@ -52,6 +66,7 @@ describe("useAccountProjectSync", () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
@@ -62,22 +77,7 @@ describe("useAccountProjectSync", () => {
     design.updatedAt = "2026-04-20T10:30:00.000Z";
     const setProjects = vi.fn();
 
-    const { result } = renderHook(() =>
-      useAccountProjectSync({
-        authUserId: null,
-        readOnly: false,
-        design,
-        projectManagerOpen: false,
-        historyPaused: false,
-        interactionSessionDepth: 0,
-        snapshotCurrentDesign: vi.fn(),
-        replaceDesign: vi.fn(),
-        setProjects,
-        setRestorePoints: vi.fn(),
-        setActiveRestorePointId: vi.fn(),
-        setSaveStatusLabel: vi.fn(),
-      })
-    );
+    const { result } = renderAccountProjectSync({ design, setProjects });
 
     await act(async () => {
       await expect(result.current.syncDesignToAccount(design)).rejects.toThrow(
@@ -104,6 +104,208 @@ describe("useAccountProjectSync", () => {
       status: "failed",
       fallbackSavedAt: expect.any(String),
       error: "Network unavailable",
+    });
+  });
+
+  it("keeps account and local copies separate when account sync reports a version conflict", async () => {
+    const design = createDefaultDesign();
+    design.id = "project-1";
+    design.title = "Race day layout";
+    design.updatedAt = "2026-04-20T10:05:00.000Z";
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "POST") {
+          return Response.json(
+            {
+              ok: false,
+              code: "project_version_conflict",
+              error: "Account project changed on another device.",
+              conflict: {
+                projectId: "project-1",
+                title: "Race day layout",
+                localUpdatedAt: "2026-04-20T10:05:00.000Z",
+                cloudUpdatedAt: "2026-04-20T10:10:00.000Z",
+              },
+              project: {
+                id: "project-1",
+                title: "Race day layout",
+                updatedAt: "2026-04-20T10:11:00.000Z",
+                designUpdatedAt: "2026-04-20T10:10:00.000Z",
+                shapeCount: 0,
+              },
+            },
+            { status: 409 }
+          );
+        }
+
+        return Response.json({
+          ok: true,
+          projects: [
+            {
+              id: "project-1",
+              title: "Race day layout",
+              updatedAt: "2026-04-20T10:11:00.000Z",
+              designUpdatedAt: "2026-04-20T10:10:00.000Z",
+              shapeCount: 0,
+            },
+          ],
+        });
+      }
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderAccountProjectSync({
+      authUserId: "user-1",
+      design,
+    });
+
+    await waitFor(() => {
+      expect(result.current.accountProjects).toHaveLength(1);
+    });
+
+    await act(async () => {
+      await expect(result.current.syncDesignToAccount(design)).rejects.toThrow(
+        AccountProjectSyncConflictError
+      );
+    });
+
+    const postCall = fetchMock.mock.calls.find(
+      ([input, init]) =>
+        String(input) === "/api/projects" && init?.method === "POST"
+    );
+    expect(postCall).toBeDefined();
+    expect(JSON.parse(String(postCall?.[1]?.body))).toMatchObject({
+      projectId: "project-1",
+      baseDesignUpdatedAt: "2026-04-20T10:10:00.000Z",
+    });
+    expect(localStorage.getItem("trackdraw-project-project-1")).toBeNull();
+    expect(result.current.projectVersionConflict).toEqual({
+      projectId: "project-1",
+      title: "Race day layout",
+      localUpdatedAt: "2026-04-20T10:05:00.000Z",
+      cloudUpdatedAt: "2026-04-20T10:10:00.000Z",
+    });
+    expect(result.current.projectSyncMetaById["project-1"]).toMatchObject({
+      status: "conflict",
+      lastSyncedAt: "2026-04-20T10:11:00.000Z",
+    });
+  });
+
+  it("opens an account project into the editor and persists it locally", async () => {
+    const activeDesign = createDefaultDesign();
+    activeDesign.id = "project-1";
+    const accountDesign: TrackDesign = {
+      ...createDefaultDesign(),
+      id: "project-2",
+      title: "Cloud race layout",
+      updatedAt: "2026-04-20T11:00:00.000Z",
+    };
+    const snapshotCurrentDesign = vi.fn();
+    const replaceDesign = vi.fn();
+    const setProjects = vi.fn();
+    const setRestorePoints = vi.fn();
+    const setActiveRestorePointId = vi.fn();
+    const setSaveStatusLabel = vi.fn();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        if (String(input) === "/api/projects/project-2") {
+          return Response.json({
+            ok: true,
+            project: { design: accountDesign },
+          });
+        }
+
+        return Response.json({ ok: true, projects: [] });
+      })
+    );
+
+    const { result } = renderAccountProjectSync({
+      authUserId: "user-1",
+      design: activeDesign,
+      snapshotCurrentDesign,
+      replaceDesign,
+      setProjects,
+      setRestorePoints,
+      setActiveRestorePointId,
+      setSaveStatusLabel,
+    });
+
+    let opened = false;
+    await act(async () => {
+      opened = await result.current.handleOpenAccountProject("project-2");
+    });
+
+    expect(opened).toBe(true);
+    expect(snapshotCurrentDesign).toHaveBeenCalled();
+    expect(replaceDesign).toHaveBeenCalledWith(accountDesign);
+    expect(setProjects).toHaveBeenCalled();
+    expect(setRestorePoints).toHaveBeenCalledWith([]);
+    expect(setActiveRestorePointId).toHaveBeenCalledWith(null);
+    expect(setSaveStatusLabel).toHaveBeenCalledWith(
+      "Project opened from account"
+    );
+    expect(
+      JSON.parse(localStorage.getItem("trackdraw-project-project-2") ?? "null")
+    ).toMatchObject({
+      id: "project-2",
+      title: "Cloud race layout",
+    });
+  });
+
+  it("keeps a conflicted account project as a separate local copy", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-20T12:00:00.000Z"));
+    const design = createDefaultDesign();
+    design.id = "project-1";
+    design.title = "Race day layout";
+    design.updatedAt = "2026-04-20T10:30:00.000Z";
+    saveProject(design);
+    const replaceDesign = vi.fn();
+    const setProjects = vi.fn();
+    const setRestorePoints = vi.fn();
+    const setActiveRestorePointId = vi.fn();
+    const setSaveStatusLabel = vi.fn();
+
+    const { result } = renderAccountProjectSync({
+      authUserId: "user-1",
+      design,
+      replaceDesign,
+      setProjects,
+      setRestorePoints,
+      setActiveRestorePointId,
+      setSaveStatusLabel,
+    });
+
+    act(() => {
+      result.current.handleKeepLocalConflictCopy();
+    });
+
+    expect(replaceDesign).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "local-copy-id",
+        title: "Race day layout (local copy)",
+        createdAt: "2026-04-20T12:00:00.000Z",
+        updatedAt: "2026-04-20T12:00:00.000Z",
+      })
+    );
+    expect(localStorage.getItem("trackdraw-project-project-1")).toBeNull();
+    expect(
+      JSON.parse(
+        localStorage.getItem("trackdraw-project-local-copy-id") ?? "null"
+      )
+    ).toMatchObject({
+      id: "local-copy-id",
+      title: "Race day layout (local copy)",
+    });
+    expect(setProjects).toHaveBeenCalled();
+    expect(setRestorePoints).toHaveBeenCalledWith([]);
+    expect(setActiveRestorePointId).toHaveBeenCalledWith(null);
+    expect(setSaveStatusLabel).toHaveBeenCalledWith("Kept as local copy");
+    expect(result.current.projectSyncMetaById["local-copy-id"]).toMatchObject({
+      status: "local-only",
+      lastSyncedAt: null,
     });
   });
 });

--- a/tests/components/editor/useEditorDialogs.test.tsx
+++ b/tests/components/editor/useEditorDialogs.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useEditorDialogs } from "@/components/editor/useEditorDialogs";
+
+describe("useEditorDialogs", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("opens the new project dialog immediately on desktop", () => {
+    const setMobileToolsOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useEditorDialogs({ isMobile: false, setMobileToolsOpen })
+    );
+
+    act(() => {
+      result.current.openNewProjectDialog();
+    });
+
+    expect(result.current.newProjectOpen).toBe(true);
+    expect(setMobileToolsOpen).not.toHaveBeenCalled();
+  });
+
+  it("closes mobile tools before opening the new project dialog after the drawer delay", () => {
+    vi.useFakeTimers();
+    const setMobileToolsOpen = vi.fn();
+    const { result } = renderHook(() =>
+      useEditorDialogs({ isMobile: true, setMobileToolsOpen })
+    );
+
+    act(() => {
+      result.current.openNewProjectDialog();
+    });
+
+    expect(setMobileToolsOpen).toHaveBeenCalledWith(false);
+    expect(result.current.newProjectOpen).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(180);
+    });
+
+    expect(result.current.newProjectOpen).toBe(true);
+  });
+
+  it("cancels pending mobile new-project timers on unmount", () => {
+    vi.useFakeTimers();
+    const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+    const { result, unmount } = renderHook(() =>
+      useEditorDialogs({ isMobile: true, setMobileToolsOpen: vi.fn() })
+    );
+
+    act(() => {
+      result.current.openNewProjectDialog();
+    });
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+});

--- a/tests/components/editor/useManualProjectSave.test.tsx
+++ b/tests/components/editor/useManualProjectSave.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
+import { useManualProjectSave } from "@/components/editor/useManualProjectSave";
+import { AccountProjectSyncConflictError } from "@/components/editor/useAccountProjectSync";
+import { createDefaultDesign } from "@/lib/track/design";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+function renderManualSave(
+  overrides: Partial<Parameters<typeof useManualProjectSave>[0]> = {}
+) {
+  const design = createDefaultDesign();
+  design.id = "project-1";
+
+  const options = {
+    readOnly: false,
+    design,
+    isAccountProject: true,
+    currentProjectSyncMeta: { status: "synced" as const },
+    handleSaveSnapshot: vi.fn(),
+    syncDesignToAccount: vi.fn(async () => undefined),
+    markProjectSyncFailed: vi.fn(),
+    setSaveStatusLabel: vi.fn(),
+    ...overrides,
+  };
+
+  return {
+    options,
+    ...renderHook(() => useManualProjectSave(options)),
+  };
+}
+
+describe("useManualProjectSave", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("snapshots and syncs account projects on manual save", async () => {
+    const { result, options } = renderManualSave();
+
+    await act(async () => {
+      await result.current.handleManualSave();
+    });
+
+    expect(options.handleSaveSnapshot).toHaveBeenCalledOnce();
+    expect(options.syncDesignToAccount).toHaveBeenCalledWith(options.design, {
+      updateStatusLabel: true,
+    });
+  });
+
+  it("only snapshots read-only, local-only, or conflicted projects", async () => {
+    const { result, options } = renderManualSave({
+      currentProjectSyncMeta: { status: "conflict" },
+    });
+
+    await act(async () => {
+      await result.current.handleManualSave();
+    });
+
+    expect(options.handleSaveSnapshot).toHaveBeenCalledOnce();
+    expect(options.syncDesignToAccount).not.toHaveBeenCalled();
+  });
+
+  it("marks cloud sync failures after saving a snapshot", async () => {
+    const syncError = new Error("D1 unavailable");
+    const { result, options } = renderManualSave({
+      syncDesignToAccount: vi.fn(async () => {
+        throw syncError;
+      }),
+    });
+
+    await act(async () => {
+      await result.current.handleManualSave();
+    });
+
+    expect(options.markProjectSyncFailed).toHaveBeenCalledWith(
+      "project-1",
+      "D1 unavailable"
+    );
+    expect(options.setSaveStatusLabel).toHaveBeenCalledWith(
+      "Cloud sync failed"
+    );
+    expect(toast.error).toHaveBeenCalledWith("Could not sync project", {
+      description: "D1 unavailable",
+    });
+  });
+
+  it("uses the review status for version conflicts", async () => {
+    const { result, options } = renderManualSave({
+      syncDesignToAccount: vi.fn(async () => {
+        throw new AccountProjectSyncConflictError({
+          projectId: "project-1",
+          title: "Race layout",
+          localUpdatedAt: "2026-06-09T10:00:00.000Z",
+          cloudUpdatedAt: "2026-06-09T10:05:00.000Z",
+        });
+      }),
+    });
+
+    await act(async () => {
+      await result.current.handleManualSave();
+    });
+
+    expect(options.setSaveStatusLabel).toHaveBeenCalledWith(
+      "Review project version"
+    );
+    expect(options.markProjectSyncFailed).not.toHaveBeenCalled();
+  });
+
+  it("handles keyboard save shortcuts outside text inputs", () => {
+    const { options } = renderManualSave();
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "s",
+          metaKey: true,
+        })
+      );
+    });
+
+    expect(options.handleSaveSnapshot).toHaveBeenCalledOnce();
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "s",
+          metaKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    expect(options.handleSaveSnapshot).toHaveBeenCalledOnce();
+    input.remove();
+  });
+});

--- a/tests/components/editor/useStarterExperience.test.tsx
+++ b/tests/components/editor/useStarterExperience.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useStarterExperience } from "@/components/editor/useStarterExperience";
+import { AccountProjectSyncConflictError } from "@/components/editor/useAccountProjectSync";
+import { createDefaultDesign } from "@/lib/track/design";
+import {
+  createMemoryStorage,
+  installWindowStorage,
+} from "../../helpers/storage";
+
+let restoreStorage: (() => void) | null = null;
+
+function renderStarterExperience(
+  overrides: Partial<Parameters<typeof useStarterExperience>[0]> = {}
+) {
+  const design = createDefaultDesign();
+  const blankDesign = createDefaultDesign();
+  blankDesign.id = "blank-design";
+
+  const options = {
+    readOnly: false,
+    authUserId: null,
+    cloudProjectsAvailable: true,
+    design,
+    designShapeCount: 0,
+    hasPath: false,
+    syncDesignToAccount: vi.fn(async () => undefined),
+    markProjectSyncFailed: vi.fn(),
+    setSaveStatusLabel: vi.fn(),
+    replaceDesign: vi.fn(),
+    handleTabChange: vi.fn(),
+    resetSelectionState: vi.fn(),
+    setActiveTool: vi.fn(),
+    fitCanvas: vi.fn(),
+    closeProjectAndToolSurfaces: vi.fn(),
+    createBlankDesign: vi.fn(() => blankDesign),
+    ...overrides,
+  };
+
+  return {
+    options,
+    blankDesign,
+    ...renderHook(() => useStarterExperience(options)),
+  };
+}
+
+describe("useStarterExperience", () => {
+  beforeEach(() => {
+    restoreStorage = installWindowStorage(createMemoryStorage());
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        callback(0);
+        return 1;
+      })
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    restoreStorage?.();
+    restoreStorage = null;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("applies a guided blank design and prepares gate placement", () => {
+    const { result, options, blankDesign } = renderStarterExperience();
+
+    act(() => {
+      result.current.applyStarterDesign("gate");
+    });
+
+    expect(options.replaceDesign).toHaveBeenCalledWith(blankDesign);
+    expect(options.handleTabChange).toHaveBeenCalledWith("2d");
+    expect(options.setActiveTool).toHaveBeenCalledWith("gate");
+    expect(options.fitCanvas).toHaveBeenCalledOnce();
+    expect(result.current.starterDismissed).toBe(true);
+    expect(result.current.starterMode).toBe("guided");
+  });
+
+  it("applies a starter layout and closes project/tool surfaces", () => {
+    const { result, options } = renderStarterExperience();
+
+    act(() => {
+      result.current.applyStarterLayout("open-practice");
+    });
+
+    expect(options.replaceDesign).toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.any(String) })
+    );
+    expect(options.resetSelectionState).toHaveBeenCalledOnce();
+    expect(options.closeProjectAndToolSurfaces).toHaveBeenCalledOnce();
+    expect(options.setActiveTool).toHaveBeenCalledWith("select");
+    expect(result.current.starterDismissed).toBe(true);
+  });
+
+  it("syncs starter designs for signed-in users and reports cloud failures", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { result, options, blankDesign } = renderStarterExperience({
+      authUserId: "user-1",
+      syncDesignToAccount: vi.fn(async () => {
+        throw new Error("Cloud unavailable");
+      }),
+    });
+
+    act(() => {
+      result.current.applyStarterDesign("blank");
+    });
+    await Promise.resolve();
+
+    expect(options.syncDesignToAccount).toHaveBeenCalledWith(blankDesign, {
+      updateStatusLabel: true,
+    });
+    expect(options.markProjectSyncFailed).toHaveBeenCalledWith(
+      "blank-design",
+      "Cloud unavailable"
+    );
+    expect(options.setSaveStatusLabel).toHaveBeenCalledWith(
+      "Cloud sync failed"
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      "[TrackDraw new-project sync]",
+      expect.any(Error)
+    );
+  });
+
+  it("sets review status when starter sync hits a project version conflict", async () => {
+    const { result, options } = renderStarterExperience({
+      authUserId: "user-1",
+      syncDesignToAccount: vi.fn(async () => {
+        throw new AccountProjectSyncConflictError({
+          projectId: "blank-design",
+          title: "Race layout",
+          localUpdatedAt: "2026-06-09T10:00:00.000Z",
+          cloudUpdatedAt: "2026-06-09T10:05:00.000Z",
+        });
+      }),
+    });
+
+    act(() => {
+      result.current.applyStarterDesign("blank");
+    });
+    await Promise.resolve();
+
+    expect(options.setSaveStatusLabel).toHaveBeenCalledWith(
+      "Review project version"
+    );
+    expect(options.markProjectSyncFailed).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/gallery/PublicGalleryGrid.test.tsx
+++ b/tests/components/gallery/PublicGalleryGrid.test.tsx
@@ -76,7 +76,9 @@ describe("PublicGalleryGrid", () => {
 
     expect(screen.getByText("No tracks yet.")).toBeTruthy();
     expect(
-      screen.getByText(/Gallery listings will appear here once TrackDraw pilots/)
+      screen.getByText(
+        /Gallery listings will appear here once TrackDraw pilots/
+      )
     ).toBeTruthy();
   });
 

--- a/tests/components/gallery/PublicGalleryGrid.test.tsx
+++ b/tests/components/gallery/PublicGalleryGrid.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+
+import type React from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import PublicGalleryGrid from "@/components/gallery/PublicGalleryGrid";
+import type { PublicGalleryEntry } from "@/lib/server/gallery";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({
+    alt,
+    fill: _fill,
+    unoptimized: _unoptimized,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & {
+    fill?: boolean;
+    unoptimized?: boolean;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img alt={alt} {...props} />
+  ),
+}));
+
+vi.mock("@/hooks/useMeasurementUnitSystem", () => ({
+  useMeasurementUnitSystem: () => ({ unitSystem: "metric" }),
+}));
+
+function galleryEntry(
+  overrides: Partial<PublicGalleryEntry> = {}
+): PublicGalleryEntry {
+  const id = overrides.id ?? "entry-1";
+
+  return {
+    id,
+    shareToken: `token-${id}`,
+    ownerUserId: "user-1",
+    galleryState: "listed",
+    galleryTitle: `Track ${id}`,
+    galleryDescription: `Description for ${id}`,
+    galleryPreviewImage: `/previews/${id}.png`,
+    galleryPublishedAt: "2026-01-15T10:00:00.000Z",
+    moderationHiddenAt: null,
+    createdAt: "2026-01-15T10:00:00.000Z",
+    updatedAt: "2026-01-15T10:00:00.000Z",
+    ownerName: "Race Pilot",
+    shareTitle: null,
+    fieldWidth: 40,
+    fieldHeight: 25,
+    shapeCount: 8,
+    ...overrides,
+  };
+}
+
+describe("PublicGalleryGrid", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows the empty gallery state when there are no public tracks", () => {
+    render(<PublicGalleryGrid entries={[]} />);
+
+    expect(screen.getByText("No tracks yet.")).toBeTruthy();
+    expect(
+      screen.getByText(/Gallery listings will appear here once TrackDraw pilots/)
+    ).toBeTruthy();
+  });
+
+  it("renders canonical share links, featured tracks, and recent pagination", async () => {
+    const user = userEvent.setup();
+    const entries = [
+      galleryEntry({
+        id: "featured",
+        shareToken: "featured-token",
+        galleryState: "featured",
+        galleryTitle: "Featured club race",
+      }),
+      ...Array.from({ length: 13 }, (_, index) =>
+        galleryEntry({
+          id: `recent-${index + 1}`,
+          shareToken: `recent-token-${index + 1}`,
+          galleryTitle: `Recent track ${index + 1}`,
+        })
+      ),
+    ];
+
+    render(
+      <PublicGalleryGrid entries={entries} mediaBaseUrl="https://media.test" />
+    );
+
+    expect(screen.getByRole("heading", { name: "Featured" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Recent" })).toBeTruthy();
+    expect(
+      screen
+        .getByRole("link", { name: /Featured club race/ })
+        .getAttribute("href")
+    ).toBe("/share/featured-token");
+    expect(screen.getByAltText("Recent track 1").getAttribute("src")).toBe(
+      "https://media.test/previews/recent-1.png"
+    );
+    expect(screen.queryByText("Recent track 13")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Load more" }));
+
+    expect(screen.getByText("Recent track 13")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Load more" })).toBeNull();
+  });
+
+  it("falls back to the TrackDraw mark when a preview image fails", () => {
+    render(
+      <PublicGalleryGrid
+        entries={[
+          galleryEntry({
+            galleryTitle: "Fallback preview",
+            galleryPreviewImage: "https://cdn.test/preview.png",
+          }),
+        ]}
+      />
+    );
+
+    const image = screen.getByAltText("Fallback preview");
+    fireEvent.error(image);
+
+    expect(screen.queryByAltText("Fallback preview")).toBeNull();
+    expect(screen.getByText("Fallback preview")).toBeTruthy();
+  });
+});

--- a/tests/helpers/api-routes.ts
+++ b/tests/helpers/api-routes.ts
@@ -1,0 +1,142 @@
+import { createDefaultDesign } from "@/lib/track/design";
+import type { AdminUser } from "@/lib/admin-users";
+import type { StoredGalleryEntry } from "@/lib/server/gallery";
+import type {
+  StoredProject,
+  StoredProjectSummary,
+} from "@/lib/server/projects";
+import type { StoredShare } from "@/lib/server/shares";
+
+export const testUser = {
+  id: "user-1",
+  email: "pilot@trackdraw.local",
+  name: "Pilot",
+  image: null,
+  role: "user" as const,
+};
+
+export const adminActor = {
+  id: "admin-1",
+  email: "admin@trackdraw.local",
+  name: "Admin",
+  image: null,
+  role: "admin" as const,
+};
+
+export const moderatorActor = {
+  id: "mod-1",
+  email: "mod@trackdraw.local",
+  name: "Moderator",
+  image: null,
+  role: "moderator" as const,
+};
+
+export function jsonRequest(url: string, method: string, body: unknown) {
+  return new Request(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+export function routeContext<T extends Record<string, string | string[]>>(
+  params: T
+) {
+  return { params: Promise.resolve(params) };
+}
+
+export function createStoredProjectFixture(
+  overrides: Partial<StoredProject> = {}
+): StoredProject {
+  const design = createDefaultDesign();
+  return {
+    id: "project-1",
+    ownerUserId: testUser.id,
+    title: "Race layout",
+    description: "",
+    design,
+    designUpdatedAt: design.updatedAt,
+    fieldWidth: design.field.width,
+    fieldHeight: design.field.height,
+    shapeCount: 0,
+    createdAt: "2026-04-20T10:00:00.000Z",
+    updatedAt: "2026-04-20T10:00:00.000Z",
+    archivedAt: null,
+    ...overrides,
+  };
+}
+
+export function createStoredProjectSummaryFixture(
+  overrides: Partial<StoredProjectSummary> = {}
+): StoredProjectSummary {
+  return {
+    id: "project-1",
+    ownerUserId: testUser.id,
+    title: "Race layout",
+    fieldWidth: 60,
+    fieldHeight: 40,
+    shapeCount: 0,
+    createdAt: "2026-04-28T09:00:00.000Z",
+    updatedAt: "2026-04-28T12:30:00.000Z",
+    ...overrides,
+  };
+}
+
+export function createStoredShareFixture(
+  overrides: Partial<StoredShare> = {}
+): StoredShare {
+  const design = createDefaultDesign();
+  return {
+    id: "share-id",
+    token: "share-token",
+    design,
+    title: design.title,
+    description: "Read-only TrackDraw plan.",
+    shapeCount: 0,
+    fieldWidth: design.field.width,
+    fieldHeight: design.field.height,
+    createdAt: "2026-04-20T10:00:00.000Z",
+    updatedAt: "2026-04-20T10:00:00.000Z",
+    publishedAt: "2026-04-20T10:00:00.000Z",
+    expiresAt: "2026-05-20T10:00:00.000Z",
+    revokedAt: null,
+    ownerUserId: null,
+    projectId: null,
+    shareType: "temporary",
+    ...overrides,
+  };
+}
+
+export function createAdminUserFixture(
+  overrides: Partial<AdminUser> = {}
+): AdminUser {
+  return {
+    id: "user-2",
+    name: "Target User",
+    email: "target@trackdraw.local",
+    image: null,
+    role: "user",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+export function createGalleryEntryFixture(
+  overrides: Partial<StoredGalleryEntry> = {}
+): StoredGalleryEntry {
+  return {
+    id: "entry-1",
+    shareToken: "share-token",
+    ownerUserId: "owner-1",
+    galleryState: "listed",
+    galleryTitle: "Track",
+    galleryDescription: "Public description",
+    galleryPreviewImage: "gallery/previews/entry-1.webp",
+    galleryPublishedAt: "2026-04-20T10:00:00.000Z",
+    moderationHiddenAt: null,
+    createdAt: "2026-04-20T09:00:00.000Z",
+    updatedAt: "2026-04-20T10:00:00.000Z",
+    ...overrides,
+  };
+}

--- a/tests/helpers/cloudflare.ts
+++ b/tests/helpers/cloudflare.ts
@@ -1,0 +1,50 @@
+import { vi } from "vitest";
+
+export type MockMediaBucket = {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+export function createMockMediaBucket(
+  overrides: Partial<MockMediaBucket> = {}
+): MockMediaBucket {
+  return {
+    get: vi.fn(async () => null),
+    put: vi.fn(async () => undefined),
+    delete: vi.fn(async () => undefined),
+    ...overrides,
+  };
+}
+
+export function createR2ObjectBody({
+  body,
+  etag = '"etag-1"',
+  cacheControl,
+  contentType,
+}: {
+  body: BodyInit;
+  etag?: string;
+  cacheControl?: string;
+  contentType?: string;
+}) {
+  return {
+    body,
+    httpEtag: etag,
+    httpMetadata: cacheControl ? { cacheControl } : undefined,
+    writeHttpMetadata(headers: Headers) {
+      if (contentType) {
+        headers.set("content-type", contentType);
+      }
+    },
+  };
+}
+
+export function installCloudflareMediaBucket(
+  getCloudflareContext: ReturnType<typeof vi.fn>,
+  bucket: MockMediaBucket | null
+) {
+  getCloudflareContext.mockResolvedValue({
+    env: bucket ? { MEDIA_BUCKET: bucket } : {},
+  });
+}

--- a/tests/helpers/d1.ts
+++ b/tests/helpers/d1.ts
@@ -1,0 +1,44 @@
+import { vi } from "vitest";
+
+export type MockD1Statement = {
+  sql: string;
+  bind: ReturnType<typeof vi.fn>;
+  first: ReturnType<typeof vi.fn>;
+  all: ReturnType<typeof vi.fn>;
+  run: ReturnType<typeof vi.fn>;
+};
+
+export function createD1Statement(result?: {
+  all?: unknown;
+  first?: unknown;
+  run?: unknown;
+}): MockD1Statement {
+  const statement: MockD1Statement = {
+    sql: "",
+    bind: vi.fn(() => statement),
+    first: vi.fn(async () => result?.first ?? null),
+    all: vi.fn(async () => result?.all ?? { results: [] }),
+    run: vi.fn(async () => result?.run ?? {}),
+  };
+
+  return statement;
+}
+
+export function createD1AllStatement(rows: unknown[]) {
+  return createD1Statement({ all: { results: rows } });
+}
+
+export function installD1Statements(
+  prepare: ReturnType<typeof vi.fn>,
+  statements: MockD1Statement[]
+) {
+  prepare.mockImplementation((sql: string) => {
+    const statement = statements.shift();
+    if (!statement) {
+      throw new Error(`Unexpected SQL: ${sql}`);
+    }
+
+    statement.sql = sql;
+    return statement;
+  });
+}

--- a/tests/helpers/editor-store.ts
+++ b/tests/helpers/editor-store.ts
@@ -1,0 +1,125 @@
+import { expect, vi } from "vitest";
+import { useEditor } from "@/store/editor";
+import type {
+  ConeShape,
+  FlagShape,
+  GateShape,
+  LadderShape,
+  PolylineShape,
+  ShapeDraft,
+} from "@/lib/types";
+
+export const EDITOR_TEST_NOW = "2026-04-13T10:00:00.000Z";
+
+export function resetEditorStore(now = EDITOR_TEST_NOW) {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(now));
+  useEditor.getState().newProject();
+  useEditor.getState().clearHistory();
+  return useEditor.getState();
+}
+
+export function setEditorTestTime(isoDate: string) {
+  vi.setSystemTime(new Date(isoDate));
+}
+
+export function getPastStatesCount() {
+  return useEditor.temporal.getState().pastStates.length;
+}
+
+export function expectPastStatesCount(count: number) {
+  expect(getPastStatesCount()).toBe(count);
+}
+
+export function expectDesignUpdatedAt(isoDate: string) {
+  expect(useEditor.getState().track.design.updatedAt).toBe(isoDate);
+}
+
+export function expectNoDesignHistoryChange(beforeUpdatedAt: string) {
+  expect(useEditor.getState().track.design.updatedAt).toBe(beforeUpdatedAt);
+  expectPastStatesCount(0);
+}
+
+export function clearHistoryAndCaptureUpdatedAt() {
+  useEditor.getState().clearHistory();
+  return useEditor.getState().track.design.updatedAt;
+}
+
+export function runHistoryStep(step: () => void) {
+  step();
+  const temporal = useEditor.temporal.getState();
+  temporal.pause();
+  useEditor.getState().sanitizeHistoryState();
+  temporal.resume();
+}
+
+export function gateDraft(
+  overrides: Partial<ShapeDraft<GateShape>> = {}
+): ShapeDraft<GateShape> {
+  return {
+    kind: "gate",
+    x: 10,
+    y: 8,
+    rotation: 0,
+    width: 2,
+    height: 2,
+    ...overrides,
+  };
+}
+
+export function flagDraft(
+  overrides: Partial<ShapeDraft<FlagShape>> = {}
+): ShapeDraft<FlagShape> {
+  return {
+    kind: "flag",
+    x: 8,
+    y: 7,
+    rotation: 0,
+    radius: 0.25,
+    ...overrides,
+  };
+}
+
+export function coneDraft(
+  overrides: Partial<ShapeDraft<ConeShape>> = {}
+): ShapeDraft<ConeShape> {
+  return {
+    kind: "cone",
+    x: 0,
+    y: 0,
+    rotation: 0,
+    radius: 1,
+    ...overrides,
+  };
+}
+
+export function ladderDraft(
+  overrides: Partial<ShapeDraft<LadderShape>> = {}
+): ShapeDraft<LadderShape> {
+  return {
+    kind: "ladder",
+    x: 0,
+    y: 0,
+    rotation: 0,
+    width: 2,
+    height: 2,
+    rungs: 3,
+    ...overrides,
+  };
+}
+
+export function polylineDraft(
+  overrides: Partial<ShapeDraft<PolylineShape>> = {}
+): ShapeDraft<PolylineShape> {
+  return {
+    kind: "polyline",
+    x: 0,
+    y: 0,
+    rotation: 0,
+    points: [
+      { x: 0, y: 0, z: 0 },
+      { x: 4, y: 0, z: 0 },
+    ],
+    ...overrides,
+  };
+}

--- a/tests/helpers/storage.ts
+++ b/tests/helpers/storage.ts
@@ -75,6 +75,8 @@ export function installWindowStorage(storage: Storage) {
   return () => {
     if (originalDescriptor) {
       Object.defineProperty(window, "localStorage", originalDescriptor);
+    } else {
+      Reflect.deleteProperty(window, "localStorage");
     }
   };
 }

--- a/tests/helpers/storage.ts
+++ b/tests/helpers/storage.ts
@@ -1,0 +1,80 @@
+import { vi } from "vitest";
+
+type MemoryStorageOptions = {
+  failSetKey?: string;
+};
+
+export function createMemoryStorageController(
+  initial: Record<string, string> = {},
+  options: MemoryStorageOptions = {}
+) {
+  const store = new Map<string, string>(Object.entries(initial));
+  let failWrites = false;
+
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear: vi.fn(() => store.clear()),
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      if (failWrites || key === options.failSetKey) {
+        throw new DOMException("Storage quota exceeded", "QuotaExceededError");
+      }
+      store.set(key, value);
+    }),
+  };
+
+  return {
+    storage,
+    setFailWrites(value: boolean) {
+      failWrites = value;
+    },
+  };
+}
+
+export function createMemoryStorage(
+  initial: Record<string, string> = {},
+  options: MemoryStorageOptions = {}
+) {
+  return createMemoryStorageController(initial, options).storage;
+}
+
+export function createThrowingStorage(): Storage {
+  return {
+    get length() {
+      return 0;
+    },
+    clear: vi.fn(),
+    getItem: vi.fn(() => {
+      throw new DOMException("Storage unavailable", "SecurityError");
+    }),
+    key: vi.fn(() => null),
+    removeItem: vi.fn(),
+    setItem: vi.fn(() => {
+      throw new DOMException("Storage unavailable", "SecurityError");
+    }),
+  };
+}
+
+export function installWindowStorage(storage: Storage) {
+  const originalDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "localStorage"
+  );
+
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+
+  return () => {
+    if (originalDescriptor) {
+      Object.defineProperty(window, "localStorage", originalDescriptor);
+    }
+  };
+}

--- a/tests/hooks/useCompleteProfile.test.tsx
+++ b/tests/hooks/useCompleteProfile.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useCompleteProfile } from "@/hooks/useCompleteProfile";
+import type { AuthUser } from "@/lib/auth-client";
+
+const mocks = vi.hoisted(() => ({
+  updateProfileName: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    updateProfileName: mocks.updateProfileName,
+  },
+}));
+
+const namelessUser: AuthUser = {
+  id: "user-1",
+  email: "pilot@example.com",
+  name: "",
+  image: null,
+};
+
+describe("useCompleteProfile", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("opens for signed-in users without a display name and stays dismissed after closing", () => {
+    const { result, rerender } = renderHook(
+      ({ authUser }) => useCompleteProfile({ readOnly: false, authUser }),
+      { initialProps: { authUser: namelessUser } }
+    );
+
+    expect(result.current.completeProfileOpen).toBe(true);
+
+    act(() => {
+      result.current.handleCompleteProfileOpenChange(false);
+    });
+    rerender({ authUser: namelessUser });
+
+    expect(result.current.completeProfileOpen).toBe(false);
+  });
+
+  it("does not prompt in read-only mode or when the profile already has a name", () => {
+    const namedUser = { ...namelessUser, name: "Race Director" };
+
+    const readOnly = renderHook(() =>
+      useCompleteProfile({ readOnly: true, authUser: namelessUser })
+    );
+    const named = renderHook(() =>
+      useCompleteProfile({ readOnly: false, authUser: namedUser })
+    );
+
+    expect(readOnly.result.current.completeProfileOpen).toBe(false);
+    expect(named.result.current.completeProfileOpen).toBe(false);
+  });
+
+  it("saves the submitted profile name through the auth client", async () => {
+    const { result } = renderHook(() =>
+      useCompleteProfile({ readOnly: false, authUser: namelessUser })
+    );
+
+    await act(async () => {
+      await result.current.handleCompleteProfileSave("Race Director");
+    });
+
+    expect(mocks.updateProfileName).toHaveBeenCalledWith("Race Director");
+  });
+});

--- a/tests/hooks/useDeveloperMode.test.tsx
+++ b/tests/hooks/useDeveloperMode.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  useDeveloperMode,
+  useDeveloperModeShortcut,
+} from "@/hooks/useDeveloperMode";
+import { createMemoryStorage, installWindowStorage } from "../helpers/storage";
+
+let restoreStorage: (() => void) | null = null;
+
+describe("useDeveloperMode", () => {
+  beforeEach(() => {
+    restoreStorage = installWindowStorage(createMemoryStorage());
+  });
+
+  afterEach(() => {
+    cleanup();
+    restoreStorage?.();
+    restoreStorage = null;
+  });
+
+  it("persists explicit developer mode changes", () => {
+    const { result } = renderHook(() => useDeveloperMode());
+
+    act(() => {
+      result.current.setEnabled(true);
+    });
+
+    expect(result.current.enabled).toBe(true);
+    expect(localStorage.getItem("trackdraw:developer-mode")).toBe("1");
+
+    act(() => {
+      result.current.setEnabled(false);
+    });
+
+    expect(result.current.enabled).toBe(false);
+    expect(localStorage.getItem("trackdraw:developer-mode")).toBeNull();
+  });
+
+  it("toggles with the developer shortcut outside text inputs", () => {
+    renderHook(() => useDeveloperModeShortcut());
+    const mode = renderHook(() => useDeveloperMode());
+
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: ".",
+          metaKey: true,
+          shiftKey: true,
+        })
+      );
+    });
+
+    expect(mode.result.current.enabled).toBe(true);
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    act(() => {
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: ".",
+          metaKey: true,
+          shiftKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    expect(mode.result.current.enabled).toBe(true);
+    input.remove();
+  });
+});

--- a/tests/hooks/useEditorHints.test.tsx
+++ b/tests/hooks/useEditorHints.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useEditorHints } from "@/hooks/useEditorHints";
+import { createMemoryStorage, installWindowStorage } from "../helpers/storage";
+
+let restoreStorage: (() => void) | null = null;
+
+describe("useEditorHints", () => {
+  beforeEach(() => {
+    restoreStorage = installWindowStorage(createMemoryStorage());
+  });
+
+  afterEach(() => {
+    cleanup();
+    restoreStorage?.();
+    restoreStorage = null;
+  });
+
+  it("persists dismissed hints and can reset guided hints", () => {
+    const { result } = renderHook(() =>
+      useEditorHints({ readOnly: false, hasPath: false })
+    );
+
+    act(() => {
+      result.current.dismissGateHint();
+      result.current.dismissDesktopPathHint();
+      result.current.dismissReview3DHint();
+    });
+
+    expect(result.current.gateHintDismissed).toBe(true);
+    expect(result.current.desktopPathHintDismissed).toBe(true);
+    expect(result.current.review3DHintDismissed).toBe(true);
+    expect(localStorage.getItem("trackdraw-hint-gate-dismissed")).toBe("true");
+
+    act(() => {
+      result.current.resetGuidedHints();
+    });
+
+    expect(result.current.gateHintDismissed).toBe(false);
+    expect(result.current.desktopPathHintDismissed).toBe(false);
+    expect(result.current.review3DHintDismissed).toBe(false);
+    expect(localStorage.getItem("trackdraw-hint-gate-dismissed")).toBeNull();
+  });
+
+  it("shows the post-path nudge only when editing completes a path", () => {
+    const { result, rerender } = renderHook(
+      ({ readOnly, hasPath }) => useEditorHints({ readOnly, hasPath }),
+      { initialProps: { readOnly: false, hasPath: false } }
+    );
+
+    expect(result.current.showPostPathNudge).toBe(false);
+
+    rerender({ readOnly: false, hasPath: true });
+
+    expect(result.current.showPostPathNudge).toBe(true);
+
+    act(() => {
+      result.current.dismissPostPathNudge();
+    });
+
+    expect(result.current.postPathNudgeDismissed).toBe(true);
+    expect(localStorage.getItem("trackdraw-hint-post-path-dismissed")).toBe(
+      "true"
+    );
+  });
+});

--- a/tests/hooks/useEditorProjects.test.tsx
+++ b/tests/hooks/useEditorProjects.test.tsx
@@ -6,7 +6,16 @@ import { toast } from "sonner";
 import { useEditorProjects } from "@/hooks/useEditorProjects";
 import { createDefaultDesign } from "@/lib/track/design";
 import { encodeDesign } from "@/lib/share";
+import {
+  createRestorePoint,
+  listRestorePointsForProject,
+  saveProject,
+} from "@/lib/projects";
 import { useEditor } from "@/store/editor";
+import {
+  createMemoryStorage,
+  createMemoryStorageController,
+} from "../helpers/storage";
 
 vi.mock("sonner", () => ({
   toast: {
@@ -14,36 +23,6 @@ vi.mock("sonner", () => ({
     success: vi.fn(),
   },
 }));
-
-function createMemoryStorage() {
-  const store = new Map<string, string>();
-  let failWrites = false;
-
-  const storage: Storage = {
-    get length() {
-      return store.size;
-    },
-    clear: vi.fn(() => store.clear()),
-    getItem: vi.fn((key: string) => store.get(key) ?? null),
-    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
-    removeItem: vi.fn((key: string) => {
-      store.delete(key);
-    }),
-    setItem: vi.fn((key: string, value: string) => {
-      if (failWrites) {
-        throw new DOMException("Storage quota exceeded", "QuotaExceededError");
-      }
-      store.set(key, value);
-    }),
-  };
-
-  return {
-    storage,
-    setFailWrites(value: boolean) {
-      failWrites = value;
-    },
-  };
-}
 
 describe("useEditorProjects", () => {
   beforeEach(() => {
@@ -61,7 +40,7 @@ describe("useEditorProjects", () => {
   });
 
   it("surfaces local autosave failures and lets the user retry", () => {
-    const localStorageMock = createMemoryStorage();
+    const localStorageMock = createMemoryStorageController();
     localStorageMock.setFailWrites(true);
     vi.stubGlobal("localStorage", localStorageMock.storage);
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -120,7 +99,7 @@ describe("useEditorProjects", () => {
   });
 
   it("opens shared links as a new editable local copy", () => {
-    vi.stubGlobal("localStorage", createMemoryStorage().storage);
+    vi.stubGlobal("localStorage", createMemoryStorage());
     const sharedDesign = createDefaultDesign();
     sharedDesign.id = "account-project-1";
     sharedDesign.title = "Shared race layout";
@@ -158,6 +137,114 @@ describe("useEditorProjects", () => {
       localStorage.getItem(`trackdraw-project-${copiedDesign?.id}`)
     ).toContain("Copy of Shared race layout");
     expect(result.current.saveStatusLabel).toBe("Editable copy created");
+    expect(result.current.restorePoints).toEqual([]);
+  });
+
+  it("opens a saved project after snapshotting the current meaningful design", () => {
+    vi.stubGlobal("localStorage", createMemoryStorage());
+    const activeDesign = createDefaultDesign();
+    activeDesign.id = "active-project";
+    activeDesign.title = "Active race layout";
+    const savedDesign = createDefaultDesign();
+    savedDesign.id = "saved-project";
+    savedDesign.title = "Saved race layout";
+    saveProject(savedDesign);
+    const replaceDesign = vi.fn();
+
+    const { result } = renderHook(() =>
+      useEditorProjects({
+        readOnly: false,
+        design: activeDesign,
+        historyPaused: false,
+        interactionSessionDepth: 0,
+        replaceDesign,
+      })
+    );
+
+    act(() => {
+      result.current.handleOpenProject("saved-project");
+    });
+
+    expect(replaceDesign).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "saved-project",
+        title: "Saved race layout",
+      })
+    );
+    expect(localStorage.getItem("trackdraw-project-active-project")).toContain(
+      "Active race layout"
+    );
+    expect(listRestorePointsForProject("active-project")).toHaveLength(1);
+    expect(result.current.restorePoints).toEqual([]);
+    expect(result.current.activeRestorePointId).toBeNull();
+    expect(result.current.saveStatusLabel).toBe("Project opened");
+  });
+
+  it("restores a snapshot and marks it as the active restore point", () => {
+    vi.stubGlobal("localStorage", createMemoryStorage());
+    const design = createDefaultDesign();
+    design.id = "project-1";
+    design.title = "Race day layout";
+    const restorePoint = createRestorePoint(design);
+    const replaceDesign = vi.fn();
+
+    const { result } = renderHook(() =>
+      useEditorProjects({
+        readOnly: false,
+        design,
+        historyPaused: false,
+        interactionSessionDepth: 0,
+        replaceDesign,
+      })
+    );
+
+    act(() => {
+      result.current.handleRestorePoint(restorePoint.id);
+    });
+
+    expect(replaceDesign).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "project-1", title: "Race day layout" })
+    );
+    expect(result.current.restorePoints).toEqual([
+      expect.objectContaining({ id: restorePoint.id }),
+    ]);
+    expect(result.current.activeRestorePointId).toBe(restorePoint.id);
+    expect(result.current.saveStatusLabel).toBe("Restored from snapshot");
+  });
+
+  it("renames the active project through the editor store and clears restore points when deleting it", () => {
+    vi.stubGlobal("localStorage", createMemoryStorage());
+    const design = createDefaultDesign();
+    design.id = "project-1";
+    design.title = "Original title";
+    saveProject(design);
+    createRestorePoint(design);
+    useEditor.getState().replaceDesign(design);
+
+    const { result } = renderHook(() =>
+      useEditorProjects({
+        readOnly: false,
+        design,
+        historyPaused: false,
+        interactionSessionDepth: 0,
+        replaceDesign: vi.fn(),
+      })
+    );
+
+    act(() => {
+      result.current.handleRenameProject("project-1", "Renamed layout");
+    });
+
+    expect(useEditor.getState().track.design.title).toBe("Renamed layout");
+    expect(localStorage.getItem("trackdraw-project-project-1")).toContain(
+      "Renamed layout"
+    );
+
+    act(() => {
+      result.current.handleDeleteProject("project-1");
+    });
+
+    expect(localStorage.getItem("trackdraw-project-project-1")).toBeNull();
     expect(result.current.restorePoints).toEqual([]);
   });
 });

--- a/tests/hooks/useMeasurementUnitSystem.test.tsx
+++ b/tests/hooks/useMeasurementUnitSystem.test.tsx
@@ -2,36 +2,17 @@
 
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createThrowingStorage,
+  installWindowStorage,
+} from "../helpers/storage";
 
-const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
-  window,
-  "localStorage"
-);
-
-function createThrowingStorage(): Storage {
-  return {
-    get length() {
-      return 0;
-    },
-    clear: vi.fn(),
-    getItem: vi.fn(() => {
-      throw new DOMException("Storage unavailable", "SecurityError");
-    }),
-    key: vi.fn(() => null),
-    removeItem: vi.fn(),
-    setItem: vi.fn(() => {
-      throw new DOMException("Storage unavailable", "SecurityError");
-    }),
-  };
-}
+let restoreStorage: (() => void) | null = null;
 
 describe("useMeasurementUnitSystem", () => {
   beforeEach(() => {
     vi.resetModules();
-    Object.defineProperty(window, "localStorage", {
-      configurable: true,
-      value: createThrowingStorage(),
-    });
+    restoreStorage = installWindowStorage(createThrowingStorage());
     Object.defineProperty(window.navigator, "languages", {
       configurable: true,
       value: ["nl-NL"],
@@ -40,13 +21,8 @@ describe("useMeasurementUnitSystem", () => {
 
   afterEach(() => {
     cleanup();
-    if (originalLocalStorageDescriptor) {
-      Object.defineProperty(
-        window,
-        "localStorage",
-        originalLocalStorageDescriptor
-      );
-    }
+    restoreStorage?.();
+    restoreStorage = null;
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });

--- a/tests/hooks/usePerfMetric.test.tsx
+++ b/tests/hooks/usePerfMetric.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment happy-dom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePerfMetric } from "@/hooks/usePerfMetric";
+import { getPerfSnapshot, resetPerfMetrics } from "@/lib/perf";
+
+describe("usePerfMetric", () => {
+  afterEach(() => {
+    cleanup();
+    resetPerfMetrics();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("records a non-production render duration on the next animation frame", () => {
+    let frameCallback: FrameRequestCallback = () => undefined;
+    let now = 100;
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        frameCallback = callback;
+        return 1;
+      })
+    );
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    renderHook(() => usePerfMetric("editor:panel"));
+
+    now = 116;
+    frameCallback?.(116);
+
+    expect(getPerfSnapshot()["editor:panel"]).toMatchObject({
+      count: 1,
+      lastMs: 16,
+    });
+  });
+
+  it("cancels the pending animation frame on unmount", () => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn(() => 42)
+    );
+    const cancelAnimationFrame = vi.fn();
+    vi.stubGlobal("cancelAnimationFrame", cancelAnimationFrame);
+
+    const { unmount } = renderHook(() => usePerfMetric("editor:panel"));
+    unmount();
+
+    expect(cancelAnimationFrame).toHaveBeenCalledWith(42);
+  });
+});

--- a/tests/hooks/usePersistentBoolean.test.tsx
+++ b/tests/hooks/usePersistentBoolean.test.tsx
@@ -2,58 +2,15 @@
 
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMemoryStorage,
+  createThrowingStorage,
+  installWindowStorage,
+} from "../helpers/storage";
 
-const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
-  window,
-  "localStorage"
-);
-
-function createMapStorage(initial: Record<string, string> = {}): Storage {
-  const store = new Map<string, string>(Object.entries(initial));
-  return {
-    get length() {
-      return store.size;
-    },
-    clear: () => store.clear(),
-    getItem: (key: string) => store.get(key) ?? null,
-    key: (index: number) => [...store.keys()][index] ?? null,
-    removeItem: (key: string) => void store.delete(key),
-    setItem: (key: string, value: string) => void store.set(key, value),
-  };
-}
-
-function createThrowingStorage(): Storage {
-  return {
-    get length() {
-      return 0;
-    },
-    clear: vi.fn(),
-    getItem: vi.fn(() => {
-      throw new DOMException("Storage unavailable", "SecurityError");
-    }),
-    key: vi.fn(() => null),
-    removeItem: vi.fn(),
-    setItem: vi.fn(() => {
-      throw new DOMException("Storage unavailable", "SecurityError");
-    }),
-  };
-}
-
+let restoreStorage: (() => void) | null = null;
 function setStorage(impl: Storage) {
-  Object.defineProperty(window, "localStorage", {
-    configurable: true,
-    value: impl,
-  });
-}
-
-function restoreStorage() {
-  if (originalLocalStorageDescriptor) {
-    Object.defineProperty(
-      window,
-      "localStorage",
-      originalLocalStorageDescriptor
-    );
-  }
+  restoreStorage = installWindowStorage(impl);
 }
 
 const KEY = "test.persistentBoolean";
@@ -64,12 +21,13 @@ describe("usePersistentBoolean", () => {
   });
 
   afterEach(() => {
-    restoreStorage();
+    restoreStorage?.();
+    restoreStorage = null;
     vi.restoreAllMocks();
   });
 
   it("initialises to false by default when nothing stored", async () => {
-    setStorage(createMapStorage());
+    setStorage(createMemoryStorage());
     const { usePersistentBoolean } =
       await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY));
@@ -77,7 +35,7 @@ describe("usePersistentBoolean", () => {
   });
 
   it("initialises to the provided defaultValue", async () => {
-    setStorage(createMapStorage());
+    setStorage(createMemoryStorage());
     const { usePersistentBoolean } =
       await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY, true));
@@ -85,7 +43,7 @@ describe("usePersistentBoolean", () => {
   });
 
   it("reads a stored 'true' value from localStorage", async () => {
-    setStorage(createMapStorage({ [KEY]: "true" }));
+    setStorage(createMemoryStorage({ [KEY]: "true" }));
     const { usePersistentBoolean } =
       await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY));
@@ -93,7 +51,7 @@ describe("usePersistentBoolean", () => {
   });
 
   it("reads a stored 'false' value, overriding a true defaultValue", async () => {
-    setStorage(createMapStorage({ [KEY]: "false" }));
+    setStorage(createMemoryStorage({ [KEY]: "false" }));
     const { usePersistentBoolean } =
       await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY, true));
@@ -101,7 +59,7 @@ describe("usePersistentBoolean", () => {
   });
 
   it("ignores unrecognised stored strings and falls back to defaultValue", async () => {
-    setStorage(createMapStorage({ [KEY]: "yes" }));
+    setStorage(createMemoryStorage({ [KEY]: "yes" }));
     const { usePersistentBoolean } =
       await import("@/hooks/usePersistentBoolean");
     const { result } = renderHook(() => usePersistentBoolean(KEY, true));
@@ -109,7 +67,7 @@ describe("usePersistentBoolean", () => {
   });
 
   it("persists a true value to localStorage when state changes", async () => {
-    const storage = createMapStorage();
+    const storage = createMemoryStorage();
     setStorage(storage);
     const { usePersistentBoolean } =
       await import("@/hooks/usePersistentBoolean");
@@ -124,7 +82,7 @@ describe("usePersistentBoolean", () => {
   });
 
   it("persists a false value to localStorage when state changes", async () => {
-    const storage = createMapStorage({ [KEY]: "true" });
+    const storage = createMemoryStorage({ [KEY]: "true" });
     setStorage(storage);
     const { usePersistentBoolean } =
       await import("@/hooks/usePersistentBoolean");
@@ -139,7 +97,7 @@ describe("usePersistentBoolean", () => {
   });
 
   it("keeps in-memory state working when localStorage.setItem throws", async () => {
-    const storage = createMapStorage();
+    const storage = createMemoryStorage();
     vi.spyOn(storage, "setItem").mockImplementation(() => {
       throw new DOMException("Storage full", "QuotaExceededError");
     });

--- a/tests/hooks/useShareUrl.test.tsx
+++ b/tests/hooks/useShareUrl.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useShareUrl } from "@/hooks/useShareUrl";
+import { encodeDesign } from "@/lib/share";
+import { createDefaultDesign } from "@/lib/track/design";
+import { useEditor } from "@/store/editor";
+
+const routeState = vi.hoisted(() => ({
+  params: {} as { token?: string },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => routeState.params,
+}));
+
+describe("useShareUrl", () => {
+  beforeEach(() => {
+    useEditor.getState().newProject();
+    useEditor.getState().clearHistory();
+    routeState.params = {};
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("imports a valid share token into the editor store", () => {
+    const sharedDesign = createDefaultDesign();
+    sharedDesign.id = "shared-design";
+    sharedDesign.title = "Shared race layout";
+    routeState.params = { token: encodeDesign(sharedDesign) };
+
+    renderHook(() => useShareUrl());
+
+    expect(useEditor.getState().track.design).toMatchObject({
+      id: "shared-design",
+      title: "Shared race layout",
+    });
+  });
+
+  it("ignores missing or invalid share tokens", () => {
+    const originalDesign = useEditor.getState().track.design;
+    routeState.params = { token: "not-a-design" };
+
+    renderHook(() => useShareUrl());
+
+    expect(useEditor.getState().track.design).toBe(originalDesign);
+  });
+});

--- a/tests/hooks/useTheme.test.tsx
+++ b/tests/hooks/useTheme.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useTheme } from "@/hooks/useTheme";
+
+describe("useTheme", () => {
+  afterEach(() => {
+    cleanup();
+    document.documentElement.className = "";
+  });
+
+  it("reads the current document theme and tracks class changes", async () => {
+    document.documentElement.classList.add("dark");
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current).toBe("dark");
+
+    await act(async () => {
+      document.documentElement.classList.remove("dark");
+    });
+
+    expect(result.current).toBe("light");
+  });
+});

--- a/tests/lib/auth-client.test.ts
+++ b/tests/lib/auth-client.test.ts
@@ -2,6 +2,7 @@
 
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createMemoryStorage, installWindowStorage } from "../helpers/storage";
 
 const useSessionMock = vi.fn();
 const signOutMock = vi.fn();
@@ -9,31 +10,7 @@ const deleteUserMock = vi.fn();
 const updateUserMock = vi.fn();
 const magicLinkMock = vi.fn();
 const passkeySignInMock = vi.fn();
-const originalLocalStorageDescriptor = Object.getOwnPropertyDescriptor(
-  window,
-  "localStorage"
-);
-
-function createMemoryStorage(): Storage {
-  const store = new Map<string, string>();
-
-  return {
-    get length() {
-      return store.size;
-    },
-    clear: vi.fn(() => {
-      store.clear();
-    }),
-    getItem: vi.fn((key: string) => store.get(key) ?? null),
-    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
-    removeItem: vi.fn((key: string) => {
-      store.delete(key);
-    }),
-    setItem: vi.fn((key: string, value: string) => {
-      store.set(key, value);
-    }),
-  };
-}
+let restoreStorage: (() => void) | null = null;
 
 vi.mock("@better-auth/passkey/client", () => ({
   passkeyClient: vi.fn(() => ({})),
@@ -60,10 +37,7 @@ describe("authClient session resolution", () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    Object.defineProperty(window, "localStorage", {
-      configurable: true,
-      value: createMemoryStorage(),
-    });
+    restoreStorage = installWindowStorage(createMemoryStorage());
 
     useSessionMock.mockReturnValue({
       data: {
@@ -96,13 +70,8 @@ describe("authClient session resolution", () => {
 
   afterEach(() => {
     cleanup();
-    if (originalLocalStorageDescriptor) {
-      Object.defineProperty(
-        window,
-        "localStorage",
-        originalLocalStorageDescriptor
-      );
-    }
+    restoreStorage?.();
+    restoreStorage = null;
     vi.unstubAllGlobals();
   });
 
@@ -138,6 +107,51 @@ describe("authClient session resolution", () => {
     });
 
     expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("normalizes unexpected account roles from the session endpoint", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        user: { role: "owner" },
+      }),
+    } as Response);
+    const { authClient } = await import("@/lib/auth-client");
+
+    const session = renderHook(() => authClient.useSession());
+
+    await waitFor(() => {
+      expect(session.result.current.data?.user.role).toBe("user");
+    });
+  });
+
+  it("keeps the browser session visible when account role resolution fails", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      json: async () => ({
+        ok: false,
+        error: "Session lookup failed",
+      }),
+    } as Response);
+    const { authClient } = await import("@/lib/auth-client");
+
+    const session = renderHook(() => authClient.useSession());
+
+    await waitFor(() => {
+      expect(session.result.current.isPending).toBe(false);
+      expect(session.result.current.error?.message).toBe(
+        "Session lookup failed"
+      );
+    });
+    expect(session.result.current.data).toMatchObject({
+      session: { id: "session-1" },
+      user: {
+        id: "user-1",
+        email: "pilot@trackdraw.local",
+      },
+    });
+    expect(session.result.current.data?.user.role).toBeUndefined();
   });
 
   it("clears the resolved role cache on signOut", async () => {
@@ -186,5 +200,39 @@ describe("authClient session resolution", () => {
       callbackURL: "/studio",
     });
     expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("trims profile names before updating the Better Auth user", async () => {
+    const { authClient } = await import("@/lib/auth-client");
+
+    await authClient.updateProfileName("  Race Director  ");
+
+    expect(updateUserMock).toHaveBeenCalledWith({ name: "Race Director" });
+  });
+
+  it("posts normalized email changes with the default studio callback", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({}),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { authClient } = await import("@/lib/auth-client");
+
+    await authClient.changeEmail({ newEmail: "  PILOT@EXAMPLE.COM " });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      new URL("/api/auth/change-email", window.location.origin),
+      {
+        method: "POST",
+        credentials: "include",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          newEmail: "pilot@example.com",
+          callbackURL: "/studio",
+        }),
+      }
+    );
   });
 });

--- a/tests/lib/map-reference/tiles.test.ts
+++ b/tests/lib/map-reference/tiles.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { getMapReferenceTileUrl } from "@/lib/map-reference/tiles";
+
+describe("map reference tiles", () => {
+  it("builds the configured satellite tile URL from xyz coordinates", () => {
+    expect(getMapReferenceTileUrl({ x: 134_122, y: 86_214, z: 18 })).toBe(
+      "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/18/86214/134122"
+    );
+  });
+});

--- a/tests/lib/projects.test.ts
+++ b/tests/lib/projects.test.ts
@@ -2,33 +2,18 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createRestorePoint,
+  deleteProjects,
+  listRestorePoints,
+  listRestorePointsForProject,
   listProjects,
   loadProject,
+  loadRestorePoint,
+  renameProject,
   saveProjectWithResult,
 } from "@/lib/projects";
 import { createDefaultDesign } from "@/lib/track/design";
-
-function createMemoryStorage(options?: { failSetKey?: string }) {
-  const store = new Map<string, string>();
-
-  return {
-    get length() {
-      return store.size;
-    },
-    clear: vi.fn(() => store.clear()),
-    getItem: vi.fn((key: string) => store.get(key) ?? null),
-    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
-    removeItem: vi.fn((key: string) => {
-      store.delete(key);
-    }),
-    setItem: vi.fn((key: string, value: string) => {
-      if (key === options?.failSetKey) {
-        throw new DOMException("Storage quota exceeded", "QuotaExceededError");
-      }
-      store.set(key, value);
-    }),
-  } satisfies Storage;
-}
+import { createMemoryStorage } from "../helpers/storage";
 
 describe("local project persistence", () => {
   beforeEach(() => {
@@ -42,7 +27,7 @@ describe("local project persistence", () => {
   it("does not add a project-list entry when the project payload write fails", () => {
     vi.stubGlobal(
       "localStorage",
-      createMemoryStorage({ failSetKey: "trackdraw-project-project-1" })
+      createMemoryStorage({}, { failSetKey: "trackdraw-project-project-1" })
     );
     const design = createDefaultDesign();
     design.id = "project-1";
@@ -75,6 +60,68 @@ describe("local project persistence", () => {
     expect(loadProject("project-1")).toMatchObject({
       id: "project-1",
       title: "Race day layout",
+    });
+  });
+
+  it("keeps project metadata and stored design titles in sync when renaming", () => {
+    const design = createDefaultDesign();
+    design.id = "project-1";
+    design.title = "Draft layout";
+    saveProjectWithResult(design);
+
+    renameProject("project-1", "Race day layout");
+
+    expect(listProjects()).toEqual([
+      expect.objectContaining({ id: "project-1", title: "Race day layout" }),
+    ]);
+    expect(loadProject("project-1")).toMatchObject({
+      id: "project-1",
+      title: "Race day layout",
+    });
+  });
+
+  it("deletes projects and only their restore points", () => {
+    const firstDesign = createDefaultDesign();
+    firstDesign.id = "project-1";
+    firstDesign.title = "First layout";
+    const secondDesign = createDefaultDesign();
+    secondDesign.id = "project-2";
+    secondDesign.title = "Second layout";
+    saveProjectWithResult(firstDesign);
+    saveProjectWithResult(secondDesign);
+    const firstRestorePoint = createRestorePoint(firstDesign);
+    const secondRestorePoint = createRestorePoint(secondDesign);
+
+    deleteProjects(["project-1"]);
+
+    expect(loadProject("project-1")).toBeNull();
+    expect(loadRestorePoint(firstRestorePoint.id)).toBeNull();
+    expect(loadProject("project-2")).toMatchObject({ id: "project-2" });
+    expect(loadRestorePoint(secondRestorePoint.id)).toMatchObject({
+      id: "project-2",
+    });
+    expect(listRestorePoints()).toEqual([
+      expect.objectContaining({ id: secondRestorePoint.id }),
+    ]);
+  });
+
+  it("prunes restore points per design instead of globally", () => {
+    const activeDesign = createDefaultDesign();
+    activeDesign.id = "project-1";
+    activeDesign.title = "Race day layout";
+    const otherDesign = createDefaultDesign();
+    otherDesign.id = "project-2";
+    otherDesign.title = "Other layout";
+    const otherRestorePoint = createRestorePoint(otherDesign);
+    const activeRestorePoints = Array.from({ length: 11 }, () =>
+      createRestorePoint(activeDesign)
+    );
+    const droppedRestorePoint = activeRestorePoints[0];
+
+    expect(listRestorePointsForProject("project-1")).toHaveLength(10);
+    expect(loadRestorePoint(droppedRestorePoint.id)).toBeNull();
+    expect(loadRestorePoint(otherRestorePoint.id)).toMatchObject({
+      id: "project-2",
     });
   });
 });

--- a/tests/lib/server/auth-email.test.ts
+++ b/tests/lib/server/auth-email.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  buildChangeEmailConfirmationEmail,
+  buildEmailVerificationEmail,
+  buildMagicLinkEmail,
+  getAuthEmailPreviewContent,
+} from "@/lib/server/auth-email";
+
+describe("auth email templates", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("builds magic-link emails with the configured TrackDraw brand URL", () => {
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://preview.trackdraw.app");
+
+    const email = buildMagicLinkEmail(
+      "https://preview.trackdraw.app/api/auth/magic-link/verify?token=abc"
+    );
+
+    expect(email.subject).toBe("Your TrackDraw sign-in link");
+    expect(email.htmlBody).toContain(
+      "https://preview.trackdraw.app/assets/brand/trackdraw-logo-color-darkbg.svg"
+    );
+    expect(email.htmlBody).toContain("Open TrackDraw");
+    expect(email.textBody).toContain("Open this one-time sign-in link");
+  });
+
+  it("escapes verification email values in HTML while keeping plain text readable", () => {
+    const email = buildEmailVerificationEmail(
+      'https://trackdraw.app/verify?token=<bad>&next="/studio"',
+      "pilot+<script>@example.com"
+    );
+
+    expect(email.htmlBody).toContain("pilot+&lt;script&gt;@example.com");
+    expect(email.htmlBody).toContain(
+      "https://trackdraw.app/verify?token=&lt;bad&gt;&amp;next=&quot;/studio&quot;"
+    );
+    expect(email.htmlBody).not.toContain("pilot+<script>@example.com");
+    expect(email.textBody).toContain("pilot+<script>@example.com");
+  });
+
+  it("describes both old and new addresses for email change confirmations", () => {
+    const email = buildChangeEmailConfirmationEmail(
+      "https://trackdraw.app/change-email?token=abc",
+      "old@example.com",
+      "new@example.com"
+    );
+
+    expect(email.subject).toBe("Confirm your TrackDraw email change");
+    expect(email.htmlBody).toContain("old@example.com");
+    expect(email.htmlBody).toContain("new@example.com");
+    expect(email.textBody).toContain(
+      "Change old@example.com to new@example.com"
+    );
+  });
+
+  it("returns preview content for all supported auth email previews", () => {
+    expect(getAuthEmailPreviewContent("magic-link").subject).toBe(
+      "Your TrackDraw sign-in link"
+    );
+    expect(getAuthEmailPreviewContent("verify-email").subject).toBe(
+      "Verify your TrackDraw email"
+    );
+    expect(getAuthEmailPreviewContent("change-email").subject).toBe(
+      "Confirm your TrackDraw email change"
+    );
+  });
+});

--- a/tests/lib/server/auth-session.test.ts
+++ b/tests/lib/server/auth-session.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createD1Statement, installD1Statements } from "../../helpers/d1";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  prepare: vi.fn(),
+}));
+
+vi.mock("@/lib/server/db", () => ({
+  getDatabase: vi.fn(async () => ({
+    prepare: mocks.prepare,
+  })),
+}));
+
+import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
+
+async function signedSessionCookie(token: string, secret: string) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(token)
+  );
+
+  return `better-auth.session_token=${encodeURIComponent(
+    `${token}.${Buffer.from(signature).toString("base64")}`
+  )}`;
+}
+
+describe("auth session resolver", () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    mocks.prepare.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns null without an auth secret or session cookie", async () => {
+    await expect(getCurrentUserFromHeaders(new Headers())).resolves.toBeNull();
+    expect(mocks.prepare).not.toHaveBeenCalled();
+  });
+
+  it("rejects tampered signed session cookies before querying the database", async () => {
+    vi.stubEnv("BETTER_AUTH_SECRET", "test-secret");
+
+    const user = await getCurrentUserFromHeaders(
+      new Headers({
+        cookie: "better-auth.session_token=session-token.invalid-signature",
+      })
+    );
+
+    expect(user).toBeNull();
+    expect(mocks.prepare).not.toHaveBeenCalled();
+  });
+
+  it("loads a valid unexpired session and normalizes the account role", async () => {
+    vi.stubEnv("BETTER_AUTH_SECRET", "test-secret");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T12:00:00.000Z"));
+    const statement = createD1Statement({
+      first: {
+        id: "user-1",
+        email: "pilot@example.com",
+        name: "Race Director",
+        image: "https://example.com/avatar.jpg",
+        role: "invalid-role",
+        expiresAt: "2026-06-09T13:00:00.000Z",
+      },
+    });
+    installD1Statements(mocks.prepare, [statement]);
+
+    const user = await getCurrentUserFromHeaders(
+      new Headers({
+        cookie: await signedSessionCookie("session-token", "test-secret"),
+      })
+    );
+
+    expect(statement.bind).toHaveBeenCalledWith("session-token");
+    expect(user).toEqual({
+      id: "user-1",
+      email: "pilot@example.com",
+      name: "Race Director",
+      image: "https://example.com/avatar.jpg",
+      role: "user",
+    });
+  });
+
+  it("rejects expired sessions after loading the session row", async () => {
+    vi.stubEnv("BETTER_AUTH_SECRET", "test-secret");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T12:00:00.000Z"));
+    installD1Statements(mocks.prepare, [
+      createD1Statement({
+        first: {
+          id: "user-1",
+          email: "pilot@example.com",
+          name: null,
+          image: null,
+          role: "admin",
+          expiresAt: "2026-06-09T11:59:59.000Z",
+        },
+      }),
+    ]);
+
+    await expect(
+      getCurrentUserFromHeaders(
+        new Headers({
+          cookie: await signedSessionCookie("session-token", "test-secret"),
+        })
+      )
+    ).resolves.toBeNull();
+  });
+});

--- a/tests/lib/server/csrf.test.ts
+++ b/tests/lib/server/csrf.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { isTrustedRequest } from "@/lib/server/csrf";
+
+describe("CSRF request trust guard", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("trusts the configured public site origin and additional auth origins", () => {
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://trackdraw.app");
+    vi.stubEnv(
+      "BETTER_AUTH_TRUSTED_ORIGINS",
+      "https://preview.trackdraw.app, https://admin.trackdraw.app"
+    );
+
+    expect(
+      isTrustedRequest(
+        new Request("https://trackdraw.app/api/projects", {
+          method: "POST",
+          headers: { origin: "https://trackdraw.app" },
+        })
+      )
+    ).toBe(true);
+    expect(
+      isTrustedRequest(
+        new Request("https://trackdraw.app/api/projects", {
+          method: "POST",
+          headers: {
+            referer: "https://admin.trackdraw.app/dashboard/gallery",
+          },
+        })
+      )
+    ).toBe(true);
+  });
+
+  it("rejects missing, malformed, and untrusted origins by default", () => {
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://trackdraw.app");
+
+    expect(
+      isTrustedRequest(new Request("https://trackdraw.app/api/projects"))
+    ).toBe(false);
+    expect(
+      isTrustedRequest(
+        new Request("https://trackdraw.app/api/projects", {
+          headers: { origin: "not a url" },
+        })
+      )
+    ).toBe(false);
+    expect(
+      isTrustedRequest(
+        new Request("https://trackdraw.app/api/projects", {
+          headers: { origin: "https://evil.example" },
+        })
+      )
+    ).toBe(false);
+  });
+});

--- a/tests/lib/server/gallery-media.test.ts
+++ b/tests/lib/server/gallery-media.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createMockMediaBucket,
+  installCloudflareMediaBucket,
+} from "../../helpers/cloudflare";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: mocks.getCloudflareContext,
+}));
+
+import {
+  deleteGalleryPreviewImage,
+  uploadGalleryPreviewImage,
+} from "@/lib/server/gallery-media";
+
+describe("gallery media storage", () => {
+  beforeEach(() => {
+    mocks.getCloudflareContext.mockReset();
+  });
+
+  it("returns null when no media bucket is configured", async () => {
+    installCloudflareMediaBucket(mocks.getCloudflareContext, null);
+
+    const key = await uploadGalleryPreviewImage({
+      galleryEntryId: "entry-1",
+      previewDataUrl: "data:image/webp;base64,not-used",
+    });
+
+    expect(key).toBeNull();
+  });
+
+  it("uploads webp previews with immutable cache metadata", async () => {
+    const bucket = createMockMediaBucket();
+    installCloudflareMediaBucket(mocks.getCloudflareContext, bucket);
+
+    const key = await uploadGalleryPreviewImage({
+      galleryEntryId: "entry-1",
+      previewDataUrl: `data:image/webp;base64,${Buffer.from("webp").toString(
+        "base64"
+      )}`,
+    });
+
+    expect(key).toBe("gallery/previews/entry-1.webp");
+    expect(bucket.put).toHaveBeenCalledWith(
+      "gallery/previews/entry-1.webp",
+      expect.any(Uint8Array),
+      {
+        httpMetadata: {
+          contentType: "image/webp",
+          cacheControl: "public, max-age=31536000, immutable",
+        },
+      }
+    );
+  });
+
+  it("rejects non-webp preview payloads before upload", async () => {
+    const bucket = createMockMediaBucket();
+    installCloudflareMediaBucket(mocks.getCloudflareContext, bucket);
+
+    await expect(
+      uploadGalleryPreviewImage({
+        galleryEntryId: "entry-1",
+        previewDataUrl: "data:image/png;base64,abc=",
+      })
+    ).rejects.toThrow("Invalid gallery preview payload");
+    expect(bucket.put).not.toHaveBeenCalled();
+  });
+
+  it("deletes configured preview keys and ignores missing buckets or keys", async () => {
+    const bucket = createMockMediaBucket();
+    installCloudflareMediaBucket(mocks.getCloudflareContext, bucket);
+
+    await deleteGalleryPreviewImage(null);
+    await deleteGalleryPreviewImage("gallery/previews/entry-1.webp");
+
+    expect(bucket.delete).toHaveBeenCalledTimes(1);
+    expect(bucket.delete).toHaveBeenCalledWith("gallery/previews/entry-1.webp");
+
+    installCloudflareMediaBucket(mocks.getCloudflareContext, null);
+    await expect(
+      deleteGalleryPreviewImage("gallery/previews/missing.webp")
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/lib/server/gallery.test.ts
+++ b/tests/lib/server/gallery.test.ts
@@ -1,4 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createD1Statement as createStatement,
+  installD1Statements,
+  type MockD1Statement,
+} from "../../helpers/d1";
 
 vi.mock("server-only", () => ({}));
 
@@ -18,49 +23,22 @@ vi.mock("@/lib/server/gallery-media", () => ({
 }));
 
 import {
+  createUnlistedGalleryEntry,
   deleteGalleryEntry,
+  getGalleryEntryByShareToken,
   getGalleryOverviewStats,
+  listGalleryEntriesForDashboard,
   listPublicGalleryEntries,
   moveGalleryEntryToFeatured,
   moveGalleryEntryToHidden,
   moveGalleryEntryToListed,
   moveGalleryEntryToUnlisted,
+  setGalleryEntryPreviewImage,
+  updateGalleryEntryMetadata,
 } from "@/lib/server/gallery";
 
-type Statement = {
-  sql: string;
-  bind: ReturnType<typeof vi.fn>;
-  all: ReturnType<typeof vi.fn>;
-  first: ReturnType<typeof vi.fn>;
-  run: ReturnType<typeof vi.fn>;
-};
-
-function createStatement(result?: {
-  all?: unknown;
-  first?: unknown;
-  run?: unknown;
-}): Statement {
-  const statement = {
-    sql: "",
-    bind: vi.fn(() => statement),
-    all: vi.fn(async () => result?.all ?? { results: [] }),
-    first: vi.fn(async () => result?.first ?? null),
-    run: vi.fn(async () => result?.run ?? {}),
-  };
-
-  return statement;
-}
-
-function installStatements(statements: Statement[]) {
-  mocks.prepare.mockImplementation((sql: string) => {
-    const statement = statements.shift();
-    if (!statement) {
-      throw new Error(`Unexpected SQL: ${sql}`);
-    }
-
-    statement.sql = sql;
-    return statement;
-  });
+function installStatements(statements: MockD1Statement[]) {
+  installD1Statements(mocks.prepare, statements);
 }
 
 describe("gallery server helpers", () => {
@@ -214,5 +192,213 @@ describe("gallery server helpers", () => {
       hidden: 1,
       unlisted: 0,
     });
+  });
+
+  it("returns null from getGalleryEntryByShareToken when no row is found", async () => {
+    installStatements([createStatement({ first: null })]);
+
+    const result = await getGalleryEntryByShareToken("unknown-token");
+    expect(result).toBeNull();
+  });
+
+  it("maps a row to a gallery entry from getGalleryEntryByShareToken", async () => {
+    installStatements([
+      createStatement({
+        first: {
+          id: "entry-x",
+          share_token: "tok-x",
+          owner_user_id: "owner-1",
+          gallery_state: "listed",
+          gallery_title: "My Layout",
+          gallery_description: "Great track",
+          gallery_preview_image: "/img/x.jpg",
+          gallery_published_at: "2026-05-01T00:00:00.000Z",
+          moderation_hidden_at: null,
+          created_at: "2026-04-01T00:00:00.000Z",
+          updated_at: "2026-05-15T00:00:00.000Z",
+        },
+      }),
+    ]);
+
+    const entry = await getGalleryEntryByShareToken("tok-x");
+    expect(entry).toMatchObject({
+      id: "entry-x",
+      shareToken: "tok-x",
+      galleryState: "listed",
+      galleryTitle: "My Layout",
+      galleryDescription: "Great track",
+      galleryPreviewImage: "/img/x.jpg",
+    });
+  });
+
+  it("returns all rows from listGalleryEntriesForDashboard", async () => {
+    const dashboardRow = {
+      id: "entry-d",
+      share_token: "tok-d",
+      owner_user_id: "owner-2",
+      gallery_state: "unlisted",
+      gallery_title: "Dashboard Track",
+      gallery_description: "",
+      gallery_preview_image: null,
+      gallery_published_at: null,
+      moderation_hidden_at: null,
+      created_at: "2026-03-01T00:00:00.000Z",
+      updated_at: "2026-03-15T00:00:00.000Z",
+      owner_name: "Alice",
+      owner_email: "alice@example.com",
+      share_title: "Dashboard Share",
+      share_expires_at: null,
+      share_revoked_at: null,
+      field_width: "40.5",
+      field_height: "20.0",
+      shape_count: 12,
+    };
+    installStatements([createStatement({ all: { results: [dashboardRow] } })]);
+
+    const entries = await listGalleryEntriesForDashboard();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: "entry-d",
+      galleryState: "unlisted",
+      ownerName: "Alice",
+      ownerEmail: "alice@example.com",
+      fieldWidth: 40.5,
+      fieldHeight: 20.0,
+      shapeCount: 12,
+    });
+  });
+
+  it("listGalleryEntriesForDashboard passes the state filter when provided", async () => {
+    const stmt = createStatement({ all: { results: [] } });
+    installStatements([stmt]);
+
+    await listGalleryEntriesForDashboard({ state: "listed" });
+    expect(stmt.bind).toHaveBeenCalledWith(1, "listed");
+  });
+
+  it("listGalleryEntriesForDashboard queries all states when state='all'", async () => {
+    const stmt = createStatement({ all: { results: [] } });
+    installStatements([stmt]);
+
+    await listGalleryEntriesForDashboard({ state: "all" });
+    expect(stmt.bind).toHaveBeenCalledWith(0, "");
+  });
+
+  it("creates an unlisted gallery entry and returns it via getGalleryEntryByShareToken", async () => {
+    const insertStmt = createStatement({ run: {} });
+    const selectStmt = createStatement({
+      first: {
+        id: "new-entry",
+        share_token: "new-tok",
+        owner_user_id: "owner-3",
+        gallery_state: "unlisted",
+        gallery_title: "New Entry",
+        gallery_description: "Fresh",
+        gallery_preview_image: null,
+        gallery_published_at: null,
+        moderation_hidden_at: null,
+        created_at: "2026-06-09T00:00:00.000Z",
+        updated_at: "2026-06-09T00:00:00.000Z",
+      },
+    });
+    installStatements([insertStmt, selectStmt]);
+
+    const entry = await createUnlistedGalleryEntry({
+      shareToken: "new-tok",
+      ownerUserId: "owner-3",
+      title: "New Entry",
+      description: "Fresh",
+    });
+
+    expect(entry).not.toBeNull();
+    expect(entry?.galleryState).toBe("unlisted");
+    expect(entry?.galleryTitle).toBe("New Entry");
+  });
+
+  it("updateGalleryEntryMetadata runs a SQL UPDATE", async () => {
+    const stmt = createStatement({ run: {} });
+    installStatements([stmt]);
+
+    await updateGalleryEntryMetadata({
+      shareToken: "tok-update",
+      title: "Updated Title",
+      description: "New desc",
+    });
+
+    expect(stmt.run).toHaveBeenCalledOnce();
+    expect(stmt.bind).toHaveBeenCalledWith(
+      "Updated Title",
+      "New desc",
+      expect.any(String),
+      "tok-update"
+    );
+  });
+
+  it("setGalleryEntryPreviewImage runs a SQL UPDATE with the given image URL", async () => {
+    const stmt = createStatement({ run: {} });
+    installStatements([stmt]);
+
+    await setGalleryEntryPreviewImage({
+      shareToken: "tok-img",
+      previewImage: "/img/preview.jpg",
+    });
+
+    expect(stmt.run).toHaveBeenCalledOnce();
+    expect(stmt.bind).toHaveBeenCalledWith(
+      "/img/preview.jpg",
+      expect.any(String),
+      "tok-img"
+    );
+  });
+
+  it("setGalleryEntryPreviewImage accepts null to clear the image", async () => {
+    const stmt = createStatement({ run: {} });
+    installStatements([stmt]);
+
+    await setGalleryEntryPreviewImage({
+      shareToken: "tok-clear",
+      previewImage: null,
+    });
+
+    expect(stmt.bind).toHaveBeenCalledWith(
+      null,
+      expect.any(String),
+      "tok-clear"
+    );
+  });
+
+  it("listGalleryEntriesForDashboard handles null field dimensions gracefully", async () => {
+    installStatements([
+      createStatement({
+        all: {
+          results: [
+            {
+              id: "e-null",
+              share_token: "t-null",
+              owner_user_id: "o-1",
+              gallery_state: "listed",
+              gallery_title: "",
+              gallery_description: "",
+              gallery_preview_image: null,
+              gallery_published_at: null,
+              moderation_hidden_at: null,
+              created_at: "2026-01-01T00:00:00.000Z",
+              updated_at: "2026-01-01T00:00:00.000Z",
+              owner_name: null,
+              owner_email: null,
+              share_title: null,
+              share_expires_at: null,
+              share_revoked_at: null,
+              field_width: null,
+              field_height: null,
+              shape_count: 0,
+            },
+          ],
+        },
+      }),
+    ]);
+
+    const entries = await listGalleryEntriesForDashboard();
+    expect(entries[0]).toMatchObject({ fieldWidth: null, fieldHeight: null });
   });
 });

--- a/tests/lib/server/projects.test.ts
+++ b/tests/lib/server/projects.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultDesign, serializeDesign } from "@/lib/track/design";
+import {
+  createD1AllStatement,
+  createD1Statement,
+  installD1Statements,
+} from "../../helpers/d1";
 
 vi.mock("server-only", () => ({}));
 
@@ -15,39 +20,13 @@ vi.mock("@/lib/server/db", () => ({
 
 import {
   ProjectVersionConflictError,
+  archiveProjectForUser,
+  getProjectForUser,
+  listProjectsForUser,
+  listProjectSummariesForUser,
   saveProjectForUser,
 } from "@/lib/server/projects";
 import type { TrackDesign } from "@/lib/types";
-
-type Statement = {
-  sql: string;
-  bind: ReturnType<typeof vi.fn>;
-  first: ReturnType<typeof vi.fn>;
-  run: ReturnType<typeof vi.fn>;
-};
-
-function createStatement(result?: { first?: unknown; run?: unknown }) {
-  const statement: Statement = {
-    sql: "",
-    bind: vi.fn(() => statement),
-    first: vi.fn(async () => result?.first ?? null),
-    run: vi.fn(async () => result?.run ?? {}),
-  };
-
-  return statement;
-}
-
-function installStatements(statements: Statement[]) {
-  mocks.prepare.mockImplementation((sql: string) => {
-    const statement = statements.shift();
-    if (!statement) {
-      throw new Error(`Unexpected SQL: ${sql}`);
-    }
-
-    statement.sql = sql;
-    return statement;
-  });
-}
 
 function projectRow(design: TrackDesign) {
   return {
@@ -75,8 +54,10 @@ describe("project server helpers", () => {
     cloudDesign.updatedAt = "2026-04-20T10:10:00.000Z";
     const localDesign = createDefaultDesign();
     localDesign.updatedAt = "2026-04-20T10:05:00.000Z";
-    const selectStatement = createStatement({ first: projectRow(cloudDesign) });
-    installStatements([selectStatement]);
+    const selectStatement = createD1Statement({
+      first: projectRow(cloudDesign),
+    });
+    installD1Statements(mocks.prepare, [selectStatement]);
 
     await expect(
       saveProjectForUser("user-1", localDesign, {
@@ -100,14 +81,14 @@ describe("project server helpers", () => {
     previousDesign.updatedAt = "2026-04-20T10:00:00.000Z";
     const nextDesign = createDefaultDesign();
     nextDesign.updatedAt = "2026-04-20T10:05:00.000Z";
-    const selectPreviousStatement = createStatement({
+    const selectPreviousStatement = createD1Statement({
       first: projectRow(previousDesign),
     });
-    const upsertStatement = createStatement();
-    const selectSavedStatement = createStatement({
+    const upsertStatement = createD1Statement();
+    const selectSavedStatement = createD1Statement({
       first: projectRow(nextDesign),
     });
-    installStatements([
+    installD1Statements(mocks.prepare, [
       selectPreviousStatement,
       upsertStatement,
       selectSavedStatement,
@@ -133,6 +114,110 @@ describe("project server helpers", () => {
       expect.any(String),
       0,
       JSON.stringify(serializeDesign(previousDesign))
+    );
+  });
+
+  it("getProjectForUser returns null when no row is found", async () => {
+    installD1Statements(mocks.prepare, [createD1Statement({ first: null })]);
+    const result = await getProjectForUser("missing", "user-1");
+    expect(result).toBeNull();
+  });
+
+  it("getProjectForUser returns a parsed project when the row exists", async () => {
+    const design = createDefaultDesign();
+    installD1Statements(mocks.prepare, [
+      createD1Statement({ first: projectRow(design) }),
+    ]);
+    const result = await getProjectForUser("project-1", "user-1");
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe("project-1");
+    expect(result?.ownerUserId).toBe("user-1");
+    expect(result?.design.id).toBe(design.id);
+  });
+
+  it("listProjectsForUser returns an empty list when no projects exist", async () => {
+    const allStmt = createD1AllStatement([]);
+    mocks.prepare.mockReturnValue(allStmt);
+
+    const result = await listProjectsForUser("user-1");
+    expect(result).toEqual([]);
+  });
+
+  it("listProjectsForUser maps rows to StoredProject objects", async () => {
+    const design = createDefaultDesign();
+    const allStmt = createD1AllStatement([projectRow(design)]);
+    mocks.prepare.mockReturnValue(allStmt);
+
+    const result = await listProjectsForUser("user-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "project-1",
+      ownerUserId: "user-1",
+      title: "Race layout",
+    });
+  });
+
+  it("listProjectSummariesForUser returns mapped summaries without design data", async () => {
+    const allStmt = createD1AllStatement([
+      {
+        id: "project-2",
+        owner_user_id: "user-1",
+        title: "Summary Track",
+        field_width: 60,
+        field_height: 40,
+        shape_count: 5,
+        created_at: "2026-05-01T00:00:00.000Z",
+        updated_at: "2026-05-10T00:00:00.000Z",
+      },
+    ]);
+    mocks.prepare.mockReturnValue(allStmt);
+
+    const result = await listProjectSummariesForUser("user-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "project-2",
+      ownerUserId: "user-1",
+      title: "Summary Track",
+      fieldWidth: 60,
+      fieldHeight: 40,
+      shapeCount: 5,
+    });
+  });
+
+  it("listProjectSummariesForUser handles null field dimensions", async () => {
+    const allStmt = createD1AllStatement([
+      {
+        id: "project-3",
+        owner_user_id: "user-1",
+        title: "No dims",
+        field_width: null,
+        field_height: null,
+        shape_count: 0,
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mocks.prepare.mockReturnValue(allStmt);
+
+    const result = await listProjectSummariesForUser("user-1");
+    expect(result[0]).toMatchObject({ fieldWidth: null, fieldHeight: null });
+  });
+
+  it("archiveProjectForUser runs an UPDATE query with the correct bindings", async () => {
+    const runStmt = createD1Statement();
+    mocks.prepare.mockReturnValue(runStmt);
+
+    await archiveProjectForUser("project-1", "user-1");
+
+    expect(runStmt.run).toHaveBeenCalledOnce();
+    expect(runStmt.bind).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      "project-1",
+      "user-1"
+    );
+    expect(mocks.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("archived_at")
     );
   });
 });

--- a/tests/lib/server/share-resolution.test.ts
+++ b/tests/lib/server/share-resolution.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultDesign } from "@/lib/track/design";
+import { encodeDesign } from "@/lib/share";
+import { createStoredShareFixture } from "../../helpers/api-routes";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/server/shares", () => ({
+  resolveStoredShare: vi.fn(),
+}));
+
+import { resolveShareView } from "@/lib/server/share-resolution";
+import { resolveStoredShare } from "@/lib/server/shares";
+
+describe("share view resolution", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns stored share details and a studio seed token for active shares", async () => {
+    const design = createDefaultDesign();
+    design.title = "Published race layout";
+    vi.mocked(resolveStoredShare).mockResolvedValue({
+      status: "available",
+      share: createStoredShareFixture({
+        design,
+        title: "Public title",
+        description: "Public description",
+      }),
+    });
+
+    const result = await resolveShareView("stored-token");
+
+    expect(result).toMatchObject({
+      source: "stored",
+      status: "available",
+      design: expect.objectContaining({ title: "Published race layout" }),
+      title: "Public title",
+      description: "Public description",
+    });
+    expect(result.status === "available" && result.studioSeedToken).toBe(
+      encodeDesign(design)
+    );
+  });
+
+  it("preserves stored expired and revoked statuses", async () => {
+    vi.mocked(resolveStoredShare).mockResolvedValue({
+      status: "expired",
+      share: createStoredShareFixture(),
+    });
+
+    await expect(resolveShareView("expired-token")).resolves.toEqual({
+      source: "stored",
+      status: "expired",
+    });
+
+    vi.mocked(resolveStoredShare).mockResolvedValue({
+      status: "revoked",
+      share: createStoredShareFixture(),
+    });
+
+    await expect(resolveShareView("revoked-token")).resolves.toEqual({
+      source: "stored",
+      status: "revoked",
+    });
+  });
+
+  it("retires legacy encoded share tokens instead of rendering them directly", async () => {
+    const design = createDefaultDesign();
+    vi.mocked(resolveStoredShare).mockResolvedValue({ status: "missing" });
+
+    await expect(resolveShareView(encodeDesign(design))).resolves.toEqual({
+      source: "legacy",
+      status: "retired",
+    });
+  });
+
+  it("marks unknown tokens as invalid legacy shares", async () => {
+    vi.mocked(resolveStoredShare).mockResolvedValue({ status: "missing" });
+
+    await expect(resolveShareView("not-a-share-token")).resolves.toEqual({
+      source: "legacy",
+      status: "invalid",
+    });
+  });
+});

--- a/tests/lib/server/shares.test.ts
+++ b/tests/lib/server/shares.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultDesign, serializeDesign } from "@/lib/track/design";
 import type { SerializedTrackDesign } from "@/lib/types";
+import {
+  createD1AllStatement,
+  createD1Statement as createStatement,
+  installD1Statements,
+  type MockD1Statement,
+} from "../../helpers/d1";
 
 vi.mock("server-only", () => ({}));
 
@@ -34,40 +40,35 @@ vi.mock("@/lib/server/gallery", () => ({
   },
 }));
 
-import { createShare } from "@/lib/server/shares";
+import {
+  createShare,
+  getSharesByUserId,
+  resolveStoredShare,
+  revokeShare,
+} from "@/lib/server/shares";
 
-type Statement = {
-  sql: string;
-  bind: ReturnType<typeof vi.fn>;
-  first: ReturnType<typeof vi.fn>;
-  run: ReturnType<typeof vi.fn>;
+function installStatements(statements: MockD1Statement[]) {
+  installD1Statements(mocks.prepare, statements);
+}
+
+type ShareRowFixture = {
+  id: string;
+  token: string;
+  design_json: string;
+  title: string;
+  description: string;
+  field_width: number;
+  field_height: number;
+  shape_count: number;
+  created_at: string;
+  updated_at: string;
+  published_at: string | null;
+  expires_at: string | null;
+  revoked_at: string | null;
+  owner_user_id: string | null;
+  project_id: string | null;
+  share_type: string;
 };
-
-function createStatement(result?: {
-  first?: unknown;
-  run?: unknown;
-}): Statement {
-  const statement = {
-    sql: "",
-    bind: vi.fn(() => statement),
-    first: vi.fn(async () => result?.first ?? null),
-    run: vi.fn(async () => result?.run ?? {}),
-  };
-
-  return statement;
-}
-
-function installStatements(statements: Statement[]) {
-  mocks.prepare.mockImplementation((sql: string) => {
-    const statement = statements.shift();
-    if (!statement) {
-      throw new Error(`Unexpected SQL: ${sql}`);
-    }
-
-    statement.sql = sql;
-    return statement;
-  });
-}
 
 function existingShareRow(serialized: SerializedTrackDesign) {
   return {
@@ -89,6 +90,151 @@ function existingShareRow(serialized: SerializedTrackDesign) {
     share_type: "published",
   };
 }
+
+function shareRow(overrides: Partial<ShareRowFixture> = {}): ShareRowFixture {
+  return {
+    ...baseShareRow(),
+    ...overrides,
+  };
+}
+
+function baseShareRow(): ShareRowFixture {
+  return {
+    id: "share-id-x",
+    token: "tok-x",
+    design_json: JSON.stringify({}),
+    title: "Test share",
+    description: "",
+    field_width: 40,
+    field_height: 20,
+    shape_count: 3,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-04-25T12:00:00.000Z",
+    published_at: null,
+    expires_at: null,
+    revoked_at: null,
+    owner_user_id: "user-1",
+    project_id: null,
+    share_type: "published",
+  };
+}
+
+describe("resolveStoredShare", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
+    mocks.prepare.mockReset();
+  });
+
+  it("returns missing when no share row exists", async () => {
+    installStatements([createStatement({ first: null })]);
+    const result = await resolveStoredShare("unknown-token");
+    expect(result.status).toBe("missing");
+  });
+
+  it("returns revoked when share has a revoked_at timestamp", async () => {
+    installStatements([
+      createStatement({
+        first: shareRow({ revoked_at: "2026-04-01T00:00:00.000Z" }),
+      }),
+    ]);
+    const result = await resolveStoredShare("tok-x");
+    expect(result.status).toBe("revoked");
+  });
+
+  it("returns expired when share expires_at is in the past", async () => {
+    installStatements([
+      createStatement({
+        first: shareRow({ expires_at: "2026-03-01T00:00:00.000Z" }),
+      }),
+    ]);
+    const result = await resolveStoredShare("tok-x");
+    expect(result.status).toBe("expired");
+  });
+
+  it("returns available when share exists and is within its expiry", async () => {
+    installStatements([
+      createStatement({
+        first: shareRow({ expires_at: "2026-12-31T00:00:00.000Z" }),
+      }),
+    ]);
+    const result = await resolveStoredShare("tok-x");
+    expect(result.status).toBe("available");
+  });
+
+  it("returns available for a published share with no expiry", async () => {
+    installStatements([createStatement({ first: shareRow() })]);
+    const result = await resolveStoredShare("tok-x");
+    expect(result.status).toBe("available");
+  });
+});
+
+describe("revokeShare", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
+    mocks.prepare.mockReset();
+    mocks.deleteGalleryEntry.mockReset();
+  });
+
+  it("executes an UPDATE query and deletes the gallery entry", async () => {
+    const stmt = createStatement();
+    installStatements([stmt]);
+
+    await revokeShare("tok-revoke");
+
+    expect(stmt.run).toHaveBeenCalledOnce();
+    expect(stmt.bind).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      "tok-revoke"
+    );
+    expect(mocks.deleteGalleryEntry).toHaveBeenCalledWith("tok-revoke");
+  });
+});
+
+describe("getSharesByUserId", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
+    mocks.prepare.mockReset();
+  });
+
+  it("returns an empty list when no shares exist for the user", async () => {
+    const stmt = createD1AllStatement([]);
+    mocks.prepare.mockReturnValue(stmt);
+
+    const result = await getSharesByUserId("user-1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns mapped user shares", async () => {
+    const row = {
+      token: "tok-user",
+      title: "My share",
+      shape_count: 4,
+      created_at: "2026-04-01T00:00:00.000Z",
+      expires_at: null,
+      project_id: "proj-1",
+      share_type: "published",
+      gallery_state: "listed",
+      gallery_title: "Gallery Title",
+      gallery_description: "Gallery desc",
+    };
+    const stmt = createD1AllStatement([row]);
+    mocks.prepare.mockReturnValue(stmt);
+
+    const result = await getSharesByUserId("user-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      token: "tok-user",
+      shapeCount: 4,
+      projectId: "proj-1",
+      shareType: "published",
+      galleryState: "listed",
+    });
+  });
+});
 
 describe("share server helpers", () => {
   beforeEach(() => {

--- a/tests/lib/server/shares.test.ts
+++ b/tests/lib/server/shares.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultDesign, serializeDesign } from "@/lib/track/design";
 import type { SerializedTrackDesign } from "@/lib/types";
 import {
@@ -46,6 +46,10 @@ import {
   resolveStoredShare,
   revokeShare,
 } from "@/lib/server/shares";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function installStatements(statements: MockD1Statement[]) {
   installD1Statements(mocks.prepare, statements);

--- a/tests/lib/server/users.test.ts
+++ b/tests/lib/server/users.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createD1AllStatement, createD1Statement } from "../../helpers/d1";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  prepare: vi.fn(),
+}));
+
+vi.mock("@/lib/server/db", () => ({
+  getDatabase: vi.fn(async () => ({
+    prepare: mocks.prepare,
+  })),
+}));
+
+import {
+  countUsersByRole,
+  countUsersForAdmin,
+  getAdminUserById,
+  getUserRoleById,
+  listUsersForAdmin,
+  updateUserRole,
+} from "@/lib/server/users";
+
+beforeEach(() => {
+  mocks.prepare.mockReset();
+});
+
+describe("getUserRoleById", () => {
+  it("returns 'user' when no row matches the user id", async () => {
+    mocks.prepare.mockReturnValue(createD1Statement({ first: null }));
+
+    const role = await getUserRoleById("missing-user");
+    expect(role).toBe("user");
+  });
+
+  it("returns 'admin' when the row has role='admin'", async () => {
+    mocks.prepare.mockReturnValue(
+      createD1Statement({ first: { role: "admin" } })
+    );
+
+    const role = await getUserRoleById("admin-user");
+    expect(role).toBe("admin");
+  });
+
+  it("returns 'user' when the row has an unrecognized role value", async () => {
+    mocks.prepare.mockReturnValue(
+      createD1Statement({ first: { role: "superuser" } })
+    );
+
+    const role = await getUserRoleById("some-user");
+    expect(role).toBe("user");
+  });
+});
+
+describe("getAdminUserById", () => {
+  it("returns null when no user matches", async () => {
+    mocks.prepare.mockReturnValue(createD1Statement({ first: null }));
+
+    const user = await getAdminUserById("not-found");
+    expect(user).toBeNull();
+  });
+
+  it("returns a mapped admin user when the row exists", async () => {
+    mocks.prepare.mockReturnValue(
+      createD1Statement({
+        first: {
+          id: "user-1",
+          name: "FPV Pilot",
+          email: "pilot@trackdraw.app",
+          image: null,
+          role: "admin",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-06-01T00:00:00.000Z",
+        },
+      })
+    );
+
+    const user = await getAdminUserById("user-1");
+    expect(user).toMatchObject({
+      id: "user-1",
+      name: "FPV Pilot",
+      email: "pilot@trackdraw.app",
+      image: null,
+      role: "admin",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+    });
+  });
+
+  it("maps a null role to 'user'", async () => {
+    mocks.prepare.mockReturnValue(
+      createD1Statement({
+        first: {
+          id: "user-2",
+          name: null,
+          email: "anon@example.com",
+          image: null,
+          role: null,
+          createdAt: "2026-01-02T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+        },
+      })
+    );
+
+    const user = await getAdminUserById("user-2");
+    expect(user?.role).toBe("user");
+  });
+});
+
+describe("listUsersForAdmin", () => {
+  it("returns an empty list when there are no users", async () => {
+    mocks.prepare.mockReturnValue(createD1AllStatement([]));
+
+    const users = await listUsersForAdmin();
+    expect(users).toEqual([]);
+  });
+
+  it("returns a mapped list of admin users", async () => {
+    mocks.prepare.mockReturnValue(
+      createD1AllStatement([
+        {
+          id: "u-1",
+          name: "Alice",
+          email: "alice@example.com",
+          image: "https://example.com/alice.jpg",
+          role: "admin",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+        {
+          id: "u-2",
+          name: "Bob",
+          email: "bob@example.com",
+          image: null,
+          role: null,
+          createdAt: "2026-02-01T00:00:00.000Z",
+          updatedAt: "2026-02-01T00:00:00.000Z",
+        },
+      ])
+    );
+
+    const users = await listUsersForAdmin();
+    expect(users).toHaveLength(2);
+    expect(users[0]).toMatchObject({ id: "u-1", name: "Alice", role: "admin" });
+    expect(users[1]).toMatchObject({ id: "u-2", name: "Bob", role: "user" });
+  });
+});
+
+describe("countUsersByRole", () => {
+  it("returns 0 when no users have the role", async () => {
+    mocks.prepare.mockReturnValue(createD1AllStatement([]));
+
+    const count = await countUsersByRole("admin");
+    expect(count).toBe(0);
+  });
+
+  it("returns 1 when exactly one user has the role", async () => {
+    mocks.prepare.mockReturnValue(createD1AllStatement([{}]));
+
+    const count = await countUsersByRole("admin");
+    expect(count).toBe(1);
+  });
+
+  it("returns 2 when at most 2 rows are returned (query uses LIMIT 2)", async () => {
+    mocks.prepare.mockReturnValue(createD1AllStatement([{}, {}]));
+
+    const count = await countUsersByRole("user");
+    expect(count).toBe(2);
+  });
+});
+
+describe("countUsersForAdmin", () => {
+  it("returns 0 when the count row is absent", async () => {
+    mocks.prepare.mockReturnValue(createD1Statement({ first: null }));
+    const count = await countUsersForAdmin();
+    expect(count).toBe(0);
+  });
+
+  it("returns the numeric count from the database row", async () => {
+    mocks.prepare.mockReturnValue(createD1Statement({ first: { count: 42 } }));
+    const count = await countUsersForAdmin();
+    expect(count).toBe(42);
+  });
+});
+
+describe("updateUserRole", () => {
+  it("returns null when the user is not found", async () => {
+    mocks.prepare.mockReturnValue(createD1Statement({ first: null }));
+
+    const result = await updateUserRole("missing", "admin");
+    expect(result).toBeNull();
+  });
+
+  it("returns the updated user when the update succeeds", async () => {
+    mocks.prepare.mockReturnValue(
+      createD1Statement({
+        first: {
+          id: "user-3",
+          name: "Carol",
+          email: "carol@example.com",
+          image: null,
+          role: "admin",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-06-09T00:00:00.000Z",
+        },
+      })
+    );
+
+    const result = await updateUserRole("user-3", "admin");
+    expect(result).toMatchObject({
+      id: "user-3",
+      name: "Carol",
+      role: "admin",
+    });
+  });
+});

--- a/tests/lib/theme.test.ts
+++ b/tests/lib/theme.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseResolvedTheme,
+  parseThemePreference,
+  resolveTheme,
+} from "@/lib/theme";
+
+describe("theme helpers", () => {
+  it("parses only supported stored theme values", () => {
+    expect(parseThemePreference("light")).toBe("light");
+    expect(parseThemePreference("dark")).toBe("dark");
+    expect(parseThemePreference("system")).toBe("system");
+    expect(parseThemePreference("auto")).toBeNull();
+    expect(parseResolvedTheme("light")).toBe("light");
+    expect(parseResolvedTheme("system")).toBeNull();
+  });
+
+  it("resolves system preferences against the media-query result", () => {
+    expect(resolveTheme("system", true)).toBe("dark");
+    expect(resolveTheme("system", false)).toBe("light");
+    expect(resolveTheme("dark", false)).toBe("dark");
+  });
+});

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -1,30 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditor } from "@/store/editor";
 import {
+  clearHistoryAndCaptureUpdatedAt,
+  coneDraft,
+  expectDesignUpdatedAt,
+  expectNoDesignHistoryChange,
+  expectPastStatesCount,
+  flagDraft,
+  gateDraft,
+  ladderDraft,
+  polylineDraft,
+  resetEditorStore,
+  runHistoryStep,
+  setEditorTestTime,
+} from "../helpers/editor-store";
+import {
   MULTIGP_CORNER_FLAG_ELEMENT_ID,
   MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
   MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID,
   getTrackElementCatalogIdentity,
 } from "@/lib/track/elements/catalog";
 
-function getPastStatesCount() {
-  return useEditor.temporal.getState().pastStates.length;
-}
-
-function runHistoryStep(step: () => void) {
-  step();
-  const temporal = useEditor.temporal.getState();
-  temporal.pause();
-  useEditor.getState().sanitizeHistoryState();
-  temporal.resume();
-}
-
 describe("editor store history", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:00:00.000Z"));
-    useEditor.getState().newProject();
-    useEditor.getState().clearHistory();
+    resetEditorStore();
   });
 
   afterEach(() => {
@@ -33,178 +32,113 @@ describe("editor store history", () => {
 
   it("does not create a history entry for a no-op shape patch", () => {
     const state = useEditor.getState();
-    const id = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2.2,
-      height: 1.9,
-    });
+    const id = state.addShape(gateDraft({ width: 2.2, height: 1.9 }));
 
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
     useEditor.getState().updateShape(id, { rotation: 0 });
 
-    expect(useEditor.getState().track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("creates a history entry when a shape patch changes the design", () => {
     const state = useEditor.getState();
-    const id = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2.2,
-      height: 1.9,
-    });
+    const id = state.addShape(gateDraft({ width: 2.2, height: 1.9 }));
 
     state.clearHistory();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:06:22.500Z"));
+    setEditorTestTime("2026-04-13T10:06:22.500Z");
 
     useEditor.getState().updateShape(id, { rotation: 5 });
 
     expect(useEditor.getState().track.design.shapeById[id]?.rotation).toBe(5);
-    expect(useEditor.getState().track.design.updatedAt).toBe(
-      "2026-04-13T10:06:22.500Z"
-    );
-    expect(getPastStatesCount()).toBe(1);
+    expectDesignUpdatedAt("2026-04-13T10:06:22.500Z");
+    expectPastStatesCount(1);
   });
 
   it("does not create a history entry for unchanged polyline points", () => {
     const state = useEditor.getState();
-    const id = state.addShape({
-      kind: "polyline",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      points: [
-        { x: 1, y: 2, z: 0 },
-        { x: 3, y: 4, z: 1 },
-      ],
-    });
+    const id = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 1, y: 2, z: 0 },
+          { x: 3, y: 4, z: 1 },
+        ],
+      })
+    );
 
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
     useEditor.getState().setPolylinePoints(id, [
       { x: 1, y: 2, z: 0 },
       { x: 3, y: 4, z: 1 },
     ]);
 
-    expect(useEditor.getState().track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("does not create a history entry when rotateShapes only targets non-rotatable shapes", () => {
     const state = useEditor.getState();
-    const coneId = state.addShape({
-      kind: "cone",
-      x: 5,
-      y: 6,
-      rotation: 0,
-      radius: 0.2,
-    });
-    const polylineId = state.addShape({
-      kind: "polyline",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      points: [
-        { x: 1, y: 2, z: 0 },
-        { x: 3, y: 4, z: 1 },
-      ],
-    });
+    const coneId = state.addShape(coneDraft({ x: 5, y: 6, radius: 0.2 }));
+    const polylineId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 1, y: 2, z: 0 },
+          { x: 3, y: 4, z: 1 },
+        ],
+      })
+    );
 
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
     useEditor.getState().rotateShapes([coneId, polylineId], 15);
 
-    expect(useEditor.getState().track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("does not create a history entry for a no-op batch patch", () => {
     const state = useEditor.getState();
-    const firstGateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2.2,
-      height: 1.9,
-    });
-    const secondGateId = state.addShape({
-      kind: "gate",
-      x: 14,
-      y: 12,
-      rotation: 0,
-      width: 2.2,
-      height: 1.9,
-    });
+    const firstGateId = state.addShape(gateDraft({ width: 2.2, height: 1.9 }));
+    const secondGateId = state.addShape(
+      gateDraft({ x: 14, y: 12, width: 2.2, height: 1.9 })
+    );
 
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
     useEditor.getState().updateShapes([firstGateId, secondGateId], {
       rotation: 0,
     });
 
-    expect(useEditor.getState().track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("creates a history entry when rotateShapes changes a rotatable shape", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2.2,
-      height: 1.9,
-    });
+    const gateId = state.addShape(gateDraft({ width: 2.2, height: 1.9 }));
 
     state.clearHistory();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:06:25.000Z"));
+    setEditorTestTime("2026-04-13T10:06:25.000Z");
 
     useEditor.getState().rotateShapes([gateId], 15);
 
     expect(useEditor.getState().track.design.shapeById[gateId]?.rotation).toBe(
       15
     );
-    expect(useEditor.getState().track.design.updatedAt).toBe(
-      "2026-04-13T10:06:25.000Z"
-    );
-    expect(getPastStatesCount()).toBe(1);
+    expectDesignUpdatedAt("2026-04-13T10:06:25.000Z");
+    expectPastStatesCount(1);
   });
 
   it("undoes and redoes a real design change through the temporal store", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2.2,
-      height: 1.9,
-    });
+    const gateId = state.addShape(gateDraft({ width: 2.2, height: 1.9 }));
 
     state.clearHistory();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:06:27.000Z"));
+    setEditorTestTime("2026-04-13T10:06:27.000Z");
     useEditor.getState().updateShape(gateId, { rotation: 20 });
 
     expect(useEditor.getState().track.design.shapeById[gateId]?.rotation).toBe(
       20
     );
-    expect(getPastStatesCount()).toBe(1);
+    expectPastStatesCount(1);
 
     runHistoryStep(useEditor.temporal.getState().undo);
     expect(useEditor.getState().track.design.shapeById[gateId]?.rotation).toBe(
@@ -219,18 +153,10 @@ describe("editor store history", () => {
 
   it("keeps shape resize changes undoable and redoable", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2,
-      height: 1.5,
-    });
+    const gateId = state.addShape(gateDraft({ height: 1.5 }));
 
     state.clearHistory();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:06:28.000Z"));
+    setEditorTestTime("2026-04-13T10:06:28.000Z");
 
     useEditor.getState().updateShape(gateId, { width: 3, height: 2 });
 
@@ -238,10 +164,8 @@ describe("editor store history", () => {
       width: 3,
       height: 2,
     });
-    expect(useEditor.getState().track.design.updatedAt).toBe(
-      "2026-04-13T10:06:28.000Z"
-    );
-    expect(getPastStatesCount()).toBe(1);
+    expectDesignUpdatedAt("2026-04-13T10:06:28.000Z");
+    expectPastStatesCount(1);
 
     runHistoryStep(useEditor.temporal.getState().undo);
     expect(useEditor.getState().track.design.shapeById[gateId]).toMatchObject({
@@ -258,14 +182,7 @@ describe("editor store history", () => {
 
   it("sanitizeHistoryState clears transient session and ui state after history steps", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2.2,
-      height: 1.9,
-    });
+    const gateId = state.addShape(gateDraft({ width: 2.2, height: 1.9 }));
 
     useEditor.getState().setSelection([gateId]);
     useEditor.getState().setHoveredShapeId(gateId);
@@ -330,81 +247,43 @@ describe("editor store history", () => {
 
   it("locks shapes only when the locked state actually changes", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2,
-      height: 2,
-    });
+    const gateId = state.addShape(gateDraft());
 
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
     state.setShapesLocked([gateId], false);
-    expect(useEditor.getState().track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
 
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:10:00.000Z"));
+    setEditorTestTime("2026-04-13T10:10:00.000Z");
     state.setShapesLocked([gateId], true);
 
     expect(useEditor.getState().track.design.shapeById[gateId]?.locked).toBe(
       true
     );
-    expect(useEditor.getState().track.design.updatedAt).toBe(
-      "2026-04-13T10:10:00.000Z"
-    );
-    expect(getPastStatesCount()).toBe(1);
+    expectDesignUpdatedAt("2026-04-13T10:10:00.000Z");
+    expectPastStatesCount(1);
   });
 
   it("does not move locked shapes or create history for locked-only nudges", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
+    const gateId = state.addShape(gateDraft({ locked: true }));
 
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
     state.nudgeShapes([gateId], 1, 1);
 
     const shape = useEditor.getState().track.design.shapeById[gateId];
     expect(shape).toMatchObject({ x: 10, y: 8 });
-    expect(useEditor.getState().track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("nudges only editable shapes in a mixed locked selection", () => {
     const state = useEditor.getState();
-    const lockedGateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
-    const editableGateId = state.addShape({
-      kind: "gate",
-      x: 12,
-      y: 9,
-      rotation: 0,
-      width: 2,
-      height: 2,
-    });
+    const lockedGateId = state.addShape(gateDraft({ locked: true }));
+    const editableGateId = state.addShape(gateDraft({ x: 12, y: 9 }));
 
     state.clearHistory();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:10:05.000Z"));
+    setEditorTestTime("2026-04-13T10:10:05.000Z");
 
     state.nudgeShapes([lockedGateId, editableGateId], 1, -2);
 
@@ -414,24 +293,15 @@ describe("editor store history", () => {
       x: 13,
       y: 7,
     });
-    expect(nextDesign.updatedAt).toBe("2026-04-13T10:10:05.000Z");
-    expect(getPastStatesCount()).toBe(1);
+    expectDesignUpdatedAt("2026-04-13T10:10:05.000Z");
+    expectPastStatesCount(1);
   });
 
   it("does not patch locked shapes or create history for locked-only updates", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
+    const gateId = state.addShape(gateDraft({ locked: true }));
 
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
     state.updateShape(gateId, { x: 20, width: 4, rotation: 45 });
 
@@ -442,33 +312,16 @@ describe("editor store history", () => {
       width: 2,
       height: 2,
     });
-    expect(useEditor.getState().track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("batch patches only editable shapes in a mixed locked selection", () => {
     const state = useEditor.getState();
-    const lockedGateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
-    const editableGateId = state.addShape({
-      kind: "gate",
-      x: 12,
-      y: 9,
-      rotation: 0,
-      width: 2,
-      height: 2,
-    });
+    const lockedGateId = state.addShape(gateDraft({ locked: true }));
+    const editableGateId = state.addShape(gateDraft({ x: 12, y: 9 }));
 
     state.clearHistory();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:10:06.000Z"));
+    setEditorTestTime("2026-04-13T10:10:06.000Z");
 
     state.updateShapes([lockedGateId, editableGateId], {
       x: 20,
@@ -484,33 +337,21 @@ describe("editor store history", () => {
       x: 20,
       width: 4,
     });
-    expect(nextDesign.updatedAt).toBe("2026-04-13T10:10:06.000Z");
-    expect(getPastStatesCount()).toBe(1);
+    expectDesignUpdatedAt("2026-04-13T10:10:06.000Z");
+    expectPastStatesCount(1);
   });
 
   it("batch switches catalog gate types while leaving locked gates unchanged", () => {
     const state = useEditor.getState();
-    const lockedGateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 35,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
-    const editableGateId = state.addShape({
-      kind: "gate",
-      x: 12,
-      y: 9,
-      rotation: 45,
-      width: 2,
-      height: 2,
-    });
+    const lockedGateId = state.addShape(
+      gateDraft({ rotation: 35, locked: true })
+    );
+    const editableGateId = state.addShape(
+      gateDraft({ x: 12, y: 9, rotation: 45 })
+    );
 
     state.clearHistory();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:10:07.000Z"));
+    setEditorTestTime("2026-04-13T10:10:07.000Z");
 
     state.updateShapesCatalogType(
       [lockedGateId, editableGateId],
@@ -538,27 +379,24 @@ describe("editor store history", () => {
       getTrackElementCatalogIdentity(nextDesign.shapeById[editableGateId]?.meta)
         ?.elementId
     ).toBe(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
-    expect(nextDesign.updatedAt).toBe("2026-04-13T10:10:07.000Z");
-    expect(getPastStatesCount()).toBe(1);
+    expectDesignUpdatedAt("2026-04-13T10:10:07.000Z");
+    expectPastStatesCount(1);
   });
 
   it("does not edit locked route waypoints or create history", () => {
     const state = useEditor.getState();
-    const routeId = state.addShape({
-      kind: "polyline",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      locked: true,
-      points: [
-        { x: 0, y: 0, z: 0 },
-        { x: 4, y: 0, z: 0 },
-        { x: 8, y: 0, z: 0 },
-      ],
-    });
+    const routeId = state.addShape(
+      polylineDraft({
+        locked: true,
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 4, y: 0, z: 0 },
+          { x: 8, y: 0, z: 0 },
+        ],
+      })
+    );
 
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
     state.setPolylinePoints(routeId, [
       { x: 1, y: 1, z: 0 },
@@ -576,25 +414,16 @@ describe("editor store history", () => {
       { x: 4, y: 0, z: 0 },
       { x: 8, y: 0, z: 0 },
     ]);
-    expect(useEditor.getState().track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("duplicates shapes, updates selection, and creates a history entry", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 5,
-      width: 2,
-      height: 2,
-    });
+    const gateId = state.addShape(gateDraft({ rotation: 5 }));
 
     state.clearHistory();
     const beforeCount = useEditor.getState().track.design.shapeOrder.length;
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:10:10.000Z"));
+    setEditorTestTime("2026-04-13T10:10:10.000Z");
     state.duplicateShapes([gateId]);
 
     const nextState = useEditor.getState();
@@ -607,122 +436,66 @@ describe("editor store history", () => {
       kind: "gate",
       rotation: 5,
     });
-    expect(getPastStatesCount()).toBe(1);
+    expectPastStatesCount(1);
   });
 
   it("does not duplicate locked shapes or create history", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 5,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
+    const gateId = state.addShape(gateDraft({ rotation: 5, locked: true }));
 
     state.setSelection([gateId]);
-    state.clearHistory();
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
     const beforeCount = useEditor.getState().track.design.shapeOrder.length;
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
 
     state.duplicateShapes([gateId]);
 
     const nextState = useEditor.getState();
     expect(nextState.track.design.shapeOrder).toHaveLength(beforeCount);
     expect(nextState.session.selection).toEqual([gateId]);
-    expect(nextState.track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("does not duplicate mixed locked selections or create history", () => {
     const state = useEditor.getState();
-    const lockedId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 5,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
-    const editableId = state.addShape({
-      kind: "flag",
-      x: 12,
-      y: 9,
-      rotation: 0,
-      radius: 0.25,
-    });
+    const lockedId = state.addShape(gateDraft({ rotation: 5, locked: true }));
+    const editableId = state.addShape(flagDraft({ x: 12, y: 9 }));
 
     state.setSelection([lockedId, editableId]);
-    state.clearHistory();
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
     const beforeCount = useEditor.getState().track.design.shapeOrder.length;
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
 
     state.duplicateShapes([lockedId, editableId]);
 
     const nextState = useEditor.getState();
     expect(nextState.track.design.shapeOrder).toHaveLength(beforeCount);
     expect(nextState.session.selection).toEqual([lockedId, editableId]);
-    expect(nextState.track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("removes selected shapes and clears them from the selection", () => {
     const state = useEditor.getState();
-    const firstId = state.addShape({
-      kind: "gate",
-      x: 5,
-      y: 5,
-      rotation: 0,
-      width: 2,
-      height: 2,
-    });
-    const secondId = state.addShape({
-      kind: "flag",
-      x: 8,
-      y: 7,
-      rotation: 0,
-      radius: 0.25,
-    });
+    const firstId = state.addShape(gateDraft({ x: 5, y: 5 }));
+    const secondId = state.addShape(flagDraft());
 
     state.setSelection([firstId, secondId]);
     state.clearHistory();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:10:20.000Z"));
+    setEditorTestTime("2026-04-13T10:10:20.000Z");
     state.removeShapes([firstId]);
 
     const nextState = useEditor.getState();
     expect(nextState.track.design.shapeById[firstId]).toBeUndefined();
     expect(nextState.session.selection).toEqual([secondId]);
-    expect(getPastStatesCount()).toBe(1);
+    expectPastStatesCount(1);
   });
 
   it("does not remove mixed locked selections or create history", () => {
     const state = useEditor.getState();
-    const lockedId = state.addShape({
-      kind: "gate",
-      x: 5,
-      y: 5,
-      rotation: 0,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
-    const editableId = state.addShape({
-      kind: "flag",
-      x: 8,
-      y: 7,
-      rotation: 0,
-      radius: 0.25,
-    });
+    const lockedId = state.addShape(gateDraft({ x: 5, y: 5, locked: true }));
+    const editableId = state.addShape(flagDraft());
 
     state.setSelection([lockedId, editableId]);
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:10:21.000Z"));
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
+    setEditorTestTime("2026-04-13T10:10:21.000Z");
 
     state.removeShapes([lockedId, editableId]);
 
@@ -730,33 +503,17 @@ describe("editor store history", () => {
     expect(nextState.track.design.shapeById[lockedId]).toBeTruthy();
     expect(nextState.track.design.shapeById[editableId]).toBeTruthy();
     expect(nextState.session.selection).toEqual([lockedId, editableId]);
-    expect(nextState.track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("does not remove grouped selections when one grouped member is locked", () => {
     const state = useEditor.getState();
-    const lockedId = state.addShape({
-      kind: "gate",
-      x: 5,
-      y: 5,
-      rotation: 0,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
-    const editableId = state.addShape({
-      kind: "flag",
-      x: 8,
-      y: 7,
-      rotation: 0,
-      radius: 0.25,
-    });
+    const lockedId = state.addShape(gateDraft({ x: 5, y: 5, locked: true }));
+    const editableId = state.addShape(flagDraft());
 
     state.groupSelection([lockedId, editableId]);
     state.setSelection([lockedId]);
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
     state.removeShapes(useEditor.getState().session.selection);
 
@@ -764,52 +521,28 @@ describe("editor store history", () => {
     expect(nextState.track.design.shapeById[lockedId]).toBeTruthy();
     expect(nextState.track.design.shapeById[editableId]).toBeTruthy();
     expect(nextState.session.selection).toEqual([lockedId, editableId]);
-    expect(nextState.track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("does not remove locked-only selections or create history", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 5,
-      y: 5,
-      rotation: 0,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
+    const gateId = state.addShape(gateDraft({ x: 5, y: 5, locked: true }));
 
     state.setSelection([gateId]);
-    state.clearHistory();
-    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
     state.removeShapes([gateId]);
 
     const nextState = useEditor.getState();
     expect(nextState.track.design.shapeById[gateId]).toBeTruthy();
     expect(nextState.session.selection).toEqual([gateId]);
-    expect(nextState.track.design.updatedAt).toBe(beforeUpdatedAt);
-    expect(getPastStatesCount()).toBe(0);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
   });
 
   it("groups and ungroups the current selection", () => {
     const state = useEditor.getState();
-    const firstId = state.addShape({
-      kind: "gate",
-      x: 5,
-      y: 5,
-      rotation: 0,
-      width: 2,
-      height: 2,
-    });
-    const secondId = state.addShape({
-      kind: "flag",
-      x: 8,
-      y: 7,
-      rotation: 0,
-      radius: 0.25,
-    });
+    const firstId = state.addShape(gateDraft({ x: 5, y: 5 }));
+    const secondId = state.addShape(flagDraft());
 
     state.clearHistory();
     const groupId = state.groupSelection([firstId, secondId]);
@@ -845,26 +578,22 @@ describe("editor store history", () => {
 
   it("joins and closes polylines when possible", () => {
     const state = useEditor.getState();
-    const firstId = state.addShape({
-      kind: "polyline",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      points: [
-        { x: 0, y: 0, z: 0 },
-        { x: 2, y: 0, z: 0 },
-      ],
-    });
-    const secondId = state.addShape({
-      kind: "polyline",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      points: [
-        { x: 2, y: 0, z: 0 },
-        { x: 4, y: 1, z: 0 },
-      ],
-    });
+    const firstId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 },
+        ],
+      })
+    );
+    const secondId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 2, y: 0, z: 0 },
+          { x: 4, y: 1, z: 0 },
+        ],
+      })
+    );
 
     state.clearHistory();
     const joinedId = state.joinPolylines([firstId, secondId]);
@@ -891,16 +620,14 @@ describe("editor store history", () => {
 
   it("keeps route waypoint insertion undoable and clears stale segment selection", () => {
     const state = useEditor.getState();
-    const routeId = state.addShape({
-      kind: "polyline",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      points: [
-        { x: 0, y: 0, z: 0 },
-        { x: 4, y: 0, z: 0 },
-      ],
-    });
+    const routeId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 4, y: 0, z: 0 },
+        ],
+      })
+    );
 
     state.setSelection([routeId]);
     state.setSegmentSelection({
@@ -909,8 +636,7 @@ describe("editor store history", () => {
       point: { x: 2, y: 0 },
     });
     state.clearHistory();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:11:00.000Z"));
+    setEditorTestTime("2026-04-13T10:11:00.000Z");
 
     state.insertPolylinePoint(routeId, 1, { x: 2, y: 1, z: 0 });
 
@@ -924,8 +650,8 @@ describe("editor store history", () => {
     ]);
     expect(nextState.session.selection).toEqual([routeId]);
     expect(nextState.ui.segmentSelection).toBeNull();
-    expect(nextState.track.design.updatedAt).toBe("2026-04-13T10:11:00.000Z");
-    expect(getPastStatesCount()).toBe(1);
+    expectDesignUpdatedAt("2026-04-13T10:11:00.000Z");
+    expectPastStatesCount(1);
 
     runHistoryStep(useEditor.temporal.getState().undo);
 
@@ -948,24 +674,15 @@ describe("editor store history", () => {
 
   it("keeps a selected route segment when the same path is selected again", () => {
     const state = useEditor.getState();
-    const routeId = state.addShape({
-      kind: "polyline",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      points: [
-        { x: 0, y: 0, z: 0 },
-        { x: 4, y: 0, z: 0 },
-      ],
-    });
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 2,
-      y: 2,
-      rotation: 0,
-      width: 2,
-      height: 1.5,
-    });
+    const routeId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 4, y: 0, z: 0 },
+        ],
+      })
+    );
+    const gateId = state.addShape(gateDraft({ x: 2, y: 2, height: 1.5 }));
 
     state.setSelection([routeId]);
     state.setSegmentSelection({
@@ -991,29 +708,21 @@ describe("editor store history", () => {
     const state = useEditor.getState();
     state.clearHistory();
 
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:12:00.000Z"));
+    setEditorTestTime("2026-04-13T10:12:00.000Z");
     state.updateField({ width: 80 });
-    vi.setSystemTime(new Date("2026-04-13T10:12:01.000Z"));
+    setEditorTestTime("2026-04-13T10:12:01.000Z");
     state.updateDesignMeta({ title: "Race Day Layout" });
 
     const nextState = useEditor.getState();
     expect(nextState.track.design.field.width).toBe(80);
     expect(nextState.track.design.title).toBe("Race Day Layout");
     expect(nextState.track.design.updatedAt).toBe("2026-04-13T10:12:01.000Z");
-    expect(getPastStatesCount()).toBe(2);
+    expectPastStatesCount(2);
   });
 
   it("resets track, session, ui, and history when replacing the design or starting a new project", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 5,
-      y: 6,
-      rotation: 0,
-      width: 2,
-      height: 2,
-    });
+    const gateId = state.addShape(gateDraft({ x: 5, y: 6 }));
 
     state.setSelection([gateId]);
     state.setHoveredShapeId(gateId);
@@ -1047,51 +756,31 @@ describe("editor store history", () => {
     expect(nextState.session.selection).toEqual([]);
     expect(nextState.ui.hoveredShapeId).toBeNull();
     expect(nextState.ui.zoom).toBe(2);
-    expect(getPastStatesCount()).toBe(0);
+    expectPastStatesCount(0);
 
     state.newProject();
     nextState = useEditor.getState();
     expect(nextState.track.design.title).toBe("New Track");
     expect(nextState.ui.zoom).toBe(1);
     expect(nextState.ui.panOffset).toEqual({ x: 0, y: 0 });
-    expect(getPastStatesCount()).toBe(0);
+    expectPastStatesCount(0);
   });
 
   it("nudges shapes and changes z-order only when movement is possible", () => {
     const state = useEditor.getState();
-    const firstId = state.addShape({
-      kind: "gate",
-      x: 1,
-      y: 2,
-      rotation: 0,
-      width: 2,
-      height: 2,
-    });
-    const secondId = state.addShape({
-      kind: "flag",
-      x: 3,
-      y: 4,
-      rotation: 0,
-      radius: 0.25,
-    });
-    const thirdId = state.addShape({
-      kind: "cone",
-      x: 5,
-      y: 6,
-      rotation: 0,
-      radius: 0.2,
-    });
+    const firstId = state.addShape(gateDraft({ x: 1, y: 2 }));
+    const secondId = state.addShape(flagDraft({ x: 3, y: 4 }));
+    const thirdId = state.addShape(coneDraft({ x: 5, y: 6, radius: 0.2 }));
 
     state.clearHistory();
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-13T10:12:10.000Z"));
+    setEditorTestTime("2026-04-13T10:12:10.000Z");
     state.nudgeShapes([firstId], 2, -1);
     expect(useEditor.getState().track.design.shapeById[firstId]).toMatchObject({
       x: 3,
       y: 1,
     });
 
-    vi.setSystemTime(new Date("2026-04-13T10:12:11.000Z"));
+    setEditorTestTime("2026-04-13T10:12:11.000Z");
     state.nudgeShapes([firstId], 0, 0);
     expect(useEditor.getState().track.design.shapeById[firstId]).toMatchObject({
       x: 3,
@@ -1119,27 +808,9 @@ describe("editor store history", () => {
 
   it("reorderShapes moves a shape before another", () => {
     const state = useEditor.getState();
-    const a = state.addShape({
-      kind: "cone",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      radius: 1,
-    });
-    const b = state.addShape({
-      kind: "cone",
-      x: 1,
-      y: 0,
-      rotation: 0,
-      radius: 1,
-    });
-    const c = state.addShape({
-      kind: "cone",
-      x: 2,
-      y: 0,
-      rotation: 0,
-      radius: 1,
-    });
+    const a = state.addShape(coneDraft());
+    const b = state.addShape(coneDraft({ x: 1 }));
+    const c = state.addShape(coneDraft({ x: 2 }));
 
     state.reorderShapes(c, a);
     expect(useEditor.getState().track.design.shapeOrder).toEqual([c, a, b]);
@@ -1147,27 +818,9 @@ describe("editor store history", () => {
 
   it("reorderShapes with null beforeId moves shape to end", () => {
     const state = useEditor.getState();
-    const a = state.addShape({
-      kind: "cone",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      radius: 1,
-    });
-    const b = state.addShape({
-      kind: "cone",
-      x: 1,
-      y: 0,
-      rotation: 0,
-      radius: 1,
-    });
-    const c = state.addShape({
-      kind: "cone",
-      x: 2,
-      y: 0,
-      rotation: 0,
-      radius: 1,
-    });
+    const a = state.addShape(coneDraft());
+    const b = state.addShape(coneDraft({ x: 1 }));
+    const c = state.addShape(coneDraft({ x: 2 }));
 
     state.reorderShapes(a, null);
     expect(useEditor.getState().track.design.shapeOrder).toEqual([b, c, a]);
@@ -1175,14 +828,8 @@ describe("editor store history", () => {
 
   it("reorderShapes is a no-op when fromId equals beforeId", () => {
     const state = useEditor.getState();
-    const a = state.addShape({
-      kind: "cone",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      radius: 1,
-    });
-    state.addShape({ kind: "cone", x: 1, y: 0, rotation: 0, radius: 1 });
+    const a = state.addShape(coneDraft());
+    state.addShape(coneDraft({ x: 1 }));
 
     const orderBefore = [...useEditor.getState().track.design.shapeOrder];
     state.reorderShapes(a, a);
@@ -1191,21 +838,10 @@ describe("editor store history", () => {
 
   it("updateShapesCatalogType switches flag types and skips locked flags", () => {
     const state = useEditor.getState();
-    const editableId = state.addShape({
-      kind: "flag",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      radius: 1,
-    });
-    const lockedId = state.addShape({
-      kind: "flag",
-      x: 1,
-      y: 0,
-      rotation: 0,
-      radius: 1,
-      locked: true,
-    });
+    const editableId = state.addShape(flagDraft({ x: 0, y: 0, radius: 1 }));
+    const lockedId = state.addShape(
+      flagDraft({ x: 1, y: 0, radius: 1, locked: true })
+    );
 
     state.updateShapesCatalogType(
       [editableId, lockedId],
@@ -1226,15 +862,7 @@ describe("editor store history", () => {
 
   it("updateShapesCatalogType switches ladder types", () => {
     const state = useEditor.getState();
-    const id = state.addShape({
-      kind: "ladder",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      width: 2,
-      height: 2,
-      rungs: 3,
-    });
+    const id = state.addShape(ladderDraft());
 
     state.updateShapesCatalogType([id], MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID);
 
@@ -1247,15 +875,9 @@ describe("editor store history", () => {
 
   it("updateShapesCatalogType does nothing when all shapes are locked", () => {
     const state = useEditor.getState();
-    const id = state.addShape({
-      kind: "gate",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      width: 3,
-      height: 3,
-      locked: true,
-    });
+    const id = state.addShape(
+      gateDraft({ x: 0, y: 0, width: 3, height: 3, locked: true })
+    );
     state.clearHistory();
 
     state.updateShapesCatalogType([id], MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID);
@@ -1263,6 +885,179 @@ describe("editor store history", () => {
     expect(
       useEditor.getState().track.design.shapeById[id]?.meta
     ).toBeUndefined();
-    expect(getPastStatesCount()).toBe(0);
+    expectPastStatesCount(0);
+  });
+
+  it("addShapes assigns unique ids to all shapes in one atomic update", () => {
+    const state = useEditor.getState();
+    const ids = state.addShapes([
+      gateDraft({ x: 0, y: 0 }),
+      flagDraft({ x: 4, y: 0 }),
+      coneDraft({ x: 8, y: 0, radius: 0.2 }),
+    ]);
+
+    expect(ids).toHaveLength(3);
+    expect(new Set(ids).size).toBe(3);
+    const design = useEditor.getState().track.design;
+    for (const id of ids) {
+      expect(design.shapeById[id]).toBeTruthy();
+    }
+    expect(design.shapeOrder.slice(-3)).toEqual(ids);
+  });
+
+  it("sets map reference, toggles visibility, clamps opacity, and normalises rotation", () => {
+    const state = useEditor.getState();
+
+    state.setMapReference({
+      type: "map",
+      provider: "esri-world-imagery",
+      mapStyle: "satellite",
+      centerLat: 51.5,
+      centerLng: 4.5,
+      zoom: 14,
+      visible: true,
+      opacity: 1,
+      rotationDeg: 0,
+      locked: false,
+    });
+
+    expect(useEditor.getState().track.design.mapReference?.type).toBe("map");
+
+    state.setMapReferenceVisibility(false);
+    expect(useEditor.getState().track.design.mapReference?.visible).toBe(false);
+
+    state.setMapReferenceOpacity(0.02);
+    expect(useEditor.getState().track.design.mapReference?.opacity).toBeCloseTo(
+      0.05
+    );
+
+    state.setMapReferenceOpacity(1.5);
+    expect(useEditor.getState().track.design.mapReference?.opacity).toBeCloseTo(
+      1
+    );
+
+    state.setMapReferenceRotation(370);
+    expect(
+      useEditor.getState().track.design.mapReference?.rotationDeg
+    ).toBeCloseTo(10);
+
+    state.clearMapReference();
+    expect(useEditor.getState().track.design.mapReference).toBeNull();
+  });
+
+  it("clearMapReference is a no-op when there is no map reference", () => {
+    const state = useEditor.getState();
+    state.clearMapReference();
+    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    state.clearMapReference();
+    expect(useEditor.getState().track.design.updatedAt).toBe(beforeUpdatedAt);
+  });
+
+  it("covers UI setters: snap, zoom, pan, active tool and placement", () => {
+    const state = useEditor.getState();
+
+    state.setSnapEnabled(false);
+    expect(useEditor.getState().ui.snapEnabled).toBe(false);
+    state.toggleSnapEnabled();
+    expect(useEditor.getState().ui.snapEnabled).toBe(true);
+
+    state.setZoom(0.05);
+    expect(useEditor.getState().ui.zoom).toBeCloseTo(0.1);
+    state.setZoom(10);
+    expect(useEditor.getState().ui.zoom).toBeCloseTo(5);
+
+    state.setPanOffset({ x: 100, y: -50 });
+    expect(useEditor.getState().ui.panOffset).toEqual({ x: 100, y: -50 });
+
+    state.setActiveTool("gate");
+    expect(useEditor.getState().ui.activeTool).toBe("gate");
+
+    state.setActivePresetId("preset-abc");
+    expect(useEditor.getState().ui.activePresetId).toBe("preset-abc");
+
+    state.setActivePlacementElementId(
+      "gate",
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
+    );
+    expect(useEditor.getState().ui.activePlacementElementId.gate).toBe(
+      MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
+    );
+    state.setActivePlacementElementId("gate", null);
+    expect(
+      useEditor.getState().ui.activePlacementElementId.gate
+    ).toBeUndefined();
+  });
+
+  it("covers remaining UI setters: waypoint hover, draft path, marquee, patches", () => {
+    const state = useEditor.getState();
+
+    state.setHoveredWaypoint({ shapeId: "s1", idx: 2 });
+    expect(useEditor.getState().ui.hoveredWaypoint).toMatchObject({
+      shapeId: "s1",
+      idx: 2,
+    });
+
+    state.setDraftPath([
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+    ]);
+    expect(useEditor.getState().ui.draftPath).toHaveLength(2);
+    state.setDraftForceClosed(true);
+    expect(useEditor.getState().ui.draftForceClosed).toBe(true);
+    state.setDraftSourceShapeId("shape-x");
+    expect(useEditor.getState().ui.draftSourceShapeId).toBe("shape-x");
+
+    state.setMarqueeRect({ x: 0, y: 0, width: 100, height: 50 });
+    expect(useEditor.getState().ui.marqueeRect).toMatchObject({ width: 100 });
+
+    state.setGroupDragPreview({
+      ids: ["a", "b"],
+      origin: { x: 5, y: 10 },
+      dx: 2,
+      dy: -1,
+    });
+    expect(useEditor.getState().ui.groupDragPreview).toMatchObject({
+      ids: ["a", "b"],
+      dx: 2,
+      dy: -1,
+    });
+
+    const gateId = state.addShape(gateDraft({ x: 0, y: 0 }));
+    state.setLiveShapePatch(gateId, { x: 5 });
+    expect(useEditor.getState().ui.liveShapePatches[gateId]).toMatchObject({
+      x: 5,
+    });
+    state.clearLiveShapePatch(gateId);
+    expect(useEditor.getState().ui.liveShapePatches[gateId]).toBeUndefined();
+  });
+
+  it("setVertexSelection clears segment selection and vice versa", () => {
+    const state = useEditor.getState();
+    const routeId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 },
+        ],
+      })
+    );
+
+    state.setSegmentSelection({
+      shapeId: routeId,
+      segmentIndex: 0,
+      point: { x: 1, y: 0 },
+    });
+    expect(useEditor.getState().ui.segmentSelection).not.toBeNull();
+
+    state.setVertexSelection({ shapeId: routeId, idx: 0 });
+    expect(useEditor.getState().ui.vertexSelection).toMatchObject({ idx: 0 });
+    expect(useEditor.getState().ui.segmentSelection).toBeNull();
+
+    state.setSegmentSelection({
+      shapeId: routeId,
+      segmentIndex: 0,
+      point: { x: 1, y: 0 },
+    });
+    expect(useEditor.getState().ui.vertexSelection).toBeNull();
   });
 });

--- a/tests/store/selectors.test.ts
+++ b/tests/store/selectors.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   selectActiveTool,
   selectDesignPolylineZRange,
@@ -22,30 +22,26 @@ import {
   selectZoom,
 } from "@/store/selectors";
 import { useEditor } from "@/store/editor";
+import {
+  flagDraft,
+  gateDraft,
+  polylineDraft,
+  resetEditorStore,
+} from "../helpers/editor-store";
 
 describe("editor selectors", () => {
   beforeEach(() => {
-    useEditor.getState().newProject();
-    useEditor.getState().clearHistory();
+    resetEditorStore();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("returns design-derived shape collections and cached references", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 10,
-      y: 8,
-      rotation: 0,
-      width: 2.2,
-      height: 1.9,
-    });
-    const flagId = state.addShape({
-      kind: "flag",
-      x: 14,
-      y: 9,
-      rotation: 0,
-      radius: 0.25,
-    });
+    const gateId = state.addShape(gateDraft({ width: 2.2, height: 1.9 }));
+    const flagId = state.addShape(flagDraft({ x: 14, y: 9 }));
 
     const snapshot = useEditor.getState();
     const shapes = selectDesignShapes(snapshot);
@@ -62,24 +58,15 @@ describe("editor selectors", () => {
 
   it("resolves selected and primary polylines plus path flags", () => {
     const state = useEditor.getState();
-    state.addShape({
-      kind: "gate",
-      x: 3,
-      y: 4,
-      rotation: 0,
-      width: 2,
-      height: 2,
-    });
-    const polylineId = state.addShape({
-      kind: "polyline",
-      x: 0,
-      y: 0,
-      rotation: 0,
-      points: [
-        { x: 1, y: 2, z: 0.5 },
-        { x: 3, y: 4, z: 2 },
-      ],
-    });
+    state.addShape(gateDraft({ x: 3, y: 4 }));
+    const polylineId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 1, y: 2, z: 0.5 },
+          { x: 3, y: 4, z: 2 },
+        ],
+      })
+    );
 
     state.setSelection([polylineId]);
 
@@ -97,24 +84,10 @@ describe("editor selectors", () => {
 
   it("tracks locked selections and ui state selectors", () => {
     const state = useEditor.getState();
-    const gateId = state.addShape({
-      kind: "gate",
-      x: 5,
-      y: 6,
-      rotation: 0,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
-    const secondGateId = state.addShape({
-      kind: "gate",
-      x: 8,
-      y: 9,
-      rotation: 0,
-      width: 2,
-      height: 2,
-      locked: true,
-    });
+    const gateId = state.addShape(gateDraft({ x: 5, y: 6, locked: true }));
+    const secondGateId = state.addShape(
+      gateDraft({ x: 8, y: 9, locked: true })
+    );
 
     state.setSelection([gateId, secondGateId]);
     state.setActiveTool("grab");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    fileParallelism: true,
     include: ["tests/**/*.test.{ts,tsx}"],
+    pool: "threads",
     restoreMocks: true,
     clearMocks: true,
     coverage: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     environment: "node",
     fileParallelism: true,
     include: ["tests/**/*.test.{ts,tsx}"],
-    pool: "threads",
+    pool: "forks",
     restoreMocks: true,
     clearMocks: true,
     coverage: {


### PR DESCRIPTION
Expand test coverage around TrackDraw’s higher-risk product flows instead of only refactoring small unit tests.

## Changes

- Added shared test helpers for editor-store fixtures, local storage, D1 statements, API route fixtures, and Cloudflare media bucket mocks.
- Expanded scenario coverage for share publishing, gallery listing/revocation, account project sync conflicts, local project persistence, restore points, auth/session behavior, API v1 routes, media serving, OpenAPI/SEO metadata, and several previously untested hooks.
- Refactored existing tests to reuse helpers and reduce duplicate setup.