### PR TITLE
feat: Add barrier track items

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See the [public roadmap discussion](https://github.com/dutchdronesquad/trackdraw
 ## What you can do
 
 - 🏁 **Design layouts to scale** - place obstacles on a real-scale canvas with Metric or Imperial measurements that map cleanly to the real world
-- 🚩 **Use official obstacle types** - place MultiGP-style gates, ladders, towers, and flags with real dimensions, or keep using custom-sized TrackDraw elements
+- 🚩 **Use official obstacle types** - place MultiGP-style gates, ladders, towers, flags, hurdles, and barriers with real dimensions, or keep using custom-sized TrackDraw elements
 - 🗺️ **Line up with real venues** - add an editor-only satellite map reference, search or choose the field center, and align it with rotation and opacity controls
 - ⚡ **Start and iterate faster** - use obstacle presets, selection grouping, and starter layouts to get from blank canvas to a workable draft quickly
 - 💾 **Manage projects safely** - keep multiple local projects, reopen older layouts, rename or export them, and roll back through restore points and snapshots

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
     "Konva",
     "shadcn",
     "wrangler",
-    "Cloudflare"
+    "Cloudflare",
+    "metalness"
   ]
 }

--- a/docs/assets/multigp-obstacle-asset-workflow.md
+++ b/docs/assets/multigp-obstacle-asset-workflow.md
@@ -1,6 +1,6 @@
 # MultiGP Obstacle Asset Workflow
 
-This document records how TrackDraw turns the MultiGP obstacle source model into runtime textures for the catalog-backed MultiGP gates, ladders, and corner flag.
+This document records how TrackDraw turns the MultiGP obstacle source model into runtime textures for the catalog-backed MultiGP gates, ladders, corner flag, and hurdle.
 
 ## Source And Attribution
 
@@ -79,7 +79,7 @@ After extracting or replacing source PNGs, downsample them and generate lossless
 npm run assets:multigp:optimize
 ```
 
-The source GLB and extracted images can be very high resolution. Runtime rendering does not need the full 4k-8k source bitmaps because the artwork is mapped onto small gate, ladder, and flag panels in an interactive 3D preview. The optimizer keeps stable basenames, preserves aspect ratios, writes optimized PNG maintenance copies, and generates lossless WebP files for the runtime catalog paths.
+The source GLB and extracted images can be very high resolution. Runtime rendering does not need the full 4k-8k source bitmaps because the artwork is mapped onto small gate, ladder, flag, and hurdle panels in an interactive 3D preview. The optimizer keeps stable basenames, preserves aspect ratios, writes optimized PNG maintenance copies, and generates lossless WebP files for the runtime catalog paths.
 
 The MultiGP corner-flag back texture is intentionally mirrored as a standalone image. The runtime back panel is rotated 180 degrees around the vertical axis, which makes the mirrored back texture read correctly in the 3D scene. Do not add an extra flag-back flip in runtime code or in the optimizer.
 
@@ -113,6 +113,7 @@ After replacing the GLB or textures:
    - MultiGP Championship Ladder 7x6
    - MultiGP Topless Ladder 7x6
    - MultiGP Corner Flag
+   - MultiGP Hurdle
 4. Confirm side-panel reading direction for gates and ladders:
    - physical left side reads bottom-to-top
    - physical right side reads top-to-bottom

--- a/docs/research/track-element-catalog.md
+++ b/docs/research/track-element-catalog.md
@@ -1,6 +1,6 @@
 # Track Element Catalog
 
-TrackDraw currently has generic editor primitives such as gate, flag, cone, ladder, dive gate, start pads, label, and race line. One useful next step is a catalog layer that knows about real track elements, official names, dimensions, 2D behavior, 3D presentation, and export/integration compatibility.
+TrackDraw currently has generic editor primitives such as gate, flag, cone, ladder, dive gate, barrier, start pads, label, and race line. One useful next step is a catalog layer that knows about real track elements, official names, dimensions, 2D behavior, 3D presentation, and export/integration compatibility.
 
 The catalog should start local and typed, not as a database. A database becomes useful later for club inventory, venue-specific kits, custom saved elements, and account-backed libraries.
 
@@ -11,6 +11,7 @@ The catalog should start local and typed, not as a database. A database becomes 
 - [x] Add initial official race-gate entries, including MultiGP-style 5x5 and 7x6 variants, without changing existing saved designs.
 - [x] Show catalog identity, official size status, and fixed official dimensions for placed catalog-backed gates.
 - [x] Extend catalog-backed MultiGP entries to gates, ladders, and the 10 ft corner flag with texture-based 3D rendering.
+- [x] Add a barrier category with TrackDraw banner/fence/net entries and the official MultiGP Hurdle.
 
 ## Reference Observations
 
@@ -77,7 +78,7 @@ Scope:
 - Add the first official gate entries after validating exact sizing and source language:
   - MultiGP Standard Gate 5x5
   - MultiGP Championship Gate 7x6
-  - Hurdles only after deciding whether they should remain `gate`-like catalog variants or become their own obstacle category
+  - Hurdles should be a separate `barrier` obstacle category rather than `gate`-like catalog variants
   - Dive gate variants only after deciding whether they should remain one `divegate` shape or become catalog-driven variants
 - Keep "Custom Gate" available through the standard TrackDraw Gate so users are not boxed into official-only dimensions.
 - Expose the official name in inspector/export summaries only when the shape was created from a catalog entry or explicitly assigned one.
@@ -93,6 +94,7 @@ Status:
 
 - Users can now place catalog-backed MultiGP-style gate variants through the normal Gate placement flow: Standard Gate 5x5 and Championship Gate 7x6. Desktop keeps the active gate type in a compact canvas placement control with a dropdown for additional variants, while mobile keeps one Gate entry in the tools drawer with a compact type picker for variants.
 - Users can also place catalog-backed MultiGP Standard Ladder 5x5, Championship Ladder 7x6, Topless Ladder 7x6, and Corner Flag entries through the same typed catalog pipeline.
+- Users can place barriers as a separate catalog-backed category, including TrackDraw banner, fence, and net entries plus the official MultiGP Hurdle.
 - Newly placed official elements remain normal TrackDraw shapes, with their source identity stored under `meta.catalog`. The inspector shows the catalog type, source, official size, and fixed official status.
 - Official sizing and color are fixed in normal editing. Custom sizing and coloring belong to the standard TrackDraw generic elements instead of modifying official catalog items.
 - Newly placed gates and ladders default with their front facing downward on the canvas so the default orientation matches the editor's front/back guide expectation.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -253,12 +253,12 @@ Current shipped foundation:
 - Toolbar placement, layout presets, and starter layouts now use shared catalog placement helpers for generic elements, keeping saved geometry meter-based and backwards compatible
 - Gate placement can now switch between the generic TrackDraw gate and catalog-backed MultiGP-style 5x5 and 7x6 gate variants through a compact desktop placement dropdown and a compact mobile Gate type picker
 - Ladder placement can switch between the generic TrackDraw ladder and catalog-backed MultiGP Standard 5x5, Championship 7x6, and Topless 7x6 ladder variants
+- Barrier placement now supports TrackDraw banner, fence, and net entries plus the official MultiGP Hurdle as a separate non-traversable obstacle category with catalog identity, 2D/3D rendering, type switching, inventory counts, and export support
 - The inspector shows catalog type, source, official size, and dimension status while keeping official gate width and height fixed in normal editing
 
 Next catalog slices:
 
 - Double Gate Tower 5x5 and 7x6: introduce as a new shape kind with its own 2D representation, 3D rendering, catalog entries, and inspector pipeline; race-line behavior is gate-like (fly through) while the physical structure resembles a two-frame tower
-- Barriers: introduce a shared element category for obstacles that block sightlines, mark field boundaries, or otherwise serve as physical barriers rather than fly-through gates; initial candidates include the MultiGP Hurdle (fly-over), standalone printed banners, fencing panels, and net sections; these share a common race-line behavior (non-traversable, no gate-pass logic) and a common 2D visual language while each having their own dimensions, catalog entries, and 3D representation; the hurdle follows official MultiGP dimensions while banners, fencing, and nets remain freely sizeable; inventory and Race Pack material counts should reflect the barrier category separately from gates and ladders
 
 #### Generated Flightpath Assistance
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -22,7 +22,7 @@ Labels used below:
 
 ## Current Priority
 
-The completed release-sized work is archived below. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, remaining focused 3D item controls, generated flightpath assistance, multilingual-readiness for international users, account-backed project lifecycle depth beyond the shipped conflict/retry baseline, a barrier element category covering hurdles, banners, fencing, and nets, user-defined layout presets replacing the current hard-coded list, and powerloop representation research in the route path.
+The completed release-sized work is archived below. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, remaining focused 3D item controls, generated flightpath assistance, multilingual-readiness for international users, account-backed project lifecycle depth beyond the shipped conflict/retry baseline, user-defined layout presets replacing the current hard-coded list, and powerloop representation research in the route path.
 
 ## Follow-up
 
@@ -50,18 +50,18 @@ The completed release-sized work is archived below. The next TrackDraw priority 
   - [ ] Preset store (`Lower priority`, `Account-backed`)
         Let users publish a preset to a public store where others can find and add it to their own preset library. Think of it as a community-driven catalog of reusable track sections — users contribute, others browse and save. Keep this out of the first implementation slice; the account-backed storage model needs to be solid first.
 
-- [ ] Barriers (`No account required`)
-      Introduce a shared element category for obstacles that block sightlines, mark field boundaries, or otherwise serve as physical barriers rather than fly-through gates. Initial candidates include the MultiGP Hurdle (fly-over), standalone printed banners, fencing panels, and net sections. These share a common non-traversable race-line behavior (no gate-pass logic) while each carrying their own dimensions, catalog entries, 2D visual language, and 3D representation. The MultiGP Hurdle follows official dimensions; banners, fencing, and nets remain freely sizeable. Inventory counts and Race Pack material lists should reflect the barrier category separately from gates and ladders.
-  - [ ] Barrier kind, catalog entries
-        Define the shared barrier kind, catalog entries for the MultiGP Hurdle, banner, fence panel, and net section, with official dimensions where applicable and free sizing elsewhere.
-  - [ ] 2D representation
-        Give each barrier type a recognizable 2D footprint that visually distinguishes it from gates and ladders without cluttering dense layouts.
-  - [ ] 3D representation
-        Render barriers in the 3D preview with proportional geometry. The hurdle should resemble the real obstacle; banners, fencing, and nets should be lightweight but readable.
-  - [ ] Inspector and type switching
-        Show barrier catalog identity, source reference where applicable, and allow in-place type switching between barrier variants the same way gates and ladders already support it.
-  - [ ] Inventory and Race Pack integration
-        Count barriers as a distinct material category in the inventory validator and Race Pack setup output.
+- [x] Barriers (`No account required`)
+      TrackDraw now has a shared barrier category for obstacles that block sightlines, mark field boundaries, or otherwise serve as physical barriers rather than fly-through gates. The first slice includes the official MultiGP Hurdle plus TrackDraw banner, fence, and net entries with non-traversable race-line behavior, catalog-backed placement, 2D/3D rendering, inspector type switching, inventory counts, and export support.
+  - [x] Barrier kind, catalog entries
+        Defined the shared barrier kind and catalog entries for the MultiGP Hurdle, banner, fence panel, and net section, with official dimensions where applicable and free sizing elsewhere.
+  - [x] 2D representation
+        Gave each barrier type a recognizable 2D footprint that visually distinguishes it from gates and ladders without cluttering dense layouts.
+  - [x] 3D representation
+        Rendered barriers in the 3D preview with proportional geometry. The hurdle uses the official panel artwork, while banners, fencing, and nets stay lightweight and readable.
+  - [x] Inspector and type switching
+        Shows barrier catalog identity, source reference where applicable, and allows in-place type switching between barrier variants the same way gates and ladders already support it.
+  - [x] Inventory and Race Pack integration
+        Counts barriers as a distinct material category in the inventory validator and Race Pack setup output.
 
 - [ ] Path editing UX (`No account required`)
       Make drawing and adjusting a path feel more natural, especially for curved layouts where the current waypoint model forces extra points to avoid sharp corners.

--- a/src/components/canvas/preview3d/items/Barrier3D.tsx
+++ b/src/components/canvas/preview3d/items/Barrier3D.tsx
@@ -1,0 +1,456 @@
+"use client";
+
+import * as THREE from "three";
+import { useMemo } from "react";
+import { useTexture } from "@react-three/drei";
+import { getBarrierVisualSpec } from "@/lib/track/elements/visual";
+import type { BarrierShape } from "@/lib/types";
+
+function parseColor(hex: string): THREE.Color {
+  return new THREE.Color(hex);
+}
+
+interface BarrierMaterialProps {
+  color: THREE.Color;
+  selected: boolean;
+  opacity?: number;
+  transparent?: boolean;
+  roughness?: number;
+  metalness?: number;
+}
+
+function barrierMaterial({
+  color,
+  selected,
+  opacity = 1,
+  transparent = false,
+  roughness = 0.7,
+  metalness = 0.05,
+}: BarrierMaterialProps) {
+  return (
+    <meshStandardMaterial
+      color={color}
+      emissive={selected ? color : new THREE.Color(0, 0, 0)}
+      emissiveIntensity={selected ? 0.22 : 0}
+      roughness={roughness}
+      metalness={metalness}
+      opacity={opacity}
+      transparent={transparent}
+    />
+  );
+}
+
+function HurdleBarrier3D({
+  shape,
+  selected,
+}: {
+  shape: BarrierShape;
+  selected: boolean;
+}) {
+  const color = useMemo(
+    () => parseColor(shape.color ?? "#f59e0b"),
+    [shape.color]
+  );
+  const w = shape.width;
+  const h = shape.height;
+  const postR = 0.04;
+  const barR = 0.03;
+
+  return (
+    <group
+      position={[shape.x, 0, shape.y]}
+      rotation={[0, (-shape.rotation * Math.PI) / 180, 0]}
+    >
+      {/* Top bar */}
+      <mesh position={[0, h, 0]}>
+        <boxGeometry args={[w, barR * 2, barR * 2]} />
+        {barrierMaterial({ color, selected })}
+      </mesh>
+      {/* Left post */}
+      <mesh position={[-w / 2, h / 2, 0]}>
+        <cylinderGeometry args={[postR, postR, h, 8]} />
+        {barrierMaterial({ color, selected })}
+      </mesh>
+      {/* Right post */}
+      <mesh position={[w / 2, h / 2, 0]}>
+        <cylinderGeometry args={[postR, postR, h, 8]} />
+        {barrierMaterial({ color, selected })}
+      </mesh>
+    </group>
+  );
+}
+
+function BannerBarrier3DTextured({
+  shape,
+  selected,
+  texturePath,
+}: {
+  shape: BarrierShape;
+  selected: boolean;
+  texturePath: string;
+}) {
+  const texture = useTexture(texturePath);
+  const color = useMemo(
+    () => parseColor(shape.color ?? "#1e3a8a"),
+    [shape.color]
+  );
+  const w = shape.width;
+  const h = shape.height;
+  const thick = 0.04;
+
+  return (
+    <group
+      position={[shape.x, 0, shape.y]}
+      rotation={[0, (-shape.rotation * Math.PI) / 180, 0]}
+    >
+      <mesh position={[0, h / 2, 0]}>
+        <boxGeometry args={[w, h, thick]} />
+        <meshStandardMaterial
+          map={texture}
+          emissive={selected ? color : new THREE.Color(0, 0, 0)}
+          emissiveIntensity={selected ? 0.22 : 0}
+          roughness={0.7}
+          metalness={0.05}
+        />
+      </mesh>
+      {/* Left post */}
+      <mesh position={[-w / 2, h / 2, 0]}>
+        <cylinderGeometry args={[0.04, 0.04, h, 8]} />
+        {barrierMaterial({
+          color: new THREE.Color("#94a3b8"),
+          selected: false,
+        })}
+      </mesh>
+      {/* Right post */}
+      <mesh position={[w / 2, h / 2, 0]}>
+        <cylinderGeometry args={[0.04, 0.04, h, 8]} />
+        {barrierMaterial({
+          color: new THREE.Color("#94a3b8"),
+          selected: false,
+        })}
+      </mesh>
+    </group>
+  );
+}
+
+function BannerBarrier3D({
+  shape,
+  selected,
+}: {
+  shape: BarrierShape;
+  selected: boolean;
+}) {
+  const visual = getBarrierVisualSpec(shape);
+  const texturePath = visual?.panel.texture ?? null;
+
+  if (texturePath) {
+    return (
+      <BannerBarrier3DTextured
+        shape={shape}
+        selected={selected}
+        texturePath={texturePath}
+      />
+    );
+  }
+
+  return <BannerBarrier3DPlain shape={shape} selected={selected} />;
+}
+
+function BannerBarrier3DPlain({
+  shape,
+  selected,
+}: {
+  shape: BarrierShape;
+  selected: boolean;
+}) {
+  const color = useMemo(
+    () => parseColor(shape.color ?? "#ec4899"),
+    [shape.color]
+  );
+  const w = shape.width;
+  const h = shape.height;
+  const thick = 0.04;
+
+  return (
+    <group
+      position={[shape.x, 0, shape.y]}
+      rotation={[0, (-shape.rotation * Math.PI) / 180, 0]}
+    >
+      <mesh position={[0, h / 2, 0]}>
+        <boxGeometry args={[w, h, thick]} />
+        {barrierMaterial({ color, selected, opacity: 0.82, transparent: true })}
+      </mesh>
+      <mesh position={[-w / 2, h / 2, 0]}>
+        <cylinderGeometry args={[0.04, 0.04, h, 8]} />
+        {barrierMaterial({
+          color: new THREE.Color("#94a3b8"),
+          selected: false,
+        })}
+      </mesh>
+      <mesh position={[w / 2, h / 2, 0]}>
+        <cylinderGeometry args={[0.04, 0.04, h, 8]} />
+        {barrierMaterial({
+          color: new THREE.Color("#94a3b8"),
+          selected: false,
+        })}
+      </mesh>
+    </group>
+  );
+}
+
+function FenceBarrier3D({
+  shape,
+  selected,
+}: {
+  shape: BarrierShape;
+  selected: boolean;
+}) {
+  const color = useMemo(
+    () => parseColor(shape.color ?? "#94a3b8"),
+    [shape.color]
+  );
+  const w = shape.width;
+  const h = shape.height;
+  const frameR = 0.045;
+  const barR = 0.016;
+  // Frame floats above the ground — supported only by the feet
+  const groundClearance = Math.min(0.16, h * 0.18);
+  const footSpread = Math.min(0.42, h * 0.45); // how far legs extend in ±Z
+  const footR = frameR * 0.85;
+  const footAttachX = w * 0.27; // where feet bracket along the width
+
+  const frameH = h - groundClearance; // height of the frame rectangle itself
+  const frameBottom = groundClearance;
+  const frameTop = h;
+  // Corner radius clamped so straight segments always have positive length
+  const cornerR = Math.min(frameR * 3, frameH * 0.32, w * 0.14);
+  const straightPostH = Math.max(0, frameH - 2 * cornerR);
+  const straightRailW = Math.max(0, w - 2 * cornerR);
+
+  const barCount = Math.max(3, Math.round((w - frameR * 4) / 0.16));
+  const innerW = w - frameR * 4;
+  const innerH = frameH - frameR * 2;
+
+  // V-leg: diagonal from (fx, groundClearance, 0) to (fx, 0, ±footSpread)
+  const legLen = Math.sqrt(
+    groundClearance * groundClearance + footSpread * footSpread
+  );
+  const legAngle = Math.PI / 2 + Math.atan2(groundClearance, footSpread);
+
+  const mat = () =>
+    barrierMaterial({ color, selected, roughness: 0.28, metalness: 0.82 });
+
+  return (
+    <group
+      position={[shape.x, 0, shape.y]}
+      rotation={[0, (-shape.rotation * Math.PI) / 180, 0]}
+    >
+      {/* Straight side posts (shortened to leave room for corner arcs) */}
+      {straightPostH > 0 && (
+        <>
+          <mesh position={[-w / 2, (frameBottom + frameTop) / 2, 0]}>
+            <cylinderGeometry args={[frameR, frameR, straightPostH, 8]} />
+            {mat()}
+          </mesh>
+          <mesh position={[w / 2, (frameBottom + frameTop) / 2, 0]}>
+            <cylinderGeometry args={[frameR, frameR, straightPostH, 8]} />
+            {mat()}
+          </mesh>
+        </>
+      )}
+      {/* Straight rails (shortened) */}
+      {straightRailW > 0 && (
+        <>
+          <mesh position={[0, frameTop, 0]} rotation={[0, 0, Math.PI / 2]}>
+            <cylinderGeometry args={[frameR, frameR, straightRailW, 8]} />
+            {mat()}
+          </mesh>
+          <mesh position={[0, frameBottom, 0]} rotation={[0, 0, Math.PI / 2]}>
+            <cylinderGeometry args={[frameR, frameR, straightRailW, 8]} />
+            {mat()}
+          </mesh>
+        </>
+      )}
+      {/*
+        Quarter-torus corners. Default torus arc (0→π/2) in XY plane goes:
+          θ=0  → (+R, 0)   θ=π/2 → (0, +R)
+        Rotating the mesh remaps which corner each arc fills:
+          top-right:    no rotation     (R,0)→(w/2)  (0,R)→(frameTop)
+          top-left:     rotY=π  → (-R,0)→(-w/2)  (0,R)→(frameTop)
+          bottom-left:  rotZ=π  → (-R,0)→(-w/2)  (0,-R)→(frameBottom)
+          bottom-right: rotX=π  → (R,0)→(w/2)   (0,-R)→(frameBottom)
+      */}
+      <mesh position={[w / 2 - cornerR, frameTop - cornerR, 0]}>
+        <torusGeometry args={[cornerR, frameR, 6, 8, Math.PI / 2]} />
+        {mat()}
+      </mesh>
+      <mesh
+        position={[-w / 2 + cornerR, frameTop - cornerR, 0]}
+        rotation={[0, Math.PI, 0]}
+      >
+        <torusGeometry args={[cornerR, frameR, 6, 8, Math.PI / 2]} />
+        {mat()}
+      </mesh>
+      <mesh
+        position={[-w / 2 + cornerR, frameBottom + cornerR, 0]}
+        rotation={[0, 0, Math.PI]}
+      >
+        <torusGeometry args={[cornerR, frameR, 6, 8, Math.PI / 2]} />
+        {mat()}
+      </mesh>
+      <mesh
+        position={[w / 2 - cornerR, frameBottom + cornerR, 0]}
+        rotation={[Math.PI, 0, 0]}
+      >
+        <torusGeometry args={[cornerR, frameR, 6, 8, Math.PI / 2]} />
+        {mat()}
+      </mesh>
+      {/* Vertical bars inside the frame */}
+      {Array.from({ length: barCount }, (_, i) => {
+        const x = -innerW / 2 + ((i + 1) / (barCount + 1)) * innerW;
+        return (
+          <mesh key={i} position={[x, frameBottom + frameR + innerH / 2, 0]}>
+            <cylinderGeometry args={[barR, barR, innerH, 6]} />
+            {mat()}
+          </mesh>
+        );
+      })}
+      {/* Two V-shaped foot structures, each with two diagonal legs to the ground */}
+      {([-footAttachX, footAttachX] as const).flatMap((fx, fi) => [
+        <mesh
+          key={`ff${fi}`}
+          position={[fx, groundClearance / 2, footSpread / 2]}
+          rotation={[legAngle, 0, 0]}
+        >
+          <cylinderGeometry args={[footR, footR, legLen, 6]} />
+          {mat()}
+        </mesh>,
+        <mesh
+          key={`fb${fi}`}
+          position={[fx, groundClearance / 2, -footSpread / 2]}
+          rotation={[-legAngle, 0, 0]}
+        >
+          <cylinderGeometry args={[footR, footR, legLen, 6]} />
+          {mat()}
+        </mesh>,
+      ])}
+    </group>
+  );
+}
+
+const NET_WIRE_RADIUS = 0.005;
+const NET_CELL_H = 0.12; // vertical wires closer together
+const NET_CELL_V = 0.22; // horizontal wires further apart
+
+function NetBarrier3D({
+  shape,
+  selected,
+}: {
+  shape: BarrierShape;
+  selected: boolean;
+}) {
+  const color = useMemo(
+    () => parseColor(shape.color ?? "#94a3b8"),
+    [shape.color]
+  );
+  const w = shape.width;
+  const h = shape.height;
+
+  const { hWires, vWires } = useMemo(() => {
+    const cols = Math.max(2, Math.round(w / NET_CELL_H));
+    const rows = Math.max(2, Math.round(h / NET_CELL_V));
+
+    const horizontalWires = Array.from({ length: rows + 1 }, (_, r) => ({
+      y: (r / rows) * h,
+    }));
+    const verticalWires = Array.from({ length: cols + 1 }, (_, c) => ({
+      x: -w / 2 + (c / cols) * w,
+    }));
+
+    return { hWires: horizontalWires, vWires: verticalWires };
+  }, [w, h]);
+
+  const postColor = new THREE.Color("#9ca3af");
+  const wireMat = (
+    <meshStandardMaterial
+      color={color}
+      emissive={selected ? color : new THREE.Color(0, 0, 0)}
+      emissiveIntensity={selected ? 0.22 : 0}
+      roughness={0.3}
+      metalness={0.7}
+    />
+  );
+  const postMat = (
+    <meshStandardMaterial
+      color={postColor}
+      emissive={selected ? postColor : new THREE.Color(0, 0, 0)}
+      emissiveIntensity={selected ? 0.22 : 0}
+      roughness={0.3}
+      metalness={0.8}
+    />
+  );
+
+  return (
+    <group
+      position={[shape.x, 0, shape.y]}
+      rotation={[0, (-shape.rotation * Math.PI) / 180, 0]}
+    >
+      {/* Horizontal wires */}
+      {hWires.map((wire, i) => (
+        <mesh
+          key={`h${i}`}
+          position={[0, wire.y, 0]}
+          rotation={[0, 0, Math.PI / 2]}
+        >
+          <cylinderGeometry args={[NET_WIRE_RADIUS, NET_WIRE_RADIUS, w, 5]} />
+          {wireMat}
+        </mesh>
+      ))}
+      {/* Vertical wires */}
+      {vWires.map((wire, i) => (
+        <mesh key={`v${i}`} position={[wire.x, h / 2, 0]}>
+          <cylinderGeometry args={[NET_WIRE_RADIUS, NET_WIRE_RADIUS, h, 5]} />
+          {wireMat}
+        </mesh>
+      ))}
+      {/* Left post */}
+      <mesh position={[-w / 2, h / 2, 0]}>
+        <cylinderGeometry args={[0.05, 0.05, h + 0.1, 8]} />
+        {postMat}
+      </mesh>
+      {/* Right post */}
+      <mesh position={[w / 2, h / 2, 0]}>
+        <cylinderGeometry args={[0.05, 0.05, h + 0.1, 8]} />
+        {postMat}
+      </mesh>
+      {/* Top rail */}
+      <mesh position={[0, h, 0]}>
+        <boxGeometry args={[w, 0.05, 0.05]} />
+        {postMat}
+      </mesh>
+    </group>
+  );
+}
+
+export function Barrier3D({
+  shape,
+  selected,
+}: {
+  shape: BarrierShape;
+  selected: boolean;
+}) {
+  switch (shape.variant) {
+    case "hurdle":
+      return <HurdleBarrier3D shape={shape} selected={selected} />;
+    case "banner":
+      return <BannerBarrier3D shape={shape} selected={selected} />;
+    case "fence":
+      return <FenceBarrier3D shape={shape} selected={selected} />;
+    case "net":
+      return <NetBarrier3D shape={shape} selected={selected} />;
+  }
+}
+
+export function getBarrierTopY(shape: BarrierShape): number {
+  return Math.max(shape.height, 0.1);
+}

--- a/src/components/canvas/preview3d/items/TrackItem3D.tsx
+++ b/src/components/canvas/preview3d/items/TrackItem3D.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/track/elements/visual";
 import { POLYLINE_3D_HEIGHT_OFFSET } from "@/lib/track/constants";
 import type {
+  BarrierShape,
   ConeShape,
   DiveGateShape,
   FlagShape,
@@ -29,6 +30,7 @@ import type {
   TowerShape,
 } from "@/lib/types";
 import { assertNever } from "@/lib/utils";
+import { Barrier3D, getBarrierTopY } from "./Barrier3D";
 import { Gate3D } from "./Gate3D";
 import { Ladder3D } from "./Ladder3D";
 import { Flag3D } from "./Flag3D";
@@ -99,6 +101,7 @@ const shapeTopYDispatch: Record<ShapeKind, (shape: Shape) => number> = {
     );
   },
   divegate: (shape) => Math.max(getDiveGateTopY(shape as DiveGateShape), 0.5),
+  barrier: (shape) => getBarrierTopY(shape as BarrierShape),
 };
 
 function getShapeTopY(shape: Shape): number {
@@ -229,6 +232,27 @@ function Shape3D({
             tiltDragRef={tiltDragRef}
             elevationOverrideRef={elevationOverrideRef}
           />
+          {isSelected && <SelectionMarker3D shape={shape} />}
+        </group>
+      );
+    case "barrier":
+      return (
+        <group onClick={(event) => onSelect(event, shape.id)}>
+          <Barrier3D shape={shape} selected={isSelected} />
+          {/* Invisible hit plane so clicks anywhere on the barrier face register,
+              even between the thin wires of net/fence variants */}
+          <mesh
+            position={[shape.x, shape.height / 2, shape.y]}
+            rotation={[0, (-shape.rotation * Math.PI) / 180, 0]}
+          >
+            <planeGeometry args={[shape.width, shape.height]} />
+            <meshBasicMaterial
+              transparent
+              opacity={0}
+              side={THREE.DoubleSide}
+              depthWrite={false}
+            />
+          </mesh>
           {isSelected && <SelectionMarker3D shape={shape} />}
         </group>
       );

--- a/src/components/canvas/renderers/shape-bounds.ts
+++ b/src/components/canvas/renderers/shape-bounds.ts
@@ -1,4 +1,5 @@
 import {
+  getBarrier2DShape,
   getCone2DShape,
   getTower2DShape,
   getDiveGate2DShape,
@@ -9,6 +10,7 @@ import {
 } from "@/lib/track/shape2d";
 import { getPolylineBounds } from "@/lib/track/polyline-derived";
 import type {
+  BarrierShape,
   ConeShape,
   DiveGateShape,
   FlagShape,
@@ -84,6 +86,10 @@ const shapeBoundsDispatch: Record<
     };
   },
   polyline: (shape, ppm) => getPolylineBounds(shape as PolylineShape, ppm),
+  barrier: (shape, ppm) => {
+    const { width, depth } = getBarrier2DShape(shape as BarrierShape, ppm);
+    return { x: -width / 2, y: -depth / 2, width, height: depth };
+  },
 };
 
 export function getShapeLocalBounds(shape: Shape, ppm: number): Bounds | null {

--- a/src/components/canvas/renderers/shape2d/barrier.tsx
+++ b/src/components/canvas/renderers/shape2d/barrier.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { Line, Rect } from "react-konva";
+import { getBarrier2DShape } from "@/lib/track/shape2d";
+import { m2px } from "@/lib/track/units";
+import type { BarrierShape } from "@/lib/types";
+
+function mixHexColor(hex: string, targetHex: string, amount: number): string {
+  const parse = (value: string) => {
+    const normalized = value.replace("#", "");
+    const full =
+      normalized.length === 3
+        ? normalized
+            .split("")
+            .map((char) => char + char)
+            .join("")
+        : normalized;
+    const parsed = Number.parseInt(full, 16);
+    if (Number.isNaN(parsed)) return { r: 0, g: 0, b: 0 };
+    return {
+      r: (parsed >> 16) & 255,
+      g: (parsed >> 8) & 255,
+      b: parsed & 255,
+    };
+  };
+
+  const source = parse(hex);
+  const target = parse(targetHex);
+  const channel = (from: number, to: number) =>
+    Math.round(from + (to - from) * amount)
+      .toString(16)
+      .padStart(2, "0");
+
+  return `#${channel(source.r, target.r)}${channel(
+    source.g,
+    target.g
+  )}${channel(source.b, target.b)}`;
+}
+
+function renderBarrierInner(
+  variant: BarrierShape["variant"],
+  width: number,
+  depth: number,
+  markColor: string,
+  edgeColor: string
+) {
+  const hw = width / 2;
+  const hh = depth / 2;
+
+  if (variant === "banner") {
+    const arrowCount = Math.max(3, Math.floor(width / 13));
+    const spacing = width / (arrowCount + 1);
+    const arm = hh * 0.62;
+    const tip = spacing * 0.28;
+    return Array.from({ length: arrowCount }, (_, i) => {
+      const ax = -hw + spacing * (i + 1);
+      return (
+        <Line
+          key={i}
+          points={[ax - tip, -arm, ax + tip, 0, ax - tip, arm]}
+          stroke={markColor}
+          strokeWidth={1.35}
+          opacity={0.78}
+          lineJoin="round"
+          listening={false}
+        />
+      );
+    });
+  }
+
+  if (variant === "hurdle") {
+    const stripeCount = Math.max(2, Math.floor(width / 12));
+    const spacing = width / stripeCount;
+    return Array.from({ length: stripeCount - 1 }, (_, i) => {
+      const sx = -hw + spacing * (i + 1);
+      return (
+        <Line
+          key={i}
+          points={[sx - hh, -hh, sx + hh, hh]}
+          stroke={markColor}
+          strokeWidth={1}
+          opacity={0.72}
+          lineCap="round"
+          listening={false}
+        />
+      );
+    });
+  }
+
+  if (variant === "fence") {
+    const postCount = Math.max(2, Math.floor(width / 14));
+    const spacing = width / postCount;
+    const posts = Array.from({ length: postCount - 1 }, (_, i) => {
+      const px = -hw + spacing * (i + 1);
+      return (
+        <Line
+          key={i}
+          points={[px, -hh, px, hh]}
+          stroke={edgeColor}
+          strokeWidth={1}
+          opacity={0.5}
+          listening={false}
+        />
+      );
+    });
+    return [
+      <Line
+        key="rail-top"
+        points={[-hw, -hh * 0.42, hw, -hh * 0.42]}
+        stroke={markColor}
+        strokeWidth={1}
+        opacity={0.55}
+        listening={false}
+      />,
+      <Line
+        key="rail-bottom"
+        points={[-hw, hh * 0.42, hw, hh * 0.42]}
+        stroke={edgeColor}
+        strokeWidth={1}
+        opacity={0.42}
+        listening={false}
+      />,
+      ...posts,
+    ];
+  }
+
+  if (variant === "net") {
+    const colCount = Math.max(2, Math.floor(width / 14));
+    const colSpacing = width / colCount;
+    const cols = Array.from({ length: colCount - 1 }, (_, i) => {
+      const px = -hw + colSpacing * (i + 1);
+      return (
+        <Line
+          key={`c${i}`}
+          points={[px, -hh, px, hh]}
+          stroke={markColor}
+          strokeWidth={0.6}
+          opacity={0.48}
+          listening={false}
+        />
+      );
+    });
+    const diagCount = Math.max(2, Math.floor(width / 20));
+    const diagSpacing = width / diagCount;
+    const diagonals = Array.from({ length: diagCount }, (_, i) => {
+      const x = -hw + diagSpacing * i;
+      return (
+        <Line
+          key={`d${i}`}
+          points={[x, hh, Math.min(hw, x + diagSpacing), -hh]}
+          stroke={edgeColor}
+          strokeWidth={0.55}
+          opacity={0.3}
+          listening={false}
+        />
+      );
+    });
+    const mid = (
+      <Line
+        key="h"
+        points={[-hw, 0, hw, 0]}
+        stroke={markColor}
+        strokeWidth={0.7}
+        opacity={0.48}
+        listening={false}
+      />
+    );
+    return [...cols, ...diagonals, mid];
+  }
+
+  return null;
+}
+
+export function renderBarrier(
+  shape: BarrierShape,
+  selected: boolean,
+  ppm: number
+) {
+  const { color, depth, radius, width } = getBarrier2DShape(shape, ppm);
+  const selectionPad = m2px(0.3, ppm);
+  const edgeColor = mixHexColor(color, "#0f172a", 0.28);
+  const shadowColor = mixHexColor(color, "#0f172a", 0.45);
+  const highlightColor = mixHexColor(color, "#ffffff", 0.52);
+  const markColor = mixHexColor(color, "#ffffff", 0.72);
+  const endCapWidth = Math.min(Math.max(depth * 0.55, 3), width * 0.08);
+  const highlightHeight = Math.max(1, depth * 0.22);
+
+  return (
+    <>
+      {selected && (
+        <Rect
+          width={width + selectionPad}
+          height={depth + selectionPad}
+          offsetX={(width + selectionPad) / 2}
+          offsetY={(depth + selectionPad) / 2}
+          stroke="#60a5fa"
+          strokeWidth={1}
+          opacity={0.85}
+          cornerRadius={2}
+          listening={false}
+        />
+      )}
+      <Rect
+        x={-width / 2 + 1}
+        y={-depth / 2 + 1.5}
+        width={width}
+        height={depth}
+        fill={shadowColor}
+        opacity={0.16}
+        cornerRadius={radius}
+        strokeEnabled={false}
+        listening={false}
+      />
+      <Rect
+        width={width}
+        height={depth}
+        offsetX={width / 2}
+        offsetY={depth / 2}
+        fill={color}
+        opacity={0.9}
+        cornerRadius={radius}
+        stroke={edgeColor}
+        strokeWidth={1}
+      />
+      <Rect
+        x={-width / 2 + 1}
+        y={-depth / 2 + 1}
+        width={Math.max(0, width - 2)}
+        height={highlightHeight}
+        fill={highlightColor}
+        opacity={0.34}
+        cornerRadius={[Math.max(0, radius - 1), Math.max(0, radius - 1), 0, 0]}
+        strokeEnabled={false}
+        listening={false}
+      />
+      <Rect
+        x={-width / 2}
+        y={-depth / 2}
+        width={endCapWidth}
+        height={depth}
+        fill={edgeColor}
+        opacity={0.32}
+        cornerRadius={[radius, 0, 0, radius]}
+        strokeEnabled={false}
+        listening={false}
+      />
+      <Rect
+        x={width / 2 - endCapWidth}
+        y={-depth / 2}
+        width={endCapWidth}
+        height={depth}
+        fill={edgeColor}
+        opacity={0.32}
+        cornerRadius={[0, radius, radius, 0]}
+        strokeEnabled={false}
+        listening={false}
+      />
+      {renderBarrierInner(shape.variant, width, depth, markColor, edgeColor)}
+    </>
+  );
+}

--- a/src/components/canvas/renderers/shape2d/index.tsx
+++ b/src/components/canvas/renderers/shape2d/index.tsx
@@ -5,6 +5,7 @@ import { Group, Line, Rect, Text } from "react-konva";
 import { useTheme } from "@/hooks/useTheme";
 import type { Shape } from "@/lib/types";
 import { getShapeLocalBounds } from "../shape-bounds";
+export { renderBarrier } from "./barrier";
 export { renderCone } from "./cone";
 export { renderDiveGate } from "./divegate";
 export { renderFlag } from "./flag";
@@ -13,6 +14,7 @@ export { renderLabel } from "./label";
 export { renderLadder } from "./ladder";
 export { renderStartFinish } from "./startfinish";
 export { renderTower } from "./tower";
+import { renderBarrier } from "./barrier";
 import { renderCone } from "./cone";
 import { renderDiveGate } from "./divegate";
 import { renderFlag } from "./flag";
@@ -159,6 +161,7 @@ export function renderHoverIndicator(shape: Shape, ppm: number) {
 }
 
 export const shape2DRenderers: Shape2DRendererMap = {
+  barrier: renderBarrier,
   cone: renderCone,
   divegate: renderDiveGate,
   flag: renderFlag,

--- a/src/components/editor/tool-icons.tsx
+++ b/src/components/editor/tool-icons.tsx
@@ -84,6 +84,31 @@ function DiveGateIcon({ className }: { className?: string }) {
   );
 }
 
+function BarrierIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      {/* Wide banner panel */}
+      <rect x="1" y="2.5" width="12" height="7" rx="0.5" />
+      {/* Left support post */}
+      <line x1="3" y1="9.5" x2="3" y2="12.5" />
+      {/* Right support post */}
+      <line x1="11" y1="9.5" x2="11" y2="12.5" />
+      {/* Three chevron marks */}
+      <polyline points="3.5,4.2 4.8,6 3.5,7.8" strokeWidth="1.3" />
+      <polyline points="6.3,4.2 7.6,6 6.3,7.8" strokeWidth="1.3" />
+      <polyline points="9.1,4.2 10.4,6 9.1,7.8" strokeWidth="1.3" />
+    </svg>
+  );
+}
+
 function iconForTool(tool: EditorTool, className: string): ReactNode {
   switch (tool) {
     case "select":
@@ -100,6 +125,8 @@ function iconForTool(tool: EditorTool, className: string): ReactNode {
       return <TowerIcon className={className} />;
     case "divegate":
       return <DiveGateIcon className={className} />;
+    case "barrier":
+      return <BarrierIcon className={className} />;
     case "startfinish":
       return <Target className={className} />;
     case "flag":
@@ -157,6 +184,7 @@ export const toolbarToolGroups: ToolGroup[] = [
       buildToolEntry("ladder", "size-3.5"),
       buildToolEntry("tower", "size-3.5"),
       buildToolEntry("divegate", "size-3.5"),
+      buildToolEntry("barrier", "size-3.5"),
       buildToolEntry("flag", "size-3.5"),
       buildToolEntry("cone", "size-3.5"),
     ],
@@ -177,6 +205,7 @@ export const mobileToolEntries: ToolEntry[] = [
   buildToolEntry("ladder", "size-5"),
   buildToolEntry("tower", "size-5"),
   buildToolEntry("divegate", "size-5"),
+  buildToolEntry("barrier", "size-5"),
   buildToolEntry("startfinish", "size-5"),
   buildToolEntry("flag", "size-5"),
   buildToolEntry("cone", "size-5"),

--- a/src/components/inspector/sections/BarrierSection.tsx
+++ b/src/components/inspector/sections/BarrierSection.tsx
@@ -1,0 +1,41 @@
+import { MeasurementNum, Row } from "@/components/inspector/shared";
+import type { MeasurementUnitSystem } from "@/lib/track/units";
+import type { BarrierShape, Shape } from "@/lib/types";
+
+export function BarrierDimensionFields({
+  shape,
+  unitSystem,
+  unitLabel,
+  updateShape,
+  hasFixedCatalogDimensions,
+}: {
+  shape: BarrierShape;
+  unitSystem: MeasurementUnitSystem;
+  unitLabel: string;
+  updateShape: (id: string, patch: Partial<Shape>) => void;
+  hasFixedCatalogDimensions: boolean;
+}) {
+  if (hasFixedCatalogDimensions) return null;
+  return (
+    <>
+      <Row label={`Width (${unitLabel})`}>
+        <MeasurementNum
+          valueMeters={shape.width}
+          unitSystem={unitSystem}
+          onChange={(value) => updateShape(shape.id, { width: value })}
+          minMeters={0.3}
+        />
+      </Row>
+      <Row label={`Height (${unitLabel})`}>
+        <MeasurementNum
+          valueMeters={shape.height}
+          unitSystem={unitSystem}
+          onChange={(value) =>
+            updateShape(shape.id, { height: Math.max(0.1, value) })
+          }
+          minMeters={0.1}
+        />
+      </Row>
+    </>
+  );
+}

--- a/src/components/inspector/views/multi-selection.tsx
+++ b/src/components/inspector/views/multi-selection.tsx
@@ -120,6 +120,7 @@ export function MultiInspectorView({
       ladder: 0,
       tower: 0,
       divegate: 0,
+      barrier: 0,
     }
   );
   const polylineIds = selectedShapes

--- a/src/components/inspector/views/single-shape.tsx
+++ b/src/components/inspector/views/single-shape.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CatalogTypeSection } from "@/components/inspector/catalog/CatalogTypeSection";
+import { BarrierDimensionFields } from "@/components/inspector/sections/BarrierSection";
 import { ConeDimensionFields } from "@/components/inspector/sections/ConeDimensionFields";
 import { DiveGateDimensionFields } from "@/components/inspector/sections/DiveGateDimensionFields";
 import { FlagDimensionFields } from "@/components/inspector/sections/FlagDimensionFields";
@@ -65,7 +66,13 @@ import {
   InspectorScrollBody,
 } from "./layout";
 
-type SingleCatalogKind = "gate" | "flag" | "ladder" | "tower" | "divegate";
+type SingleCatalogKind =
+  | "gate"
+  | "flag"
+  | "ladder"
+  | "tower"
+  | "divegate"
+  | "barrier";
 
 function getSingleDefaultCatalogEntryId(
   kind: SingleCatalogKind
@@ -83,7 +90,8 @@ function getSingleCatalogKind(shape: Shape): SingleCatalogKind | null {
     shape.kind === "flag" ||
     shape.kind === "ladder" ||
     shape.kind === "tower" ||
-    shape.kind === "divegate"
+    shape.kind === "divegate" ||
+    shape.kind === "barrier"
   ) {
     return shape.kind;
   }
@@ -563,6 +571,15 @@ export function SingleInspectorView({
                 updateShape={updateShape}
                 hasFixedCatalogDimensions={hasFixedCatalogDimensions}
                 fixedDiveGateElevationVariant={fixedDiveGateElevationVariant}
+              />
+            )}
+            {shape.kind === "barrier" && (
+              <BarrierDimensionFields
+                shape={shape}
+                unitSystem={unitSystem}
+                unitLabel={unitLabel}
+                updateShape={updateShape}
+                hasFixedCatalogDimensions={hasFixedCatalogDimensions}
               />
             )}
           </Section>

--- a/src/lib/editor/catalog-type-patch.ts
+++ b/src/lib/editor/catalog-type-patch.ts
@@ -48,11 +48,14 @@ function buildCatalogTypePatchInner<S extends CatalogPatchShape>(
         Object.entries(shape.meta).filter(([k]) => k !== "catalog")
       )
     : {};
-  const newCatalogIdentity = createTrackElementCatalogIdentity(entry);
+  const newCatalogIdentity =
+    entry.official || entry.kind === "barrier"
+      ? createTrackElementCatalogIdentity(entry)
+      : undefined;
   const newMeta =
-    Object.keys(strippedMeta).length > 0
+    newCatalogIdentity || Object.keys(strippedMeta).length > 0
       ? { ...strippedMeta, catalog: newCatalogIdentity }
-      : { catalog: newCatalogIdentity };
+      : undefined;
 
   return { ...draft, meta: newMeta } as unknown as Partial<S>;
 }

--- a/src/lib/editor/catalog-type-patch.ts
+++ b/src/lib/editor/catalog-type-patch.ts
@@ -11,6 +11,7 @@ import {
   hasCatalogPlacement,
 } from "@/lib/track/items/registry";
 import type {
+  BarrierShape,
   DiveGateShape,
   FlagShape,
   GateShape,
@@ -24,7 +25,8 @@ type CatalogPatchShape =
   | FlagShape
   | LadderShape
   | TowerShape
-  | DiveGateShape;
+  | DiveGateShape
+  | BarrierShape;
 
 function isCatalogPatchShape(shape: Shape): shape is CatalogPatchShape {
   return hasCatalogPlacement(shape.kind);
@@ -46,13 +48,11 @@ function buildCatalogTypePatchInner<S extends CatalogPatchShape>(
         Object.entries(shape.meta).filter(([k]) => k !== "catalog")
       )
     : {};
-  const newCatalogIdentity = entry.official
-    ? createTrackElementCatalogIdentity(entry)
-    : undefined;
+  const newCatalogIdentity = createTrackElementCatalogIdentity(entry);
   const newMeta =
-    newCatalogIdentity || Object.keys(strippedMeta).length > 0
+    Object.keys(strippedMeta).length > 0
       ? { ...strippedMeta, catalog: newCatalogIdentity }
-      : undefined;
+      : { catalog: newCatalogIdentity };
 
   return { ...draft, meta: newMeta } as unknown as Partial<S>;
 }
@@ -151,4 +151,14 @@ export function buildDiveGateCatalogTypePatch(
     shape,
     targetEntryId
   ) as Partial<DiveGateShape> | null;
+}
+
+export function buildBarrierCatalogTypePatch(
+  shape: BarrierShape,
+  targetEntryId: TrackElementCatalogId
+): Partial<BarrierShape> | null {
+  return buildCatalogTypePatch(
+    shape,
+    targetEntryId
+  ) as Partial<BarrierShape> | null;
 }

--- a/src/lib/editor/tool-registry.ts
+++ b/src/lib/editor/tool-registry.ts
@@ -70,9 +70,11 @@ export function createShapeForTool(
     defaultEntry && entry?.kind !== defaultEntry.kind
       ? (defaultForTool ?? entryId)
       : entryId;
+  const resolvedEntry = getTrackElementCatalogEntry(resolvedEntryId);
   return createCatalogShapeDraft(resolvedEntryId, {
     x: point.x,
     y: point.y,
-    includeCatalogMetadata: true,
+    includeCatalogMetadata:
+      resolvedEntry?.official === true || resolvedEntry?.kind === "barrier",
   });
 }

--- a/src/lib/editor/tool-registry.ts
+++ b/src/lib/editor/tool-registry.ts
@@ -70,11 +70,9 @@ export function createShapeForTool(
     defaultEntry && entry?.kind !== defaultEntry.kind
       ? (defaultForTool ?? entryId)
       : entryId;
-  const resolvedEntry = getTrackElementCatalogEntry(resolvedEntryId);
-
   return createCatalogShapeDraft(resolvedEntryId, {
     x: point.x,
     y: point.y,
-    includeCatalogMetadata: resolvedEntry?.official === true,
+    includeCatalogMetadata: true,
   });
 }

--- a/src/lib/export/exportSvg.ts
+++ b/src/lib/export/exportSvg.ts
@@ -1,4 +1,5 @@
 import type {
+  BarrierShape,
   TrackDesign,
   Shape,
   ShapeKind,
@@ -27,6 +28,7 @@ import {
   getLadder2DShape,
   getTower2DShape,
 } from "../track/shape2d";
+import { barrierToSvg } from "./svg/barrier";
 import { coneToSvg } from "./svg/cone";
 import { diveGateToSvg } from "./svg/divegate";
 import { flagToSvg } from "./svg/flag";
@@ -48,6 +50,7 @@ const shapeToSvgDispatch: Record<
   ShapeKind,
   (shape: Shape, ppm: number, primaryPolylineId: string | null) => string
 > = {
+  barrier: (shape, ppm) => barrierToSvg(shape as BarrierShape, ppm),
   gate: (shape, ppm) => gateToSvg(shape as GateShape, ppm),
   flag: (shape, ppm) => flagToSvg(shape as FlagShape, ppm),
   cone: (shape, ppm) => coneToSvg(shape as ConeShape, ppm),

--- a/src/lib/export/flythrough/barrier.ts
+++ b/src/lib/export/flythrough/barrier.ts
@@ -81,7 +81,7 @@ function getBarrierDefaultColor(variant: BarrierShape["variant"]): string {
     case "banner":
       return "#ec4899";
     case "fence":
-      return "#84cc16";
+      return "#94a3b8";
     case "net":
       return "#06b6d4";
   }

--- a/src/lib/export/flythrough/barrier.ts
+++ b/src/lib/export/flythrough/barrier.ts
@@ -1,0 +1,88 @@
+import * as THREE from "three";
+import type { BarrierShape } from "@/lib/types";
+
+export function addBarrierSceneShapes(
+  shape: BarrierShape,
+  scene: THREE.Scene
+): void {
+  const color = new THREE.Color(
+    shape.color ?? getBarrierDefaultColor(shape.variant)
+  );
+  const w = shape.width;
+  const h = shape.height;
+  const rotY = (-shape.rotation * Math.PI) / 180;
+
+  const group = new THREE.Group();
+  group.position.set(shape.x, 0, shape.y);
+  group.rotation.y = rotY;
+
+  if (shape.variant === "hurdle") {
+    const barGeo = new THREE.BoxGeometry(w, 0.06, 0.06);
+    const barMat = new THREE.MeshStandardMaterial({ color, roughness: 0.7 });
+    const bar = new THREE.Mesh(barGeo, barMat);
+    bar.position.set(0, h, 0);
+    group.add(bar);
+
+    const postGeo = new THREE.CylinderGeometry(0.04, 0.04, h, 8);
+    const postMat = new THREE.MeshStandardMaterial({ color, roughness: 0.7 });
+    [-w / 2, w / 2].forEach((x) => {
+      const post = new THREE.Mesh(postGeo, postMat);
+      post.position.set(x, h / 2, 0);
+      group.add(post);
+    });
+  } else if (shape.variant === "banner") {
+    const panelGeo = new THREE.BoxGeometry(w, h, 0.04);
+    const panelMat = new THREE.MeshStandardMaterial({
+      color,
+      roughness: 0.6,
+      transparent: true,
+      opacity: 0.82,
+    });
+    const panel = new THREE.Mesh(panelGeo, panelMat);
+    panel.position.set(0, h / 2, 0);
+    group.add(panel);
+  } else if (shape.variant === "fence") {
+    const railGeo = new THREE.BoxGeometry(w, 0.04, 0.04);
+    const mat = new THREE.MeshStandardMaterial({ color, roughness: 0.7 });
+    [h - 0.02, h / 2].forEach((y) => {
+      const rail = new THREE.Mesh(railGeo, mat);
+      rail.position.set(0, y, 0);
+      group.add(rail);
+    });
+    const postCount = Math.max(2, Math.round(w / 1.5) + 1);
+    const postGeo = new THREE.CylinderGeometry(0.04, 0.04, h, 8);
+    for (let i = 0; i < postCount; i++) {
+      const x = -w / 2 + (w / (postCount - 1)) * i;
+      const post = new THREE.Mesh(postGeo, mat);
+      post.position.set(x, h / 2, 0);
+      group.add(post);
+    }
+  } else {
+    // net
+    const netGeo = new THREE.BoxGeometry(w, h, 0.025);
+    const netMat = new THREE.MeshStandardMaterial({
+      color,
+      roughness: 0.5,
+      transparent: true,
+      opacity: 0.55,
+    });
+    const net = new THREE.Mesh(netGeo, netMat);
+    net.position.set(0, h / 2, 0);
+    group.add(net);
+  }
+
+  scene.add(group);
+}
+
+function getBarrierDefaultColor(variant: BarrierShape["variant"]): string {
+  switch (variant) {
+    case "hurdle":
+      return "#f59e0b";
+    case "banner":
+      return "#ec4899";
+    case "fence":
+      return "#84cc16";
+    case "net":
+      return "#06b6d4";
+  }
+}

--- a/src/lib/export/flythroughSceneShapes.ts
+++ b/src/lib/export/flythroughSceneShapes.ts
@@ -1,5 +1,6 @@
 import * as THREE from "three";
 import type {
+  BarrierShape,
   ConeShape,
   DiveGateShape,
   FlagShape,
@@ -10,6 +11,7 @@ import type {
   StartFinishShape,
   TowerShape,
 } from "@/lib/types";
+import { addBarrierSceneShapes } from "./flythrough/barrier";
 import { addGateSceneShapes } from "./flythrough/gate";
 import { addTowerSceneShapes } from "./flythrough/tower";
 import { addLadderSceneShapes } from "./flythrough/ladder";
@@ -24,6 +26,8 @@ type FlythroughRenderer = (
 ) => Promise<void> | void;
 
 const flythroughRenderers: Record<ShapeKind, FlythroughRenderer> = {
+  barrier: (shape, scene) =>
+    addBarrierSceneShapes(shape as BarrierShape, scene),
   gate: (shape, scene) => addGateSceneShapes(shape as GateShape, scene),
   tower: (shape, scene) => addTowerSceneShapes(shape as TowerShape, scene),
   ladder: (shape, scene) => addLadderSceneShapes(shape as LadderShape, scene),

--- a/src/lib/export/svg/barrier.ts
+++ b/src/lib/export/svg/barrier.ts
@@ -1,0 +1,76 @@
+import { getBarrier2DShape } from "@/lib/track/shape2d";
+import type { BarrierShape } from "@/lib/types";
+import { m } from "./utils";
+
+export function barrierToSvg(s: BarrierShape, ppm: number): string {
+  const cx = m(s.x, ppm);
+  const cy = m(s.y, ppm);
+  const { color, depth, radius, variant, width } = getBarrier2DShape(s, ppm);
+  const x = cx - width / 2;
+  const y = cy - depth / 2;
+  const r = radius;
+
+  const fill = `fill="${color}" fill-opacity="0.16"`;
+  const stroke = `stroke="${color}" stroke-width="1.5" fill="none"`;
+  const rect = (attrs: string) =>
+    `<rect x="${x}" y="${y}" width="${width}" height="${depth}" rx="${r}" ${attrs}/>`;
+
+  const inner = getBarrierInnerSvg(variant, cx, cy, width, depth, color);
+
+  return `<g transform="rotate(${s.rotation},${cx},${cy})">
+    ${rect(fill)}
+    ${rect(stroke)}
+    ${inner}
+  </g>`;
+}
+
+function getBarrierInnerSvg(
+  variant: BarrierShape["variant"],
+  cx: number,
+  cy: number,
+  width: number,
+  height: number,
+  color: string
+): string {
+  const hw = width / 2;
+  const hh = height / 2;
+
+  if (variant === "hurdle") {
+    const stripeCount = Math.max(2, Math.floor(width / 12));
+    const spacing = width / stripeCount;
+    return Array.from({ length: stripeCount - 1 }, (_, i) => {
+      const sx = cx - hw + spacing * (i + 1);
+      return `<line x1="${sx - hh}" y1="${cy - hh}" x2="${sx + hh}" y2="${cy + hh}" stroke="${color}" stroke-width="0.8" opacity="0.5"/>`;
+    }).join("\n    ");
+  }
+
+  if (variant === "fence") {
+    const postCount = Math.max(2, Math.floor(width / 14));
+    const spacing = width / postCount;
+    return Array.from({ length: postCount - 1 }, (_, i) => {
+      const px = cx - hw + spacing * (i + 1);
+      return `<line x1="${px}" y1="${cy - hh}" x2="${px}" y2="${cy + hh}" stroke="${color}" stroke-width="0.8" opacity="0.5"/>`;
+    }).join("\n    ");
+  }
+
+  if (variant === "net") {
+    const colCount = Math.max(2, Math.floor(width / 14));
+    const colSpacing = width / colCount;
+    const cols = Array.from({ length: colCount - 1 }, (_, i) => {
+      const px = cx - hw + colSpacing * (i + 1);
+      return `<line x1="${px}" y1="${cy - hh}" x2="${px}" y2="${cy + hh}" stroke="${color}" stroke-width="0.6" opacity="0.4"/>`;
+    }).join("\n    ");
+    const hLine = `<line x1="${cx - hw}" y1="${cy}" x2="${cx + hw}" y2="${cy}" stroke="${color}" stroke-width="0.6" opacity="0.4"/>`;
+    return `${cols}\n    ${hLine}`;
+  }
+
+  // banner: chevron arrow marks
+  const arrowCount = Math.max(3, Math.floor(width / 13));
+  const spacing = width / (arrowCount + 1);
+  const arm = hh * 0.65;
+  const tip = spacing * 0.3;
+  return Array.from({ length: arrowCount }, (_, i) => {
+    const ax = cx - hw + spacing * (i + 1);
+    return `<polyline points="${ax - tip},${cy - arm} ${ax + tip},${cy} ${ax - tip},${cy + arm}" stroke="${color}" stroke-width="1.2" fill="none" stroke-linejoin="round" opacity="0.5"/>`;
+  }).join("\n    ");
+}

--- a/src/lib/planning/inventory.ts
+++ b/src/lib/planning/inventory.ts
@@ -16,6 +16,7 @@ export function createEmptyInventoryProfile(): InventoryProfile {
     startfinish: 0,
     flag: 0,
     cone: 0,
+    barrier: 0,
   };
 }
 

--- a/src/lib/track/elements/catalog.ts
+++ b/src/lib/track/elements/catalog.ts
@@ -1,6 +1,12 @@
 import { feetToMeters, type MeasurementUnitSystem } from "@/lib/track/units";
-import type { PolylineShape, Shape, ShapeDraft } from "@/lib/types";
+import type {
+  BarrierVariant,
+  PolylineShape,
+  Shape,
+  ShapeDraft,
+} from "@/lib/types";
 
+// TrackDraw generic elements
 export const TRACKDRAW_GATE_ELEMENT_ID = "trackdraw-generic-gate";
 export const TRACKDRAW_FLAG_ELEMENT_ID = "trackdraw-generic-flag";
 export const TRACKDRAW_CONE_ELEMENT_ID = "trackdraw-generic-cone";
@@ -10,7 +16,11 @@ export const TRACKDRAW_START_FINISH_ELEMENT_ID =
 export const TRACKDRAW_LADDER_ELEMENT_ID = "trackdraw-generic-ladder";
 export const TRACKDRAW_DIVE_GATE_ELEMENT_ID = "trackdraw-generic-dive-gate";
 export const TRACKDRAW_TOWER_ELEMENT_ID = "trackdraw-generic-tower";
+export const TRACKDRAW_BANNER_ELEMENT_ID = "trackdraw-generic-banner";
+export const TRACKDRAW_FENCE_ELEMENT_ID = "trackdraw-generic-fence";
+export const TRACKDRAW_NET_ELEMENT_ID = "trackdraw-generic-net";
 
+// MultiGP elements
 export const MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID = "multigp-standard-gate-5x5";
 export const MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID =
   "multigp-championship-gate-7x6";
@@ -29,8 +39,10 @@ export const MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID =
   "multigp-topless-ladder-7x6";
 export const MULTIGP_DIVE_GATE_7X6_ELEMENT_ID = "multigp-dive-gate-7x6";
 export const MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID = "multigp-launch-gate-7x6";
+export const MULTIGP_HURDLE_ELEMENT_ID = "multigp-hurdle";
 
 export type TrackElementCatalogId =
+  // TrackDraw
   | typeof TRACKDRAW_GATE_ELEMENT_ID
   | typeof TRACKDRAW_FLAG_ELEMENT_ID
   | typeof TRACKDRAW_CONE_ELEMENT_ID
@@ -39,6 +51,10 @@ export type TrackElementCatalogId =
   | typeof TRACKDRAW_LADDER_ELEMENT_ID
   | typeof TRACKDRAW_DIVE_GATE_ELEMENT_ID
   | typeof TRACKDRAW_TOWER_ELEMENT_ID
+  | typeof TRACKDRAW_BANNER_ELEMENT_ID
+  | typeof TRACKDRAW_FENCE_ELEMENT_ID
+  | typeof TRACKDRAW_NET_ELEMENT_ID
+  // MultiGP
   | typeof MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID
   | typeof MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID
   | typeof MULTIGP_TOWER_5X5_ELEMENT_ID
@@ -50,7 +66,8 @@ export type TrackElementCatalogId =
   | typeof MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID
   | typeof MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID
   | typeof MULTIGP_DIVE_GATE_7X6_ELEMENT_ID
-  | typeof MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID;
+  | typeof MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID
+  | typeof MULTIGP_HURDLE_ELEMENT_ID;
 
 type PlaceableCatalogShape = Exclude<Shape, PolylineShape>;
 export type TrackElementShapeDraft = ShapeDraft<PlaceableCatalogShape>;
@@ -213,12 +230,24 @@ export interface LaunchGateVisualSpec {
 
 export type DiveGateVisualSpec = ArchDiveGateVisualSpec | LaunchGateVisualSpec;
 
+export interface BannerBarrierVisualSpec {
+  kind: "barrier";
+  variant: "banner";
+  panel: {
+    color: string;
+    texture: string;
+  };
+}
+
+export type BarrierVisualSpec = BannerBarrierVisualSpec;
+
 export type TrackElementVisualSpec =
   | GateVisualSpec
   | FlagVisualSpec
   | LadderVisualSpec
   | TowerVisualSpec
-  | DiveGateVisualSpec;
+  | DiveGateVisualSpec
+  | BarrierVisualSpec;
 
 export interface TrackElementCatalogEntry {
   id: TrackElementCatalogId;
@@ -275,7 +304,8 @@ function isPlaceableCatalogShapeKind(
     value === "label" ||
     value === "startfinish" ||
     value === "ladder" ||
-    value === "divegate"
+    value === "divegate" ||
+    value === "barrier"
   );
 }
 
@@ -1186,6 +1216,123 @@ export const trackElementCatalog = [
     } satisfies DiveGateVisualSpec,
     exportHints: { simulatorFriendly: true },
   },
+  {
+    id: TRACKDRAW_BANNER_ELEMENT_ID,
+    name: "TrackDraw Banner",
+    organization: "TrackDraw",
+    kind: "barrier",
+    dimensions: {
+      widthMeters: 3,
+      heightMeters: 2,
+      display: { unitSystem: "metric", label: "3 × 2 m" },
+    },
+    defaultShape: {
+      kind: "barrier",
+      variant: "banner" as BarrierVariant,
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: 3,
+      height: 2,
+      color: "#ec4899",
+    },
+    tags: ["boundary", "banner"],
+    render2d: { icon: "barrier" },
+    render3d: { modelHint: "barrier-banner" },
+    exportHints: { simulatorFriendly: false },
+  },
+  {
+    id: TRACKDRAW_FENCE_ELEMENT_ID,
+    name: "TrackDraw Fence",
+    organization: "TrackDraw",
+    kind: "barrier",
+    dimensions: {
+      widthMeters: 3,
+      heightMeters: 1.2,
+      display: { unitSystem: "metric", label: "3 × 1.2 m" },
+    },
+    defaultShape: {
+      kind: "barrier",
+      variant: "fence" as BarrierVariant,
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: 3,
+      height: 1.2,
+      color: "#94a3b8",
+    },
+    tags: ["boundary", "fence"],
+    render2d: { icon: "barrier" },
+    render3d: { modelHint: "barrier-fence" },
+    exportHints: { simulatorFriendly: false },
+  },
+  {
+    id: TRACKDRAW_NET_ELEMENT_ID,
+    name: "TrackDraw Net",
+    organization: "TrackDraw",
+    kind: "barrier",
+    dimensions: {
+      widthMeters: 3,
+      heightMeters: 2,
+      display: { unitSystem: "metric", label: "3 × 2 m" },
+    },
+    defaultShape: {
+      kind: "barrier",
+      variant: "net" as BarrierVariant,
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: 3,
+      height: 2,
+      color: "#06b6d4",
+    },
+    tags: ["boundary", "net"],
+    render2d: { icon: "barrier" },
+    render3d: { modelHint: "barrier-net" },
+    exportHints: { simulatorFriendly: false },
+  },
+  {
+    id: MULTIGP_HURDLE_ELEMENT_ID,
+    name: "MultiGP Hurdle",
+    organization: "MultiGP",
+    kind: "barrier",
+    official: true,
+    editable: { color: false, dimensions: false },
+    dimensions: {
+      widthMeters: feetToMeters(10),
+      heightMeters: feetToMeters(5),
+      display: { unitSystem: "imperial", label: "10 ft wide, 5 ft tall" },
+    },
+    defaultShape: {
+      kind: "barrier",
+      variant: "banner" as BarrierVariant,
+      x: 0,
+      y: 0,
+      rotation: 0,
+      width: feetToMeters(10),
+      height: feetToMeters(5),
+      color: "#1e3a8a",
+    },
+    tags: ["hurdle", "fly-over", "multigp"],
+    sources: [
+      {
+        label: "MultiGP Drone Race Course Obstacles",
+        url: "https://www.multigp.com/multigp-drone-race-course-obstacles/",
+      },
+    ],
+    render2d: { icon: "barrier" },
+    render3d: { modelHint: "barrier-banner" },
+    visual: {
+      kind: "barrier",
+      variant: "banner",
+      panel: {
+        color: "#1e3a8a",
+        texture:
+          "/assets/models/textures/multigp-obstacles/5x10-hurdle-multigp.webp",
+      },
+    } satisfies BarrierVisualSpec,
+    exportHints: { simulatorFriendly: false },
+  },
 ] satisfies TrackElementCatalogEntry[];
 
 const trackElementCatalogMap = new Map(
@@ -1220,6 +1367,11 @@ export function getTrackElementCatalogTexturePaths(): string[] {
     if (visual.kind === "divegate") {
       paths.add(visual.banner.sideTexture);
       paths.add(visual.banner.topTexture);
+      continue;
+    }
+
+    if (visual.kind === "barrier") {
+      paths.add(visual.panel.texture);
     }
   }
 

--- a/src/lib/track/elements/visual.ts
+++ b/src/lib/track/elements/visual.ts
@@ -1,4 +1,5 @@
 import type {
+  BarrierShape,
   TowerShape,
   DiveGateShape,
   FlagShape,
@@ -11,6 +12,7 @@ import {
   TRACKDRAW_TOWER_ELEMENT_ID,
   getTrackElementCatalogEntry,
   getTrackElementCatalogIdentity,
+  type BarrierVisualSpec,
   type DiveGateVisualSpec,
   type TowerVisualSpec,
   type FrameOnlyGateVisualSpec,
@@ -138,6 +140,14 @@ export function getDiveGateElevationMin(shape: DiveGateShape): number {
 export function getDiveGateElevationMax(shape: DiveGateShape): number | null {
   const entry = getTrackElementCatalogEntry(getDiveGateEntryId(shape));
   return entry?.elevationMaxMeters ?? null;
+}
+
+export function getBarrierVisualSpec(
+  shape: BarrierShape
+): BarrierVisualSpec | null {
+  const visual = getTrackElementVisualSpec(shape);
+  if (visual?.kind === "barrier") return visual;
+  return null;
 }
 
 function getFallbackGateVisualSpec(shape: GateShape): FrameOnlyGateVisualSpec {

--- a/src/lib/track/items/registry.ts
+++ b/src/lib/track/items/registry.ts
@@ -1,4 +1,5 @@
 import {
+  TRACKDRAW_BANNER_ELEMENT_ID,
   TRACKDRAW_CONE_ELEMENT_ID,
   TRACKDRAW_DIVE_GATE_ELEMENT_ID,
   TRACKDRAW_FLAG_ELEMENT_ID,
@@ -29,7 +30,8 @@ export type TrackItemToolId =
   | "startfinish"
   | "ladder"
   | "tower"
-  | "divegate";
+  | "divegate"
+  | "barrier";
 
 export type CatalogPlacementToolId = Exclude<TrackItemToolId, "polyline">;
 
@@ -286,6 +288,32 @@ export const trackItemAdapters = [
         complexity: "heavy" as const,
       };
     },
+  },
+  {
+    kind: "barrier",
+    label: "Barrier",
+    inventory: true,
+    tool: {
+      id: "barrier",
+      label: "Barrier",
+      mobileLabel: "Barrier",
+      shortcut: "B",
+      defaultCatalogEntryId: TRACKDRAW_BANNER_ELEMENT_ID,
+      catalogPlacement: true,
+    },
+    orientation: { facing: 0, canvasGuide: 90, previewGuide: 0 },
+    numberedObstacle: false,
+    setupHardObstacle: false,
+    rotateHandle3d: true,
+    canvasRenderRotationOffsetDeg: 180,
+    routeToleranceWidthFactor: 0,
+    getSetupProfile: () => ({
+      priority: 4,
+      prepMinutes: 2,
+      placeMinutes: 2,
+      note: "Set up barriers after the main gates and obstacles are positioned.",
+      complexity: "standard" as const,
+    }),
   },
 ] satisfies TrackItemAdapter[];
 

--- a/src/lib/track/orientation.ts
+++ b/src/lib/track/orientation.ts
@@ -1,4 +1,5 @@
 import type {
+  BarrierShape,
   DiveGateShape,
   FlagShape,
   GateShape,
@@ -41,7 +42,8 @@ type OrientationShape =
   | StartFinishShape
   | DiveGateShape
   | FlagShape
-  | LabelShape;
+  | LabelShape
+  | BarrierShape;
 
 export function resolveShapeOrientationDegrees(
   shape: OrientationShape,

--- a/src/lib/track/shape2d.ts
+++ b/src/lib/track/shape2d.ts
@@ -10,6 +10,7 @@ import {
   getMultiGpLaunchGateLayout,
 } from "@/lib/track/render3d-layout";
 import type {
+  BarrierShape,
   ConeShape,
   TowerShape,
   DiveGateShape,
@@ -208,6 +209,27 @@ export function getTower2DShape(shape: TowerShape, ppm: number) {
     variant: "frame-only" as const,
     width: openingWidth,
   };
+}
+
+export function getBarrier2DShape(shape: BarrierShape, ppm: number) {
+  const width = m2px(shape.width, ppm);
+  const depth = Math.max(m2px(0.15, ppm), 6);
+  const radius = Math.min(4, depth / 4);
+  const color = shape.color ?? getBarrierDefaultColor(shape.variant);
+  return { color, depth, radius, variant: shape.variant, width };
+}
+
+function getBarrierDefaultColor(variant: BarrierShape["variant"]): string {
+  switch (variant) {
+    case "hurdle":
+      return "#f59e0b";
+    case "banner":
+      return "#ec4899";
+    case "fence":
+      return "#94a3b8";
+    case "net":
+      return "#06b6d4";
+  }
 }
 
 export function getDiveGateArchPanelPath(options: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,11 +9,12 @@ export type ShapeKind =
   | "polyline"
   | "startfinish"
   | "ladder"
-  | "divegate";
+  | "divegate"
+  | "barrier";
 
 export type InventoryShapeKind = Extract<
   ShapeKind,
-  "gate" | "flag" | "cone" | "startfinish" | "ladder" | "divegate"
+  "gate" | "flag" | "cone" | "startfinish" | "ladder" | "divegate" | "barrier"
 >;
 
 export type InventoryProfile = Record<InventoryShapeKind, number>;
@@ -87,6 +88,15 @@ export interface DiveGateShape extends BaseShape {
   elevation?: number; // m height of frame center above ground (generic variant, default 3.0)
 }
 
+export type BarrierVariant = "hurdle" | "banner" | "fence" | "net";
+
+export interface BarrierShape extends BaseShape {
+  kind: "barrier";
+  variant: BarrierVariant;
+  width: number; // m horizontal span
+  height: number; // m height above ground (top of barrier)
+}
+
 export interface PolylinePoint {
   x: number;
   y: number;
@@ -112,7 +122,8 @@ export type Shape =
   | PolylineShape
   | StartFinishShape
   | LadderShape
-  | DiveGateShape;
+  | DiveGateShape
+  | BarrierShape;
 
 export type ShapeDraft<T extends Shape = Shape> = T extends Shape
   ? Omit<T, "id">

--- a/tests/components/canvas/TrackPreview3D.editor.test.tsx
+++ b/tests/components/canvas/TrackPreview3D.editor.test.tsx
@@ -150,6 +150,7 @@ const inventory = {
   startfinish: 0,
   flag: 0,
   cone: 0,
+  barrier: 0,
 };
 
 function createPreviewDesign(routeLocked: boolean) {

--- a/tests/components/canvas/TrackPreview3D.large.test.tsx
+++ b/tests/components/canvas/TrackPreview3D.large.test.tsx
@@ -99,6 +99,7 @@ const inventory = {
   startfinish: 0,
   flag: 0,
   cone: 0,
+  barrier: 0,
 };
 
 function createDensePreviewDesign() {

--- a/tests/lib/editor/tool-registry-and-catalog-type-patch.test.ts
+++ b/tests/lib/editor/tool-registry-and-catalog-type-patch.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCatalogTypePatch,
+  buildBarrierCatalogTypePatch,
   buildGateCatalogTypePatch,
   buildLadderCatalogTypePatch,
   buildTowerCatalogTypePatch,
@@ -20,12 +21,19 @@ import {
   MULTIGP_DOUBLE_GATE_TOWER_5X5_ELEMENT_ID,
   MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
   MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID,
+  TRACKDRAW_BANNER_ELEMENT_ID,
+  TRACKDRAW_FENCE_ELEMENT_ID,
   TRACKDRAW_FLAG_ELEMENT_ID,
   TRACKDRAW_GATE_ELEMENT_ID,
   TRACKDRAW_LADDER_ELEMENT_ID,
   TRACKDRAW_TOWER_ELEMENT_ID,
 } from "@/lib/track/elements/catalog";
-import type { GateShape, LadderShape, TowerShape } from "@/lib/types";
+import type {
+  BarrierShape,
+  GateShape,
+  LadderShape,
+  TowerShape,
+} from "@/lib/types";
 import { feetToMeters } from "@/lib/track/units";
 
 describe("editor tool helpers", () => {
@@ -131,6 +139,30 @@ describe("editor tool helpers", () => {
           elementId: MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
           assignedKind: "gate",
           official: true,
+        },
+      },
+    });
+  });
+
+  it("keeps catalog identity for generic barrier variants", () => {
+    const shape = createShapeForTool(
+      "barrier",
+      { x: 6, y: 8 },
+      {
+        activePlacementElementId: {
+          barrier: TRACKDRAW_FENCE_ELEMENT_ID,
+        },
+      }
+    );
+
+    expect(shape).toMatchObject({
+      kind: "barrier",
+      variant: "fence",
+      meta: {
+        catalog: {
+          elementId: TRACKDRAW_FENCE_ELEMENT_ID,
+          assignedKind: "barrier",
+          official: false,
         },
       },
     });
@@ -342,5 +374,36 @@ describe("buildLadderCatalogTypePatch", () => {
       color: "#14b8a6",
     });
     expect(patch?.meta?.catalog).toBeUndefined();
+  });
+});
+
+describe("buildBarrierCatalogTypePatch", () => {
+  it("switches between generic barrier variants and keeps catalog identity", () => {
+    const bannerShape = createCatalogShapeDraft(TRACKDRAW_BANNER_ELEMENT_ID, {
+      x: 3,
+      y: 4,
+      rotation: 45,
+      includeCatalogMetadata: true,
+    }) as BarrierShape & { id: string };
+    bannerShape.id = "barrier-1";
+
+    const patch = buildBarrierCatalogTypePatch(
+      bannerShape,
+      TRACKDRAW_FENCE_ELEMENT_ID
+    );
+
+    expect(patch).toMatchObject({
+      kind: "barrier",
+      variant: "fence",
+      x: 3,
+      y: 4,
+      rotation: 45,
+      meta: {
+        catalog: expect.objectContaining({
+          elementId: TRACKDRAW_FENCE_ELEMENT_ID,
+          official: false,
+        }),
+      },
+    });
   });
 });

--- a/tests/lib/export/exportPdf.test.ts
+++ b/tests/lib/export/exportPdf.test.ts
@@ -87,6 +87,7 @@ const inventory = {
   startfinish: 0,
   flag: 0,
   cone: 0,
+  barrier: 0,
 };
 
 function createDensePracticalDesign() {

--- a/tests/lib/export/exportPng.test.ts
+++ b/tests/lib/export/exportPng.test.ts
@@ -11,6 +11,7 @@ const inventory = {
   startfinish: 0,
   flag: 0,
   cone: 0,
+  barrier: 0,
 };
 
 function createDensePracticalDesign() {

--- a/tests/lib/export/exportSvg.test.ts
+++ b/tests/lib/export/exportSvg.test.ts
@@ -12,6 +12,7 @@ const inventory = {
   startfinish: 0,
   flag: 0,
   cone: 0,
+  barrier: 0,
 };
 
 function createDesign() {

--- a/tests/lib/export/exportVelocidroneTrk.test.ts
+++ b/tests/lib/export/exportVelocidroneTrk.test.ts
@@ -16,6 +16,7 @@ const inventory = {
   startfinish: 0,
   flag: 0,
   cone: 0,
+  barrier: 0,
 };
 
 function createVelocidroneReadyDesign() {

--- a/tests/lib/planning/inventory.test.ts
+++ b/tests/lib/planning/inventory.test.ts
@@ -16,6 +16,7 @@ describe("planning inventory helpers", () => {
       startfinish: 0,
       flag: 0,
       cone: 0,
+      barrier: 0,
     });
 
     expect(
@@ -32,6 +33,7 @@ describe("planning inventory helpers", () => {
       startfinish: 0,
       flag: 4,
       cone: 0,
+      barrier: 0,
     });
   });
 
@@ -60,6 +62,7 @@ describe("planning inventory helpers", () => {
       gate: 1,
       flag: 1,
       cone: 0,
+      barrier: 0,
     });
 
     const design = normalizeDesign({
@@ -76,6 +79,7 @@ describe("planning inventory helpers", () => {
         startfinish: 0,
         flag: 0,
         cone: 0,
+        barrier: 0,
       },
       field: { width: 60, height: 40, origin: "tl", gridStep: 1, ppm: 20 },
       shapes,
@@ -104,6 +108,7 @@ describe("planning inventory helpers", () => {
         startfinish: 0,
         flag: 2,
         cone: 0,
+        barrier: 0,
       },
       field: { width: 60, height: 40, origin: "tl", gridStep: 1, ppm: 20 },
       shapes: [

--- a/tests/lib/planning/setup-estimate.test.ts
+++ b/tests/lib/planning/setup-estimate.test.ts
@@ -9,6 +9,7 @@ const inventory = {
   startfinish: 1,
   ladder: 1,
   divegate: 1,
+  barrier: 0,
 };
 
 describe("setup estimate helpers", () => {
@@ -130,6 +131,7 @@ describe("setup estimate helpers", () => {
         startfinish: 1,
         ladder: 0,
         divegate: 0,
+        barrier: 0,
       },
       field: { width: 60, height: 40, origin: "tl", gridStep: 1, ppm: 20 },
       shapes: [

--- a/tests/lib/server/api-projects.test.ts
+++ b/tests/lib/server/api-projects.test.ts
@@ -18,6 +18,7 @@ const inventory = {
   startfinish: 0,
   ladder: 0,
   divegate: 0,
+  barrier: 0,
 };
 
 function makeDesign(shapes: Shape[]): TrackDesign {

--- a/tests/lib/track/alt.test.ts
+++ b/tests/lib/track/alt.test.ts
@@ -9,6 +9,7 @@ const inventory = {
   startfinish: 0,
   ladder: 0,
   divegate: 0,
+  barrier: 0,
 };
 
 describe("track altitude helpers", () => {

--- a/tests/lib/track/design.test.ts
+++ b/tests/lib/track/design.test.ts
@@ -17,6 +17,7 @@ const inventory = {
   startfinish: 0,
   ladder: 0,
   divegate: 0,
+  barrier: 0,
 };
 
 describe("track design helpers", () => {

--- a/tests/lib/track/items/registry.test.ts
+++ b/tests/lib/track/items/registry.test.ts
@@ -18,6 +18,7 @@ const shapeKinds: ShapeKind[] = [
   "startfinish",
   "ladder",
   "divegate",
+  "barrier",
 ];
 
 describe("track item adapters", () => {
@@ -64,6 +65,7 @@ describe("getInventoryKinds", () => {
     expect(inventoryKinds).toContain("startfinish");
     expect(inventoryKinds).toContain("ladder");
     expect(inventoryKinds).toContain("divegate");
+    expect(inventoryKinds).toContain("barrier");
   });
 
   it("excludes non-inventory kinds", () => {

--- a/tests/lib/track/obstacleNumbering.test.ts
+++ b/tests/lib/track/obstacleNumbering.test.ts
@@ -13,6 +13,7 @@ const inventory = {
   startfinish: 1,
   ladder: 2,
   divegate: 2,
+  barrier: 0,
 };
 
 function makeDesign(shapes: Shape[]): TrackDesign {

--- a/tests/lib/track/overlay-prep.test.ts
+++ b/tests/lib/track/overlay-prep.test.ts
@@ -10,6 +10,7 @@ const inventory = {
   startfinish: 0,
   flag: 0,
   cone: 0,
+  barrier: 0,
 };
 
 const raceLine: Shape = {

--- a/tests/lib/track/shape-groups.test.ts
+++ b/tests/lib/track/shape-groups.test.ts
@@ -23,6 +23,7 @@ describe("shape group helpers", () => {
       startfinish: 0,
       flag: 0,
       cone: 0,
+      barrier: 0,
     },
     field: { width: 60, height: 40, origin: "tl", gridStep: 1, ppm: 20 },
     shapes: [

--- a/tests/lib/track/timing.test.ts
+++ b/tests/lib/track/timing.test.ts
@@ -14,6 +14,7 @@ const inventory = {
   startfinish: 0,
   flag: 0,
   cone: 0,
+  barrier: 0,
 };
 
 describe("track timing markers", () => {

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -744,6 +744,7 @@ describe("editor store history", () => {
         startfinish: 0,
         ladder: 0,
         divegate: 0,
+        barrier: 0,
       },
       field: { width: 40, height: 20, origin: "tl", gridStep: 1, ppm: 20 },
       shapes: [],


### PR DESCRIPTION
- Adds barrier as a catalog-backed track item with banner, fence, net, and MultiGP hurdle entries.
- Adds 2D and 3D rendering, inspector dimension controls, bounds, inventory support, and toolbar placement.
- Adds SVG and flythrough export support plus regression fixture updates for the expanded inventory shape set.