### PR TITLE
feat: Improve path drawing UX and curve preview

### DIFF
--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -44,10 +44,10 @@ The completed release-sized work is archived below. The next TrackDraw priority 
 
 - [ ] Path editing UX (`No account required`)
       Make drawing and adjusting a path feel more natural, especially for curved layouts where the current waypoint model forces extra points to avoid sharp corners.
-  - [ ] Path drawing interaction improvements
-        Improve waypoint placement and drag feedback so tracing a line feels more deliberate and less error-prone, especially on touch and trackpad.
-  - [ ] Automatic curve smoothing
-        Evaluate Catmull-Rom splines or chord-length parameterization to produce smoother curves from the same waypoints without manual handle editing, with backwards-compatible geometry.
+  - [x] Path drawing interaction improvements
+        Removed the misleading straight rubber-band preview in favour of the live Catmull-Rom curve preview, added a persistent start-point ring so users can see where the path began during long-form drawing, and tightened the desktop minimum waypoint gap to 0.15 m to reduce accidental duplicate placements.
+  - [x] Automatic curve smoothing
+        Catmull-Rom splines (chord-length parameterized) were already the sole rendering path for committed polylines. The drawing overlay now also relies on the smooth preview exclusively, making the curve shape visible from the first waypoint onwards.
   - [ ] Per-waypoint curve strength (`Research`)
         Only pursue if automatic smoothing is not sufficient and if there is an interaction model that works on both desktop and mobile. Direct canvas handles are likely too fiddly on touch; validate an inspector- or gesture-based alternative first before committing to an approach.
 

--- a/src/components/canvas/editor/TrackCanvasEditorOverlays.tsx
+++ b/src/components/canvas/editor/TrackCanvasEditorOverlays.tsx
@@ -138,7 +138,7 @@ export default function TrackCanvasEditorOverlays({
             strokeWidth={m2px(0.28, designPpm)}
             lineCap="round"
             lineJoin="round"
-            opacity={0.2}
+            opacity={0.25}
           />
           <Line
             points={draftPreviewSmoothPx}
@@ -146,7 +146,7 @@ export default function TrackCanvasEditorOverlays({
             strokeWidth={m2px(0.18, designPpm)}
             lineCap="round"
             lineJoin="round"
-            opacity={0.55}
+            opacity={0.65}
           />
         </>
       ) : null}
@@ -163,7 +163,7 @@ export default function TrackCanvasEditorOverlays({
         />
       ) : null}
 
-      {draftPointsPx.length > 0 && cursor
+      {draftPointsPx.length > 0 && cursor && draftPreviewSmoothPx.length < 4
         ? (() => {
             const endX = snapTarget
               ? m2px(snapTarget.x, designPpm)
@@ -200,6 +200,21 @@ export default function TrackCanvasEditorOverlays({
             );
           })()
         : null}
+
+      {activeTool === "polyline" &&
+      draftPointsPx.length >= 2 &&
+      !draftCloseTarget ? (
+        <Group listening={false}>
+          <Circle
+            x={draftPointsPx[0]}
+            y={draftPointsPx[1]}
+            radius={Math.max(5, m2px(0.1, designPpm))}
+            stroke="#22c55e"
+            strokeWidth={1.5}
+            opacity={0.6}
+          />
+        </Group>
+      ) : null}
 
       {draftCloseTarget ? (
         <Group listening={false}>

--- a/src/components/canvas/editor/useTrackCanvasInteractions.ts
+++ b/src/components/canvas/editor/useTrackCanvasInteractions.ts
@@ -155,7 +155,7 @@ export function useTrackCanvasInteractions({
   const closeLoopRadiusMeters = Math.max(designField.gridStep * 1.25, 0.9);
   const minWaypointGapMeters = isMobile
     ? Math.max(designField.gridStep * 0.7, 0.45)
-    : 0.05;
+    : 0.15;
   const mobileTapMoveThresholdPx = 10;
   const lastCursorKeyRef = useRef("");
   const lastHorizontalScrollTimeRef = useRef(0);


### PR DESCRIPTION
- Replaced the straight rubber-band line with the live Catmull-Rom smooth preview during path drawing — the rubber band implied a straight segment, which was misleading given curves always render smooth.
- Added a persistent green start-point ring that stays visible for the full duration of drawing, so users always know where a loop closure will connect. It hides automatically when the amber close-loop indicator takes over.
- Bumped the smooth preview opacity slightly (0.20 → 0.25 / 0.55 → 0.65) so the live curve shape is easier to read while tracing.
- Increased the desktop minimum waypoint gap from 0.05 m to 0.15 m to reduce accidental near-duplicate waypoints from hesitation clicks.
