### PR TITLE
Fix strftime format and gallery delete order

### DIFF
--- a/src/lib/server/gallery.ts
+++ b/src/lib/server/gallery.ts
@@ -420,20 +420,21 @@ export async function moveGalleryEntryToUnlisted(shareToken: string) {
 
 export async function deleteGalleryEntry(shareToken: string) {
   const db = await getDatabase();
-  const deleted = await db
+  const existing = await getGalleryEntryByShareToken(shareToken);
+
+  if (existing?.galleryPreviewImage) {
+    await deleteGalleryPreviewImage(existing.galleryPreviewImage);
+  }
+
+  await db
     .prepare(
       `
         delete from gallery_entries
         where share_token = ?
-        returning gallery_preview_image
       `
     )
     .bind(shareToken)
-    .first<{ gallery_preview_image: string | null }>();
-
-  if (deleted?.gallery_preview_image) {
-    await deleteGalleryPreviewImage(deleted.gallery_preview_image);
-  }
+    .run();
 }
 
 export async function moveGalleryEntryToListed(shareToken: string) {

--- a/src/lib/server/gallery.ts
+++ b/src/lib/server/gallery.ts
@@ -420,10 +420,20 @@ export async function moveGalleryEntryToUnlisted(shareToken: string) {
 
 export async function deleteGalleryEntry(shareToken: string) {
   const db = await getDatabase();
-  const existing = await getGalleryEntryByShareToken(shareToken);
+  const row = await db
+    .prepare(
+      `
+        select gallery_preview_image
+        from gallery_entries
+        where share_token = ?
+        limit 1
+      `
+    )
+    .bind(shareToken)
+    .first<{ gallery_preview_image: string | null }>();
 
-  if (existing?.galleryPreviewImage) {
-    await deleteGalleryPreviewImage(existing.galleryPreviewImage);
+  if (row?.gallery_preview_image) {
+    await deleteGalleryPreviewImage(row.gallery_preview_image);
   }
 
   await db

--- a/src/lib/server/share-retention.ts
+++ b/src/lib/server/share-retention.ts
@@ -13,13 +13,13 @@ export async function cleanupExpiredShares(db: D1Database) {
       delete from shares
       where (
            revoked_at is not null
-           and revoked_at < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-30 days')
+           and revoked_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')
          )
          or (
            share_type = 'temporary'
            and
            expires_at is not null
-           and expires_at < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-30 days')
+           and expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')
          )
     `
     )

--- a/tests/lib/server/gallery.test.ts
+++ b/tests/lib/server/gallery.test.ts
@@ -142,10 +142,25 @@ describe("gallery server helpers", () => {
   });
 
   it("deletes the R2 preview when a gallery entry is deleted", async () => {
-    const deleteStatement = createStatement({
-      first: { gallery_preview_image: "gallery/previews/entry-1.webp" },
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
+    const entryStatement = createStatement({
+      first: {
+        id: "entry-1",
+        share_token: "share-1",
+        owner_user_id: "user-1",
+        gallery_state: "listed",
+        gallery_title: "Track",
+        gallery_description: "A public track.",
+        gallery_preview_image: "gallery/previews/entry-1.webp",
+        gallery_published_at: null,
+        moderation_hidden_at: null,
+        created_at: "2026-04-20T09:00:00.000Z",
+        updated_at: "2026-04-20T10:00:00.000Z",
+      },
     });
-    installStatements([deleteStatement]);
+    const deleteStatement = createStatement();
+    installStatements([entryStatement, deleteStatement]);
 
     await deleteGalleryEntry("share-1");
 
@@ -153,7 +168,6 @@ describe("gallery server helpers", () => {
       "gallery/previews/entry-1.webp"
     );
     expect(deleteStatement.sql).toContain("delete from gallery_entries");
-    expect(deleteStatement.sql).toContain("returning gallery_preview_image");
     expect(deleteStatement.bind).toHaveBeenCalledWith("share-1");
   });
 

--- a/tests/lib/server/gallery.test.ts
+++ b/tests/lib/server/gallery.test.ts
@@ -142,28 +142,16 @@ describe("gallery server helpers", () => {
   });
 
   it("deletes the R2 preview when a gallery entry is deleted", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
-    const entryStatement = createStatement({
-      first: {
-        id: "entry-1",
-        share_token: "share-1",
-        owner_user_id: "user-1",
-        gallery_state: "listed",
-        gallery_title: "Track",
-        gallery_description: "A public track.",
-        gallery_preview_image: "gallery/previews/entry-1.webp",
-        gallery_published_at: null,
-        moderation_hidden_at: null,
-        created_at: "2026-04-20T09:00:00.000Z",
-        updated_at: "2026-04-20T10:00:00.000Z",
-      },
+    const previewStatement = createStatement({
+      first: { gallery_preview_image: "gallery/previews/entry-1.webp" },
     });
     const deleteStatement = createStatement();
-    installStatements([entryStatement, deleteStatement]);
+    installStatements([previewStatement, deleteStatement]);
 
     await deleteGalleryEntry("share-1");
 
+    expect(previewStatement.sql).toContain("select gallery_preview_image");
+    expect(previewStatement.bind).toHaveBeenCalledWith("share-1");
     expect(mocks.deleteGalleryPreviewImage).toHaveBeenCalledWith(
       "gallery/previews/entry-1.webp"
     );

--- a/tests/lib/server/share-retention.test.ts
+++ b/tests/lib/server/share-retention.test.ts
@@ -15,6 +15,9 @@ describe("share retention", () => {
     expect(sql).toContain(
       "revoked_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
     );
+    expect(sql).toContain(
+      "expires_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
+    );
     expect(run).toHaveBeenCalled();
   });
 });

--- a/tests/lib/server/share-retention.test.ts
+++ b/tests/lib/server/share-retention.test.ts
@@ -13,7 +13,7 @@ describe("share retention", () => {
     const sql = prepare.mock.calls[0][0];
     expect(sql).toContain("share_type = 'temporary'");
     expect(sql).toContain(
-      "revoked_at < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-30 days')"
+      "revoked_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 days')"
     );
     expect(run).toHaveBeenCalled();
   });


### PR DESCRIPTION
Follow-up to the D1 optimisation PR based on review feedback:

- Fix `cleanupExpiredShares`: replace `%S` with `%f` in the `strftime` cutoff so the generated timestamp includes milliseconds (`…T00:00:00.000Z`) and compares correctly against `Date#toISOString()` values stored in `revoked_at` and `expires_at`
- Revert `deleteGalleryEntry` to SELECT → R2 delete → DB delete: the `DELETE … RETURNING` approach removed the row before the R2 object was deleted, making retries impossible if the R2 call failed; the original order ensures the DB row is still present for any retry
