### PR TITLE
feat: Refine tower and ladder track item rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See the [public roadmap discussion](https://github.com/dutchdronesquad/trackdraw
 ## What you can do
 
 - 🏁 **Design layouts to scale** - place obstacles on a real-scale canvas with Metric or Imperial measurements that map cleanly to the real world
-- 🚩 **Use official obstacle types** - place MultiGP-style gates, ladders, and flags with real dimensions, or keep using custom-sized TrackDraw elements
+- 🚩 **Use official obstacle types** - place MultiGP-style gates, ladders, towers, and flags with real dimensions, or keep using custom-sized TrackDraw elements
 - 🗺️ **Line up with real venues** - add an editor-only satellite map reference, search or choose the field center, and align it with rotation and opacity controls
 - ⚡ **Start and iterate faster** - use obstacle presets, selection grouping, and starter layouts to get from blank canvas to a workable draft quickly
 - 💾 **Manage projects safely** - keep multiple local projects, reopen older layouts, rename or export them, and roll back through restore points and snapshots

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -21,7 +21,7 @@ The most useful next product move is deepening the race-day workflow, keeping th
 - Race director page with pilot line, timing/start box placement, and ops notes
 - Usability and reliability pass focused on recovery states, mobile ergonomics, editor interactions, exports, sharing, and larger layouts
 - Path editing UX improvements for smoother curves and a more natural drawing experience
-- Catalog-backed official track elements beyond the shipped MultiGP gate, flag, and ladder set, including Dive Gate, Launch Gate, and a new Double Gate Tower shape kind
+- Catalog-backed official track elements beyond the shipped MultiGP gate, flag, ladder, dive gate, launch gate, and tower set
 - Focused 3D item controls where direct manipulation is safer and faster than inspector-only editing
 - Account-backed custom banner texture support for official-size gates, ladders, and flags, so clubs can preview their own printed banners on MultiGP-sized hardware
 - Generated flightpath research as a separate route-authoring assist

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -32,8 +32,8 @@ The completed release-sized work is archived below. The next TrackDraw priority 
 - [x] MultiGP Launch Gate 7x6 (`No account required`)
       Catalog-backed gate variant with official 7×6 ft dimensions and a 3D box-frame rendering with four configurable banner panels. Shares the gate shape kind and inspector pipeline. Banner panels now cast and receive shadows correctly with correct texture orientations.
 
-- [ ] MultiGP Double Gate Tower 5x5 and 7x6 (`No account required`)
-      New shape kind with its own 2D representation, 3D rendering, catalog entries, and inspector pipeline. Race-line behavior is gate-like (fly through); physical structure is a two-frame tower.
+- [x] MultiGP Double Gate Tower 5x5 and 7x6 (`No account required`)
+      Catalog-backed tower variants now cover MultiGP Tower and Double Gate Tower 5x5 and 7x6 sizes with 2D placement, 3D rendering, texture placement, inspector support, and flythrough coverage.
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.

--- a/src/components/canvas/preview3d/items/Gate3D.tsx
+++ b/src/components/canvas/preview3d/items/Gate3D.tsx
@@ -182,7 +182,7 @@ function PanelFrameGateTexturePlanes({
         <mesh>
           <planeGeometry args={[leftPanelWidth, h]} />
           <meshStandardMaterial
-            map={panelTextures.left.texture}
+            map={panelTextures.right.texture}
             roughness={0.72}
             metalness={0.01}
             side={THREE.FrontSide}
@@ -193,7 +193,7 @@ function PanelFrameGateTexturePlanes({
         <mesh>
           <planeGeometry args={[rightPanelWidth, h]} />
           <meshStandardMaterial
-            map={panelTextures.right.texture}
+            map={panelTextures.left.texture}
             roughness={0.72}
             metalness={0.01}
             side={THREE.FrontSide}

--- a/src/components/canvas/preview3d/items/Ladder3D.tsx
+++ b/src/components/canvas/preview3d/items/Ladder3D.tsx
@@ -199,7 +199,7 @@ function PanelFrameLadderSectionTexturePlanes({
         <mesh>
           <planeGeometry args={[leftPanelWidth, openingH]} />
           <meshStandardMaterial
-            map={panelTextures.left.texture}
+            map={panelTextures.right.texture}
             roughness={0.72}
             metalness={0.01}
             side={THREE.FrontSide}
@@ -213,7 +213,7 @@ function PanelFrameLadderSectionTexturePlanes({
         <mesh>
           <planeGeometry args={[rightPanelWidth, openingH]} />
           <meshStandardMaterial
-            map={panelTextures.right.texture}
+            map={panelTextures.left.texture}
             roughness={0.72}
             metalness={0.01}
             side={THREE.FrontSide}
@@ -483,7 +483,7 @@ export function Ladder3D({
   const ladderVisual = getLadderVisualSpec(shape);
   const color = shape.color ?? "#3b82f6";
   const w = shape.width ?? 1.5;
-  const totalH = shape.height ?? 4.5;
+  const totalH = shape.height ?? 6;
   const rungs = Math.max(1, shape.rungs ?? 3);
   const baseY = Math.max(shape.elevation ?? 0, 0);
   const thick = 0.2;

--- a/src/components/canvas/preview3d/items/Tower3D.tsx
+++ b/src/components/canvas/preview3d/items/Tower3D.tsx
@@ -52,6 +52,9 @@ function getTowerVisualSpecFor3D(shape: TowerShape): TowerVisualSpec | null {
 }
 
 function TowerPanelFrameTexturePlanes({
+  bottomPanelHeight,
+  bottomPanelW,
+  bottomPanelY,
   catalogId,
   frontZ,
   h,
@@ -59,11 +62,15 @@ function TowerPanelFrameTexturePlanes({
   leftPanelX,
   rightPanelWidth,
   rightPanelX,
+  renderBottomPanel,
   textures,
   topPanelHeight,
   topPanelW,
   topPanelY,
 }: {
+  bottomPanelHeight: number;
+  bottomPanelW: number;
+  bottomPanelY: number;
   catalogId?: string;
   frontZ: number;
   h: number;
@@ -71,6 +78,7 @@ function TowerPanelFrameTexturePlanes({
   leftPanelX: number;
   rightPanelWidth: number;
   rightPanelX: number;
+  renderBottomPanel: boolean;
   textures: GatePanelTextureVisualSpec;
   topPanelHeight: number;
   topPanelW: number;
@@ -115,6 +123,14 @@ function TowerPanelFrameTexturePlanes({
           "top",
           mapping.top.flipX,
           mapping.top.flipY
+        )
+      : null;
+    const bottomFlips = mapping.bottom
+      ? getEffectiveFlips(
+          catalogId,
+          "bottom",
+          mapping.bottom.flipX,
+          mapping.bottom.flipY
         )
       : null;
     return {
@@ -163,6 +179,23 @@ function TowerPanelFrameTexturePlanes({
               flipY: mapping.top.flipY,
             }
           : null,
+      bottom:
+        mapping.bottom && bottomFlips
+          ? {
+              texture: cloneTextureForPanel(mapping.bottom.texture, {
+                rotation: getEffectiveRotation(
+                  catalogId,
+                  "bottom",
+                  mapping.bottom.rotation
+                ),
+                ...bottomFlips,
+              }),
+              rotation: mapping.bottom.rotation,
+              source: mapping.bottom.source,
+              flipX: mapping.bottom.flipX,
+              flipY: mapping.bottom.flipY,
+            }
+          : null,
     };
     // overrideVersion is intentionally included to trigger re-clone on cycle
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -202,6 +235,15 @@ function TowerPanelFrameTexturePlanes({
         panelTextures.top.flipY,
         panelTextures.top.rotation
       );
+    if (panelTextures.bottom)
+      registerPanel(
+        catalogId,
+        "bottom",
+        panelTextures.bottom.source,
+        panelTextures.bottom.flipX,
+        panelTextures.bottom.flipY,
+        panelTextures.bottom.rotation
+      );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [catalogId]);
 
@@ -211,7 +253,7 @@ function TowerPanelFrameTexturePlanes({
         <mesh>
           <planeGeometry args={[leftPanelWidth, h]} />
           <meshStandardMaterial
-            map={panelTextures.left.texture}
+            map={panelTextures.right.texture}
             roughness={0.72}
             metalness={0.01}
             side={THREE.FrontSide}
@@ -222,7 +264,7 @@ function TowerPanelFrameTexturePlanes({
         <mesh>
           <planeGeometry args={[rightPanelWidth, h]} />
           <meshStandardMaterial
-            map={panelTextures.right.texture}
+            map={panelTextures.left.texture}
             roughness={0.72}
             metalness={0.01}
             side={THREE.FrontSide}
@@ -240,6 +282,19 @@ function TowerPanelFrameTexturePlanes({
           />
         </mesh>
       </group>
+      {renderBottomPanel ? (
+        <group position={[0, bottomPanelY, frontZ]} rotation={[0, Math.PI, 0]}>
+          <mesh>
+            <planeGeometry args={[bottomPanelW, bottomPanelHeight]} />
+            <meshStandardMaterial
+              map={panelTextures.bottom?.texture ?? null}
+              roughness={0.68}
+              metalness={0.02}
+              side={THREE.FrontSide}
+            />
+          </mesh>
+        </group>
+      ) : null}
     </>
   );
 }
@@ -256,7 +311,11 @@ export function getTowerTopY(shape: TowerShape): number {
     towerVisual?.variant === "panel-frame"
       ? openingH + towerVisual.panels.top.heightMeters
       : openingH;
-  return (shape.elevation ?? 0) + levelCount * levelPitch;
+  const bottomPanelHeight =
+    towerVisual?.variant === "panel-frame" && levelCount === 1
+      ? towerVisual.panels.top.heightMeters
+      : 0;
+  return (shape.elevation ?? 0) + bottomPanelHeight + levelCount * levelPitch;
 }
 
 function PanelFrameTower3D({
@@ -299,6 +358,8 @@ function PanelFrameTower3D({
     metalness: 0.01,
   };
   const levelPitch = layout.outerTopY;
+  const hasBottomPanel = levelCount === 1;
+  const bottomPanelY = -layout.topPanelHeight / 2;
 
   return (
     <group ref={outerRef} position={[shape.x, 0, shape.y]} rotation={rot}>
@@ -322,7 +383,11 @@ function PanelFrameTower3D({
           ))
         : null}
       {Array.from({ length: levelCount }, (_, index) => {
-        const baseY = elevation + index * levelPitch;
+        const baseY =
+          elevation +
+          (hasBottomPanel ? layout.topPanelHeight : 0) +
+          index * levelPitch;
+        const renderBottomPanel = hasBottomPanel && index === 0;
         return (
           <group key={index} position={[0, baseY, 0]}>
             <mesh
@@ -434,8 +499,29 @@ function PanelFrameTower3D({
                 emissiveIntensity={selected ? 0.28 : 0.04}
               />
             </mesh>
+            {renderBottomPanel ? (
+              <mesh position={[0, bottomPanelY, 0]} castShadow receiveShadow>
+                <boxGeometry
+                  args={[
+                    layout.topPanelW,
+                    layout.topPanelHeight,
+                    layout.panelDepth,
+                  ]}
+                />
+                <meshStandardMaterial
+                  color={visual.panels.top.color}
+                  roughness={0.64}
+                  metalness={0.03}
+                  emissive={selected ? "#60a5fa" : visual.panels.top.color}
+                  emissiveIntensity={selected ? 0.28 : 0.04}
+                />
+              </mesh>
+            ) : null}
             <Suspense fallback={null}>
               <TowerPanelFrameTexturePlanes
+                bottomPanelHeight={layout.topPanelHeight}
+                bottomPanelW={layout.topPanelW}
+                bottomPanelY={bottomPanelY}
                 catalogId={catalogId}
                 frontZ={layout.frontZ}
                 h={layout.h}
@@ -443,6 +529,7 @@ function PanelFrameTower3D({
                 leftPanelX={layout.leftPanelX}
                 rightPanelWidth={layout.rightPanelWidth}
                 rightPanelX={layout.rightPanelX}
+                renderBottomPanel={renderBottomPanel}
                 textures={visual.textures}
                 topPanelHeight={layout.topPanelHeight}
                 topPanelW={layout.topPanelW}

--- a/src/components/canvas/renderers/shape2d/gate.tsx
+++ b/src/components/canvas/renderers/shape2d/gate.tsx
@@ -11,7 +11,7 @@ export function renderGate(shape: GateShape, selected: boolean, ppm: number) {
   const base = getGate2DShape(shape, ppm);
   const color = marker ? getTimingMarkerColor(marker) : base.color;
   const { radius, width } = base;
-  const barHeight = Math.max(base.depth, 6);
+  const barHeight = Math.max(base.depth, 7);
   const selectionPad = m2px(0.3, ppm);
 
   if (base.variant === "panel-frame") {

--- a/src/components/canvas/renderers/shape2d/ladder.tsx
+++ b/src/components/canvas/renderers/shape2d/ladder.tsx
@@ -11,7 +11,7 @@ export function renderLadder(
   ppm: number
 ) {
   const ladder2d = getLadder2DShape(shape, ppm);
-  const barHeight = Math.max(ladder2d.depth, 8);
+  const barHeight = Math.max(ladder2d.depth, 7);
   const selectionPad = m2px(0.3, ppm);
   const { color, radius, width } = ladder2d;
   return (

--- a/src/components/canvas/renderers/shape2d/tower.tsx
+++ b/src/components/canvas/renderers/shape2d/tower.tsx
@@ -7,7 +7,8 @@ import type { TowerShape } from "@/lib/types";
 
 export function renderTower(shape: TowerShape, selected: boolean, ppm: number) {
   const tower = getTower2DShape(shape, ppm);
-  const { depth, levelCount, radius, totalDepth, width } = tower;
+  const { depth, levelCount, radius, width } = tower;
+  const barHeight = Math.max(depth, 7);
   const selectionPad = m2px(0.3, ppm);
 
   const strokeColor =
@@ -18,9 +19,9 @@ export function renderTower(shape: TowerShape, selected: boolean, ppm: number) {
       {selected && (
         <Rect
           width={width + selectionPad}
-          height={totalDepth + selectionPad}
+          height={barHeight + selectionPad}
           offsetX={(width + selectionPad) / 2}
-          offsetY={(totalDepth + selectionPad) / 2}
+          offsetY={(barHeight + selectionPad) / 2}
           stroke="#60a5fa"
           strokeWidth={1}
           opacity={0.85}
@@ -32,9 +33,9 @@ export function renderTower(shape: TowerShape, selected: boolean, ppm: number) {
         <>
           <Rect
             x={-width / 2}
-            y={-depth / 2}
+            y={-barHeight / 2}
             width={tower.panels.leftWidth}
-            height={depth}
+            height={barHeight}
             fill={tower.panels.leftColor}
             opacity={0.94}
             cornerRadius={[radius, 0, 0, radius]}
@@ -42,18 +43,18 @@ export function renderTower(shape: TowerShape, selected: boolean, ppm: number) {
           />
           <Rect
             x={-tower.openingWidth / 2}
-            y={-depth / 2}
+            y={-barHeight / 2}
             width={tower.openingWidth}
-            height={depth}
+            height={barHeight}
             fill={tower.panels.topColor}
             opacity={0.9}
             strokeEnabled={false}
           />
           <Rect
             x={width / 2 - tower.panels.rightWidth}
-            y={-depth / 2}
+            y={-barHeight / 2}
             width={tower.panels.rightWidth}
-            height={depth}
+            height={barHeight}
             fill={tower.panels.rightColor}
             opacity={0.94}
             cornerRadius={[0, radius, radius, 0]}
@@ -63,34 +64,38 @@ export function renderTower(shape: TowerShape, selected: boolean, ppm: number) {
       ) : (
         <Rect
           width={width}
-          height={depth}
+          height={barHeight}
           offsetX={width / 2}
-          offsetY={depth / 2}
+          offsetY={barHeight / 2}
           fill={tower.color}
           opacity={0.88}
           cornerRadius={radius}
           strokeEnabled={false}
         />
       )}
-      <Rect
-        width={width}
-        height={depth}
-        offsetX={width / 2}
-        offsetY={depth / 2}
-        fillEnabled={false}
-        stroke={strokeColor}
-        strokeWidth={1}
-        opacity={0.88}
-        cornerRadius={radius}
-      />
-      <Line
-        points={[-width / 2, 0, width / 2, 0]}
-        stroke={strokeColor}
-        strokeWidth={1}
-        opacity={levelCount > 1 ? 0.62 : 0.28}
-        dash={levelCount > 1 ? [3, 2] : [2, 4]}
-        listening={false}
-      />
+      {tower.variant === "panel-frame" ? (
+        <Rect
+          width={width}
+          height={barHeight}
+          offsetX={width / 2}
+          offsetY={barHeight / 2}
+          fillEnabled={false}
+          stroke={strokeColor}
+          strokeWidth={1}
+          opacity={0.88}
+          cornerRadius={radius}
+        />
+      ) : null}
+      {levelCount > 1 ? (
+        <Line
+          points={[-width / 2, 0, width / 2, 0]}
+          stroke={strokeColor}
+          strokeWidth={1}
+          opacity={0.62}
+          dash={[3, 2]}
+          listening={false}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/components/inspector/sections/LadderSection.tsx
+++ b/src/components/inspector/sections/LadderSection.tsx
@@ -71,14 +71,15 @@ export function LadderSection({
         <Num
           value={shape.rungs}
           onChange={(value) => {
-            const clampedRungs = Math.round(Math.max(1, Math.min(10, value)));
+            const clampedRungs = Math.round(Math.max(3, Math.min(5, value)));
             updateShape(shape.id, {
               rungs: clampedRungs,
-              height: clampedRungs * 1.5,
+              height: clampedRungs * 2,
             });
           }}
           step={1}
-          min={1}
+          min={3}
+          max={5}
         />
       </Row>
     </Section>

--- a/src/components/inspector/shared.tsx
+++ b/src/components/inspector/shared.tsx
@@ -149,11 +149,13 @@ export function Num({
   onChange,
   step = 0.1,
   min,
+  max,
 }: {
   value: number;
   onChange: (value: number) => void;
   step?: number;
   min?: number;
+  max?: number;
 }) {
   const { startBatch, finishBatch } = useInspectorInputBatch();
 
@@ -162,6 +164,7 @@ export function Num({
       type="number"
       step={step}
       min={min}
+      max={max}
       value={value}
       onFocus={startBatch}
       onBlur={finishBatch}

--- a/src/lib/export/flythrough/gate.ts
+++ b/src/lib/export/flythrough/gate.ts
@@ -130,13 +130,13 @@ async function createOfficialGateGroup(
 
   addPanelTexturePlane(
     group,
-    cloneTextureForPanel(textureMapping.left.texture, textureMapping.left),
+    cloneTextureForPanel(textureMapping.right.texture, textureMapping.right),
     [leftPanelWidth, h],
     [leftPanelX, h / 2, frontZ]
   );
   addPanelTexturePlane(
     group,
-    cloneTextureForPanel(textureMapping.right.texture, textureMapping.right),
+    cloneTextureForPanel(textureMapping.left.texture, textureMapping.left),
     [rightPanelWidth, h],
     [rightPanelX, h / 2, frontZ]
   );

--- a/src/lib/export/flythrough/ladder.ts
+++ b/src/lib/export/flythrough/ladder.ts
@@ -158,13 +158,13 @@ async function createPanelFrameLadderGroup(
     );
     addPanelTexturePlane(
       group,
-      cloneTextureForPanel(textureMapping.left.texture, textureMapping.left),
+      cloneTextureForPanel(textureMapping.right.texture, textureMapping.right),
       [leftPanelWidth, openingH],
       [-w / 2 - leftPanelWidth / 2, section.openingMidY, frontZ]
     );
     addPanelTexturePlane(
       group,
-      cloneTextureForPanel(textureMapping.right.texture, textureMapping.right),
+      cloneTextureForPanel(textureMapping.left.texture, textureMapping.left),
       [rightPanelWidth, openingH],
       [w / 2 + rightPanelWidth / 2, section.openingMidY, frontZ]
     );
@@ -197,7 +197,7 @@ export async function addLadderSceneShapes(
 
   const color = shape.color ?? "#3b82f6";
   const w = shape.width ?? 1.5;
-  const totalH = shape.height ?? 4.5;
+  const totalH = shape.height ?? 6;
   const rungs = Math.max(1, shape.rungs ?? 3);
   const baseY = Math.max(shape.elevation ?? 0, 0);
   const thick = 0.2;

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -112,6 +112,7 @@ export interface GatePanelTextureVisualSpec {
     left?: PanelTexturePlacementSpec<"left" | "right" | "top">;
     right?: PanelTexturePlacementSpec<"left" | "right" | "top">;
     top?: PanelTexturePlacementSpec<"left" | "right" | "top">;
+    bottom?: PanelTexturePlacementSpec<"left" | "right" | "top">;
   };
 }
 
@@ -350,9 +351,10 @@ const panelFrameGateVisual = {
       "/assets/models/textures/multigp-obstacles/MultiGP-2017-Airgate-right-panel-regular-50-percent.webp",
     top: "/assets/models/textures/multigp-obstacles/MultiGP-2017-Airgate-top-regular-50-percent.webp",
     placement: {
-      left: { source: "right", orientation: { textureTopEdgeFaces: "top" } },
-      right: { source: "left", orientation: { textureTopEdgeFaces: "top" } },
+      left: { source: "left", orientation: { textureTopEdgeFaces: "top" } },
+      right: { source: "right", orientation: { textureTopEdgeFaces: "top" } },
       top: { source: "top", orientation: { textureTopEdgeFaces: "top" } },
+      bottom: { source: "top", orientation: { textureTopEdgeFaces: "top" } },
     },
   },
 } satisfies GateVisualSpec;
@@ -370,9 +372,12 @@ const panelFrameChampionshipGateVisual = {
       "/assets/models/textures/multigp-obstacles/large-side-panel-multigp.webp",
     top: "/assets/models/textures/multigp-obstacles/large-top-multigp.webp",
     placement: {
-      left: { source: "left", orientation: { flipX: true } },
-      right: { source: "left", orientation: { flipX: true } },
-      top: { source: "top", orientation: { flipX: true } },
+      left: { source: "left", orientation: { textureTopEdgeFaces: "top" } },
+      right: {
+        source: "left",
+        orientation: { textureTopEdgeFaces: "bottom" },
+      },
+      top: { source: "top", orientation: { textureTopEdgeFaces: "top" } },
     },
   },
 } satisfies GateVisualSpec;
@@ -390,7 +395,18 @@ const panelFrameChampionshipTowerVisual = {
   variant: "panel-frame",
   panels: panelFrameChampionshipGateVisual.panels,
   frame: panelFrameChampionshipGateVisual.frame,
-  textures: panelFrameChampionshipGateVisual.textures,
+  textures: {
+    ...panelFrameChampionshipGateVisual.textures,
+    placement: {
+      left: { source: "left", orientation: { textureTopEdgeFaces: "top" } },
+      right: {
+        source: "left",
+        orientation: { textureTopEdgeFaces: "bottom" },
+      },
+      top: { source: "top", orientation: { textureTopEdgeFaces: "top" } },
+      bottom: { source: "top", orientation: { textureTopEdgeFaces: "top" } },
+    },
+  },
 } satisfies TowerVisualSpec;
 
 export const trackElementCatalog = [
@@ -853,11 +869,11 @@ export const trackElementCatalog = [
         top: "/assets/models/textures/multigp-obstacles/MultiGP-2017-Airgate-top-regular-50-percent.webp",
         placement: {
           left: {
-            source: "right",
+            source: "left",
             orientation: { textureTopEdgeFaces: "top" },
           },
           right: {
-            source: "left",
+            source: "right",
             orientation: { textureTopEdgeFaces: "top" },
           },
           top: { source: "top", orientation: { textureTopEdgeFaces: "top" } },
@@ -923,7 +939,7 @@ export const trackElementCatalog = [
         placement: {
           left: {
             source: "left",
-            orientation: { textureTopEdgeFaces: "bottom" },
+            orientation: { textureTopEdgeFaces: "top" },
           },
           right: {
             source: "left",
@@ -992,7 +1008,7 @@ export const trackElementCatalog = [
         placement: {
           left: {
             source: "left",
-            orientation: { textureTopEdgeFaces: "bottom" },
+            orientation: { textureTopEdgeFaces: "top" },
           },
           right: {
             source: "left",

--- a/src/lib/track/render3d-layout.ts
+++ b/src/lib/track/render3d-layout.ts
@@ -38,6 +38,7 @@ export interface PanelFrameTextureMapping<T> {
   left: ResolvedTexturePanel<T>;
   right: ResolvedTexturePanel<T>;
   top: ResolvedTexturePanel<T> | null;
+  bottom: ResolvedTexturePanel<T> | null;
 }
 
 export interface LaunchGateBannerTextureMapping<T> {
@@ -157,37 +158,41 @@ export function resolvePanelFrameTextureMapping<T>(
   textureSpec: GatePanelTextureVisualSpec,
   loaded: { left: T; right: T; top: T | null }
 ): PanelFrameTextureMapping<T> {
-  const symmetric = textureSpec.left === textureSpec.right;
   const topSource = textureSpec.top ? "top" : "left";
-  const leftFallback: PanelTexturePlacementSpec<"left" | "right" | "top"> =
-    symmetric
-      ? {
-          source: "left",
-          orientation: { textureTopEdgeFaces: "bottom" },
-        }
-      : { source: "right" };
-  const rightFallback: PanelTexturePlacementSpec<"left" | "right" | "top"> = {
+  const leftFallback: PanelTexturePlacementSpec<"left" | "right" | "top"> = {
     source: "left",
   };
+  const rightFallback: PanelTexturePlacementSpec<"left" | "right" | "top"> = {
+    source: "right",
+  };
+  const loadedTextures = loaded as Record<"left" | "right" | "top", T>;
 
   return {
     left: resolvePanelTexture(
       textureSpec.placement?.left,
       leftFallback,
-      loaded as Record<"left" | "right" | "top", T>
+      loadedTextures
     ),
     right: resolvePanelTexture(
       textureSpec.placement?.right,
       rightFallback,
-      loaded as Record<"left" | "right" | "top", T>
+      loadedTextures
     ),
     top: loaded.top
       ? resolvePanelTexture(
           textureSpec.placement?.top,
           { source: topSource },
-          loaded as Record<"left" | "right" | "top", T>
+          loadedTextures
         )
       : null,
+    bottom:
+      loaded.top || textureSpec.placement?.bottom?.source !== "top"
+        ? resolvePanelTexture(
+            textureSpec.placement?.bottom,
+            { source: topSource },
+            loadedTextures
+          )
+        : null,
   };
 }
 
@@ -303,7 +308,7 @@ export function getPanelFrameLadderLayout(
   visual: PanelFrameLadderVisualSpec
 ) {
   const w = shape.width ?? 1.5;
-  const totalOpeningH = shape.height ?? 4.5;
+  const totalOpeningH = shape.height ?? 6;
   const rungs = Math.max(1, shape.rungs ?? 3);
   const baseY = Math.max(shape.elevation ?? 0, 0);
   const leftPanelWidth = visual.panels.left.widthMeters;
@@ -372,7 +377,7 @@ export function getLadderRenderedHeight(
   shape: LadderShape,
   visual: PanelFrameLadderVisualSpec | null
 ) {
-  const height = shape.height ?? 4.5;
+  const height = shape.height ?? 6;
   if (!visual) return height;
   return getPanelFrameLadderLayout(shape, visual).totalH;
 }

--- a/src/lib/track/shape2d.ts
+++ b/src/lib/track/shape2d.ts
@@ -20,6 +20,7 @@ import type {
 } from "@/lib/types";
 
 const DIVE_GATE_2D_BANNER_VISUAL_SCALE = 0.82;
+const TRACKDRAW_FRAME_2D_DEPTH_METERS = 0.2;
 
 export function getGate2DShape(shape: GateShape, ppm: number) {
   const visual = getGateVisualSpec(shape);
@@ -129,7 +130,7 @@ export function getStartFinish2DShape(shape: StartFinishShape, ppm: number) {
 export function getLadder2DShape(shape: LadderShape, ppm: number) {
   const ladderVisual = getLadderVisualSpec(shape);
   const openingWidth = m2px(shape.width ?? 2, ppm);
-  const depth = m2px(0.18, ppm);
+  const depth = m2px(TRACKDRAW_FRAME_2D_DEPTH_METERS, ppm);
 
   if (ladderVisual?.variant === "panel-frame") {
     const leftPanelWidth = m2px(ladderVisual.panels.left.widthMeters, ppm);
@@ -161,7 +162,13 @@ export function getTower2DShape(shape: TowerShape, ppm: number) {
   const visual = getTowerVisualSpec(shape);
   const openingWidth = m2px(shape.width ?? 2, ppm);
   const levelCount = Math.max(1, Math.min(4, Math.round(shape.levels ?? 1)));
-  const depth = Math.max(m2px(shape.thick ?? 0.18, ppm), m2px(0.14, ppm));
+  const depth =
+    visual?.variant === "panel-frame"
+      ? Math.max(m2px(visual.frame.diameterMeters, ppm), m2px(0.12, ppm))
+      : Math.max(
+          m2px(shape.thick ?? TRACKDRAW_FRAME_2D_DEPTH_METERS, ppm),
+          m2px(TRACKDRAW_FRAME_2D_DEPTH_METERS, ppm)
+        );
 
   if (visual?.variant === "panel-frame") {
     const leftPanelWidth = m2px(visual.panels.left.widthMeters, ppm);

--- a/tests/lib/track/shape2d.test.ts
+++ b/tests/lib/track/shape2d.test.ts
@@ -74,7 +74,7 @@ describe("track 2d shape helpers", () => {
         },
         ppm
       ).depth
-    ).toBeCloseTo(3.6);
+    ).toBeCloseTo(4);
   });
 
   it("builds flag and cone bounds", () => {
@@ -167,6 +167,16 @@ describe("track 2d shape helpers", () => {
     expect(tower.openingWidth).toBeCloseTo(feetToMeters(5) * ppm);
     expect(tower.width).toBeCloseTo(feetToMeters(7) * ppm);
     expect(tower.totalDepth).toBe(tower.depth);
+
+    const gate = getGate2DShape(
+      createCatalogShapeDraft(MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID, {
+        x: 0,
+        y: 0,
+        includeCatalogMetadata: true,
+      }) as GateShape,
+      ppm
+    );
+    expect(tower.depth).toBe(gate.depth);
   });
 
   it("uses a top-down footprint for the official MultiGP dive gate", () => {


### PR DESCRIPTION
Refines the TrackDraw and MultiGP tower/ladder item behavior across 2D, 3D, texture placement, and export paths.

- Adds explicit bottom-panel texture placement for MultiGP towers and fixes 5x5/7x6 tower texture orientation.
- Corrects MultiGP tower 3D proportions, bottom banner placement, single-tower height, and double-gate tower banner behavior.
- Updates TrackDraw ladder defaults to 6m with 3-5 gates and keeps 2m per gate.
- Aligns 2D stroke thickness for TrackDraw gate, ladder, and tower.
- Updates flythrough/3D ladder fallbacks to match the new 6m default.