### PR TITLE
perf: reduce Cloudflare Worker bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
-        "@scalar/nextjs-api-reference": "^0.11.0",
         "@tanstack/react-table": "^8.21.3",
         "better-auth": "^1.6.0",
         "class-variance-authority": "^0.7.1",
@@ -5822,82 +5821,6 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@scalar/client-side-rendering": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@scalar/client-side-rendering/-/client-side-rendering-0.2.4.tgz",
-      "integrity": "sha512-IQC39aQQXKsZXOqQw0LNiZ/gQ1WxHpF+WLTo/hurn0S/FmNHlBGUAhFyt1BeDSUYxics7ixgzQatKJDggafBTw==",
-      "license": "MIT",
-      "dependencies": {
-        "@scalar/schemas": "0.5.0",
-        "@scalar/types": "0.14.0",
-        "@scalar/validation": "0.6.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@scalar/helpers": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@scalar/helpers/-/helpers-0.8.2.tgz",
-      "integrity": "sha512-qNbqUjSB3S4Gr4A0oANcm5G1Ip+EqBxICYKhe9YzmnaBpbmW6shxqpiivApTvvuDf+uIhR3uMwWyVQbYcGLsxA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@scalar/nextjs-api-reference": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@scalar/nextjs-api-reference/-/nextjs-api-reference-0.11.4.tgz",
-      "integrity": "sha512-kV1YmZPooQlDaJZF/HJPFZc8oHO3MB1urR8sWhWYXM0GYDigNZO3w9PIZdP2RN7IMvRr+bGxlD2U9g5SsSSW6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@scalar/client-side-rendering": "0.2.4"
-      },
-      "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "next": "^15.0.0 || ^16.0.0",
-        "react": "^19.0.0"
-      }
-    },
-    "node_modules/@scalar/schemas": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@scalar/schemas/-/schemas-0.5.0.tgz",
-      "integrity": "sha512-aV0PWqFpQft9a6d4Z6HOTHKDaA+K4AquxSPfBDI1c5f6lMe5l3zViww/iBQA/Yw+V1+Y2iwSVzhuxaktC1UiMg==",
-      "license": "MIT",
-      "dependencies": {
-        "@scalar/helpers": "0.8.2",
-        "@scalar/validation": "0.6.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@scalar/types": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@scalar/types/-/types-0.14.0.tgz",
-      "integrity": "sha512-aS1FvHbKhBC51mWqXmhkPe6lmhCd9+u//DQ1YTiCWOz4/fXAdWfwHvW9UZ7AzzcGwGiCo9diE81xV+UvSI1qIg==",
-      "license": "MIT",
-      "dependencies": {
-        "@scalar/helpers": "0.8.2",
-        "nanoid": "^5.1.6",
-        "type-fest": "^5.3.1",
-        "zod": "^4.3.5"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@scalar/validation": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@scalar/validation/-/validation-0.6.0.tgz",
-      "integrity": "sha512-tpmmG+/xRE2Kn9RpflU3AIyZv08v10+E1ZrJCx7z6+/91zHVxy0M73kC1LT4/8PbYNt85ywyC8+n+D99JdMcGA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -17654,18 +17577,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -18016,21 +17927,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
-    "@scalar/nextjs-api-reference": "^0.11.0",
     "@tanstack/react-table": "^8.21.3",
     "better-auth": "^1.6.0",
     "class-variance-authority": "^0.7.1",

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -1,8 +1,5 @@
-import { ApiReference } from "@scalar/nextjs-api-reference";
-
-export const GET = ApiReference({
+const CONFIGURATION = JSON.stringify({
   url: "/api/v1/openapi.json",
-  pageTitle: "TrackDraw API Docs",
   theme: "default",
   layout: "modern",
   showSidebar: true,
@@ -14,3 +11,28 @@ export const GET = ApiReference({
   documentDownloadType: "json",
   showOperationId: true,
 });
+
+const HTML = `<!doctype html>
+<html>
+  <head>
+    <title>TrackDraw API Docs</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script type="text/javascript">
+      Scalar.createApiReference('#app', ${CONFIGURATION})
+    </script>
+  </body>
+</html>`;
+
+export function GET() {
+  return new Response(HTML, {
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}

--- a/src/app/api/docs/route.ts
+++ b/src/app/api/docs/route.ts
@@ -13,7 +13,7 @@ const CONFIGURATION = JSON.stringify({
 });
 
 const HTML = `<!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>TrackDraw API Docs</title>
     <meta charset="utf-8" />
@@ -21,7 +21,11 @@ const HTML = `<!doctype html>
   </head>
   <body>
     <div id="app"></div>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/@scalar/api-reference@1.60.0"
+      integrity="sha384-4BdmZQQTc462+ocGPo+GP3Hi/eQjMQTmNkSU9J5w3FD6hGUEmU2PqNRnbklONt4R"
+      crossorigin="anonymous"
+    ></script>
     <script type="text/javascript">
       Scalar.createApiReference('#app', ${CONFIGURATION})
     </script>

--- a/src/app/dashboard/metrics/page.tsx
+++ b/src/app/dashboard/metrics/page.tsx
@@ -8,7 +8,7 @@ import {
   PlanLimitChart,
   UserGrowthChart,
   UserPopulationChart,
-} from "@/components/dashboard/MetricsCharts";
+} from "@/components/dashboard/MetricsChartsLoader";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 import { hasCapability } from "@/lib/server/authorization";
 import { getAdminMetrics } from "@/lib/server/metrics";

--- a/src/components/dashboard/MetricsChartsLoader.tsx
+++ b/src/components/dashboard/MetricsChartsLoader.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+export const UserPopulationChart = dynamic(
+  () => import("./MetricsCharts").then((m) => m.UserPopulationChart),
+  { ssr: false }
+);
+
+export const ContentOverviewChart = dynamic(
+  () => import("./MetricsCharts").then((m) => m.ContentOverviewChart),
+  { ssr: false }
+);
+
+export const UserGrowthChart = dynamic(
+  () => import("./MetricsCharts").then((m) => m.UserGrowthChart),
+  { ssr: false }
+);
+
+export const PlanLimitChart = dynamic(
+  () => import("./MetricsCharts").then((m) => m.PlanLimitChart),
+  { ssr: false }
+);


### PR DESCRIPTION
## Summary

- Replace `@scalar/nextjs-api-reference` with a minimal HTML route handler that loads Scalar from CDN — removes ~3.3 MB of Scalar schema/type packages (`@scalar/schemas`, `@scalar/types`, `@scalar/helpers`, `@scalar/validation`) that were being bundled into the Cloudflare Worker for no reason (the Scalar UI was already loaded from CDN at runtime anyway)
- Move recharts out of the SSR/server bundle by lazy-loading `MetricsCharts` via a new `"use client"` wrapper (`MetricsChartsLoader`) with `ssr: false` — recharts (372 KB client chunk) was being compiled into the Worker server chunks even though it's only needed client-side on the admin metrics dashboard