### PR TITLE
feat: Add 3D tower elevation controls

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -17,6 +17,7 @@ Current PVAs:
 - `trackdraw-rest-api-pva.md` — account-backed REST API, expiring API tokens, OpenAPI docs, and phased endpoint rollout
 - `live-race-overlay-pva.md` — real-time race overlay integration with `rh-stream-overlays`
 - `map-field-overlay-pva.md` — map-based field placement with hybrid asset storage
+- `3d-transform-controls-pva.md` — focused 3D move/rotate gizmo and orbit-control stabilization
 
 ### `research/`
 

--- a/docs/pva/3d-transform-controls-pva.md
+++ b/docs/pva/3d-transform-controls-pva.md
@@ -1,0 +1,259 @@
+# 3D Transform Controls PVA
+
+Date: June 9, 2026
+
+Status: draft, not approved for full build
+
+## Decision Summary
+
+Recommended direction:
+
+- keep 3D direct manipulation as a focused editor feature, not a full modeling surface
+- keep an explicit `Select`, `Move`, and `Rotate` mode in the 3D preview
+- keep orbit camera controls available in normal navigation and disabled only while a transform drag is active
+- use a visible transform gizmo for selected unlocked obstacles
+- support move by axis and by plane, but persist only TrackDraw's supported object placement data: `x`, `y`, and `rotation`
+- keep height/elevation edits separate from move/rotate because TrackDraw shapes do not have one generic vertical position field
+- treat the current `TransformControls` implementation as an exploration spike, not as accepted UX
+
+The desired result is closer to TrackForge-style direct manipulation: clear camera orbit, clear selected-object move handles, and a rotation ring that feels predictable. The current implementation proves the integration path is possible, but it is not stable or useful enough yet.
+
+## Approval Recommendation
+
+Approve a narrow follow-up only if TrackDraw accepts:
+
+- 3D controls remain single-selection only in v1
+- locked objects and read-only/share/embed views remain non-editable
+- the gizmo cannot write `null`, `NaN`, or unsupported fields into live patches or saved shapes
+- undo/redo records one action per completed drag, not every intermediate pointer move
+- 2D editor behavior remains the source of truth for broad editing, selection, snapping, export, and mobile reliability
+- mobile can ship with a reduced version if desktop quality is reached first
+
+Do not approve dimension, scale, or multi-object 3D transforms until move/rotate are stable.
+
+## Go / No-Go Criteria
+
+Go for implementation if:
+
+- selecting one unlocked object shows one obvious transform target
+- camera orbit works normally when not dragging a gizmo
+- dragging a move axis updates only the intended ground-plane coordinate
+- dragging a move plane feels free within the ground plane and respects grid snapping when enabled
+- dragging rotate updates only yaw rotation
+- releasing a drag never flashes back to the previous value before showing the committed value
+- inspector values remain valid during live dragging
+- undo/redo returns the object to the pre-drag and post-drag states cleanly
+- switching tools or selection during a drag cancels safely
+
+No-go or delay if:
+
+- transform controls can still produce invalid `x`, `y`, `rotation`, `null`, or `NaN` values
+- camera orbit and object transform compete for the same pointer gesture
+- plane handles imply vertical movement that TrackDraw cannot persist
+- mobile interaction requires tiny handles or fragile gestures
+- the implementation requires broad changes to the canvas store, shape schema, or shared UI primitives
+
+## Product Flow
+
+### Select Mode
+
+Purpose:
+
+- navigate and inspect the 3D scene
+- keep existing focused item controls visible, such as route elevation, tower elevation, ladder elevation, dive-gate tilt, and legacy rotate helpers if still needed
+
+Expected behavior:
+
+1. User clicks an object to select it.
+2. User orbits, pans, and zooms the camera with existing controls.
+3. No move/rotate gizmo is shown unless the user switches mode.
+
+### Move Mode
+
+Purpose:
+
+- quickly reposition a selected obstacle in the 3D preview.
+
+Expected behavior:
+
+1. User selects a single unlocked non-polyline obstacle.
+2. User switches to `Move`.
+3. A transform gizmo appears at the object's ground anchor.
+4. X/Z axis handles move along one ground axis.
+5. A ground-plane handle moves freely over the field.
+6. Grid snapping follows the editor snap setting.
+7. Live preview updates the object and inspector without committing history.
+8. Mouse/touch release commits one store update.
+
+Important constraint:
+
+- TrackDraw stores 2D placement as `shape.x` and `shape.y`, rendered as Three.js X/Z. Generic vertical Y movement should not be persisted from this mode.
+
+### Rotate Mode
+
+Purpose:
+
+- quickly adjust yaw orientation in 3D.
+
+Expected behavior:
+
+1. User selects a single unlocked rotatable obstacle.
+2. User switches to `Rotate`.
+3. A visible yaw rotation ring appears at the object anchor.
+4. Dragging the ring updates `shape.rotation`.
+5. Rotation snaps to the existing 5 degree step unless a future UX decision changes snapping behavior.
+6. Mouse/touch release commits one store update.
+
+## Codebase Anchor
+
+Current relevant files:
+
+- [src/components/canvas/editor/TrackPreview3D.tsx](../../src/components/canvas/editor/TrackPreview3D.tsx) — 3D preview shell, selection, orbit controls, tool overlay, live patch integration
+- [src/components/canvas/editor/edit-scene-content.tsx](../../src/components/canvas/editor/edit-scene-content.tsx) — direct 3D handles and the current transform-control spike
+- [src/components/canvas/editor/useTrackPreview3DInteractions.ts](../../src/components/canvas/editor/useTrackPreview3DInteractions.ts) — existing direct drag sessions for elevation, tilt, and legacy rotate behavior
+- [src/components/canvas/preview3d/shared-scene.tsx](../../src/components/canvas/preview3d/shared-scene.tsx) — selected shape rendering and shared scene helpers
+- [src/store/editor.ts](../../src/store/editor.ts) — live shape patch state and core editor actions
+- [src/components/inspector/Inspector.tsx](../../src/components/inspector/Inspector.tsx) — merges live shape patches into the selected inspector view
+- [src/components/inspector/shared.tsx](../../src/components/inspector/shared.tsx) — numeric formatting and inspector inputs
+
+Current spike concerns:
+
+- `TransformControls` emits object state through Three.js primitives, which can produce invalid intermediate values if the adapter is not strict.
+- Drei's `TransformControls` can disable default orbit controls, but TrackDraw still needs explicit state so wheel, middle-mouse panning, and hints stay coherent.
+- Showing only the ground-plane move affordance may require either a custom wrapper around `TransformControls` or a custom TrackDraw gizmo, because generic 3D controls include axes/planes that imply unsupported vertical movement.
+
+## Technical Model
+
+### Transform Adapter
+
+Create a dedicated adapter between Three.js controls and TrackDraw shape patches.
+
+Responsibilities:
+
+- own one invisible `THREE.Object3D` target per selected shape
+- sync target from the selected shape only when not dragging
+- convert target position from Three.js X/Z into TrackDraw `x/y`
+- convert target yaw into TrackDraw `rotation`
+- reject non-finite values before writing live patches
+- clamp unsupported axes back to the TrackDraw ground plane
+- expose `onStart`, `onLivePatch`, `onCommit`, and `onCancel`
+
+The adapter should be testable without rendering the full 3D scene where possible.
+
+### Interaction Session
+
+Use the same session model as existing direct 3D controls:
+
+- `startSession` on transform drag start
+- pause history during live drag
+- write live patch during drag
+- commit one `updateShape` on mouse/touch release
+- clear live patch after commit
+- cancel and clear live patch on blur, tool switch, selection switch, or unmount
+
+### Camera Controls
+
+Orbit controls should be treated as a sibling interaction, not a fallback:
+
+- enabled when no transform drag is active
+- disabled while transform dragging
+- still available in Select mode
+- not blocked merely because a selected object has a gizmo visible
+
+### Gizmo Choice
+
+Two implementation options should be compared in a small spike:
+
+1. Keep Drei `TransformControls` and restrict it with an adapter.
+2. Build a lightweight custom TrackDraw gizmo for move X, move Z, move XZ plane, and yaw rotation.
+
+The custom gizmo may be preferable if Drei's generic controls keep implying vertical movement or produce confusing hit targets.
+
+## Phase Plan
+
+### Phase 0: Stabilize Current Spike
+
+Goal: make the current implementation safe enough to keep behind the toolbar while evaluating UX.
+
+Checklist:
+
+- [ ] prevent transform live patches from writing invalid values
+- [ ] prevent inspector crashes during transform drag
+- [ ] verify orbit controls are disabled only during active drag
+- [ ] verify undo/redo creates one history entry per drag
+- [ ] verify switching away from Move/Rotate clears any live patch
+- [ ] verify locked/read-only states hide or disable controls
+
+### Phase 1: UX Spike With Acceptance Notes
+
+Goal: decide whether Drei `TransformControls` can meet TrackDraw's UX needs.
+
+Checklist:
+
+- [ ] test move X axis, Z axis, and XZ plane on desktop
+- [ ] test rotate yaw ring on desktop
+- [ ] test pointer release, pointer cancel, blur, and selection change
+- [ ] test grid snapping on and off
+- [ ] test small objects, large towers, gates, ladders, flags, cones, labels, and start/finish
+- [ ] capture notes on confusing or unsupported handles
+- [ ] decide: keep Drei, wrap/customize Drei, or build custom gizmo
+
+### Phase 2: Productionize Chosen Gizmo
+
+Goal: make the chosen interaction reliable enough for normal editing.
+
+Checklist:
+
+- [ ] move transform adapter into a focused module or hook
+- [ ] remove any dead legacy transform code
+- [ ] keep existing elevation/tilt controls in Select mode
+- [ ] add focused tests for transform patch sanitization and commit behavior
+- [ ] verify no shape schema or export behavior changes
+- [ ] update changelog only after the behavior is accepted
+
+### Phase 3: Mobile Decision
+
+Goal: decide whether mobile gets full transform controls or a reduced version.
+
+Checklist:
+
+- [ ] test touch hit targets on phone-sized viewport
+- [ ] confirm one-finger orbit vs transform drag does not conflict
+- [ ] decide whether mobile starts with Select-only plus existing elevation handles
+- [ ] document any deferred mobile behavior in the roadmap
+
+## Validation Plan
+
+Run when Node/npm are available:
+
+- `npm run lint`
+- `npm run type`
+- `npm run test`
+
+Manual validation:
+
+- desktop Chrome: select, move axis, move plane, rotate, undo, redo
+- desktop Safari: select, move axis, move plane, rotate, undo, redo
+- mobile viewport: select, orbit, accidental drag resistance
+- inspector: no crashes or invalid values while dragging
+- read-only/share/embed: no editable gizmo visible
+
+## Open Questions
+
+- Should Move mode show only ground-plane controls, or also show the vertical axis visually while clamping it away?
+- Should Rotate mode use Drei's full rotation control or a custom single yaw ring?
+- Should grid snapping apply while dragging the plane only, or also while dragging a single axis?
+- Should holding a modifier temporarily disable snapping?
+- Should mobile get the same gizmo or a simpler inspector-assisted direct control?
+
+## Current Recommendation
+
+Do not continue adding dimension handles yet.
+
+First decide whether Drei `TransformControls` can be made to feel good enough. If not, build a TrackDraw-specific gizmo with only the controls the data model can safely persist:
+
+- move X
+- move Z
+- move XZ plane
+- rotate yaw
+

--- a/docs/pva/3d-transform-controls-pva.md
+++ b/docs/pva/3d-transform-controls-pva.md
@@ -256,4 +256,3 @@ First decide whether Drei `TransformControls` can be made to feel good enough. I
 - move Z
 - move XZ plane
 - rotate yaw
-

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -279,6 +279,7 @@ Current shipped foundation:
 - Catalog-backed MultiGP-style gates, ladders, and corner flags now carry visual metadata for panel sizes, PVC frame placement, and texture-backed artwork; the live 3D preview and flythrough export consume shared layout helpers and extracted runtime textures while generic TrackDraw elements stay lightweight
 - MultiGP Dive Gate 7x6 and Launch Gate 7x6 are now catalog-backed with correct 3D arch and box-frame rendering respectively; banner panels cast and receive shadows correctly and texture orientations are accurate across all four panels
 - All MultiGP obstacle texture orientations (standard gate, championship gate, standard ladder, championship ladder, topless ladder, launch gate) are now correct and verified; the `ArchDiveGateVisualSpec` banner placement API mirrors the launch gate pattern so dive gate textures are fully configurable
+- Selected editable towers can be lifted directly in the 3D preview within their bounded elevation range; fixed-dimension catalog towers remain inspector- and catalog-protected
 
 Important boundary:
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -272,7 +272,7 @@ Feature tracks:
 
 - 3D preview realism and lighting: improve scene readability with sun/directional lighting, shadows, contrast, and more realistic gate/flag presentation before adding heavy asset workflows
 - Catalog-aware element rendering: use catalog visual metadata such as panel sizes, PVC frame placement, and texture-backed artwork to render official elements consistently across 3D preview and export paths while keeping generic elements lightweight
-- Focused 3D item controls: add direct controls for common edits such as elevation, rotation, scaling, and orientation only where undo/redo, lock state, and mobile behavior remain safe
+- Focused 3D item controls: add direct controls for common edits such as elevation, rotation, scaling, and orientation only where undo/redo, lock state, and mobile behavior remain safe; move/rotate gizmo work is tracked in [3D Transform Controls PVA](../pva/3d-transform-controls-pva.md)
 
 Current shipped foundation:
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -39,8 +39,8 @@ The completed release-sized work is archived below. The next TrackDraw priority 
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.
   - [x] Editable tower elevation handle
         Selected custom towers can now be lifted directly in the 3D view with the same live-preview, undo/redo, lock-state, mobile drag behavior, and bounded elevation range used by existing 3D elevation controls. Fixed-dimension catalog towers remain protected.
-  - [ ] 3D transform handles
-        Prototype selected-item controls for elevation, rotation, scale, and orientation only where the behavior is predictable across 2D and 3D.
+  - [ ] 3D transform gizmo and edit mode toolbar
+        Draft PVA: [3D Transform Controls PVA](../pva/3d-transform-controls-pva.md). Prototype selected-item move and rotate controls with orbit-friendly camera behavior only where the interaction is predictable across 2D and 3D. Do not add dimension handles until move/rotate are accepted.
 
 - [ ] Path editing UX (`No account required`)
       Make drawing and adjusting a path feel more natural, especially for curved layouts where the current waypoint model forces extra points to avoid sharp corners.

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -37,6 +37,8 @@ The completed release-sized work is archived below. The next TrackDraw priority 
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.
+  - [x] Editable tower elevation handle
+        Selected custom towers can now be lifted directly in the 3D view with the same live-preview, undo/redo, lock-state, mobile drag behavior, and bounded elevation range used by existing 3D elevation controls. Fixed-dimension catalog towers remain protected.
   - [ ] 3D transform handles
         Prototype selected-item controls for elevation, rotation, scale, and orientation only where the behavior is predictable across 2D and 3D.
 

--- a/src/components/canvas/editor/TrackPreview3D.tsx
+++ b/src/components/canvas/editor/TrackPreview3D.tsx
@@ -37,7 +37,11 @@ import {
   getTrackElementCatalogIdentity,
 } from "@/lib/track/elements/catalog";
 import { has3dRotateHandle } from "@/lib/track/items/registry";
-import { getDiveGateVisualSpec } from "@/lib/track/elements/visual";
+import {
+  getDiveGateVisualSpec,
+  getTowerElevationMax,
+  getTowerElevationMin,
+} from "@/lib/track/elements/visual";
 import { useEditor } from "@/store/editor";
 import {
   useSessionActions,
@@ -59,6 +63,7 @@ import {
   GateRotateHandle3D,
   LadderElevationHandle3D,
   PolylineElevationHandles3D,
+  TowerElevationHandle3D,
 } from "@/components/canvas/editor/edit-scene-content";
 import {
   AxisGizmoOverlay,
@@ -320,6 +325,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
       handleLadderElevationDragStart,
       handleRotateDragStart,
       handleTiltDragStart,
+      handleTowerElevationDragStart,
       isMiddleMousePanning,
       ladderElevationDrag,
       ladderElevationDragValueRef,
@@ -328,6 +334,8 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
       rotationDragValueRef,
       tiltDrag,
       tiltDragValueRef,
+      towerElevationDrag,
+      towerElevationDragValueRef,
     } = useTrackPreview3DInteractions({
       beginInteraction,
       endInteraction,
@@ -371,6 +379,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
       !rotationDrag &&
       !tiltDrag &&
       !ladderElevationDrag &&
+      !towerElevationDrag &&
       !diveGateElevationDrag;
 
     useEffect(() => {
@@ -442,6 +451,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
                 rotationDrag ||
                 tiltDrag ||
                 ladderElevationDrag ||
+                towerElevationDrag ||
                 diveGateElevationDrag
               )
           )
@@ -538,9 +548,11 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
                 elevationOverrideRef={
                   ladderElevationDrag?.shapeId === shape.id
                     ? ladderElevationDragValueRef
-                    : diveGateElevationDrag?.shapeId === shape.id
-                      ? diveGateElevationDragValueRef
-                      : undefined
+                    : towerElevationDrag?.shapeId === shape.id
+                      ? towerElevationDragValueRef
+                      : diveGateElevationDrag?.shapeId === shape.id
+                        ? diveGateElevationDragValueRef
+                        : undefined
                 }
               />
             </Suspense>
@@ -588,6 +600,45 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
                   isDragging={ladderElevationDrag?.shapeId === shape.id}
                   isMobile={isMobile}
                   elevationOverrideRef={ladderElevationDragValueRef}
+                />
+              );
+            })}
+
+          {!flyMode &&
+            !readOnly &&
+            shapes.map((shape) => {
+              if (
+                !selectedIdSet.has(shape.id) ||
+                shape.locked ||
+                shape.kind !== "tower"
+              ) {
+                return null;
+              }
+              const catalogEntry = getTrackElementCatalogEntry(
+                getTrackElementCatalogIdentity(shape.meta)?.elementId
+              );
+              if (
+                catalogEntry?.kind === "tower" &&
+                catalogEntry.editable?.dimensions === false
+              ) {
+                return null;
+              }
+              return (
+                <TowerElevationHandle3D
+                  key={`tower-elevation-${shape.id}`}
+                  shape={shape}
+                  onDragStart={(event) =>
+                    handleTowerElevationDragStart(
+                      event,
+                      shape.id,
+                      shape.elevation ?? 0
+                    )
+                  }
+                  isDragging={towerElevationDrag?.shapeId === shape.id}
+                  isMobile={isMobile}
+                  elevationOverrideRef={towerElevationDragValueRef}
+                  elevationMin={getTowerElevationMin(shape)}
+                  elevationMax={getTowerElevationMax(shape)}
                 />
               );
             })}
@@ -697,6 +748,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
               !rotationDrag &&
               !tiltDrag &&
               !ladderElevationDrag &&
+              !towerElevationDrag &&
               !diveGateElevationDrag
             }
             minDistance={8}
@@ -723,6 +775,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
                 !rotationDrag &&
                 !tiltDrag &&
                 !ladderElevationDrag &&
+                !towerElevationDrag &&
                 !diveGateElevationDrag
               }
               enableDamping
@@ -751,6 +804,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
                 !rotationDrag &&
                 !tiltDrag &&
                 !ladderElevationDrag &&
+                !towerElevationDrag &&
                 !diveGateElevationDrag
               }
               enableDamping

--- a/src/components/canvas/editor/edit-scene-content.tsx
+++ b/src/components/canvas/editor/edit-scene-content.tsx
@@ -21,6 +21,7 @@ import {
   getMultiGpDiveGateArchTopY,
   getMultiGpLaunchGateTopY,
 } from "@/lib/track/render3d-layout";
+import { getTowerTopY } from "@/components/canvas/preview3d/items/Tower3D";
 import type {
   DiveGateShape,
   FlagShape,
@@ -29,6 +30,142 @@ import type {
   PolylineShape,
   TowerShape,
 } from "@/lib/types";
+
+export function TowerElevationHandle3D({
+  shape,
+  onDragStart,
+  isDragging,
+  isMobile,
+  elevationOverrideRef,
+  elevationMin,
+  elevationMax,
+}: {
+  shape: TowerShape;
+  onDragStart: (event: ThreeEvent<PointerEvent>) => void;
+  isDragging: boolean;
+  isMobile: boolean;
+  elevationOverrideRef: RefObject<number | null>;
+  elevationMin: number;
+  elevationMax: number | null;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const guideGroupRef = useRef<THREE.Group>(null);
+  const guideColor = isDragging ? "#f59e0b" : hovered ? "#bfdbfe" : "#93c5fd";
+  const guideHeight = 0.65;
+  const handleY = 0.42;
+  const gripRadius = isMobile
+    ? isDragging
+      ? 0.22
+      : 0.2
+    : isDragging
+      ? 0.18
+      : 0.16;
+  const gripHeight = isMobile
+    ? isDragging
+      ? 0.26
+      : 0.22
+    : isDragging
+      ? 0.2
+      : 0.17;
+  const touchTargetRadius = isMobile ? 0.34 : gripRadius;
+  const touchTargetHeight = isMobile ? 0.58 : gripHeight;
+  const getHandleBaseY = (elevation: number) =>
+    getTowerTopY({
+      ...shape,
+      elevation: Math.max(elevationMin, elevation),
+    });
+  const topY = getHandleBaseY(shape.elevation ?? elevationMin);
+  const minHandleBaseY = getHandleBaseY(elevationMin);
+  const maxHandleBaseY =
+    elevationMax == null ? null : getHandleBaseY(elevationMax);
+  const rangeHeight =
+    maxHandleBaseY == null ? 0 : Math.max(0, maxHandleBaseY - minHandleBaseY);
+
+  useFrame(() => {
+    if (!guideGroupRef.current) return;
+    const liveElevation = elevationOverrideRef.current;
+    if (liveElevation === null) return;
+    guideGroupRef.current.position.set(
+      shape.x,
+      getHandleBaseY(liveElevation),
+      shape.y
+    );
+  });
+
+  return (
+    <>
+      {maxHandleBaseY !== null && rangeHeight > 0 ? (
+        <group position={[shape.x, 0, shape.y]}>
+          <mesh position={[0, minHandleBaseY + rangeHeight / 2, 0]}>
+            <cylinderGeometry args={[0.028, 0.028, rangeHeight, 16]} />
+            <meshBasicMaterial
+              color={guideColor}
+              transparent
+              opacity={isDragging ? 0.38 : hovered ? 0.3 : 0.18}
+            />
+          </mesh>
+          {[minHandleBaseY, maxHandleBaseY].map((limitY) => (
+            <mesh
+              key={limitY}
+              position={[0, limitY, 0]}
+              rotation={[-Math.PI / 2, 0, 0]}
+            >
+              <ringGeometry args={[0.05, 0.1, 20]} />
+              <meshBasicMaterial
+                color={guideColor}
+                transparent
+                opacity={isDragging ? 0.7 : hovered ? 0.55 : 0.35}
+                side={THREE.DoubleSide}
+              />
+            </mesh>
+          ))}
+        </group>
+      ) : null}
+      <group ref={guideGroupRef} position={[shape.x, topY, shape.y]}>
+        <mesh position={[0, guideHeight / 2, 0]}>
+          <cylinderGeometry args={[0.028, 0.028, guideHeight, 16]} />
+          <meshBasicMaterial color={guideColor} transparent opacity={0.5} />
+        </mesh>
+        <mesh
+          position={[0, handleY, 0]}
+          onPointerDown={(event) => {
+            event.stopPropagation();
+            onDragStart(event);
+          }}
+          onPointerOver={() => setHovered(true)}
+          onPointerOut={() => setHovered(false)}
+        >
+          <cylinderGeometry
+            args={[touchTargetRadius, touchTargetRadius, touchTargetHeight, 24]}
+          />
+          <meshBasicMaterial transparent opacity={0} depthWrite={false} />
+        </mesh>
+        <mesh position={[0, handleY, 0]}>
+          <cylinderGeometry args={[gripRadius, gripRadius, gripHeight, 24]} />
+          <meshStandardMaterial
+            color={isDragging ? "#f59e0b" : hovered ? "#38bdf8" : "#1e293b"}
+            emissive={isDragging ? "#fbbf24" : hovered ? "#7dd3fc" : "#60a5fa"}
+            emissiveIntensity={isDragging ? 1 : hovered ? 0.62 : 0.28}
+            roughness={0.16}
+            metalness={0.14}
+          />
+        </mesh>
+        <mesh position={[0, handleY + gripHeight * 0.26, 0]}>
+          <coneGeometry
+            args={[gripRadius * 0.78, Math.max(gripHeight * 0.6, 0.08), 24]}
+          />
+          <meshStandardMaterial
+            color={isDragging ? "#fff3c4" : hovered ? "#f8fbff" : "#cbd5e1"}
+            emissive={isDragging ? "#fbbf24" : hovered ? "#bae6fd" : "#93c5fd"}
+            emissiveIntensity={isDragging ? 0.7 : hovered ? 0.38 : 0.16}
+            roughness={0.12}
+            metalness={0.08}
+          />
+        </mesh>
+      </group>
+    </>
+  );
+}
 
 export function LadderElevationHandle3D({
   shape,

--- a/src/components/canvas/editor/useTrackPreview3DInteractions.ts
+++ b/src/components/canvas/editor/useTrackPreview3DInteractions.ts
@@ -16,6 +16,8 @@ import {
   getDiveGateElevationMax,
   getDiveGateElevationMin,
   getDiveGateVisualSpec,
+  getTowerElevationMax,
+  getTowerElevationMin,
 } from "@/lib/track/elements/visual";
 import type {
   DiveGateShape,
@@ -23,6 +25,7 @@ import type {
   PolylinePoint,
   PolylineShape,
   Shape,
+  TowerShape,
 } from "@/lib/types";
 import { getShapeCanvasRenderRotationOffset } from "@/lib/track/items/registry";
 import {
@@ -96,6 +99,10 @@ function getLiveRotationYawRadians(shape: Shape, rotation: number) {
   return (-meshRotation * Math.PI) / 180;
 }
 
+function clampElevation(value: number, min: number, max: number | null) {
+  return Math.min(max ?? Infinity, Math.max(min, value));
+}
+
 export function useTrackPreview3DInteractions({
   beginInteraction,
   endInteraction,
@@ -135,6 +142,11 @@ export function useTrackPreview3DInteractions({
     startClientY: number;
     startElevation: number;
   } | null>(null);
+  const [towerElevationDrag, setTowerElevationDrag] = useState<{
+    shapeId: string;
+    startClientY: number;
+    startElevation: number;
+  } | null>(null);
   const [diveGateElevationDrag, setDiveGateElevationDrag] = useState<{
     shapeId: string;
     startClientY: number;
@@ -155,11 +167,14 @@ export function useTrackPreview3DInteractions({
   const rotationDragRef = useRef(rotationDrag);
   const tiltDragRef = useRef(tiltDrag);
   const ladderElevationDragRef = useRef(ladderElevationDrag);
+  const towerElevationDragRef = useRef(towerElevationDrag);
   const diveGateElevationDragRef = useRef(diveGateElevationDrag);
   const dragAnimationFrameRef = useRef<number | null>(null);
   const rotationDragAnimationFrameRef = useRef<number | null>(null);
   const tiltDragAnimationFrameRef = useRef<number | null>(null);
   const ladderElevationDragAnimationFrameRef = useRef<number | null>(null);
+  const towerElevationDragAnimationFrameRef = useRef<number | null>(null);
+  const towerElevationClearAnimationFrameRef = useRef<number | null>(null);
   const diveGateElevationDragAnimationFrameRef = useRef<number | null>(null);
   const pendingElevationClientRef = useRef<{ x: number; y: number } | null>(
     null
@@ -170,10 +185,12 @@ export function useTrackPreview3DInteractions({
   const pendingTiltClientYRef = useRef<number | null>(null);
   const pendingTiltClientXRef = useRef<number | null>(null);
   const pendingLadderElevationClientYRef = useRef<number | null>(null);
+  const pendingTowerElevationClientYRef = useRef<number | null>(null);
   const pendingDiveGateElevationClientYRef = useRef<number | null>(null);
   const rotationDragValueRef = useRef<number | null>(null);
   const tiltDragValueRef = useRef<number | null>(null);
   const ladderElevationDragValueRef = useRef<number | null>(null);
+  const towerElevationDragValueRef = useRef<number | null>(null);
   const diveGateElevationDragValueRef = useRef<number | null>(null);
   const dragRotationGroupRef = useRef<THREE.Group>(null);
   const cameraRef = useRef<THREE.Camera | null>(null);
@@ -198,6 +215,10 @@ export function useTrackPreview3DInteractions({
   useEffect(() => {
     ladderElevationDragRef.current = ladderElevationDrag;
   }, [ladderElevationDrag]);
+
+  useEffect(() => {
+    towerElevationDragRef.current = towerElevationDrag;
+  }, [towerElevationDrag]);
 
   useEffect(() => {
     diveGateElevationDragRef.current = diveGateElevationDrag;
@@ -690,6 +711,61 @@ export function useTrackPreview3DInteractions({
     [shapeById, startSession]
   );
 
+  const applyTowerElevationDrag = useCallback(
+    (clientY: number) => {
+      const drag = towerElevationDragRef.current;
+      if (!drag) return;
+      const shape = shapeById[drag.shapeId];
+      if (!shape || shape.kind !== "tower") return;
+      const deltaMeters = (drag.startClientY - clientY) * 0.035;
+      const nextElevation = +clampElevation(
+        drag.startElevation + deltaMeters,
+        getTowerElevationMin(shape),
+        getTowerElevationMax(shape)
+      );
+      const roundedNextElevation = +nextElevation.toFixed(2);
+      const currentElevation =
+        towerElevationDragValueRef.current ??
+        (shape as TowerShape).elevation ??
+        0;
+      if (Math.abs(currentElevation - roundedNextElevation) < 0.01) return;
+      towerElevationDragValueRef.current = roundedNextElevation;
+      setLiveShapePatch(drag.shapeId, { elevation: roundedNextElevation });
+    },
+    [setLiveShapePatch, shapeById]
+  );
+
+  const handleTowerElevationDragStart = useCallback(
+    (
+      event: ThreeEvent<PointerEvent>,
+      shapeId: string,
+      currentElevation: number
+    ) => {
+      event.stopPropagation();
+      const shape = shapeById[shapeId];
+      if (!shape || shape.kind !== "tower" || shape.locked) return;
+      if (!startSession()) return;
+      if (towerElevationClearAnimationFrameRef.current !== null) {
+        window.cancelAnimationFrame(
+          towerElevationClearAnimationFrameRef.current
+        );
+        towerElevationClearAnimationFrameRef.current = null;
+      }
+      const clampedElevation = clampElevation(
+        currentElevation,
+        getTowerElevationMin(shape),
+        getTowerElevationMax(shape)
+      );
+      towerElevationDragValueRef.current = +clampedElevation.toFixed(2);
+      setTowerElevationDrag({
+        shapeId,
+        startClientY: event.nativeEvent.clientY,
+        startElevation: clampedElevation,
+      });
+    },
+    [shapeById, startSession]
+  );
+
   useEffect(() => {
     if (!tiltDrag) return;
 
@@ -885,6 +961,119 @@ export function useTrackPreview3DInteractions({
     updateShape,
   ]);
 
+  useEffect(() => {
+    if (!towerElevationDrag) return;
+
+    let finished = false;
+    const cleanupListeners = () => {
+      window.removeEventListener("mousemove", handleMouseMove);
+      window.removeEventListener("mouseup", stopDrag);
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", stopDrag);
+      window.removeEventListener("touchcancel", cancelDrag);
+      window.removeEventListener("blur", cancelDrag);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      if (towerElevationDragAnimationFrameRef.current !== null) {
+        window.cancelAnimationFrame(
+          towerElevationDragAnimationFrameRef.current
+        );
+        towerElevationDragAnimationFrameRef.current = null;
+      }
+    };
+
+    const finishDrag = () => {
+      if (finished) return;
+      finished = true;
+      const drag = towerElevationDragRef.current;
+      const finalElevation = towerElevationDragValueRef.current;
+      cleanupListeners();
+      finishSession(() => {
+        if (drag && finalElevation !== null) {
+          updateShape(drag.shapeId, { elevation: finalElevation });
+        }
+        if (drag) {
+          clearLiveShapePatch(drag.shapeId);
+        }
+      });
+      setTowerElevationDrag(null);
+      towerElevationClearAnimationFrameRef.current =
+        window.requestAnimationFrame(() => {
+          towerElevationClearAnimationFrameRef.current = null;
+          if (towerElevationDragRef.current === null) {
+            towerElevationDragValueRef.current = null;
+          }
+        });
+    };
+
+    const handleMouseMove = (event: MouseEvent) => {
+      pendingTowerElevationClientYRef.current = event.clientY;
+      if (towerElevationDragAnimationFrameRef.current !== null) return;
+      towerElevationDragAnimationFrameRef.current =
+        window.requestAnimationFrame(() => {
+          towerElevationDragAnimationFrameRef.current = null;
+          if (pendingTowerElevationClientYRef.current !== null) {
+            applyTowerElevationDrag(pendingTowerElevationClientYRef.current);
+          }
+        });
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      if (!event.touches.length) return;
+      event.preventDefault();
+      pendingTowerElevationClientYRef.current = event.touches[0].clientY;
+      if (towerElevationDragAnimationFrameRef.current !== null) return;
+      towerElevationDragAnimationFrameRef.current =
+        window.requestAnimationFrame(() => {
+          towerElevationDragAnimationFrameRef.current = null;
+          if (pendingTowerElevationClientYRef.current !== null) {
+            applyTowerElevationDrag(pendingTowerElevationClientYRef.current);
+          }
+        });
+    };
+
+    const stopDrag = () => {
+      finishDrag();
+    };
+
+    const cancelDrag = () => {
+      if (finished) return;
+      finished = true;
+      cleanupListeners();
+      towerElevationDragValueRef.current = null;
+      cancelSession(() => {
+        const drag = towerElevationDragRef.current;
+        if (drag) {
+          clearLiveShapePatch(drag.shapeId);
+        }
+        setTowerElevationDrag(null);
+      });
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "hidden") return;
+      cancelDrag();
+    };
+
+    window.addEventListener("mousemove", handleMouseMove);
+    window.addEventListener("mouseup", stopDrag);
+    window.addEventListener("touchmove", handleTouchMove, { passive: false });
+    window.addEventListener("touchend", stopDrag);
+    window.addEventListener("touchcancel", cancelDrag);
+    window.addEventListener("blur", cancelDrag);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      cancelDrag();
+    };
+  }, [
+    applyTowerElevationDrag,
+    cancelSession,
+    clearLiveShapePatch,
+    finishSession,
+    towerElevationDrag,
+    updateShape,
+  ]);
+
   const applyDiveGateElevationDrag = useCallback(
     (clientY: number) => {
       const drag = diveGateElevationDragRef.current;
@@ -1056,6 +1245,7 @@ export function useTrackPreview3DInteractions({
     handleLadderElevationDragStart,
     handleRotateDragStart,
     handleTiltDragStart,
+    handleTowerElevationDragStart,
     isMiddleMousePanning,
     ladderElevationDrag,
     ladderElevationDragValueRef,
@@ -1064,5 +1254,7 @@ export function useTrackPreview3DInteractions({
     rotationDragValueRef,
     tiltDrag,
     tiltDragValueRef,
+    towerElevationDrag,
+    towerElevationDragValueRef,
   };
 }

--- a/src/components/canvas/preview3d/items/Tower3D.tsx
+++ b/src/components/canvas/preview3d/items/Tower3D.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { useTexture } from "@react-three/drei";
-import { Suspense, useEffect, useMemo, type Ref } from "react";
+import { useFrame } from "@react-three/fiber";
+import {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type Ref,
+  type RefObject,
+} from "react";
 import * as THREE from "three";
 import {
   getEffectiveFlips,
@@ -22,6 +31,7 @@ import {
   type TowerVisualSpec,
 } from "@/lib/track/elements/catalog";
 import type { GateShape, TowerShape } from "@/lib/types";
+import { assignGroupRef } from "./texture-cache";
 
 function cloneTextureForPanel(
   texture: THREE.Texture,
@@ -547,12 +557,63 @@ export function Tower3D({
   selected = false,
   shape,
   outerRef,
+  elevationOverrideRef,
 }: {
   selected?: boolean;
   shape: TowerShape;
   outerRef?: Ref<THREE.Group>;
+  elevationOverrideRef?: RefObject<number | null>;
 }) {
   const visual = getTowerVisualSpecFor3D(shape);
+  const color = shape.color ?? "#38bdf8";
+  const w = shape.width ?? 2;
+  const h = shape.height ?? 2;
+  const thick = shape.thick ?? 0.2;
+  const levelCount = getTowerLevelCount(shape);
+  const elevation = Math.max(shape.elevation ?? 0, 0);
+  const totalH = elevation + levelCount * h;
+  const leftPostRef = useRef<THREE.Mesh>(null);
+  const rightPostRef = useRef<THREE.Mesh>(null);
+  const levelBarRefs = useRef<Array<THREE.Mesh | null>>([]);
+  const rot: [number, number, number] = [
+    0,
+    (-(shape.rotation + 180) * Math.PI) / 180,
+    0,
+  ];
+  const matProps = {
+    color,
+    emissive: selected ? "#60a5fa" : color,
+    emissiveIntensity: selected ? 0.55 : 0.08,
+  };
+  const setGroupRefs = useCallback(
+    (node: THREE.Group | null) => {
+      assignGroupRef(outerRef, node);
+    },
+    [outerRef]
+  );
+
+  useFrame(() => {
+    const liveElevation = elevationOverrideRef?.current;
+    const nextElevation =
+      liveElevation == null ? elevation : Math.max(liveElevation, 0);
+    const nextTotalH = nextElevation + levelCount * h;
+    const postScaleY = totalH > 0 ? nextTotalH / totalH : 1;
+
+    for (const postRef of [leftPostRef, rightPostRef]) {
+      const post = postRef.current;
+      if (!post) continue;
+      post.position.y = nextTotalH / 2;
+      post.scale.y = postScaleY;
+    }
+
+    for (let index = 0; index <= levelCount; index += 1) {
+      const bar = levelBarRefs.current[index];
+      if (bar) {
+        bar.position.y = nextElevation + index * h;
+      }
+    }
+  });
+
   if (visual?.variant === "panel-frame") {
     return (
       <PanelFrameTower3D
@@ -564,38 +625,27 @@ export function Tower3D({
     );
   }
 
-  const color = shape.color ?? "#38bdf8";
-  const w = shape.width ?? 2;
-  const h = shape.height ?? 2;
-  const thick = shape.thick ?? 0.2;
-  const levelCount = getTowerLevelCount(shape);
-  const elevation = Math.max(shape.elevation ?? 0, 0);
-  const totalH = elevation + levelCount * h;
-  const rot: [number, number, number] = [
-    0,
-    (-(shape.rotation + 180) * Math.PI) / 180,
-    0,
-  ];
-  const matProps = {
-    color,
-    emissive: selected ? "#60a5fa" : color,
-    emissiveIntensity: selected ? 0.55 : 0.08,
-  };
-
   return (
-    <group ref={outerRef} position={[shape.x, 0, shape.y]} rotation={rot}>
-      <mesh position={[-w / 2, totalH / 2, 0]} castShadow>
+    <group ref={setGroupRefs} position={[shape.x, 0, shape.y]} rotation={rot}>
+      <mesh ref={leftPostRef} position={[-w / 2, totalH / 2, 0]} castShadow>
         <boxGeometry args={[thick, totalH, thick]} />
         <meshStandardMaterial {...matProps} />
       </mesh>
-      <mesh position={[w / 2, totalH / 2, 0]} castShadow>
+      <mesh ref={rightPostRef} position={[w / 2, totalH / 2, 0]} castShadow>
         <boxGeometry args={[thick, totalH, thick]} />
         <meshStandardMaterial {...matProps} />
       </mesh>
       {Array.from({ length: levelCount + 1 }, (_, index) => {
         const y = elevation + index * h;
         return (
-          <mesh key={index} position={[0, y, 0]} castShadow>
+          <mesh
+            key={index}
+            ref={(node) => {
+              levelBarRefs.current[index] = node;
+            }}
+            position={[0, y, 0]}
+            castShadow
+          >
             <boxGeometry args={[w + thick, thick, thick]} />
             <meshStandardMaterial {...matProps} />
           </mesh>

--- a/src/components/canvas/preview3d/items/Tower3D.tsx
+++ b/src/components/canvas/preview3d/items/Tower3D.tsx
@@ -594,8 +594,9 @@ export function Tower3D({
 
   useFrame(() => {
     const liveElevation = elevationOverrideRef?.current;
-    const nextElevation =
-      liveElevation == null ? elevation : Math.max(liveElevation, 0);
+    if (liveElevation == null) return;
+
+    const nextElevation = Math.max(liveElevation, 0);
     const nextTotalH = nextElevation + levelCount * h;
     const postScaleY = totalH > 0 ? nextTotalH / totalH : 1;
 

--- a/src/components/canvas/preview3d/items/TrackItem3D.tsx
+++ b/src/components/canvas/preview3d/items/TrackItem3D.tsx
@@ -159,7 +159,12 @@ function Shape3D({
     case "tower":
       return (
         <group onClick={(event) => onSelect(event, shape.id)}>
-          <Tower3D shape={shape} selected={isSelected} outerRef={outerRef} />
+          <Tower3D
+            shape={shape}
+            selected={isSelected}
+            outerRef={outerRef}
+            elevationOverrideRef={elevationOverrideRef}
+          />
           {isSelected && <SelectionMarker3D shape={shape} />}
         </group>
       );

--- a/src/components/inspector/sections/TowerSection.tsx
+++ b/src/components/inspector/sections/TowerSection.tsx
@@ -4,6 +4,10 @@ import {
   Row,
   Section,
 } from "@/components/inspector/shared";
+import {
+  getTowerElevationMax,
+  getTowerElevationMin,
+} from "@/lib/track/elements/visual";
 import type { MeasurementUnitSystem } from "@/lib/track/units";
 import type { Shape, TowerShape } from "@/lib/types";
 
@@ -44,9 +48,15 @@ export function TowerDimensionFields({
           valueMeters={shape.elevation ?? 0}
           unitSystem={unitSystem}
           onChange={(value) =>
-            updateShape(shape.id, { elevation: Math.max(0, value) })
+            updateShape(shape.id, {
+              elevation: Math.min(
+                getTowerElevationMax(shape) ?? Infinity,
+                Math.max(getTowerElevationMin(shape), value)
+              ),
+            })
           }
-          minMeters={0}
+          minMeters={getTowerElevationMin(shape)}
+          maxMeters={getTowerElevationMax(shape) ?? undefined}
         />
       </Row>
       <Row label={`Thickness (${unitLabel})`}>

--- a/src/components/inspector/sections/TowerSection.tsx
+++ b/src/components/inspector/sections/TowerSection.tsx
@@ -25,6 +25,14 @@ export function TowerDimensionFields({
   hasFixedCatalogDimensions: boolean;
 }) {
   if (hasFixedCatalogDimensions) return null;
+
+  const elevationMin = getTowerElevationMin(shape);
+  const elevationMax = getTowerElevationMax(shape);
+  const displayedElevation = Math.min(
+    elevationMax ?? Infinity,
+    Math.max(elevationMin, shape.elevation ?? elevationMin)
+  );
+
   return (
     <>
       <Row label={`Width (${unitLabel})`}>
@@ -45,18 +53,18 @@ export function TowerDimensionFields({
       </Row>
       <Row label={`Elevation (${unitLabel})`}>
         <MeasurementNum
-          valueMeters={shape.elevation ?? 0}
+          valueMeters={displayedElevation}
           unitSystem={unitSystem}
           onChange={(value) =>
             updateShape(shape.id, {
               elevation: Math.min(
-                getTowerElevationMax(shape) ?? Infinity,
-                Math.max(getTowerElevationMin(shape), value)
+                elevationMax ?? Infinity,
+                Math.max(elevationMin, value)
               ),
             })
           }
-          minMeters={getTowerElevationMin(shape)}
-          maxMeters={getTowerElevationMax(shape) ?? undefined}
+          minMeters={elevationMin}
+          maxMeters={elevationMax ?? undefined}
         />
       </Row>
       <Row label={`Thickness (${unitLabel})`}>

--- a/src/components/inspector/shared.tsx
+++ b/src/components/inspector/shared.tsx
@@ -13,7 +13,12 @@ import {
 } from "@/lib/track/units";
 import { ChevronDown } from "lucide-react";
 
-export const fmt = (value: number) => Number(value.toFixed(2));
+export const fmt = (value: number | null | undefined) =>
+  Number(
+    (typeof value === "number" && Number.isFinite(value) ? value : 0).toFixed(
+      2
+    )
+  );
 
 export function useInspectorInputBatch() {
   const { beginInteraction, endInteraction, pauseHistory, resumeHistory } =

--- a/src/components/inspector/shared.tsx
+++ b/src/components/inspector/shared.tsx
@@ -15,9 +15,7 @@ import { ChevronDown } from "lucide-react";
 
 export const fmt = (value: number | null | undefined) =>
   Number(
-    (typeof value === "number" && Number.isFinite(value) ? value : 0).toFixed(
-      2
-    )
+    (typeof value === "number" && Number.isFinite(value) ? value : 0).toFixed(2)
   );
 
 export function useInspectorInputBatch() {

--- a/src/lib/canvas/interaction-helpers.ts
+++ b/src/lib/canvas/interaction-helpers.ts
@@ -11,6 +11,10 @@ import type { PolylineShape, Shape } from "@/lib/types";
 import type { Group as KonvaGroup } from "konva/lib/Group";
 import type { Stage as KonvaStage } from "konva/lib/Stage";
 
+function finiteOrZero(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
 export function buildSnapIndex(shapes: Shape[], snapCellSize: number) {
   const index = new Map<string, Shape[]>();
 
@@ -139,23 +143,37 @@ export function buildCursorState(
   snappedMeters: { x: number; y: number },
   stepPx: number
 ): CursorState {
+  const safePointer = {
+    x: finiteOrZero(pointer.x),
+    y: finiteOrZero(pointer.y),
+  };
+  const safeRawMeters = {
+    x: finiteOrZero(rawMeters.x),
+    y: finiteOrZero(rawMeters.y),
+  };
+  const safeSnappedMeters = {
+    x: finiteOrZero(snappedMeters.x),
+    y: finiteOrZero(snappedMeters.y),
+  };
+  const safeStepPx = Math.max(1, finiteOrZero(stepPx));
+
   return {
-    rawMeters,
-    snappedMeters,
-    rawPx: { x: pointer.x, y: pointer.y },
+    rawMeters: safeRawMeters,
+    snappedMeters: safeSnappedMeters,
+    rawPx: safePointer,
     snappedPx: {
-      x: Math.round(pointer.x / stepPx) * stepPx,
-      y: Math.round(pointer.y / stepPx) * stepPx,
+      x: Math.round(safePointer.x / safeStepPx) * safeStepPx,
+      y: Math.round(safePointer.y / safeStepPx) * safeStepPx,
     },
   };
 }
 
 export function getCursorStateKey(cursor: CursorState) {
   return [
-    cursor.rawPx.x.toFixed(2),
-    cursor.rawPx.y.toFixed(2),
-    cursor.snappedMeters.x.toFixed(2),
-    cursor.snappedMeters.y.toFixed(2),
+    finiteOrZero(cursor.rawPx.x).toFixed(2),
+    finiteOrZero(cursor.rawPx.y).toFixed(2),
+    finiteOrZero(cursor.snappedMeters.x).toFixed(2),
+    finiteOrZero(cursor.snappedMeters.y).toFixed(2),
   ].join("|");
 }
 

--- a/src/lib/canvas/snap.ts
+++ b/src/lib/canvas/snap.ts
@@ -14,6 +14,16 @@ function isFiniteSnapPoint(point: { x?: unknown; y?: unknown } | null) {
   return Boolean(point && isFiniteNumber(point.x) && isFiniteNumber(point.y));
 }
 
+function sanitizeSnapPoint(point: { x?: unknown; y?: unknown }): {
+  x: number;
+  y: number;
+} {
+  return {
+    x: isFiniteNumber(point.x) ? point.x : 0,
+    y: isFiniteNumber(point.y) ? point.y : 0,
+  };
+}
+
 interface FindNearestSnapCandidateOptions {
   candidates: Shape[];
   excludeIds?: Iterable<string>;
@@ -253,7 +263,7 @@ export function resolveSnapPosition({
   excludeIds,
 }: ResolveSnapPositionOptions): { x: number; y: number } {
   if (!isFiniteSnapPoint(pos)) {
-    return { x: 0, y: 0 };
+    return sanitizeSnapPoint(pos);
   }
 
   if (snapToShapes) {

--- a/src/lib/canvas/snap.ts
+++ b/src/lib/canvas/snap.ts
@@ -6,6 +6,14 @@ type SnapPoint = { x: number; y: number };
 const ROUTE_WAYPOINT_SNAP_RADIUS_RATIO = 0.55;
 const ROUTE_WAYPOINT_SNAP_RADIUS_MAX_METERS = 0.65;
 
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isFiniteSnapPoint(point: { x?: unknown; y?: unknown } | null) {
+  return Boolean(point && isFiniteNumber(point.x) && isFiniteNumber(point.y));
+}
+
 interface FindNearestSnapCandidateOptions {
   candidates: Shape[];
   excludeIds?: Iterable<string>;
@@ -39,6 +47,7 @@ function findNearestSnapCandidate({
 
   for (const candidate of candidates) {
     if (excludeIdSet?.has(candidate.id)) continue;
+    if (!isFiniteSnapPoint(candidate)) continue;
     const dist = Math.hypot(candidate.x - pos.x, candidate.y - pos.y);
     if (dist < minDist) {
       minDist = dist;
@@ -54,6 +63,13 @@ function projectPointOntoSegment(
   start: SnapPoint,
   end: SnapPoint
 ) {
+  if (
+    !isFiniteSnapPoint(point) ||
+    !isFiniteSnapPoint(start) ||
+    !isFiniteSnapPoint(end)
+  ) {
+    return null;
+  }
   const dx = end.x - start.x;
   const dy = end.y - start.y;
   const lengthSquared = dx * dx + dy * dy;
@@ -111,7 +127,7 @@ function findNearestRouteSnapPoint({
         routePoints[index - 1],
         routePoints[index]
       );
-      if (projection.distance < minDist) {
+      if (projection && projection.distance < minDist) {
         minDist = projection.distance;
         nearest = projection.point;
       }
@@ -147,6 +163,7 @@ function findNearestRouteWaypointCandidate({
     if (excludeIdSet?.has(route.id)) continue;
 
     for (const [index, point] of route.points.entries()) {
+      if (!isFiniteSnapPoint(point)) continue;
       const dist = Math.hypot(point.x - pos.x, point.y - pos.y);
       if (dist < minDist) {
         minDist = dist;
@@ -176,6 +193,7 @@ function resolveAxisAlignmentSnap({
 
   for (const candidate of candidates) {
     if (excludeIdSet?.has(candidate.id)) continue;
+    if (!isFiniteSnapPoint(candidate)) continue;
 
     const dx = Math.abs(candidate.x - pos.x);
     if (dx < bestXDistance) {
@@ -234,6 +252,10 @@ export function resolveSnapPosition({
   routeCandidates,
   excludeIds,
 }: ResolveSnapPositionOptions): { x: number; y: number } {
+  if (!isFiniteSnapPoint(pos)) {
+    return { x: 0, y: 0 };
+  }
+
   if (snapToShapes) {
     const shapeSnap = findNearestSnapPoint({
       candidates,

--- a/src/lib/inspector/single/view-model.ts
+++ b/src/lib/inspector/single/view-model.ts
@@ -2,15 +2,19 @@ import { shapeKindLabels } from "@/lib/track/items/registry";
 import { getShapeGroupId, getShapeGroupName } from "@/lib/track/shape-groups";
 import type { Shape } from "@/lib/types";
 
+function finiteOrZero(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
 export function getShapeAnchorPosition(shape: Shape) {
   if (shape.kind !== "polyline" || shape.points.length === 0) {
-    return { x: shape.x, y: shape.y };
+    return { x: finiteOrZero(shape.x), y: finiteOrZero(shape.y) };
   }
 
   const totals = shape.points.reduce(
     (accumulator, point) => ({
-      x: accumulator.x + point.x,
-      y: accumulator.y + point.y,
+      x: accumulator.x + finiteOrZero(point.x),
+      y: accumulator.y + finiteOrZero(point.y),
     }),
     { x: 0, y: 0 }
   );
@@ -46,9 +50,9 @@ export function getInsertedWaypointMidpoint(
   next: { x: number; y: number; z?: number }
 ) {
   return {
-    x: +((current.x + next.x) / 2).toFixed(2),
-    y: +((current.y + next.y) / 2).toFixed(2),
-    z: +(((current.z ?? 0) + (next.z ?? 0)) / 2).toFixed(2),
+    x: +((finiteOrZero(current.x) + finiteOrZero(next.x)) / 2).toFixed(2),
+    y: +((finiteOrZero(current.y) + finiteOrZero(next.y)) / 2).toFixed(2),
+    z: +((finiteOrZero(current.z) + finiteOrZero(next.z)) / 2).toFixed(2),
   };
 }
 
@@ -63,8 +67,8 @@ export function getNextAppendedWaypoint(
 ) {
   const lastPoint = point ?? { x: 0, y: 0, z: 0 };
   return {
-    x: +(lastPoint.x + 1).toFixed(2),
-    y: +(lastPoint.y + 1).toFixed(2),
-    z: lastPoint.z ?? 0,
+    x: +(finiteOrZero(lastPoint.x) + 1).toFixed(2),
+    y: +(finiteOrZero(lastPoint.y) + 1).toFixed(2),
+    z: finiteOrZero(lastPoint.z),
   };
 }

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -510,6 +510,8 @@ export const trackElementCatalog = [
     tags: ["technical", "practice", "tower"],
     render2d: { icon: "tower" },
     render3d: { modelHint: "tower" },
+    elevationMinMeters: 1.5,
+    elevationMaxMeters: 4,
     exportHints: { simulatorFriendly: true },
   },
   {

--- a/src/lib/track/elements/visual.ts
+++ b/src/lib/track/elements/visual.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/lib/types";
 import {
   TRACKDRAW_DIVE_GATE_ELEMENT_ID,
+  TRACKDRAW_TOWER_ELEMENT_ID,
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
   type DiveGateVisualSpec,
@@ -95,6 +96,22 @@ export function getTowerVisualSpec(shape: TowerShape): TowerVisualSpec | null {
   const visual = getTrackElementVisualSpec(shape);
   if (visual?.kind === "tower") return visual;
   return null;
+}
+
+function getTowerEntryId(shape: TowerShape) {
+  const catalogIdentity = getTrackElementCatalogIdentity(shape.meta);
+  if (catalogIdentity) return catalogIdentity.elementId;
+  return TRACKDRAW_TOWER_ELEMENT_ID;
+}
+
+export function getTowerElevationMin(shape: TowerShape): number {
+  const entry = getTrackElementCatalogEntry(getTowerEntryId(shape));
+  return entry?.elevationMinMeters ?? 0;
+}
+
+export function getTowerElevationMax(shape: TowerShape): number | null {
+  const entry = getTrackElementCatalogEntry(getTowerEntryId(shape));
+  return entry?.elevationMaxMeters ?? null;
 }
 
 export function getDiveGateVisualSpec(

--- a/tests/lib/canvas/snap.test.ts
+++ b/tests/lib/canvas/snap.test.ts
@@ -153,6 +153,30 @@ describe("canvas snap helpers", () => {
     ).toEqual({ x: 10, y: 10 });
   });
 
+  it("sanitizes non-finite positions without snapping finite axes to the origin", () => {
+    expect(
+      resolveSnapPosition({
+        pos: { x: Number.NaN, y: 8 },
+        snapToGrid: true,
+        snapToShapes: true,
+        gridStep: 1,
+        magneticRadiusMeters: 1,
+        candidates,
+      })
+    ).toEqual({ x: 0, y: 8 });
+
+    expect(
+      resolveSnapPosition({
+        pos: { x: 12, y: Number.POSITIVE_INFINITY },
+        snapToGrid: true,
+        snapToShapes: true,
+        gridStep: 1,
+        magneticRadiusMeters: 1,
+        candidates,
+      })
+    ).toEqual({ x: 12, y: 0 });
+  });
+
   it("snaps to nearby race-line segments before axis alignment and grid", () => {
     expect(
       resolveSnapPosition({


### PR DESCRIPTION
- Add direct 3D tower elevation editing for editable custom towers, including bounded min/max elevation, live preview, and undo/redo-safe drag handling
- Update tower 3D rendering and inspector behavior so tower elevation uses shared visual defaults and catalog-backed fixed-dimension towers stay protected
- Harden snap/cursor/inspector formatting against invalid coordinates so transient `null`/non-finite values do not crash editor interactions
- Add a draft 3D Transform Controls PVA to guide the next iteration for gizmo + orbit controls before treating move/rotate controls as accepted UX

## Notes

The 3D transform gizmo work is intentionally documented as a draft PVA, not marked as shipped. The branch keeps tower elevation as the concrete user-facing improvement and frames broader gizmo/orbit controls as follow-up validation work.