### PR TITLE
feat: Add i18n foundation

### DIFF
--- a/docs/pva/i18n-multilingual-pva.md
+++ b/docs/pva/i18n-multilingual-pva.md
@@ -1,0 +1,124 @@
+# I18n Multilingual Experience PVA
+
+Date: June 25, 2026
+
+Status: draft, approved for phase 1 build
+
+## Decision Summary
+
+Recommended direction:
+
+- use next-intl without URL routing — locale is a user preference, not a URL segment
+- store locale in a Zustand persist store under `trackdraw.locale`, using browser language as the initial default
+- use nested JSON message catalogs per namespace, one directory per locale under `messages/`
+- integrate via a single `NextIntlClientProvider` in the root layout, bootstrapped server-side from a locale cookie to prevent hydration flash
+- roll out namespace by namespace rather than converting all surfaces at once
+- expose a language picker in the account menu / settings surface, accessible without an account
+
+The desired result is a product that detects the user's browser language on first visit, can be manually overridden, and persists that preference independently from measurement units. URL structure, share links, and gallery routes remain unchanged.
+
+## Rationale
+
+URL-based locale routing (`/nl/studio`, `/en/gallery`) offers better SEO on the landing page but requires a large routing refactor — every `app/` path gets a `[locale]` dynamic segment and middleware. The product direction says solo workflow speed comes before marketing optimization. The share link compatibility requirement and the editor-focused usage pattern make a preference-based approach a significantly safer first step.
+
+next-intl has an explicit "without routing" mode designed for this. The Zustand persist pattern is already established in this codebase for measurement units and editor hints, so locale storage follows an existing convention rather than introducing a new one.
+
+## Approval Recommendation
+
+Approve phase 1 (architecture + editor namespace pilot) if TrackDraw accepts:
+
+- locale does not change URLs, share links, or embed routes
+- the `NextIntlClientProvider` wraps the full app tree at the root layout level
+- message files live under `messages/` at the project root, one subdirectory per locale
+- the locale store uses `navigator.languages` as default and falls back to `en` if no match is found
+- the editor namespace ships first as the pilot before other surfaces are migrated
+- untranslated strings fall back to the English message, never to a missing-key error
+
+Do not approve automatic machine translation, locale-based URL redirection, or changes to the share/embed routing contract before the editor pilot is stable.
+
+## Go / No-Go Criteria
+
+Go for phase 1 implementation if:
+
+- adding the `NextIntlClientProvider` does not affect editor load time or hydration behavior
+- switching locale updates all translated strings without a full page reload
+- the locale store tab-syncs correctly, matching the behavior of the measurement unit store
+- the editor namespace can be translated without touching the catalog metadata or shape schema
+- untranslated namespaces continue to render English strings without errors
+- the ThemeBootstrap pattern can be reused for locale bootstrapping without duplication
+
+No-go or delay if:
+
+- next-intl without routing introduces incompatibilities with the OpenNext Cloudflare runtime
+- the `NextIntlClientProvider` requires passing all locale messages through a Server Component boundary in a way that breaks static rendering for the landing page
+- locale switching causes editor state loss, undo stack corruption, or autosave conflicts
+
+## Architecture
+
+### Library
+
+next-intl (without i18n routing mode). Chosen over react-i18next for native App Router and Server Component support, and over lingui to avoid a compile step.
+
+### Locale Store
+
+`src/store/locale.ts` — Zustand persist store, same structure as `measurement-unit.ts`:
+
+- key: `trackdraw.locale`
+- default: derived from `navigator.languages` matched against supported locales, falling back to `en`
+- tab-sync via `storage` event
+- no legacy migration shim needed (new key)
+
+Supported locales are defined in `src/lib/i18n/locales.ts` as a typed constant so the store and the provider share the same source of truth.
+
+### Provider Integration
+
+A `LocaleBootstrap` client component (same pattern as `ThemeBootstrap`) reads the locale cookie on the server render and passes it as a prop to the root layout. The `NextIntlClientProvider` wraps the app tree just inside the root layout body, receiving the resolved locale and the matching message bundle.
+
+The locale cookie (`trackdraw.locale`) is written by the Zustand store's `onRehydrateStorage` callback so server renders after the first visit stay in sync without an extra network round-trip.
+
+### Message Catalog Structure
+
+```
+messages/
+  en/
+    common.json       ← shared labels: buttons, statuses, errors
+    editor.json       ← toolbar, tools, status bar, context menus
+    inspector.json    ← inspector panels and property fields
+    dialogs.json      ← share, account, project, import/export dialogs
+    landing.json      ← marketing page copy
+    dashboard.json    ← admin dashboard and operator tooling
+  nl/
+    common.json
+    editor.json
+    ... (add as translated)
+```
+
+Namespaces map directly to `useTranslations('editor')`, `useTranslations('inspector')`, etc.
+
+### Rollout Order
+
+Phase 1 — architecture + editor pilot:
+1. Install next-intl, add `src/lib/i18n/locales.ts`
+2. `src/store/locale.ts` Zustand persist store
+3. `LocaleBootstrap` component + `NextIntlClientProvider` in root layout
+4. `messages/en/editor.json` covering Toolbar and StatusBar strings
+5. Convert `Toolbar.tsx` and `StatusBar.tsx` to `useTranslations('editor')`
+6. Language picker stub in account menu
+
+Phase 2 — inspector + dialogs (~200 strings)
+
+Phase 3 — landing page (~500+ strings)
+
+Phase 4 — dashboard + remaining surfaces
+
+### Language Picker Placement
+
+A language selector appears in the same settings/account area as the measurement unit toggle. It is visible and functional without an account. The initial UI is minimal — a dropdown with language name in the target language (e.g., "Nederlands", "English").
+
+## Out of Scope
+
+- URL-based locale routing
+- Machine translation or automated string extraction
+- Locale-aware date/number formatting beyond what next-intl provides out of the box
+- Locale-specific legal pages (privacy, terms) in phase 1
+- Right-to-left layout support

--- a/docs/pva/i18n-multilingual-pva.md
+++ b/docs/pva/i18n-multilingual-pva.md
@@ -98,6 +98,7 @@ Namespaces map directly to `useTranslations('editor')`, `useTranslations('inspec
 ### Rollout Order
 
 Phase 1 — architecture + editor pilot:
+
 1. Install next-intl, add `src/lib/i18n/locales.ts`
 2. `src/store/locale.ts` Zustand persist store
 3. `LocaleBootstrap` component + `NextIntlClientProvider` in root layout

--- a/docs/pva/i18n-multilingual-pva.md
+++ b/docs/pva/i18n-multilingual-pva.md
@@ -11,7 +11,7 @@ Recommended direction:
 - use next-intl without URL routing — locale is a user preference, not a URL segment
 - store locale in a Zustand persist store under `trackdraw.locale`, using browser language as the initial default
 - use nested JSON message catalogs per namespace, one directory per locale under `messages/`
-- integrate via a single `NextIntlClientProvider` in the root layout, bootstrapped server-side from a locale cookie to prevent hydration flash
+- integrate via a single `NextIntlClientProvider` in the root layout, with `src/i18n/request.ts` resolving locale/messages server-side from the locale cookie or request language
 - roll out namespace by namespace rather than converting all surfaces at once
 - expose a language picker in the account menu / settings surface, accessible without an account
 
@@ -45,7 +45,7 @@ Go for phase 1 implementation if:
 - the locale store tab-syncs correctly, matching the behavior of the measurement unit store
 - the editor namespace can be translated without touching the catalog metadata or shape schema
 - untranslated namespaces continue to render English strings without errors
-- the ThemeBootstrap pattern can be reused for locale bootstrapping without duplication
+- locale bootstrapping stays server-side through `src/i18n/request.ts` and does not duplicate the ThemeBootstrap client pattern
 
 No-go or delay if:
 
@@ -72,9 +72,9 @@ Supported locales are defined in `src/lib/i18n/locales.ts` as a typed constant s
 
 ### Provider Integration
 
-A `LocaleBootstrap` client component (same pattern as `ThemeBootstrap`) reads the locale cookie on the server render and passes it as a prop to the root layout. The `NextIntlClientProvider` wraps the app tree just inside the root layout body, receiving the resolved locale and the matching message bundle.
+`src/i18n/request.ts` resolves the locale and message bundle for next-intl on the server. `src/app/layout.tsx` reads `getLocale()` and `getMessages()` and wraps the app tree in `NextIntlClientProvider`.
 
-The locale cookie (`trackdraw.locale`) is written by the Zustand store's `onRehydrateStorage` callback so server renders after the first visit stay in sync without an extra network round-trip.
+The locale cookie (`trackdraw-locale`) is written by the Zustand store's `onRehydrateStorage` callback so server renders after the first visit stay in sync without an extra network round-trip.
 
 ### Message Catalog Structure
 
@@ -101,7 +101,7 @@ Phase 1 — architecture + editor pilot:
 
 1. Install next-intl, add `src/lib/i18n/locales.ts`
 2. `src/store/locale.ts` Zustand persist store
-3. `LocaleBootstrap` component + `NextIntlClientProvider` in root layout
+3. `src/i18n/request.ts` server locale/message resolver + `NextIntlClientProvider` in root layout
 4. `messages/en/editor.json` covering Toolbar and StatusBar strings
 5. Convert `Toolbar.tsx` and `StatusBar.tsx` to `useTranslations('editor')`
 6. Language picker stub in account menu

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -55,12 +55,16 @@ The completed release-sized work is archived below. The next TrackDraw priority 
   - [ ] Drag-to-reorder obstacles (prerequisite)
         Wire up the drag handles in the track items list so users can explicitly set the intended race sequence before generating a path. The store action is ready; this is a UI-only change gated on the path generator being useful enough to justify the interaction.
 
-- [ ] Multilingual product experience (`Research`, `No account required`)
-      Use the regional measurement work as a first locale-aware foundation, then evaluate a full i18n layer for the public site, editor, share pages, and exported handoff copy.
-  - [ ] I18n architecture and text inventory
-        Audit hard-coded UI, export, share, legal-adjacent, dashboard, and error/recovery copy so translatable product text can move behind a stable message catalog without weakening type safety.
-  - [ ] Language detection and override
-        Use browser language as an initial default when no explicit language preference exists, but keep language selection manually overridable and independent from measurement units.
+- [ ] Multilingual product experience (`No account required`)
+      Use the regional measurement work as a first locale-aware foundation, then evaluate a full i18n layer for the public site, editor, share pages, and exported handoff copy. Architecture PVA: [I18n Multilingual PVA](../pva/i18n-multilingual-pva.md).
+  - [ ] I18n architecture + editor pilot
+        Install next-intl (without routing), add a Zustand locale store, wire the NextIntlClientProvider into the root layout, and convert the editor Toolbar and StatusBar as the pilot namespace. Language picker stub in account menu. See PVA phase 1.
+  - [ ] Inspector + dialogs namespace
+        Migrate inspector panels and the share, account, project, and import/export dialogs to the message catalog (~200 strings).
+  - [ ] Landing page namespace
+        Migrate all hard-coded marketing copy to the message catalog (~500+ strings).
+  - [ ] Dashboard + remaining surfaces
+        Migrate admin dashboard and any remaining hard-coded copy.
   - [ ] First language rollout
         Choose the first supported languages from actual user demand and translation-maintenance capacity, with English as the stable fallback for incomplete translations.
   - [ ] Translation QA boundary

--- a/messages/en/editor.json
+++ b/messages/en/editor.json
@@ -1,0 +1,37 @@
+{
+  "toolbar": {
+    "homepageLabel": "Go to homepage",
+    "projects": "Projects",
+    "projectsTooltip": "Manage projects",
+    "import": "Import",
+    "importTooltip": "Import JSON",
+    "export": "Export",
+    "exportTooltip": "Export track"
+  },
+  "statusBar": {
+    "snapActive": "Snap",
+    "snapOn": "Snap On",
+    "snapOff": "Snap Off",
+    "snapIsOn": "Snap is on",
+    "snapIsOff": "Snap is off",
+    "snapOnDescription": "Points and drags lock to nearby grid positions, objects, and route points. Hold Alt while placing or dragging to bypass it once.",
+    "snapOffDescription": "Placement and dragging stay freeform until you turn snap back on.",
+    "selected": "{count} selected",
+    "grouped": "Grouped",
+    "groupNamed": "Group: {name}",
+    "groups": "{count} groups",
+    "devOn": "Dev On",
+    "dev": "Dev"
+  },
+  "accountMenu": {
+    "checkingAuth": "Checking auth…",
+    "signIn": "Sign in",
+    "signedIn": "Signed in",
+    "noDisplayName": "No display name set",
+    "trackdrawAccount": "TrackDraw account",
+    "profile": "Profile",
+    "dashboard": "Dashboard",
+    "signOut": "Sign out",
+    "signingOut": "Signing out…"
+  }
+}

--- a/messages/en/editor.json
+++ b/messages/en/editor.json
@@ -33,5 +33,12 @@
     "dashboard": "Dashboard",
     "signOut": "Sign out",
     "signingOut": "Signing out…"
+  },
+  "languagePicker": {
+    "ariaLabel": "Language"
+  },
+  "accountProfile": {
+    "languageLabel": "Language",
+    "languageDescription": "Changes apply immediately"
   }
 }

--- a/messages/nl/editor.json
+++ b/messages/nl/editor.json
@@ -1,0 +1,37 @@
+{
+  "toolbar": {
+    "homepageLabel": "Naar de homepage",
+    "projects": "Projecten",
+    "projectsTooltip": "Projecten beheren",
+    "import": "Importeren",
+    "importTooltip": "JSON importeren",
+    "export": "Exporteren",
+    "exportTooltip": "Track exporteren"
+  },
+  "statusBar": {
+    "snapActive": "Snap",
+    "snapOn": "Snap aan",
+    "snapOff": "Snap uit",
+    "snapIsOn": "Snap staat aan",
+    "snapIsOff": "Snap staat uit",
+    "snapOnDescription": "Punten en slepen vergrendelen naar nabije rasterposities, objecten en routepunten. Houd Alt ingedrukt tijdens plaatsen of slepen om het eenmalig te omzeilen.",
+    "snapOffDescription": "Plaatsen en slepen blijven vrij totdat je snap weer aanzet.",
+    "selected": "{count} geselecteerd",
+    "grouped": "Gegroepeerd",
+    "groupNamed": "Groep: {name}",
+    "groups": "{count} groepen",
+    "devOn": "Dev aan",
+    "dev": "Dev"
+  },
+  "accountMenu": {
+    "checkingAuth": "Authenticatie controleren…",
+    "signIn": "Inloggen",
+    "signedIn": "Ingelogd",
+    "noDisplayName": "Geen weergavenaam ingesteld",
+    "trackdrawAccount": "TrackDraw-account",
+    "profile": "Profiel",
+    "dashboard": "Dashboard",
+    "signOut": "Uitloggen",
+    "signingOut": "Uitloggen…"
+  }
+}

--- a/messages/nl/editor.json
+++ b/messages/nl/editor.json
@@ -33,5 +33,12 @@
     "dashboard": "Dashboard",
     "signOut": "Uitloggen",
     "signingOut": "Uitloggen…"
+  },
+  "languagePicker": {
+    "ariaLabel": "Taal"
+  },
+  "accountProfile": {
+    "languageLabel": "Taal",
+    "languageDescription": "Wijzigingen worden direct toegepast"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "mediabunny": "^1.40.1",
         "nanoid": "^5.1.6",
         "next": "^16.1.0",
+        "next-intl": "^4.13.0",
         "next-themes": "^0.4.6",
         "postgres": "^3.4.7",
         "react": "^19.2.0",
@@ -2930,6 +2931,36 @@
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz",
+      "integrity": "sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.11.tgz",
+      "integrity": "sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.10"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.10.tgz",
+      "integrity": "sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.10.tgz",
+      "integrity": "sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.6"
+      }
+    },
     "node_modules/@hexagon/base64": {
       "version": "1.1.28",
       "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
@@ -4261,6 +4292,319 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@peculiar/asn1-android": {
@@ -5822,6 +6166,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -6666,6 +7016,222 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.43.tgz",
+      "integrity": "sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.43.tgz",
+      "integrity": "sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.43.tgz",
+      "integrity": "sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.43.tgz",
+      "integrity": "sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.43.tgz",
+      "integrity": "sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.43.tgz",
+      "integrity": "sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.43.tgz",
+      "integrity": "sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.43.tgz",
+      "integrity": "sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.43.tgz",
+      "integrity": "sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.43.tgz",
+      "integrity": "sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.43.tgz",
+      "integrity": "sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.43.tgz",
+      "integrity": "sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -6673,6 +7239,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -9935,7 +10510,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -12119,6 +12693,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/icu-minify": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.13.0.tgz",
+      "integrity": "sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -12218,6 +12807,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.8.tgz",
+      "integrity": "sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.6",
+        "@formatjs/icu-messageformat-parser": "3.5.11"
       }
     },
     "node_modules/iobuffer": {
@@ -13983,6 +14582,83 @@
         }
       }
     },
+    "node_modules/next-intl": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.13.0.tgz",
+      "integrity": "sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.13.0",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.13.0",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.13.0"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.13.0.tgz",
+      "integrity": "sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==",
+      "license": "MIT"
+    },
+    "node_modules/next-intl/node_modules/@swc/core": {
+      "version": "1.15.43",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.43.tgz",
+      "integrity": "sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.27"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.43",
+        "@swc/core-darwin-x64": "1.15.43",
+        "@swc/core-linux-arm-gnueabihf": "1.15.43",
+        "@swc/core-linux-arm64-gnu": "1.15.43",
+        "@swc/core-linux-arm64-musl": "1.15.43",
+        "@swc/core-linux-ppc64-gnu": "1.15.43",
+        "@swc/core-linux-s390x-gnu": "1.15.43",
+        "@swc/core-linux-x64-gnu": "1.15.43",
+        "@swc/core-linux-x64-musl": "1.15.43",
+        "@swc/core-win32-arm64-msvc": "1.15.43",
+        "@swc/core-win32-ia32-msvc": "1.15.43",
+        "@swc/core-win32-x64-msvc": "1.15.43"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -14096,6 +14772,12 @@
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -14969,6 +15651,12 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -18236,6 +18924,27 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.13.0.tgz",
+      "integrity": "sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.13.0",
+        "intl-messageformat": "^11.1.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/use-sidecar": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "mediabunny": "^1.40.1",
     "nanoid": "^5.1.6",
     "next": "^16.1.0",
+    "next-intl": "^4.13.0",
     "next-themes": "^0.4.6",
     "postgres": "^3.4.7",
     "react": "^19.2.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata, Viewport } from "next";
 import { cookies } from "next/headers";
 import "./globals.css";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages } from "next-intl/server";
 import ThemeBootstrap from "@/components/ThemeBootstrap";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -98,10 +100,12 @@ export default async function RootLayout({
     cookieStore.get(THEME_COOKIE)?.value,
     cookieStore.get(RESOLVED_THEME_COOKIE)?.value
   );
+  const locale = await getLocale();
+  const messages = await getMessages();
 
   return (
     <html
-      lang="en"
+      lang={locale}
       className={initialTheme === "dark" ? "dark" : undefined}
       style={{ colorScheme: initialTheme }}
       data-scroll-behavior="smooth"
@@ -109,7 +113,9 @@ export default async function RootLayout({
     >
       <body className="font-sans antialiased">
         <ThemeBootstrap />
-        <TooltipProvider delayDuration={500}>{children}</TooltipProvider>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <TooltipProvider delayDuration={500}>{children}</TooltipProvider>
+        </NextIntlClientProvider>
         <Toaster position="bottom-right" richColors />
       </body>
     </html>

--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { Languages } from "lucide-react";
+import { useLocaleStore } from "@/store/locale";
+import { supportedLocales, type SupportedLocale } from "@/lib/i18n/locales";
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+} from "@/components/ui/select";
+
+const localeConfig: Record<SupportedLocale, { label: string; abbr: string; flag: string }> = {
+  en: { label: "English", abbr: "EN", flag: "🇬🇧" },
+  nl: { label: "Nederlands", abbr: "NL", flag: "🇳🇱" },
+};
+
+interface LanguagePickerProps {
+  className?: string;
+  variant?: "compact" | "full";
+}
+
+export function LanguagePicker({ className, variant = "compact" }: LanguagePickerProps) {
+  const locale = useLocaleStore((s) => s.locale);
+  const setLocale = useLocaleStore((s) => s.setLocale);
+  const router = useRouter();
+  const config = localeConfig[locale];
+
+  function handleChange(value: string) {
+    if (value === locale) return;
+    setLocale(value as SupportedLocale);
+    router.refresh();
+  }
+
+  return (
+    <Select value={locale} onValueChange={handleChange}>
+      {variant === "compact" ? (
+        <SelectTrigger
+          className={cn(
+            "text-muted-foreground hover:bg-muted hover:text-foreground h-8 gap-1.5 rounded-md border-0 px-2 text-xs shadow-none lg:h-7 lg:px-2",
+            className
+          )}
+          aria-label="Language"
+        >
+          <Languages className="size-3.5 shrink-0" />
+          <span className="font-mono">{config.abbr}</span>
+        </SelectTrigger>
+      ) : (
+        <SelectTrigger
+          className={cn("h-8 rounded-lg px-2.5 text-sm shadow-none", className)}
+          aria-label="Language"
+        >
+          {config.flag} {config.label}
+        </SelectTrigger>
+      )}
+      <SelectContent>
+        {supportedLocales.map((l) => (
+          <SelectItem key={l} value={l}>
+            {localeConfig[l].flag} {localeConfig[l].label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -1,10 +1,17 @@
 "use client";
 
+import { useSyncExternalStore } from "react";
 import { Languages } from "lucide-react";
 import { useLocaleStore } from "@/store/locale";
-import { supportedLocales, type SupportedLocale } from "@/lib/i18n/locales";
+import {
+  defaultLocale,
+  isValidLocale,
+  supportedLocales,
+  type SupportedLocale,
+} from "@/lib/i18n/locales";
 import { useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
+import { useTranslations } from "next-intl";
 import {
   Select,
   SelectContent,
@@ -29,14 +36,23 @@ export function LanguagePicker({
   className,
   variant = "compact",
 }: LanguagePickerProps) {
-  const locale = useLocaleStore((s) => s.locale);
+  const t = useTranslations("editor");
+  // useSyncExternalStore with a server snapshot ensures SSR renders defaultLocale,
+  // matching the Zustand store's initial state before localStorage rehydration.
+  const rawLocale = useSyncExternalStore(
+    useLocaleStore.subscribe,
+    () => useLocaleStore.getState().locale,
+    () => defaultLocale
+  );
+  const locale = isValidLocale(rawLocale) ? rawLocale : defaultLocale;
   const setLocale = useLocaleStore((s) => s.setLocale);
   const router = useRouter();
   const config = localeConfig[locale];
 
   function handleChange(value: string) {
     if (value === locale) return;
-    setLocale(value as SupportedLocale);
+    if (!isValidLocale(value)) return;
+    setLocale(value);
     router.refresh();
   }
 
@@ -48,7 +64,7 @@ export function LanguagePicker({
             "text-muted-foreground hover:bg-muted hover:text-foreground h-8 gap-1.5 rounded-md border-0 px-2 text-xs shadow-none lg:h-7 lg:px-2",
             className
           )}
-          aria-label="Language"
+          aria-label={t("languagePicker.ariaLabel")}
         >
           <Languages className="size-3.5 shrink-0" />
           <span className="font-mono">{config.abbr}</span>
@@ -56,7 +72,7 @@ export function LanguagePicker({
       ) : (
         <SelectTrigger
           className={cn("h-8 rounded-lg px-2.5 text-sm shadow-none", className)}
-          aria-label="Language"
+          aria-label={t("languagePicker.ariaLabel")}
         >
           {config.flag} {config.label}
         </SelectTrigger>

--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -12,7 +12,10 @@ import {
   SelectTrigger,
 } from "@/components/ui/select";
 
-const localeConfig: Record<SupportedLocale, { label: string; abbr: string; flag: string }> = {
+const localeConfig: Record<
+  SupportedLocale,
+  { label: string; abbr: string; flag: string }
+> = {
   en: { label: "English", abbr: "EN", flag: "🇬🇧" },
   nl: { label: "Nederlands", abbr: "NL", flag: "🇳🇱" },
 };
@@ -22,7 +25,10 @@ interface LanguagePickerProps {
   variant?: "compact" | "full";
 }
 
-export function LanguagePicker({ className, variant = "compact" }: LanguagePickerProps) {
+export function LanguagePicker({
+  className,
+  variant = "compact",
+}: LanguagePickerProps) {
   const locale = useLocaleStore((s) => s.locale);
   const setLocale = useLocaleStore((s) => s.setLocale);
   const router = useRouter();

--- a/src/components/dialogs/AccountDialog/ProfileView.tsx
+++ b/src/components/dialogs/AccountDialog/ProfileView.tsx
@@ -8,6 +8,7 @@ import {
 } from "./shared";
 import { getDisplayName } from "./utils";
 import { LanguagePicker } from "@/components/LanguagePicker";
+import { useTranslations } from "next-intl";
 
 type ProfileUser = {
   email?: string | null;
@@ -41,6 +42,8 @@ export function AccountProfileView({
   onResetError,
   onSave,
 }: ProfileViewProps) {
+  const t = useTranslations("editor");
+
   if (isPending) {
     return <AccountDialogLoading />;
   }
@@ -117,9 +120,11 @@ export function AccountProfileView({
 
       <div className="border-border/60 flex items-center justify-between gap-4 border-t pt-5">
         <div>
-          <p className="text-sm font-medium">Language</p>
+          <p className="text-sm font-medium">
+            {t("accountProfile.languageLabel")}
+          </p>
           <p className="text-muted-foreground mt-0.5 text-xs">
-            Changes apply immediately
+            {t("accountProfile.languageDescription")}
           </p>
         </div>
         <LanguagePicker variant="full" className="w-40" />

--- a/src/components/dialogs/AccountDialog/ProfileView.tsx
+++ b/src/components/dialogs/AccountDialog/ProfileView.tsx
@@ -7,6 +7,7 @@ import {
   AccountDialogNotSignedIn,
 } from "./shared";
 import { getDisplayName } from "./utils";
+import { LanguagePicker } from "@/components/LanguagePicker";
 
 type ProfileUser = {
   email?: string | null;
@@ -113,6 +114,16 @@ export function AccountProfileView({
       </div>
 
       <AccountDialogError error={error} />
+
+      <div className="border-border/60 flex items-center justify-between gap-4 border-t pt-5">
+        <div>
+          <p className="text-sm font-medium">Language</p>
+          <p className="text-muted-foreground mt-0.5 text-xs">
+            Changes apply immediately
+          </p>
+        </div>
+        <LanguagePicker variant="full" className="w-40" />
+      </div>
     </div>
   );
 }

--- a/src/components/editor/AccountMenu.tsx
+++ b/src/components/editor/AccountMenu.tsx
@@ -24,7 +24,10 @@ function canAccessDashboard(user: unknown): boolean {
   );
 }
 
-type UserLike = { email?: string | null; name?: string | null } | null | undefined;
+type UserLike =
+  | { email?: string | null; name?: string | null }
+  | null
+  | undefined;
 
 function getUserDisplayName(user: UserLike, signedInLabel: string) {
   return user?.name?.trim() || user?.email?.trim() || signedInLabel;
@@ -190,7 +193,11 @@ export default function AccountMenu({ collapsed = false }: AccountMenuProps) {
             className={cn(accountMenuItemClassName, "justify-start")}
           >
             <LogOut className="size-4" />
-            <span>{signingOut ? t("accountMenu.signingOut") : t("accountMenu.signOut")}</span>
+            <span>
+              {signingOut
+                ? t("accountMenu.signingOut")
+                : t("accountMenu.signOut")}
+            </span>
           </Button>
         </div>
       </PopoverContent>

--- a/src/components/editor/AccountMenu.tsx
+++ b/src/components/editor/AccountMenu.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/popover";
 import { authClient } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
+import { useTranslations } from "next-intl";
 
 function canAccessDashboard(user: unknown): boolean {
   return (
@@ -23,34 +24,19 @@ function canAccessDashboard(user: unknown): boolean {
   );
 }
 
-function getUserDisplayName(
-  user:
-    | {
-        email?: string | null;
-        name?: string | null;
-      }
-    | null
-    | undefined
-) {
-  return user?.name?.trim() || user?.email?.trim() || "Signed in";
+type UserLike = { email?: string | null; name?: string | null } | null | undefined;
+
+function getUserDisplayName(user: UserLike, signedInLabel: string) {
+  return user?.name?.trim() || user?.email?.trim() || signedInLabel;
 }
 
 function getUserSecondaryLabel(
-  user:
-    | {
-        email?: string | null;
-        name?: string | null;
-      }
-    | null
-    | undefined
+  user: UserLike,
+  labels: { trackdrawAccount: string; noDisplayName: string; signedIn: string }
 ) {
-  if (user?.name?.trim() && user.email?.trim()) {
-    return "TrackDraw account";
-  }
-  if (!user?.name?.trim() && user?.email?.trim()) {
-    return "No display name set";
-  }
-  return "Signed in";
+  if (user?.name?.trim() && user.email?.trim()) return labels.trackdrawAccount;
+  if (!user?.name?.trim() && user?.email?.trim()) return labels.noDisplayName;
+  return labels.signedIn;
 }
 
 const accountMenuItemClassName =
@@ -61,6 +47,7 @@ interface AccountMenuProps {
 }
 
 export default function AccountMenu({ collapsed = false }: AccountMenuProps) {
+  const t = useTranslations("editor");
   const { data, isPending } = authClient.useSession();
   const [menuOpen, setMenuOpen] = useState(false);
   const [accountOpen, setAccountOpen] = useState(false);
@@ -86,7 +73,7 @@ export default function AccountMenu({ collapsed = false }: AccountMenuProps) {
   if (isPending) {
     return (
       <span className="text-muted-foreground block px-3 pb-1 text-xs">
-        Checking auth…
+        {t("accountMenu.checkingAuth")}
       </span>
     );
   }
@@ -105,7 +92,7 @@ export default function AccountMenu({ collapsed = false }: AccountMenuProps) {
         <span className="flex size-4 shrink-0 items-center justify-center">
           <LogIn className="size-3.5" />
         </span>
-        {!collapsed && <span>Sign in</span>}
+        {!collapsed && <span>{t("accountMenu.signIn")}</span>}
       </Link>
     );
   }
@@ -128,10 +115,14 @@ export default function AccountMenu({ collapsed = false }: AccountMenuProps) {
         {!collapsed && (
           <span className="min-w-0 flex-1 text-left">
             <span className="text-foreground block truncate text-[12px] font-medium">
-              {getUserDisplayName(user)}
+              {getUserDisplayName(user, t("accountMenu.signedIn"))}
             </span>
             <span className="text-muted-foreground block truncate pt-0.5 text-[10px]">
-              {getUserSecondaryLabel(user)}
+              {getUserSecondaryLabel(user, {
+                trackdrawAccount: t("accountMenu.trackdrawAccount"),
+                noDisplayName: t("accountMenu.noDisplayName"),
+                signedIn: t("accountMenu.signedIn"),
+              })}
             </span>
           </span>
         )}
@@ -152,10 +143,10 @@ export default function AccountMenu({ collapsed = false }: AccountMenuProps) {
             />
             <div className="min-w-0 flex-1 text-left">
               <p className="text-foreground truncate text-[12px] font-medium">
-                {getUserDisplayName(user)}
+                {getUserDisplayName(user, t("accountMenu.signedIn"))}
               </p>
               <p className="text-muted-foreground truncate pt-0.5 text-[11px]">
-                {user?.email ?? "TrackDraw account"}
+                {user?.email ?? t("accountMenu.trackdrawAccount")}
               </p>
             </div>
           </div>
@@ -174,7 +165,7 @@ export default function AccountMenu({ collapsed = false }: AccountMenuProps) {
             <span className="text-muted-foreground flex size-4 shrink-0 items-center justify-center">
               <UserRound className="size-4" />
             </span>
-            <span className="flex-1">Profile</span>
+            <span className="flex-1">{t("accountMenu.profile")}</span>
           </button>
           {canAccessDashboard(user) ? (
             <Link
@@ -185,7 +176,7 @@ export default function AccountMenu({ collapsed = false }: AccountMenuProps) {
               <span className="text-muted-foreground flex size-4 shrink-0 items-center justify-center">
                 <LayoutDashboard className="size-4" />
               </span>
-              <span className="flex-1">Dashboard</span>
+              <span className="flex-1">{t("accountMenu.dashboard")}</span>
             </Link>
           ) : null}
         </div>
@@ -199,7 +190,7 @@ export default function AccountMenu({ collapsed = false }: AccountMenuProps) {
             className={cn(accountMenuItemClassName, "justify-start")}
           >
             <LogOut className="size-4" />
-            <span>{signingOut ? "Signing out…" : "Sign out"}</span>
+            <span>{signingOut ? t("accountMenu.signingOut") : t("accountMenu.signOut")}</span>
           </Button>
         </div>
       </PopoverContent>

--- a/src/components/editor/Header.tsx
+++ b/src/components/editor/Header.tsx
@@ -57,6 +57,14 @@ const ThemeToggle = dynamic(
   { ssr: false }
 );
 
+const LanguagePicker = dynamic(
+  () =>
+    import("@/components/LanguagePicker").then((mod) => ({
+      default: mod.LanguagePicker,
+    })),
+  { ssr: false }
+);
+
 const INSPECTOR_WIDTH = "21.25rem";
 
 function parseAccountDialogView(
@@ -485,6 +493,10 @@ export default function Header({
             )
           ) : null}
 
+          <div className="bg-border/80 mx-1 hidden h-5 w-px lg:block lg:h-4" />
+          <div className="hidden lg:block">
+            <LanguagePicker />
+          </div>
           <div className="bg-border/80 mx-1 hidden h-5 w-px lg:block lg:h-4" />
           <div className="hidden lg:block">
             <ThemeToggle />

--- a/src/components/editor/StatusBar.tsx
+++ b/src/components/editor/StatusBar.tsx
@@ -158,7 +158,9 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
       {/* Selection count */}
       {selectionCount > 0 && (
         <>
-          <span className="text-foreground/75">{t("statusBar.selected", { count: selectionCount })}</span>
+          <span className="text-foreground/75">
+            {t("statusBar.selected", { count: selectionCount })}
+          </span>
           {selectedGroupLabel && (
             <>
               <span className="text-muted-foreground/45">·</span>

--- a/src/components/editor/StatusBar.tsx
+++ b/src/components/editor/StatusBar.tsx
@@ -18,6 +18,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/AppTooltip";
+import { useTranslations } from "next-intl";
 
 interface StatusBarProps {
   cursorPos?: { x: number; y: number } | null;
@@ -25,6 +26,7 @@ interface StatusBarProps {
 }
 
 export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
+  const t = useTranslations("editor");
   const { enabled, toggle } = useDeveloperMode();
   const { unitSystem } = useMeasurementUnitSystem();
   const { toggleSnapEnabled } = useUiActions();
@@ -53,10 +55,12 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
             (shape) => getShapeGroupId(shape) === selectedGroupIds[0]
           );
           const groupName = namedShape ? getShapeGroupName(namedShape) : null;
-          return groupName ? `Group: ${groupName}` : "Grouped";
+          return groupName
+            ? t("statusBar.groupNamed", { name: groupName })
+            : t("statusBar.grouped");
         })()
       : selectedGroupIds.length > 1
-        ? `${selectedGroupIds.length} groups`
+        ? t("statusBar.groups", { count: selectedGroupIds.length })
         : null;
   const activeToolLabel =
     activeTool === "preset" && activePreset
@@ -129,18 +133,22 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
               )}
             />
             <span>
-              {snapEnabled ? (snapActive ? "Snap" : "Snap On") : "Snap Off"}
+              {snapEnabled
+                ? snapActive
+                  ? t("statusBar.snapActive")
+                  : t("statusBar.snapOn")
+                : t("statusBar.snapOff")}
             </span>
           </button>
         </TooltipTrigger>
         <TooltipContent side="top" sideOffset={6} className="max-w-64">
           <span className="block font-medium">
-            {snapEnabled ? "Snap is on" : "Snap is off"}
+            {snapEnabled ? t("statusBar.snapIsOn") : t("statusBar.snapIsOff")}
           </span>
           <span className="mt-1 block opacity-80">
             {snapEnabled
-              ? "Points and drags lock to nearby grid positions, objects, and route points. Hold Alt while placing or dragging to bypass it once."
-              : "Placement and dragging stay freeform until you turn snap back on."}
+              ? t("statusBar.snapOnDescription")
+              : t("statusBar.snapOffDescription")}
           </span>
         </TooltipContent>
       </Tooltip>
@@ -150,7 +158,7 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
       {/* Selection count */}
       {selectionCount > 0 && (
         <>
-          <span className="text-foreground/75">{selectionCount} selected</span>
+          <span className="text-foreground/75">{t("statusBar.selected", { count: selectionCount })}</span>
           {selectedGroupLabel && (
             <>
               <span className="text-muted-foreground/45">·</span>
@@ -176,7 +184,7 @@ export default function StatusBar({ cursorPos, snapActive }: StatusBarProps) {
             onClick={toggle}
             className="text-muted-foreground/65 hover:text-foreground hover:bg-muted pointer-events-auto inline-flex h-5 items-center rounded px-1.5 text-[11px] transition-colors"
           >
-            {enabled ? "Dev On" : "Dev"}
+            {enabled ? t("statusBar.devOn") : t("statusBar.dev")}
           </button>
           <span className="text-muted-foreground/45">·</span>
         </>

--- a/src/components/editor/Toolbar.tsx
+++ b/src/components/editor/Toolbar.tsx
@@ -30,6 +30,7 @@ import { useSessionActions, useUiActions } from "@/store/actions";
 import { authClient } from "@/lib/auth-client";
 import { useEffect, useState } from "react";
 import { Download, FolderOpen, Import } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 const AccountMenu = dynamic(() => import("@/components/editor/AccountMenu"), {
   ssr: false,
@@ -99,6 +100,7 @@ export default function Toolbar({
   onOpenPresets,
   collapsed,
 }: ToolbarProps) {
+  const t = useTranslations("editor");
   const activeTool = useEditor((state) => state.ui.activeTool);
   const { setActiveTool } = useUiActions();
   const { setSelection } = useSessionActions();
@@ -212,7 +214,7 @@ export default function Toolbar({
           <Link
             href="/"
             className="flex items-center justify-center rounded-md opacity-90 transition-opacity hover:opacity-100"
-            aria-label="Go to homepage"
+            aria-label={t("toolbar.homepageLabel")}
           >
             {collapsed ? (
               <TrackDrawIcon className="text-foreground/80 size-6" />
@@ -334,22 +336,22 @@ export default function Toolbar({
           <SidebarMenu className="gap-0 space-y-1" key="projects-footer-v3">
             {renderFooterAction({
               key: "projects",
-              label: "Projects",
-              tooltip: "Manage projects",
+              label: t("toolbar.projects"),
+              tooltip: t("toolbar.projectsTooltip"),
               icon: <FolderOpen className="size-3.5" />,
               onClick: onOpenProjectManager,
             })}
             {renderFooterAction({
               key: "import",
-              label: "Import",
-              tooltip: "Import JSON",
+              label: t("toolbar.import"),
+              tooltip: t("toolbar.importTooltip"),
               icon: <Import className="size-3.5" />,
               onClick: onImport,
             })}
             {renderFooterAction({
               key: "export",
-              label: "Export",
-              tooltip: "Export track",
+              label: t("toolbar.export"),
+              tooltip: t("toolbar.exportTooltip"),
               icon: <Download className="size-3.5" />,
               onClick: onExport,
             })}

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,6 +1,10 @@
 import { getRequestConfig } from "next-intl/server";
-import { cookies } from "next/headers";
-import { defaultLocale, isValidLocale } from "@/lib/i18n/locales";
+import { cookies, headers } from "next/headers";
+import {
+  defaultLocale,
+  getLocaleFromAcceptLanguage,
+  isValidLocale,
+} from "@/lib/i18n/locales";
 import { LOCALE_COOKIE } from "@/lib/i18n/locales";
 import enEditor from "../../messages/en/editor.json";
 import nlEditor from "../../messages/nl/editor.json";
@@ -13,7 +17,10 @@ const messages = {
 export default getRequestConfig(async () => {
   const cookieStore = await cookies();
   const raw = cookieStore.get(LOCALE_COOKIE)?.value;
-  const locale = isValidLocale(raw) ? raw : defaultLocale;
+  const requestHeaders = await headers();
+  const locale = isValidLocale(raw)
+    ? raw
+    : getLocaleFromAcceptLanguage(requestHeaders.get("accept-language"));
 
   return {
     locale,

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,22 @@
+import { getRequestConfig } from "next-intl/server";
+import { cookies } from "next/headers";
+import { defaultLocale, isValidLocale } from "@/lib/i18n/locales";
+import { LOCALE_COOKIE } from "@/lib/i18n/locales";
+import enEditor from "../../messages/en/editor.json";
+import nlEditor from "../../messages/nl/editor.json";
+
+const messages = {
+  en: { editor: enEditor },
+  nl: { editor: nlEditor },
+} as const;
+
+export default getRequestConfig(async () => {
+  const cookieStore = await cookies();
+  const raw = cookieStore.get(LOCALE_COOKIE)?.value;
+  const locale = isValidLocale(raw) ? raw : defaultLocale;
+
+  return {
+    locale,
+    messages: messages[locale] ?? messages[defaultLocale],
+  };
+});

--- a/src/lib/i18n/locales.ts
+++ b/src/lib/i18n/locales.ts
@@ -10,6 +10,33 @@ export function isValidLocale(value: unknown): value is SupportedLocale {
   return supportedLocales.includes(value as SupportedLocale);
 }
 
+export function getLocaleFromAcceptLanguage(
+  value: string | null | undefined
+): SupportedLocale {
+  if (!value) return defaultLocale;
+
+  const candidates = value
+    .split(",")
+    .map((part) => {
+      const [tag, ...params] = part.trim().split(";");
+      const q = params
+        .map((param) => param.trim())
+        .find((param) => param.startsWith("q="));
+      const weight = q ? Number.parseFloat(q.slice(2)) : 1;
+      return {
+        code: tag?.split("-")[0],
+        weight: Number.isFinite(weight) ? weight : 0,
+      };
+    })
+    .sort((a, b) => b.weight - a.weight);
+
+  for (const candidate of candidates) {
+    if (isValidLocale(candidate.code)) return candidate.code;
+  }
+
+  return defaultLocale;
+}
+
 export function getLocaleFromBrowser(): SupportedLocale {
   if (typeof navigator === "undefined") return defaultLocale;
   for (const lang of navigator.languages) {

--- a/src/lib/i18n/locales.ts
+++ b/src/lib/i18n/locales.ts
@@ -1,0 +1,20 @@
+export const supportedLocales = ["en", "nl"] as const;
+export type SupportedLocale = (typeof supportedLocales)[number];
+
+export const defaultLocale: SupportedLocale = "en";
+export const LOCALE_COOKIE = "trackdraw-locale";
+export const LOCALE_STORAGE_KEY = "trackdraw.locale";
+export const LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+
+export function isValidLocale(value: unknown): value is SupportedLocale {
+  return supportedLocales.includes(value as SupportedLocale);
+}
+
+export function getLocaleFromBrowser(): SupportedLocale {
+  if (typeof navigator === "undefined") return defaultLocale;
+  for (const lang of navigator.languages) {
+    const code = lang.split("-")[0];
+    if (isValidLocale(code)) return code as SupportedLocale;
+  }
+  return defaultLocale;
+}

--- a/src/store/locale.ts
+++ b/src/store/locale.ts
@@ -25,20 +25,67 @@ function writeCookie(locale: SupportedLocale) {
   }
 }
 
+function normalizeLocale(locale: unknown): SupportedLocale {
+  return isValidLocale(locale) ? locale : defaultLocale;
+}
+
+const localeStorageBackend = {
+  getItem: (name: string): string | null => {
+    try {
+      const raw = localStorage.getItem(name);
+      if (!raw) return null;
+
+      const parsed: unknown = JSON.parse(raw);
+      if (!parsed || typeof parsed !== "object" || !("state" in parsed)) {
+        return null;
+      }
+
+      const envelope = parsed as {
+        state?: { locale?: unknown };
+        version?: unknown;
+      };
+      return JSON.stringify({
+        ...envelope,
+        state: {
+          ...envelope.state,
+          locale: normalizeLocale(envelope.state?.locale),
+        },
+      });
+    } catch {
+      return null;
+    }
+  },
+  setItem: (name: string, value: string) => {
+    try {
+      localStorage.setItem(name, value);
+    } catch {
+      /* storage unavailable */
+    }
+  },
+  removeItem: (name: string) => {
+    try {
+      localStorage.removeItem(name);
+    } catch {
+      /* storage unavailable */
+    }
+  },
+};
+
 export const useLocaleStore = create<LocaleState>()(
   persist(
     (set) => ({
       locale: getLocaleFromBrowser(),
       setLocale: (locale) => {
-        writeCookie(locale);
-        set({ locale });
+        const nextLocale = normalizeLocale(locale);
+        writeCookie(nextLocale);
+        set({ locale: nextLocale });
       },
     }),
     {
       name: LOCALE_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => localeStorageBackend),
       onRehydrateStorage: () => (state) => {
-        if (state) writeCookie(state.locale);
+        if (state) writeCookie(normalizeLocale(state.locale));
       },
     }
   )

--- a/src/store/locale.ts
+++ b/src/store/locale.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+import {
+  defaultLocale,
+  getLocaleFromBrowser,
+  isValidLocale,
+  LOCALE_COOKIE,
+  LOCALE_COOKIE_MAX_AGE,
+  LOCALE_STORAGE_KEY,
+  type SupportedLocale,
+} from "@/lib/i18n/locales";
+
+type LocaleState = {
+  locale: SupportedLocale;
+  setLocale: (locale: SupportedLocale) => void;
+};
+
+function writeCookie(locale: SupportedLocale) {
+  try {
+    document.cookie = `${LOCALE_COOKIE}=${locale}; Max-Age=${LOCALE_COOKIE_MAX_AGE}; Path=/; SameSite=Lax`;
+  } catch {
+    // storage unavailable
+  }
+}
+
+export const useLocaleStore = create<LocaleState>()(
+  persist(
+    (set) => ({
+      locale: getLocaleFromBrowser(),
+      setLocale: (locale) => {
+        writeCookie(locale);
+        set({ locale });
+      },
+    }),
+    {
+      name: LOCALE_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+      onRehydrateStorage: () => (state) => {
+        if (state) writeCookie(state.locale);
+      },
+    }
+  )
+);
+
+export function useLocale(): SupportedLocale {
+  return useLocaleStore((s) => s.locale);
+}
+
+// Sync locale changes made in other browser tabs.
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", (e) => {
+    if (e.key === LOCALE_STORAGE_KEY) {
+      void useLocaleStore.persist.rehydrate();
+    }
+  });
+}
+
+// Validate stored value on rehydration; fall back to default if corrupted.
+useLocaleStore.persist.onFinishHydration((state) => {
+  if (!isValidLocale(state.locale)) {
+    useLocaleStore.setState({ locale: defaultLocale });
+    writeCookie(defaultLocale);
+  }
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,51 @@
+import { createElement, type ReactElement, type ReactNode } from "react";
+import { vi } from "vitest";
+import { NextIntlClientProvider } from "next-intl";
+import { createTranslator } from "use-intl/core";
+import enEditor from "../messages/en/editor.json";
+
+const messages = {
+  editor: enEditor,
+};
+
+vi.mock("@testing-library/react", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@testing-library/react")>();
+
+  return {
+    ...actual,
+    render: (ui: ReactElement, options?: Parameters<typeof actual.render>[1]) =>
+      actual.render(ui, {
+        wrapper: (({ children }: { children: ReactNode }) =>
+          createElement(
+            NextIntlClientProvider as never,
+            { locale: "en", messages } as never,
+            children
+          )) as never,
+        ...options,
+      }),
+  };
+});
+
+vi.mock("next-intl/server", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next-intl/server")>();
+
+  return {
+    ...actual,
+    getTranslations: async (
+      namespaceOrOpts?: string | { namespace?: string }
+    ) => {
+      const namespace =
+        typeof namespaceOrOpts === "string"
+          ? namespaceOrOpts
+          : namespaceOrOpts?.namespace;
+      return createTranslator({
+        locale: "en",
+        messages,
+        namespace: namespace as never,
+      });
+    },
+    getLocale: async () => "en",
+    getMessages: async () => messages,
+  };
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     environment: "node",
     fileParallelism: true,
     include: ["tests/**/*.test.{ts,tsx}"],
+    setupFiles: ["tests/setup.ts"],
     pool: "forks",
     restoreMocks: true,
     clearMocks: true,


### PR DESCRIPTION
Part 1 of the EN/NL i18n stack.

This adds the multilingual foundation: next-intl wiring, locale configuration, locale state, root provider integration, language picker, and the first editor namespace migration.

Why: keep the architecture reviewable before the broader UI surface migration lands.

Validation already run on the complete stack:
- npm run i18n:check
- npm run i18n:scan-hardcoded
- npm run type
- npm run lint
- npm run build