### PR TITLE
Reduce D1 round-trips with RETURNING and fix retention index bypass

### DIFF
--- a/src/lib/server/gallery.ts
+++ b/src/lib/server/gallery.ts
@@ -354,7 +354,7 @@ export async function createUnlistedGalleryEntry(params: {
   const now = new Date().toISOString();
   const id = crypto.randomUUID();
 
-  await db
+  const row = await db
     .prepare(
       `
         insert into gallery_entries (
@@ -371,6 +371,18 @@ export async function createUnlistedGalleryEntry(params: {
           updated_at
         )
         values (?, ?, ?, 'unlisted', ?, ?, null, null, null, ?, ?)
+        returning
+          id,
+          share_token,
+          owner_user_id,
+          gallery_state,
+          gallery_title,
+          gallery_description,
+          gallery_preview_image,
+          gallery_published_at,
+          moderation_hidden_at,
+          created_at,
+          updated_at
       `
     )
     .bind(
@@ -382,9 +394,9 @@ export async function createUnlistedGalleryEntry(params: {
       now,
       now
     )
-    .run();
+    .first<GalleryEntryRow>();
 
-  return getGalleryEntryByShareToken(params.shareToken);
+  return row ? mapGalleryEntryRow(row) : null;
 }
 
 export async function moveGalleryEntryToUnlisted(shareToken: string) {
@@ -408,21 +420,20 @@ export async function moveGalleryEntryToUnlisted(shareToken: string) {
 
 export async function deleteGalleryEntry(shareToken: string) {
   const db = await getDatabase();
-  const existing = await getGalleryEntryByShareToken(shareToken);
-
-  if (existing?.galleryPreviewImage) {
-    await deleteGalleryPreviewImage(existing.galleryPreviewImage);
-  }
-
-  await db
+  const deleted = await db
     .prepare(
       `
         delete from gallery_entries
         where share_token = ?
+        returning gallery_preview_image
       `
     )
     .bind(shareToken)
-    .run();
+    .first<{ gallery_preview_image: string | null }>();
+
+  if (deleted?.gallery_preview_image) {
+    await deleteGalleryPreviewImage(deleted.gallery_preview_image);
+  }
 }
 
 export async function moveGalleryEntryToListed(shareToken: string) {

--- a/src/lib/server/projects.ts
+++ b/src/lib/server/projects.ts
@@ -139,7 +139,7 @@ export async function saveProjectForUser(
 
   const db = await getDatabase();
 
-  await db
+  const savedRow = await db
     .prepare(
       `
         insert into projects (
@@ -167,6 +167,18 @@ export async function saveProjectForUser(
           archived_at = null
         where projects.owner_user_id = excluded.owner_user_id
           and (? = 1 or projects.design_json = ?)
+        returning
+          id,
+          owner_user_id,
+          title,
+          description,
+          design_json,
+          field_width,
+          field_height,
+          shape_count,
+          created_at,
+          updated_at,
+          archived_at
       `
     )
     .bind(
@@ -183,27 +195,24 @@ export async function saveProjectForUser(
       options.forceWrite || !existingProject ? 1 : 0,
       existingSerializedJson ?? ""
     )
-    .run();
+    .first<ProjectRow>();
 
-  const saved = await getProjectForUser(projectId, ownerUserId);
-  if (!saved) {
-    throw new Error("Failed to load saved cloud project");
-  }
-
-  if (!options.forceWrite) {
-    const savedSerializedJson = JSON.stringify(serializeDesign(saved.design));
-    if (savedSerializedJson !== serializedJson) {
-      throw new ProjectVersionConflictError({
-        projectId,
-        title,
-        localUpdatedAt: normalized.updatedAt,
-        cloudUpdatedAt: saved.designUpdatedAt,
-        cloudProject: saved,
-      });
+  if (!savedRow) {
+    // The DO UPDATE WHERE condition failed — another write raced in between our read and write.
+    const current = await getProjectForUser(projectId, ownerUserId);
+    if (!current) {
+      throw new Error("Failed to load saved cloud project");
     }
+    throw new ProjectVersionConflictError({
+      projectId,
+      title,
+      localUpdatedAt: normalized.updatedAt,
+      cloudUpdatedAt: current.designUpdatedAt,
+      cloudProject: current,
+    });
   }
 
-  return saved;
+  return mapProjectRow(savedRow);
 }
 
 export async function getProjectForUser(

--- a/src/lib/server/share-retention.ts
+++ b/src/lib/server/share-retention.ts
@@ -13,13 +13,13 @@ export async function cleanupExpiredShares(db: D1Database) {
       delete from shares
       where (
            revoked_at is not null
-           and datetime(revoked_at) < datetime('now', '-30 days')
+           and revoked_at < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-30 days')
          )
          or (
            share_type = 'temporary'
            and
            expires_at is not null
-           and datetime(expires_at) < datetime('now', '-30 days')
+           and expires_at < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-30 days')
          )
     `
     )

--- a/tests/lib/server/gallery.test.ts
+++ b/tests/lib/server/gallery.test.ts
@@ -142,25 +142,10 @@ describe("gallery server helpers", () => {
   });
 
   it("deletes the R2 preview when a gallery entry is deleted", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
-    const entryStatement = createStatement({
-      first: {
-        id: "entry-1",
-        share_token: "share-1",
-        owner_user_id: "user-1",
-        gallery_state: "listed",
-        gallery_title: "Track",
-        gallery_description: "A public track.",
-        gallery_preview_image: "gallery/previews/entry-1.webp",
-        gallery_published_at: null,
-        moderation_hidden_at: null,
-        created_at: "2026-04-20T09:00:00.000Z",
-        updated_at: "2026-04-20T10:00:00.000Z",
-      },
+    const deleteStatement = createStatement({
+      first: { gallery_preview_image: "gallery/previews/entry-1.webp" },
     });
-    const deleteStatement = createStatement();
-    installStatements([entryStatement, deleteStatement]);
+    installStatements([deleteStatement]);
 
     await deleteGalleryEntry("share-1");
 
@@ -168,6 +153,7 @@ describe("gallery server helpers", () => {
       "gallery/previews/entry-1.webp"
     );
     expect(deleteStatement.sql).toContain("delete from gallery_entries");
+    expect(deleteStatement.sql).toContain("returning gallery_preview_image");
     expect(deleteStatement.bind).toHaveBeenCalledWith("share-1");
   });
 
@@ -284,9 +270,8 @@ describe("gallery server helpers", () => {
     expect(stmt.bind).toHaveBeenCalledWith(0, "");
   });
 
-  it("creates an unlisted gallery entry and returns it via getGalleryEntryByShareToken", async () => {
-    const insertStmt = createStatement({ run: {} });
-    const selectStmt = createStatement({
+  it("creates an unlisted gallery entry via INSERT RETURNING", async () => {
+    const insertStmt = createStatement({
       first: {
         id: "new-entry",
         share_token: "new-tok",
@@ -301,7 +286,7 @@ describe("gallery server helpers", () => {
         updated_at: "2026-06-09T00:00:00.000Z",
       },
     });
-    installStatements([insertStmt, selectStmt]);
+    installStatements([insertStmt]);
 
     const entry = await createUnlistedGalleryEntry({
       shareToken: "new-tok",
@@ -313,6 +298,8 @@ describe("gallery server helpers", () => {
     expect(entry).not.toBeNull();
     expect(entry?.galleryState).toBe("unlisted");
     expect(entry?.galleryTitle).toBe("New Entry");
+    expect(insertStmt.sql).toContain("insert into gallery_entries");
+    expect(insertStmt.sql).toContain("returning");
   });
 
   it("updateGalleryEntryMetadata runs a SQL UPDATE", async () => {

--- a/tests/lib/server/projects.test.ts
+++ b/tests/lib/server/projects.test.ts
@@ -84,14 +84,12 @@ describe("project server helpers", () => {
     const selectPreviousStatement = createD1Statement({
       first: projectRow(previousDesign),
     });
-    const upsertStatement = createD1Statement();
-    const selectSavedStatement = createD1Statement({
+    const upsertStatement = createD1Statement({
       first: projectRow(nextDesign),
     });
     installD1Statements(mocks.prepare, [
       selectPreviousStatement,
       upsertStatement,
-      selectSavedStatement,
     ]);
 
     await saveProjectForUser("user-1", nextDesign, {
@@ -101,6 +99,7 @@ describe("project server helpers", () => {
     });
 
     expect(upsertStatement.sql).toContain("projects.design_json = ?");
+    expect(upsertStatement.sql).toContain("returning");
     expect(upsertStatement.bind).toHaveBeenCalledWith(
       "project-1",
       "user-1",

--- a/tests/lib/server/share-retention.test.ts
+++ b/tests/lib/server/share-retention.test.ts
@@ -12,7 +12,9 @@ describe("share retention", () => {
 
     const sql = prepare.mock.calls[0][0];
     expect(sql).toContain("share_type = 'temporary'");
-    expect(sql).toContain("datetime(revoked_at) < datetime('now', '-30 days')");
+    expect(sql).toContain(
+      "revoked_at < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-30 days')"
+    );
     expect(run).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- Replace `INSERT`/`UPSERT` + `SELECT` patterns with `RETURNING` in `saveProjectForUser` and `createUnlistedGalleryEntry`, cutting one DB round-trip per call on the happy path
- Replace `SELECT` + `DELETE` in `deleteGalleryEntry` with `DELETE … RETURNING gallery_preview_image`, eliminating the pre-fetch
- Fix `cleanupExpiredShares`: `datetime(col)` wrappers in the `WHERE` clause prevented SQLite from using the `revoked_at` / `expires_at` indexes; replaced with `strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-30 days')` to keep the ISO string format comparable

Race-condition handling in `saveProjectForUser` is preserved: an empty `RETURNING` result (DO UPDATE WHERE condition failed) triggers a `getProjectForUser` lookup and throws `ProjectVersionConflictError`, same as before.
