### PR TITLE
refactor: Client-state persistence consolidation

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -30,7 +30,7 @@ The most useful next product move is deepening the race-day workflow, keeping th
 - Regional measurement units so international users can work with familiar Metric or Imperial presets while TrackDraw keeps meter-based geometry internally
 - Multilingual product experience built on the same locale-aware foundation, starting with explicit language choice and controlled translation scope
 
-Lower-priority follow-up such as share version history, gallery collections, dashboard operator tooling, Velocidrone export stabilization, AR, and build mode should stay parked until there is clearer need.
+Lower-priority follow-up such as share version history, gallery collections, Velocidrone export stabilization, AR, and build mode should stay parked until there is clearer need.
 
 ## Product Principles
 
@@ -686,6 +686,33 @@ Likely account-backed follow-up:
 - Curated gallery collections
 - Shared venue or club records, including shared inventory profiles
 - Identity-aware comments and review threads
+
+## v1.12.0 Archive
+
+<details>
+<summary>Completed release work archived with v1.12.0</summary>
+
+### Dashboard Operator Tooling (`Account-backed`)
+
+Admins and moderators can now inspect the state of specific accounts, shares, and API keys from within the existing dashboard surfaces without digging through database records.
+
+Included:
+
+- User inspect sheet opened from the users table, showing a stats strip (projects, active shares, gallery entries, API keys), role badge, last login, created date, recent audit events, and a change-role section with self-role-change protection
+- Gallery inspect dialog opened from gallery rows, showing share type, embed availability with a direct link, project ID, share created/updated dates, expiry and revocation detail, owner, gallery state, and preview media status
+- API keys overview at `/dashboard/api-keys` listing all keys across all accounts with status badge, request count, last-used timestamp, and expiry; clickable rows open an inspect sheet with rate limit config, permissions, key prefix, and owner details
+- Admin metrics dashboard with user population breakdown, active share and gallery counts, and an active API keys KPI
+
+### Client-State Persistence Consolidation (`No account required`)
+
+Editor and unit preference state that was spread across multiple localStorage patterns is now unified under Zustand `persist` stores.
+
+Included:
+
+- `useMeasurementUnitSystem` migrated from a manual `useSyncExternalStore` + custom event pattern to a Zustand `persist` store; legacy raw-string storage format is migrated transparently on first read with no change to the hook interface
+- `useEditorHints` migrated from five separate localStorage keys with manual get/set/remove calls to a single Zustand `persist` store under `trackdraw.editorHints`; all dismissed-hint states are stored as one JSON object, making `resetGuidedHints` a single store reset with no change to the hook interface
+
+</details>
 
 ## v1.11.0 Archive
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -687,10 +687,10 @@ Likely account-backed follow-up:
 - Shared venue or club records, including shared inventory profiles
 - Identity-aware comments and review threads
 
-## v1.12.0 Archive
+## v1.11.0 Archive
 
 <details>
-<summary>Completed release work archived with v1.12.0</summary>
+<summary>Completed release work archived with v1.11.0</summary>
 
 ### Dashboard Operator Tooling (`Account-backed`)
 
@@ -711,13 +711,6 @@ Included:
 
 - `useMeasurementUnitSystem` migrated from a manual `useSyncExternalStore` + custom event pattern to a Zustand `persist` store; legacy raw-string storage format is migrated transparently on first read with no change to the hook interface
 - `useEditorHints` migrated from five separate localStorage keys with manual get/set/remove calls to a single Zustand `persist` store under `trackdraw.editorHints`; all dismissed-hint states are stored as one JSON object, making `resetGuidedHints` a single store reset with no change to the hook interface
-
-</details>
-
-## v1.11.0 Archive
-
-<details>
-<summary>Completed release work archived with v1.11.0</summary>
 
 ### User-Defined Track Sections (`Account-backed`)
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -37,12 +37,8 @@ The completed release-sized work is archived below. The next TrackDraw priority 
       Replace the hard-coded section list with a user-created, account-backed section library. A user selects shapes on the canvas and saves them as a named section. Sections are account-backed only — no local storage for logged-out users in the first version. Paths and route lines are never captured — only non-polyline shapes. Local-first storage and local-to-account migration were intentionally deferred.
   - [x] Selection-to-section creation flow
         Users select one or more non-path shapes and trigger "Save as track section". A dialog prompts for a name and stores the normalized shape set (positions relative to centroid) as a new section record. Paths are excluded from capture; the existing `PlaceablePresetShape` type enforces this.
-  - [ ] Local section storage — deferred
-        Intentionally not shipped in the first version. Local-first storage for logged-out users can be added later without data-model changes.
   - [x] Account-backed section storage
         Database schema with owner account, name, shape payload, and timestamps. Shape format stays compatible with the existing `LayoutPreset` array so `placeLayoutPreset` works unchanged.
-  - [ ] Local-to-account migration — deferred
-        No local section state exists in the first version, so migration was skipped. Can be added alongside local storage if that ships later.
   - [x] Section management UI
         Rename and delete actions per section in the picker. Inline rename, confirmation on delete. Empty state guides users toward saving their first section from a canvas selection.
   - [x] Remove hard-coded sections
@@ -98,12 +94,12 @@ The completed release-sized work is archived below. The next TrackDraw priority 
 
 ## Later Product Follow-up
 
-- [ ] Client-state persistence consolidation (`Lower priority`, `No account required`)
+- [x] Client-state persistence consolidation (`Lower priority`, `No account required`)
       The codebase uses several patterns for localStorage: direct calls, `usePersistentBoolean`, and Zustand `persist`. Migrate the cases where state is shared across multiple components to Zustand `persist` so the read/write contract is consistent and reactive by default. Direct localStorage calls for truly local, single-consumer values (theme bootstrap, sidebar collapsed) can stay as-is.
-  - [ ] Migrate `useMeasurementUnitSystem` to Zustand `persist`
-        The hook already manages its own read/write cycle internally. Replacing it with a Zustand store + `persist` middleware removes the manual `localStorage` calls and makes the unit preference reactive across any future consumers without extra wiring.
-  - [ ] Evaluate `useEditorHints` for Zustand `persist`
-        Editor hints use five separate `localStorage` keys with manual get/set/remove calls. A single persisted store would simplify the surface and make it easier to reset all hints at once.
+  - [x] Migrate `useMeasurementUnitSystem` to Zustand `persist`
+        Replaced the manual `useSyncExternalStore` + custom event pattern with a Zustand `persist` store (`src/store/measurement-unit.ts`). Legacy raw-string storage format is migrated transparently on first read. Hook interface unchanged.
+  - [x] Migrate `useEditorHints` to Zustand `persist`
+        Replaced five separate `localStorage` keys and manual get/set/remove calls with a single persisted Zustand store (`src/store/editor-hints.ts`) under `trackdraw.editorHints`. All five dismissed states are now stored as one object, making `resetGuidedHints` a single store reset. Hook interface unchanged.
 
 - [ ] VelociDrone experimental export stabilization (`Lower priority`, `No account required`)
       Keep this parked until there is appetite to validate more real layouts and tighten prefab mapping/orientation edge cases.

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -101,6 +101,9 @@ The completed release-sized work is archived below. The next TrackDraw priority 
   - [x] Migrate `useEditorHints` to Zustand `persist`
         Replaced five separate `localStorage` keys and manual get/set/remove calls with a single persisted Zustand store (`src/store/editor-hints.ts`) under `trackdraw.editorHints`. All five dismissed states are now stored as one object, making `resetGuidedHints` a single store reset. Hook interface unchanged.
 
+- [ ] Remove legacy localStorage migration shims (`Lower priority`, `No account required`)
+      Two migration shims were added in v1.11.0 to preserve existing user preferences after the Zustand persist migration. Remove them once enough releases have passed that the old keys are no longer realistically present. The shims live in `src/store/measurement-unit.ts` (legacy raw-string format for `trackdraw.measurementUnitSystem`) and `src/store/editor-hints.ts` (legacy `trackdraw-hint-*-dismissed` per-key format). Safe to remove no earlier than v1.13.0.
+
 - [ ] VelociDrone experimental export stabilization (`Lower priority`, `No account required`)
       Keep this parked until there is appetite to validate more real layouts and tighten prefab mapping/orientation edge cases.
 

--- a/src/hooks/editor/useEditorHints.ts
+++ b/src/hooks/editor/useEditorHints.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useEditorHintsStore } from "@/store/editor-hints";
 
 export function useEditorHints({
@@ -21,7 +21,7 @@ export function useEditorHints({
     dismissDesktopPreviewHint,
     dismissReview3DHint,
     dismissPostPathNudge,
-    resetGuidedHints,
+    resetGuidedHints: storeResetGuidedHints,
   } = useEditorHintsStore();
 
   const [showPostPathNudge, setShowPostPathNudge] = useState(false);
@@ -34,6 +34,11 @@ export function useEditorHints({
     }
     prevHasPath.current = hasPath;
   }, [hasPath, readOnly]);
+
+  const resetGuidedHints = useCallback(() => {
+    storeResetGuidedHints();
+    setShowPostPathNudge(false);
+  }, [storeResetGuidedHints]);
 
   return {
     gateHintDismissed,

--- a/src/hooks/editor/useEditorHints.ts
+++ b/src/hooks/editor/useEditorHints.ts
@@ -1,22 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-
-const HINT_STORAGE_KEYS = {
-  gate: "trackdraw-hint-gate-dismissed",
-  path: "trackdraw-hint-path-dismissed",
-  preview: "trackdraw-hint-preview-dismissed",
-  review3d: "trackdraw-hint-review3d-dismissed",
-  postPath: "trackdraw-hint-post-path-dismissed",
-} as const;
-
-function readStorage(key: string): boolean {
-  try {
-    return localStorage.getItem(key) === "true";
-  } catch {
-    return false;
-  }
-}
+import { useEffect, useRef, useState } from "react";
+import { useEditorHintsStore } from "@/store/editor-hints";
 
 export function useEditorHints({
   readOnly,
@@ -25,24 +10,23 @@ export function useEditorHints({
   readOnly: boolean;
   hasPath: boolean;
 }) {
-  const [gateHintDismissed, setGateHintDismissed] = useState(() =>
-    readStorage(HINT_STORAGE_KEYS.gate)
-  );
-  const [desktopPathHintDismissed, setDesktopPathHintDismissed] = useState(() =>
-    readStorage(HINT_STORAGE_KEYS.path)
-  );
-  const [desktopPreviewHintDismissed, setDesktopPreviewHintDismissed] =
-    useState(() => readStorage(HINT_STORAGE_KEYS.preview));
-  const [review3DHintDismissed, setReview3DHintDismissed] = useState(() =>
-    readStorage(HINT_STORAGE_KEYS.review3d)
-  );
-  const [postPathNudgeDismissed, setPostPathNudgeDismissed] = useState(() =>
-    readStorage(HINT_STORAGE_KEYS.postPath)
-  );
+  const {
+    gateHintDismissed,
+    desktopPathHintDismissed,
+    desktopPreviewHintDismissed,
+    review3DHintDismissed,
+    postPathNudgeDismissed,
+    dismissGateHint,
+    dismissDesktopPathHint,
+    dismissDesktopPreviewHint,
+    dismissReview3DHint,
+    dismissPostPathNudge,
+    resetGuidedHints,
+  } = useEditorHintsStore();
+
   const [showPostPathNudge, setShowPostPathNudge] = useState(false);
   const prevHasPath = useRef(false);
 
-  // Detect first path completion and show a one-time nudge toward 3D preview.
   useEffect(() => {
     if (readOnly) return;
     if (!prevHasPath.current && hasPath) {
@@ -50,70 +34,6 @@ export function useEditorHints({
     }
     prevHasPath.current = hasPath;
   }, [hasPath, readOnly]);
-
-  const dismissGateHint = useCallback(() => {
-    setGateHintDismissed(true);
-    try {
-      localStorage.setItem(HINT_STORAGE_KEYS.gate, "true");
-    } catch {
-      /* ignore */
-    }
-  }, []);
-
-  const dismissDesktopPathHint = useCallback(() => {
-    setDesktopPathHintDismissed(true);
-    try {
-      localStorage.setItem(HINT_STORAGE_KEYS.path, "true");
-    } catch {
-      /* ignore */
-    }
-  }, []);
-
-  const dismissDesktopPreviewHint = useCallback(() => {
-    setDesktopPreviewHintDismissed(true);
-    try {
-      localStorage.setItem(HINT_STORAGE_KEYS.preview, "true");
-    } catch {
-      /* ignore */
-    }
-  }, []);
-
-  const dismissReview3DHint = useCallback(() => {
-    setReview3DHintDismissed(true);
-    try {
-      localStorage.setItem(HINT_STORAGE_KEYS.review3d, "true");
-    } catch {
-      /* ignore */
-    }
-  }, []);
-
-  const dismissPostPathNudge = useCallback(() => {
-    setPostPathNudgeDismissed(true);
-    try {
-      localStorage.setItem(HINT_STORAGE_KEYS.postPath, "true");
-    } catch {
-      /* ignore */
-    }
-  }, []);
-
-  const resetGuidedHints = useCallback(() => {
-    setGateHintDismissed(false);
-    setDesktopPathHintDismissed(false);
-    setDesktopPreviewHintDismissed(false);
-    setReview3DHintDismissed(false);
-    setPostPathNudgeDismissed(false);
-    setShowPostPathNudge(false);
-    prevHasPath.current = false;
-    try {
-      localStorage.removeItem(HINT_STORAGE_KEYS.gate);
-      localStorage.removeItem(HINT_STORAGE_KEYS.path);
-      localStorage.removeItem(HINT_STORAGE_KEYS.preview);
-      localStorage.removeItem(HINT_STORAGE_KEYS.review3d);
-      localStorage.removeItem(HINT_STORAGE_KEYS.postPath);
-    } catch {
-      /* ignore */
-    }
-  }, []);
 
   return {
     gateHintDismissed,

--- a/src/hooks/useMeasurementUnitSystem.ts
+++ b/src/hooks/useMeasurementUnitSystem.ts
@@ -1,73 +1,14 @@
 "use client";
 
-import { useSyncExternalStore } from "react";
-import {
-  getMeasurementUnitSystemFromLocales,
-  MEASUREMENT_STORAGE_KEY,
-  normalizeMeasurementUnitSystem,
-  type MeasurementUnitSystem,
-} from "@/lib/track/units";
-
-const EVENT = "trackdraw-measurement-unit-system";
-let memoryUnitSystem: MeasurementUnitSystem | null = null;
-
-function getBrowserDefault(): MeasurementUnitSystem {
-  if (typeof navigator === "undefined") return "metric";
-  return getMeasurementUnitSystemFromLocales(navigator.languages);
-}
-
-function getSnapshot(): MeasurementUnitSystem {
-  if (typeof window === "undefined") return "metric";
-
-  try {
-    const stored = normalizeMeasurementUnitSystem(
-      window.localStorage.getItem(MEASUREMENT_STORAGE_KEY)
-    );
-    return stored ?? memoryUnitSystem ?? getBrowserDefault();
-  } catch {
-    return memoryUnitSystem ?? getBrowserDefault();
-  }
-}
-
-function subscribe(callback: () => void) {
-  if (typeof window === "undefined") return () => {};
-
-  const handleStorage = (event: StorageEvent) => {
-    if (event.key === MEASUREMENT_STORAGE_KEY) callback();
-  };
-
-  window.addEventListener(EVENT, callback);
-  window.addEventListener("storage", handleStorage);
-
-  return () => {
-    window.removeEventListener(EVENT, callback);
-    window.removeEventListener("storage", handleStorage);
-  };
-}
+import { useMeasurementUnitStore } from "@/store/measurement-unit";
+import type { MeasurementUnitSystem } from "@/lib/track/units";
 
 export function setMeasurementUnitSystem(unitSystem: MeasurementUnitSystem) {
-  if (typeof window === "undefined") return;
-
-  memoryUnitSystem = unitSystem;
-
-  try {
-    window.localStorage.setItem(MEASUREMENT_STORAGE_KEY, unitSystem);
-  } catch {
-    // Keep the in-memory UI responsive even when storage is unavailable.
-  }
-
-  window.dispatchEvent(new Event(EVENT));
+  useMeasurementUnitStore.getState().setUnitSystem(unitSystem);
 }
 
 export function useMeasurementUnitSystem() {
-  const unitSystem = useSyncExternalStore<MeasurementUnitSystem>(
-    subscribe,
-    getSnapshot,
-    () => "metric"
-  );
-
-  return {
-    unitSystem,
-    setUnitSystem: setMeasurementUnitSystem,
-  };
+  const unitSystem = useMeasurementUnitStore((s) => s.unitSystem);
+  const setUnitSystem = useMeasurementUnitStore((s) => s.setUnitSystem);
+  return { unitSystem, setUnitSystem };
 }

--- a/src/store/editor-hints.ts
+++ b/src/store/editor-hints.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type EditorHintsState = {
+  gateHintDismissed: boolean;
+  desktopPathHintDismissed: boolean;
+  desktopPreviewHintDismissed: boolean;
+  review3DHintDismissed: boolean;
+  postPathNudgeDismissed: boolean;
+  dismissGateHint: () => void;
+  dismissDesktopPathHint: () => void;
+  dismissDesktopPreviewHint: () => void;
+  dismissReview3DHint: () => void;
+  dismissPostPathNudge: () => void;
+  resetGuidedHints: () => void;
+};
+
+// Access localStorage lazily so the reference is re-evaluated on each call.
+// This ensures test mocks installed after module load are picked up correctly.
+const lazyLocalStorage = {
+  getItem: (name: string): string | null => {
+    try {
+      return localStorage.getItem(name);
+    } catch {
+      return null;
+    }
+  },
+  setItem: (name: string, value: string) => {
+    try {
+      localStorage.setItem(name, value);
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  removeItem: (name: string) => {
+    try {
+      localStorage.removeItem(name);
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};
+
+export const useEditorHintsStore = create<EditorHintsState>()(
+  persist(
+    (set) => ({
+      gateHintDismissed: false,
+      desktopPathHintDismissed: false,
+      desktopPreviewHintDismissed: false,
+      review3DHintDismissed: false,
+      postPathNudgeDismissed: false,
+      dismissGateHint: () => set({ gateHintDismissed: true }),
+      dismissDesktopPathHint: () => set({ desktopPathHintDismissed: true }),
+      dismissDesktopPreviewHint: () =>
+        set({ desktopPreviewHintDismissed: true }),
+      dismissReview3DHint: () => set({ review3DHintDismissed: true }),
+      dismissPostPathNudge: () => set({ postPathNudgeDismissed: true }),
+      resetGuidedHints: () =>
+        set({
+          gateHintDismissed: false,
+          desktopPathHintDismissed: false,
+          desktopPreviewHintDismissed: false,
+          review3DHintDismissed: false,
+          postPathNudgeDismissed: false,
+        }),
+    }),
+    {
+      name: "trackdraw.editorHints",
+      storage: createJSONStorage(() => lazyLocalStorage),
+      partialize: (state) => ({
+        gateHintDismissed: state.gateHintDismissed,
+        desktopPathHintDismissed: state.desktopPathHintDismissed,
+        desktopPreviewHintDismissed: state.desktopPreviewHintDismissed,
+        review3DHintDismissed: state.review3DHintDismissed,
+        postPathNudgeDismissed: state.postPathNudgeDismissed,
+      }),
+    }
+  )
+);

--- a/src/store/editor-hints.ts
+++ b/src/store/editor-hints.ts
@@ -17,12 +17,59 @@ type EditorHintsState = {
   resetGuidedHints: () => void;
 };
 
+// Legacy per-key storage used before this store was introduced.
+const LEGACY_KEYS = {
+  gate: "trackdraw-hint-gate-dismissed",
+  path: "trackdraw-hint-path-dismissed",
+  preview: "trackdraw-hint-preview-dismissed",
+  review3d: "trackdraw-hint-review3d-dismissed",
+  postPath: "trackdraw-hint-post-path-dismissed",
+} as const;
+
 // Access localStorage lazily so the reference is re-evaluated on each call.
 // This ensures test mocks installed after module load are picked up correctly.
-const lazyLocalStorage = {
+// On first load, migrates any persisted values from the legacy per-key format.
+const legacyAwareBackend = {
   getItem: (name: string): string | null => {
     try {
-      return localStorage.getItem(name);
+      const raw = localStorage.getItem(name);
+      if (raw) {
+        try {
+          const parsed: unknown = JSON.parse(raw);
+          if (parsed && typeof parsed === "object" && "state" in parsed)
+            return raw;
+        } catch {
+          /* malformed JSON, fall through to legacy check */
+        }
+      }
+      // No valid envelope yet — check for legacy per-key values
+      const gateHintDismissed =
+        localStorage.getItem(LEGACY_KEYS.gate) === "true";
+      const desktopPathHintDismissed =
+        localStorage.getItem(LEGACY_KEYS.path) === "true";
+      const desktopPreviewHintDismissed =
+        localStorage.getItem(LEGACY_KEYS.preview) === "true";
+      const review3DHintDismissed =
+        localStorage.getItem(LEGACY_KEYS.review3d) === "true";
+      const postPathNudgeDismissed =
+        localStorage.getItem(LEGACY_KEYS.postPath) === "true";
+      const hasAnyLegacy =
+        gateHintDismissed ||
+        desktopPathHintDismissed ||
+        desktopPreviewHintDismissed ||
+        review3DHintDismissed ||
+        postPathNudgeDismissed;
+      if (!raw && !hasAnyLegacy) return null;
+      return JSON.stringify({
+        state: {
+          gateHintDismissed,
+          desktopPathHintDismissed,
+          desktopPreviewHintDismissed,
+          review3DHintDismissed,
+          postPathNudgeDismissed,
+        },
+        version: 0,
+      });
     } catch {
       return null;
     }
@@ -68,7 +115,7 @@ export const useEditorHintsStore = create<EditorHintsState>()(
     }),
     {
       name: "trackdraw.editorHints",
-      storage: createJSONStorage(() => lazyLocalStorage),
+      storage: createJSONStorage(() => legacyAwareBackend),
       partialize: (state) => ({
         gateHintDismissed: state.gateHintDismissed,
         desktopPathHintDismissed: state.desktopPathHintDismissed,

--- a/src/store/measurement-unit.ts
+++ b/src/store/measurement-unit.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import {
+  getMeasurementUnitSystemFromLocales,
+  MEASUREMENT_STORAGE_KEY,
+  normalizeMeasurementUnitSystem,
+  type MeasurementUnitSystem,
+} from "@/lib/track/units";
+
+type MeasurementUnitState = {
+  unitSystem: MeasurementUnitSystem;
+  setUnitSystem: (unitSystem: MeasurementUnitSystem) => void;
+};
+
+function getBrowserDefault(): MeasurementUnitSystem {
+  if (typeof navigator === "undefined") return "metric";
+  return getMeasurementUnitSystemFromLocales(navigator.languages);
+}
+
+// Handles legacy format: the old hook stored a raw string ("metric" / "imperial")
+// directly in localStorage instead of a Zustand JSON envelope. On first read we
+// migrate transparently so existing user preferences are preserved.
+const legacyAwareBackend = {
+  getItem: (name: string): string | null => {
+    try {
+      const raw = localStorage.getItem(name);
+      if (!raw) return null;
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && "state" in parsed) {
+        return raw;
+      }
+      // Legacy raw string — wrap in Zustand envelope
+      const normalized = normalizeMeasurementUnitSystem(raw);
+      return JSON.stringify({
+        state: { unitSystem: normalized ?? getBrowserDefault() },
+        version: 0,
+      });
+    } catch {
+      return null;
+    }
+  },
+  setItem: (name: string, value: string) => {
+    try {
+      localStorage.setItem(name, value);
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  removeItem: (name: string) => {
+    try {
+      localStorage.removeItem(name);
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};
+
+export const useMeasurementUnitStore = create<MeasurementUnitState>()(
+  persist(
+    (set) => ({
+      unitSystem: getBrowserDefault(),
+      setUnitSystem: (unitSystem) => set({ unitSystem }),
+    }),
+    {
+      name: MEASUREMENT_STORAGE_KEY,
+      storage: createJSONStorage(() => legacyAwareBackend),
+    }
+  )
+);

--- a/src/store/measurement-unit.ts
+++ b/src/store/measurement-unit.ts
@@ -27,9 +27,14 @@ const legacyAwareBackend = {
     try {
       const raw = localStorage.getItem(name);
       if (!raw) return null;
-      const parsed: unknown = JSON.parse(raw);
-      if (parsed && typeof parsed === "object" && "state" in parsed) {
-        return raw;
+      // Check for a valid Zustand envelope first
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        if (parsed && typeof parsed === "object" && "state" in parsed) {
+          return raw;
+        }
+      } catch {
+        // Not valid JSON — must be a legacy raw string like "metric"/"imperial"
       }
       // Legacy raw string — wrap in Zustand envelope
       const normalized = normalizeMeasurementUnitSystem(raw);
@@ -69,3 +74,12 @@ export const useMeasurementUnitStore = create<MeasurementUnitState>()(
     }
   )
 );
+
+// Sync changes made in other browser tabs back into this store.
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === MEASUREMENT_STORAGE_KEY) {
+      void useMeasurementUnitStore.persist.rehydrate();
+    }
+  });
+}

--- a/tests/hooks/useEditorHints.test.tsx
+++ b/tests/hooks/useEditorHints.test.tsx
@@ -3,13 +3,23 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useEditorHints } from "@/hooks/editor/useEditorHints";
+import { useEditorHintsStore } from "@/store/editor-hints";
 import { createMemoryStorage, installWindowStorage } from "../helpers/storage";
+
+const STORAGE_KEY = "trackdraw.editorHints";
 
 let restoreStorage: (() => void) | null = null;
 
 describe("useEditorHints", () => {
   beforeEach(() => {
     restoreStorage = installWindowStorage(createMemoryStorage());
+    useEditorHintsStore.setState({
+      gateHintDismissed: false,
+      desktopPathHintDismissed: false,
+      desktopPreviewHintDismissed: false,
+      review3DHintDismissed: false,
+      postPathNudgeDismissed: false,
+    });
   });
 
   afterEach(() => {
@@ -32,7 +42,10 @@ describe("useEditorHints", () => {
     expect(result.current.gateHintDismissed).toBe(true);
     expect(result.current.desktopPathHintDismissed).toBe(true);
     expect(result.current.review3DHintDismissed).toBe(true);
-    expect(localStorage.getItem("trackdraw-hint-gate-dismissed")).toBe("true");
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}") as {
+      state?: { gateHintDismissed?: boolean };
+    };
+    expect(stored.state?.gateHintDismissed).toBe(true);
 
     act(() => {
       result.current.resetGuidedHints();
@@ -41,7 +54,10 @@ describe("useEditorHints", () => {
     expect(result.current.gateHintDismissed).toBe(false);
     expect(result.current.desktopPathHintDismissed).toBe(false);
     expect(result.current.review3DHintDismissed).toBe(false);
-    expect(localStorage.getItem("trackdraw-hint-gate-dismissed")).toBeNull();
+    const storedAfterReset = JSON.parse(
+      localStorage.getItem(STORAGE_KEY) ?? "{}"
+    ) as { state?: { gateHintDismissed?: boolean } };
+    expect(storedAfterReset.state?.gateHintDismissed).toBe(false);
   });
 
   it("shows the post-path nudge only when editing completes a path", () => {
@@ -61,8 +77,9 @@ describe("useEditorHints", () => {
     });
 
     expect(result.current.postPathNudgeDismissed).toBe(true);
-    expect(localStorage.getItem("trackdraw-hint-post-path-dismissed")).toBe(
-      "true"
-    );
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}") as {
+      state?: { postPathNudgeDismissed?: boolean };
+    };
+    expect(stored.state?.postPathNudgeDismissed).toBe(true);
   });
 });

--- a/tests/hooks/useMeasurementUnitSystem.test.tsx
+++ b/tests/hooks/useMeasurementUnitSystem.test.tsx
@@ -3,6 +3,7 @@
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  createMemoryStorage,
   createThrowingStorage,
   installWindowStorage,
 } from "../helpers/storage";
@@ -39,5 +40,18 @@ describe("useMeasurementUnitSystem", () => {
     });
 
     expect(result.current.unitSystem).toBe("imperial");
+  });
+
+  it("migrates legacy raw-string format on first load", async () => {
+    restoreStorage?.();
+    restoreStorage = installWindowStorage(
+      createMemoryStorage({ "trackdraw.measurementUnitSystem": "imperial" })
+    );
+
+    const { useMeasurementUnitStore } =
+      await import("@/store/measurement-unit");
+    await useMeasurementUnitStore.persist.rehydrate();
+
+    expect(useMeasurementUnitStore.getState().unitSystem).toBe("imperial");
   });
 });


### PR DESCRIPTION
## Summary

- Migrates `useMeasurementUnitSystem` from a manual `useSyncExternalStore` + custom event pattern to a Zustand `persist` store (`src/store/measurement-unit.ts`); legacy raw-string localStorage format is migrated transparently on first read with no change to the hook interface
- Migrates `useEditorHints` from five separate localStorage keys to a single Zustand `persist` store (`src/store/editor-hints.ts`) under `trackdraw.editorHints`; all dismissed states stored as one JSON object, `resetGuidedHints` is now a single store reset with no change to the hook interface