### PR TITLE
fix: Scope client i18n messages by route

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -12,6 +12,7 @@ import {
 import { countActiveApiKeysForAdmin } from "@/lib/server/api-keys";
 import { getGalleryOverviewStats } from "@/lib/server/gallery";
 import { countUsersForAdmin } from "@/lib/server/users";
+import LanguageProvider from "@/i18n/LanguageProvider";
 
 export default async function DashboardLayout({
   children,
@@ -41,28 +42,30 @@ export default async function DashboardLayout({
   ]);
 
   return (
-    <SidebarProvider
-      style={
-        {
-          "--header-height": "calc(var(--spacing) * 12)",
-          "--radius": "0.625rem",
-        } as React.CSSProperties
-      }
-    >
-      <DashboardAppSidebar
-        currentUser={{
-          name: currentUserName,
-          email: currentUserEmail,
-          role: user.role,
-        }}
-        visibleModules={visibleModules}
-        itemBadges={{
-          ...(galleryStats ? { gallery: galleryStats.total } : {}),
-          ...(totalUsers !== null ? { users: totalUsers } : {}),
-          ...(activeApiKeys !== null ? { "api-keys": activeApiKeys } : {}),
-        }}
-      />
-      <SidebarInset className="ml-0!">{children}</SidebarInset>
-    </SidebarProvider>
+    <LanguageProvider namespaces={["common", "dashboard"]}>
+      <SidebarProvider
+        style={
+          {
+            "--header-height": "calc(var(--spacing) * 12)",
+            "--radius": "0.625rem",
+          } as React.CSSProperties
+        }
+      >
+        <DashboardAppSidebar
+          currentUser={{
+            name: currentUserName,
+            email: currentUserEmail,
+            role: user.role,
+          }}
+          visibleModules={visibleModules}
+          itemBadges={{
+            ...(galleryStats ? { gallery: galleryStats.total } : {}),
+            ...(totalUsers !== null ? { users: totalUsers } : {}),
+            ...(activeApiKeys !== null ? { "api-keys": activeApiKeys } : {}),
+          }}
+        />
+        <SidebarInset className="ml-0!">{children}</SidebarInset>
+      </SidebarProvider>
+    </LanguageProvider>
   );
 }

--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import LanguageProvider from "@/i18n/LanguageProvider";
 
 export const metadata: Metadata = {
   title: "Track Embed",
@@ -14,5 +15,9 @@ export default function EmbedLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <LanguageProvider namespaces={["common", "editor", "share"]}>
+      {children}
+    </LanguageProvider>
+  );
 }

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -5,6 +5,7 @@ import PublicGalleryGrid from "@/components/gallery/PublicGalleryGrid";
 import { Footer } from "@/components/landing/Footer";
 import { PublicSiteHeader } from "@/components/landing/PublicSiteHeader";
 import { listPublicGalleryEntries } from "@/lib/server/gallery";
+import LanguageProvider from "@/i18n/LanguageProvider";
 import {
   DEFAULT_OG_IMAGE_ALT,
   DEFAULT_SOCIAL_IMAGE,
@@ -94,41 +95,46 @@ export default async function GalleryPage() {
         dangerouslySetInnerHTML={{ __html: serializeJsonLd(itemListJsonLd) }}
       />
 
-      <div className="bg-background min-h-screen overflow-x-clip">
-        <PublicSiteHeader currentPage="gallery" />
+      <LanguageProvider namespaces={["common", "landing"]}>
+        <div className="bg-background min-h-screen overflow-x-clip">
+          <PublicSiteHeader currentPage="gallery" />
 
-        <main>
-          <section className="relative pb-10 sm:pb-14">
-            <div className="pointer-events-none absolute -top-32 left-0 h-150 w-150 rounded-full bg-[#1E93DB] opacity-[0.06] blur-[120px]" />
+          <main>
+            <section className="relative pb-10 sm:pb-14">
+              <div className="pointer-events-none absolute -top-32 left-0 h-150 w-150 rounded-full bg-[#1E93DB] opacity-[0.06] blur-[120px]" />
 
-            <div className="relative z-10 mx-auto w-full max-w-6xl px-6 py-14 sm:py-20">
-              <div className="mx-auto max-w-3xl text-center">
-                <p className="text-muted-foreground text-[11px] font-semibold tracking-[0.2em] uppercase">
-                  {t("gallery.sectionLabel")}
-                </p>
-                <h1 className="mt-4 text-[clamp(34px,9vw,56px)] leading-[1.02] font-semibold tracking-[-0.04em] text-balance sm:leading-[1.08]">
-                  <span className="block">{t("gallery.headingLine1")}</span>
-                  <span className="from-brand-primary mt-1.5 block bg-linear-to-r to-sky-300 bg-clip-text pb-1 leading-[1.12] text-transparent sm:mt-0">
-                    {t("gallery.headingLine2")}
-                  </span>
-                </h1>
-                <p className="text-muted-foreground mx-auto mt-5 max-w-2xl text-[15px] leading-7">
-                  {t("gallery.description")}
-                </p>
+              <div className="relative z-10 mx-auto w-full max-w-6xl px-6 py-14 sm:py-20">
+                <div className="mx-auto max-w-3xl text-center">
+                  <p className="text-muted-foreground text-[11px] font-semibold tracking-[0.2em] uppercase">
+                    {t("gallery.sectionLabel")}
+                  </p>
+                  <h1 className="mt-4 text-[clamp(34px,9vw,56px)] leading-[1.02] font-semibold tracking-[-0.04em] text-balance sm:leading-[1.08]">
+                    <span className="block">{t("gallery.headingLine1")}</span>
+                    <span className="from-brand-primary mt-1.5 block bg-linear-to-r to-sky-300 bg-clip-text pb-1 leading-[1.12] text-transparent sm:mt-0">
+                      {t("gallery.headingLine2")}
+                    </span>
+                  </h1>
+                  <p className="text-muted-foreground mx-auto mt-5 max-w-2xl text-[15px] leading-7">
+                    {t("gallery.description")}
+                  </p>
+                </div>
               </div>
-            </div>
-          </section>
+            </section>
 
-          <section
-            id="gallery-grid"
-            className="relative z-20 mx-auto -mt-8 max-w-6xl px-4 pb-12 sm:-mt-10 sm:px-6 sm:pb-16"
-          >
-            <PublicGalleryGrid entries={entries} mediaBaseUrl={mediaBaseUrl} />
-          </section>
-        </main>
+            <section
+              id="gallery-grid"
+              className="relative z-20 mx-auto -mt-8 max-w-6xl px-4 pb-12 sm:-mt-10 sm:px-6 sm:pb-16"
+            >
+              <PublicGalleryGrid
+                entries={entries}
+                mediaBaseUrl={mediaBaseUrl}
+              />
+            </section>
+          </main>
 
-        <Footer />
-      </div>
+          <Footer />
+        </div>
+      </LanguageProvider>
     </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,10 +2,12 @@ import type { Metadata, Viewport } from "next";
 import { cookies } from "next/headers";
 import "./globals.css";
 import { NextIntlClientProvider } from "next-intl";
-import { getLocale, getMessages } from "next-intl/server";
+import { getLocale } from "next-intl/server";
 import ThemeBootstrap from "@/components/ThemeBootstrap";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { isValidLocale } from "@/lib/i18n/locales";
+import { pickMessages } from "@/i18n/messages";
 import {
   DEFAULT_SOCIAL_IMAGE,
   DEFAULT_SOCIAL_IMAGE_HEIGHT,
@@ -100,8 +102,9 @@ export default async function RootLayout({
     cookieStore.get(THEME_COOKIE)?.value,
     cookieStore.get(RESOLVED_THEME_COOKIE)?.value
   );
-  const locale = await getLocale();
-  const messages = await getMessages();
+  const rawLocale = await getLocale();
+  const locale = isValidLocale(rawLocale) ? rawLocale : "en";
+  const messages = pickMessages(locale, ["common"]);
 
   return (
     <html

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import LanguageProvider from "@/i18n/LanguageProvider";
 
 export const metadata: Metadata = {
   title: "Sign in",
@@ -14,5 +15,9 @@ export default function LoginLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <LanguageProvider namespaces={["common", "login"]}>
+      {children}
+    </LanguageProvider>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,6 +73,7 @@ import {
   RevealStagger,
   RevealStaggerItem,
 } from "@/components/landing/Motion";
+import LanguageProvider from "@/i18n/LanguageProvider";
 
 // ── Eyebrow label ───────────────────────────────────────────────
 function Eyebrow({
@@ -249,366 +250,370 @@ export default async function Home() {
     "inline-flex min-h-7.5 items-center rounded-full border px-3.5 py-1 text-xs font-medium";
 
   return (
-    <div id="top" className="bg-background text-foreground min-h-screen">
-      <script
-        id="software-application-jsonld"
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: serializeJsonLd(softwareApplicationJsonLd),
-        }}
-      />
-      <script
-        id="video-object-jsonld"
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: serializeJsonLd(videoObjectJsonLd),
-        }}
-      />
-      <script
-        id="faq-page-jsonld"
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: serializeJsonLd(faqPageJsonLd),
-        }}
-      />
-      {/* ── Nav ─────────────────────────────────────────────── */}
-      <PublicSiteHeader currentPage="home" />
+    <LanguageProvider namespaces={["common", "landing"]}>
+      <div id="top" className="bg-background text-foreground min-h-screen">
+        <script
+          id="software-application-jsonld"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: serializeJsonLd(softwareApplicationJsonLd),
+          }}
+        />
+        <script
+          id="video-object-jsonld"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: serializeJsonLd(videoObjectJsonLd),
+          }}
+        />
+        <script
+          id="faq-page-jsonld"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: serializeJsonLd(faqPageJsonLd),
+          }}
+        />
+        {/* ── Nav ─────────────────────────────────────────────── */}
+        <PublicSiteHeader currentPage="home" />
 
-      {/* ── Hero ────────────────────────────────────────────── */}
-      <div className="relative overflow-hidden">
-        {/* Ambient glow — top-left, keyed to the text column */}
-        <div className="pointer-events-none absolute -top-32 left-0 h-150 w-150 rounded-full bg-[#1E93DB] opacity-[0.06] blur-[120px]" />
+        {/* ── Hero ────────────────────────────────────────────── */}
+        <div className="relative overflow-hidden">
+          {/* Ambient glow — top-left, keyed to the text column */}
+          <div className="pointer-events-none absolute -top-32 left-0 h-150 w-150 rounded-full bg-[#1E93DB] opacity-[0.06] blur-[120px]" />
 
-        <section className="relative z-10 mx-auto w-full max-w-6xl px-6 py-14 sm:py-24">
-          <div className="grid items-center gap-12 lg:grid-cols-[1fr_1.45fr] lg:gap-16">
-            {/* Left: text */}
-            <div>
-              <Reveal>
-                <div className="flex items-center gap-3">
-                  <span
-                    className={`border-brand-primary/25 bg-brand-primary/8 text-brand-primary ${heroPillClassName} gap-2`}
+          <section className="relative z-10 mx-auto w-full max-w-6xl px-6 py-14 sm:py-24">
+            <div className="grid items-center gap-12 lg:grid-cols-[1fr_1.45fr] lg:gap-16">
+              {/* Left: text */}
+              <div>
+                <Reveal>
+                  <div className="flex items-center gap-3">
+                    <span
+                      className={`border-brand-primary/25 bg-brand-primary/8 text-brand-primary ${heroPillClassName} gap-2`}
+                    >
+                      <span className="bg-brand-primary size-1.5 animate-pulse rounded-full" />
+                      {t("hero.eyebrow")}
+                    </span>
+                    <VersionTag
+                      className={`${heroPillClassName} border-amber-500/30 bg-amber-500/10 font-sans text-amber-500 hover:bg-amber-500/15 hover:text-amber-400`}
+                    />
+                  </div>
+                </Reveal>
+
+                <Reveal delay={0.07} className="mt-5">
+                  <h1 className="text-[clamp(40px,11vw,58px)] leading-[1.04] font-semibold tracking-[-0.04em] sm:leading-[1.08]">
+                    {t("hero.headingLine1")}
+                    <br />
+                    <span className="from-brand-primary bg-linear-to-r to-sky-300 bg-clip-text text-transparent">
+                      {t("hero.headingLine2")}
+                    </span>
+                  </h1>
+                </Reveal>
+
+                <Reveal delay={0.13} className="mt-5">
+                  <p className="text-muted-foreground max-w-sm text-[15px] leading-7">
+                    {t("hero.description")}
+                  </p>
+                </Reveal>
+
+                <Reveal
+                  delay={0.18}
+                  className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center"
+                >
+                  <Link
+                    href="/studio"
+                    className="inline-flex h-10 items-center justify-center gap-2 rounded-full bg-[#1E93DB] px-6 text-sm font-medium text-white shadow-lg shadow-[#1E93DB]/25 transition hover:brightness-110"
                   >
-                    <span className="bg-brand-primary size-1.5 animate-pulse rounded-full" />
-                    {t("hero.eyebrow")}
-                  </span>
-                  <VersionTag
-                    className={`${heroPillClassName} border-amber-500/30 bg-amber-500/10 font-sans text-amber-500 hover:bg-amber-500/15 hover:text-amber-400`}
-                  />
-                </div>
-              </Reveal>
+                    {t("hero.ctaStudio")} <ArrowRight className="size-3.5" />
+                  </Link>
+                  <a
+                    href="#features"
+                    className="border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground inline-flex h-10 items-center justify-center gap-2 rounded-full border px-6 text-sm transition"
+                  >
+                    {t("hero.ctaFeatures")}
+                  </a>
+                </Reveal>
 
-              <Reveal delay={0.07} className="mt-5">
-                <h1 className="text-[clamp(40px,11vw,58px)] leading-[1.04] font-semibold tracking-[-0.04em] sm:leading-[1.08]">
-                  {t("hero.headingLine1")}
-                  <br />
-                  <span className="from-brand-primary bg-linear-to-r to-sky-300 bg-clip-text text-transparent">
-                    {t("hero.headingLine2")}
-                  </span>
-                </h1>
-              </Reveal>
+                <Reveal delay={0.23}>
+                  <ul className="mt-8 grid grid-cols-2 gap-x-4 gap-y-2.5">
+                    {[
+                      t("hero.feature1"),
+                      t("hero.feature2"),
+                      t("hero.feature3"),
+                      t("hero.feature4"),
+                    ].map((item) => (
+                      <li
+                        key={item}
+                        className="text-muted-foreground flex items-center gap-2 text-sm"
+                      >
+                        <span className="bg-brand-primary/15 flex size-4 shrink-0 items-center justify-center rounded-full">
+                          <Check className="text-brand-primary size-2.5" />
+                        </span>
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                </Reveal>
+              </div>
 
-              <Reveal delay={0.13} className="mt-5">
-                <p className="text-muted-foreground max-w-sm text-[15px] leading-7">
-                  {t("hero.description")}
+              {/* Right: product demo */}
+              <Reveal delay={0.12}>
+                <LandingVideo className="sm:min-h-90" />
+              </Reveal>
+            </div>
+          </section>
+        </div>
+
+        <main>
+          {/* ── Features grid ────────────────────────────────── */}
+          <section id="features" className="border-border/40 border-t">
+            <div className="mx-auto w-full max-w-6xl px-6 py-14 sm:py-20">
+              <Reveal className="mb-12">
+                <Eyebrow>{t("features.sectionTitle")}</Eyebrow>
+                <h2 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">
+                  {t("features.sectionHeading")}
+                </h2>
+                <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-7">
+                  {t("features.sectionDescription")}
                 </p>
               </Reveal>
 
-              <Reveal
-                delay={0.18}
-                className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center"
-              >
-                <Link
-                  href="/studio"
-                  className="inline-flex h-10 items-center justify-center gap-2 rounded-full bg-[#1E93DB] px-6 text-sm font-medium text-white shadow-lg shadow-[#1E93DB]/25 transition hover:brightness-110"
-                >
-                  {t("hero.ctaStudio")} <ArrowRight className="size-3.5" />
-                </Link>
-                <a
-                  href="#features"
-                  className="border-border text-muted-foreground hover:border-foreground/30 hover:text-foreground inline-flex h-10 items-center justify-center gap-2 rounded-full border px-6 text-sm transition"
-                >
-                  {t("hero.ctaFeatures")}
-                </a>
-              </Reveal>
-
-              <Reveal delay={0.23}>
-                <ul className="mt-8 grid grid-cols-2 gap-x-4 gap-y-2.5">
-                  {[
-                    t("hero.feature1"),
-                    t("hero.feature2"),
-                    t("hero.feature3"),
-                    t("hero.feature4"),
-                  ].map((item) => (
-                    <li
-                      key={item}
-                      className="text-muted-foreground flex items-center gap-2 text-sm"
+              <RevealStagger className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {features.map((f) => (
+                  <RevealStaggerItem key={f.title} className="h-full">
+                    <div
+                      className={`group border-border/50 bg-card/20 hover:bg-card/45 relative flex h-full flex-col gap-4 overflow-hidden rounded-2xl border p-6 transition-all duration-300 ${f.border}`}
                     >
-                      <span className="bg-brand-primary/15 flex size-4 shrink-0 items-center justify-center rounded-full">
-                        <Check className="text-brand-primary size-2.5" />
-                      </span>
-                      {item}
-                    </li>
-                  ))}
-                </ul>
-              </Reveal>
-            </div>
-
-            {/* Right: product demo */}
-            <Reveal delay={0.12}>
-              <LandingVideo className="sm:min-h-90" />
-            </Reveal>
-          </div>
-        </section>
-      </div>
-
-      <main>
-        {/* ── Features grid ────────────────────────────────── */}
-        <section id="features" className="border-border/40 border-t">
-          <div className="mx-auto w-full max-w-6xl px-6 py-14 sm:py-20">
-            <Reveal className="mb-12">
-              <Eyebrow>{t("features.sectionTitle")}</Eyebrow>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">
-                {t("features.sectionHeading")}
-              </h2>
-              <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-7">
-                {t("features.sectionDescription")}
-              </p>
-            </Reveal>
-
-            <RevealStagger className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {features.map((f) => (
-                <RevealStaggerItem key={f.title} className="h-full">
-                  <div
-                    className={`group border-border/50 bg-card/20 hover:bg-card/45 relative flex h-full flex-col gap-4 overflow-hidden rounded-2xl border p-6 transition-all duration-300 ${f.border}`}
-                  >
-                    <div
-                      className={`pointer-events-none absolute inset-0 bg-linear-to-br ${f.surface} opacity-80 transition-opacity duration-300 group-hover:opacity-100`}
-                    />
-                    {/* Per-card colour glow in the top-right corner */}
-                    <div
-                      className="pointer-events-none absolute -top-6 -right-6 size-28 rounded-full opacity-0 blur-2xl transition-opacity duration-500 group-hover:opacity-100"
-                      style={{ background: f.glow }}
-                    />
-                    <div
-                      className={`relative inline-flex size-9 items-center justify-center rounded-xl border border-white/8 ${f.bg}`}
-                    >
-                      <f.icon className={`size-4 ${f.color}`} />
+                      <div
+                        className={`pointer-events-none absolute inset-0 bg-linear-to-br ${f.surface} opacity-80 transition-opacity duration-300 group-hover:opacity-100`}
+                      />
+                      {/* Per-card colour glow in the top-right corner */}
+                      <div
+                        className="pointer-events-none absolute -top-6 -right-6 size-28 rounded-full opacity-0 blur-2xl transition-opacity duration-500 group-hover:opacity-100"
+                        style={{ background: f.glow }}
+                      />
+                      <div
+                        className={`relative inline-flex size-9 items-center justify-center rounded-xl border border-white/8 ${f.bg}`}
+                      >
+                        <f.icon className={`size-4 ${f.color}`} />
+                      </div>
+                      <div className="relative">
+                        <h3 className="text-sm font-semibold">{f.title}</h3>
+                        <p className="text-muted-foreground mt-1.5 text-sm leading-6">
+                          {f.text}
+                        </p>
+                      </div>
                     </div>
-                    <div className="relative">
-                      <h3 className="text-sm font-semibold">{f.title}</h3>
-                      <p className="text-muted-foreground mt-1.5 text-sm leading-6">
-                        {f.text}
+                  </RevealStaggerItem>
+                ))}
+              </RevealStagger>
+            </div>
+          </section>
+
+          {/* ── In depth ─────────────────────────────────────── */}
+          <section
+            id="in-depth"
+            className="border-border/40 bg-muted/[0.035] border-t"
+          >
+            <div className="mx-auto w-full max-w-6xl px-6 py-14 sm:py-20">
+              <Reveal className="mb-12 sm:mb-20">
+                <Eyebrow>{t("workflow.sectionEyebrow")}</Eyebrow>
+                <h2 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">
+                  {t("workflow.sectionHeading")}
+                </h2>
+                <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-7">
+                  {t("workflow.sectionDescription")}
+                </p>
+              </Reveal>
+
+              <div className="space-y-16 sm:space-y-28">
+                <Reveal>
+                  <div className="grid items-center gap-8 sm:gap-10 lg:grid-cols-2 lg:gap-12">
+                    <Screenshot
+                      src={getSiteMediaUrl(
+                        "/landing/screenshots/editor-element-library.png"
+                      )}
+                      alt="TrackDraw 2D layout editor with obstacle library and track plan"
+                      className="order-last lg:order-first"
+                    />
+                    <div className="order-first lg:order-last">
+                      <div className="border-brand-primary/20 bg-brand-primary/8 text-brand-primary inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-semibold tracking-[0.15em] uppercase">
+                        <Route className="size-3" />{" "}
+                        {t("workflow.layout.title")}
+                      </div>
+                      <h3 className="mt-4 text-xl font-semibold tracking-tight">
+                        {t("workflow.layout.subtitle")}
+                      </h3>
+                      <p className="text-muted-foreground mt-3 text-sm leading-7">
+                        {t("workflow.layout.description")}
                       </p>
+                      <ul className="mt-5 space-y-2.5">
+                        {[
+                          t("workflow.layout.bullet1"),
+                          t("workflow.layout.bullet2"),
+                          t("workflow.layout.bullet3"),
+                        ].map((b) => (
+                          <li
+                            key={b}
+                            className="text-muted-foreground flex items-center gap-2.5 text-sm"
+                          >
+                            <CheckCircle2 className="text-brand-primary size-3.5 shrink-0" />{" "}
+                            {b}
+                          </li>
+                        ))}
+                      </ul>
                     </div>
                   </div>
-                </RevealStaggerItem>
-              ))}
-            </RevealStagger>
-          </div>
-        </section>
+                </Reveal>
 
-        {/* ── In depth ─────────────────────────────────────── */}
-        <section
-          id="in-depth"
-          className="border-border/40 bg-muted/[0.035] border-t"
-        >
-          <div className="mx-auto w-full max-w-6xl px-6 py-14 sm:py-20">
-            <Reveal className="mb-12 sm:mb-20">
-              <Eyebrow>{t("workflow.sectionEyebrow")}</Eyebrow>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">
-                {t("workflow.sectionHeading")}
-              </h2>
-              <p className="text-muted-foreground mt-4 max-w-2xl text-sm leading-7">
-                {t("workflow.sectionDescription")}
-              </p>
-            </Reveal>
-
-            <div className="space-y-16 sm:space-y-28">
-              <Reveal>
-                <div className="grid items-center gap-8 sm:gap-10 lg:grid-cols-2 lg:gap-12">
-                  <Screenshot
-                    src={getSiteMediaUrl(
-                      "/landing/screenshots/editor-element-library.png"
-                    )}
-                    alt="TrackDraw 2D layout editor with obstacle library and track plan"
-                    className="order-last lg:order-first"
-                  />
-                  <div className="order-first lg:order-last">
-                    <div className="border-brand-primary/20 bg-brand-primary/8 text-brand-primary inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-semibold tracking-[0.15em] uppercase">
-                      <Route className="size-3" /> {t("workflow.layout.title")}
+                <Reveal>
+                  <div className="grid items-center gap-8 sm:gap-9 lg:grid-cols-[1.28fr_0.72fr] lg:gap-14">
+                    <div>
+                      <div className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/20 bg-emerald-500/8 px-3 py-1 text-[11px] font-semibold tracking-[0.15em] text-emerald-400 uppercase">
+                        <ClipboardCheck className="size-3" />{" "}
+                        {t("workflow.fineTune.title")}
+                      </div>
+                      <h3 className="mt-4 text-xl font-semibold tracking-tight">
+                        {t("workflow.fineTune.subtitle")}
+                      </h3>
+                      <p className="text-muted-foreground mt-3 text-sm leading-7">
+                        {t("workflow.fineTune.description")}
+                      </p>
+                      <ul className="mt-5 space-y-2.5">
+                        {[
+                          t("workflow.fineTune.bullet1"),
+                          t("workflow.fineTune.bullet2"),
+                          t("workflow.fineTune.bullet3"),
+                        ].map((b) => (
+                          <li
+                            key={b}
+                            className="text-muted-foreground flex items-center gap-2.5 text-sm"
+                          >
+                            <CheckCircle2 className="size-3.5 shrink-0 text-emerald-400" />{" "}
+                            {b}
+                          </li>
+                        ))}
+                      </ul>
                     </div>
-                    <h3 className="mt-4 text-xl font-semibold tracking-tight">
-                      {t("workflow.layout.subtitle")}
-                    </h3>
-                    <p className="text-muted-foreground mt-3 text-sm leading-7">
-                      {t("workflow.layout.description")}
-                    </p>
-                    <ul className="mt-5 space-y-2.5">
-                      {[
-                        t("workflow.layout.bullet1"),
-                        t("workflow.layout.bullet2"),
-                        t("workflow.layout.bullet3"),
-                      ].map((b) => (
-                        <li
-                          key={b}
-                          className="text-muted-foreground flex items-center gap-2.5 text-sm"
-                        >
-                          <CheckCircle2 className="text-brand-primary size-3.5 shrink-0" />{" "}
-                          {b}
-                        </li>
-                      ))}
-                    </ul>
+                    <Screenshot
+                      src={getSiteMediaUrl(
+                        "/landing/screenshots/editor-mobile-settings.png"
+                      )}
+                      alt="TrackDraw mobile editor with settings panel open"
+                      aspect="portrait"
+                      accentClassName="bg-emerald-500/16"
+                      className="mx-auto w-full max-w-51.25 self-center sm:max-w-57.5 lg:max-w-62.5"
+                    />
                   </div>
-                </div>
-              </Reveal>
+                </Reveal>
 
-              <Reveal>
-                <div className="grid items-center gap-8 sm:gap-9 lg:grid-cols-[1.28fr_0.72fr] lg:gap-14">
-                  <div>
-                    <div className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/20 bg-emerald-500/8 px-3 py-1 text-[11px] font-semibold tracking-[0.15em] text-emerald-400 uppercase">
-                      <ClipboardCheck className="size-3" />{" "}
-                      {t("workflow.fineTune.title")}
+                <Reveal>
+                  <div className="grid items-center gap-8 sm:gap-10 lg:grid-cols-2 lg:gap-12">
+                    <Screenshot
+                      src={getSiteMediaUrl(
+                        "/landing/screenshots/editor-3d-flythroug.png"
+                      )}
+                      alt="TrackDraw 3D preview showing track flow and elevation"
+                      className="order-last lg:order-first"
+                    />
+                    <div className="order-first lg:order-last">
+                      <div className="inline-flex items-center gap-1.5 rounded-full border border-purple-500/20 bg-purple-500/8 px-3 py-1 text-[11px] font-semibold tracking-[0.15em] text-purple-400 uppercase">
+                        <Orbit className="size-3" />{" "}
+                        {t("workflow.preview.title")}
+                      </div>
+                      <h3 className="mt-4 text-xl font-semibold tracking-tight">
+                        {t("workflow.preview.subtitle")}
+                      </h3>
+                      <p className="text-muted-foreground mt-3 text-sm leading-7">
+                        {t("workflow.preview.description")}
+                      </p>
+                      <ul className="mt-5 space-y-2.5">
+                        {[
+                          t("workflow.preview.bullet1"),
+                          t("workflow.preview.bullet2"),
+                          t("workflow.preview.bullet3"),
+                        ].map((b) => (
+                          <li
+                            key={b}
+                            className="text-muted-foreground flex items-center gap-2.5 text-sm"
+                          >
+                            <CheckCircle2 className="size-3.5 shrink-0 text-purple-400" />{" "}
+                            {b}
+                          </li>
+                        ))}
+                      </ul>
                     </div>
-                    <h3 className="mt-4 text-xl font-semibold tracking-tight">
-                      {t("workflow.fineTune.subtitle")}
-                    </h3>
-                    <p className="text-muted-foreground mt-3 text-sm leading-7">
-                      {t("workflow.fineTune.description")}
-                    </p>
-                    <ul className="mt-5 space-y-2.5">
-                      {[
-                        t("workflow.fineTune.bullet1"),
-                        t("workflow.fineTune.bullet2"),
-                        t("workflow.fineTune.bullet3"),
-                      ].map((b) => (
-                        <li
-                          key={b}
-                          className="text-muted-foreground flex items-center gap-2.5 text-sm"
-                        >
-                          <CheckCircle2 className="size-3.5 shrink-0 text-emerald-400" />{" "}
-                          {b}
-                        </li>
-                      ))}
-                    </ul>
                   </div>
-                  <Screenshot
-                    src={getSiteMediaUrl(
-                      "/landing/screenshots/editor-mobile-settings.png"
-                    )}
-                    alt="TrackDraw mobile editor with settings panel open"
-                    aspect="portrait"
-                    accentClassName="bg-emerald-500/16"
-                    className="mx-auto w-full max-w-51.25 self-center sm:max-w-57.5 lg:max-w-62.5"
-                  />
-                </div>
-              </Reveal>
+                </Reveal>
 
-              <Reveal>
-                <div className="grid items-center gap-8 sm:gap-10 lg:grid-cols-2 lg:gap-12">
-                  <Screenshot
-                    src={getSiteMediaUrl(
-                      "/landing/screenshots/editor-3d-flythroug.png"
-                    )}
-                    alt="TrackDraw 3D preview showing track flow and elevation"
-                    className="order-last lg:order-first"
-                  />
-                  <div className="order-first lg:order-last">
-                    <div className="inline-flex items-center gap-1.5 rounded-full border border-purple-500/20 bg-purple-500/8 px-3 py-1 text-[11px] font-semibold tracking-[0.15em] text-purple-400 uppercase">
-                      <Orbit className="size-3" /> {t("workflow.preview.title")}
+                <Reveal>
+                  <div className="grid items-center gap-8 sm:gap-9 lg:grid-cols-[1.28fr_0.72fr] lg:gap-14">
+                    <div>
+                      <div className="border-brand-secondary/20 bg-brand-secondary/8 text-brand-secondary inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-semibold tracking-[0.15em] uppercase">
+                        <Share2 className="size-3" />{" "}
+                        {t("workflow.handOff.title")}
+                      </div>
+                      <h3 className="mt-4 text-xl font-semibold tracking-tight">
+                        {t("workflow.handOff.subtitle")}
+                      </h3>
+                      <p className="text-muted-foreground mt-3 text-sm leading-7">
+                        {t("workflow.handOff.description")}
+                      </p>
+                      <ul className="mt-5 space-y-2.5">
+                        {[
+                          t("workflow.handOff.bullet1"),
+                          t("workflow.handOff.bullet2"),
+                          t("workflow.handOff.bullet3"),
+                        ].map((b) => (
+                          <li
+                            key={b}
+                            className="text-muted-foreground flex items-center gap-2.5 text-sm"
+                          >
+                            <CheckCircle2 className="text-brand-secondary size-3.5 shrink-0" />{" "}
+                            {b}
+                          </li>
+                        ))}
+                      </ul>
+                      <Link
+                        href="/gallery"
+                        className="text-brand-secondary hover:text-brand-secondary/85 mt-6 inline-flex items-center gap-2 text-sm font-medium transition-colors"
+                      >
+                        {t("workflow.handOff.gallery")}
+                        <ArrowRight className="size-3.5" />
+                      </Link>
                     </div>
-                    <h3 className="mt-4 text-xl font-semibold tracking-tight">
-                      {t("workflow.preview.subtitle")}
-                    </h3>
-                    <p className="text-muted-foreground mt-3 text-sm leading-7">
-                      {t("workflow.preview.description")}
-                    </p>
-                    <ul className="mt-5 space-y-2.5">
-                      {[
-                        t("workflow.preview.bullet1"),
-                        t("workflow.preview.bullet2"),
-                        t("workflow.preview.bullet3"),
-                      ].map((b) => (
-                        <li
-                          key={b}
-                          className="text-muted-foreground flex items-center gap-2.5 text-sm"
-                        >
-                          <CheckCircle2 className="size-3.5 shrink-0 text-purple-400" />{" "}
-                          {b}
-                        </li>
-                      ))}
-                    </ul>
+                    <Screenshot
+                      src={getSiteMediaUrl(
+                        "/landing/screenshots/editor-share-readonly-mobile.png"
+                      )}
+                      alt="TrackDraw read-only shared view open on mobile"
+                      aspect="portrait"
+                      accentClassName="bg-brand-secondary/18"
+                      className="mx-auto w-full max-w-51.25 self-center sm:max-w-57.5 lg:max-w-62.5"
+                    />
                   </div>
-                </div>
-              </Reveal>
-
-              <Reveal>
-                <div className="grid items-center gap-8 sm:gap-9 lg:grid-cols-[1.28fr_0.72fr] lg:gap-14">
-                  <div>
-                    <div className="border-brand-secondary/20 bg-brand-secondary/8 text-brand-secondary inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-semibold tracking-[0.15em] uppercase">
-                      <Share2 className="size-3" />{" "}
-                      {t("workflow.handOff.title")}
-                    </div>
-                    <h3 className="mt-4 text-xl font-semibold tracking-tight">
-                      {t("workflow.handOff.subtitle")}
-                    </h3>
-                    <p className="text-muted-foreground mt-3 text-sm leading-7">
-                      {t("workflow.handOff.description")}
-                    </p>
-                    <ul className="mt-5 space-y-2.5">
-                      {[
-                        t("workflow.handOff.bullet1"),
-                        t("workflow.handOff.bullet2"),
-                        t("workflow.handOff.bullet3"),
-                      ].map((b) => (
-                        <li
-                          key={b}
-                          className="text-muted-foreground flex items-center gap-2.5 text-sm"
-                        >
-                          <CheckCircle2 className="text-brand-secondary size-3.5 shrink-0" />{" "}
-                          {b}
-                        </li>
-                      ))}
-                    </ul>
-                    <Link
-                      href="/gallery"
-                      className="text-brand-secondary hover:text-brand-secondary/85 mt-6 inline-flex items-center gap-2 text-sm font-medium transition-colors"
-                    >
-                      {t("workflow.handOff.gallery")}
-                      <ArrowRight className="size-3.5" />
-                    </Link>
-                  </div>
-                  <Screenshot
-                    src={getSiteMediaUrl(
-                      "/landing/screenshots/editor-share-readonly-mobile.png"
-                    )}
-                    alt="TrackDraw read-only shared view open on mobile"
-                    aspect="portrait"
-                    accentClassName="bg-brand-secondary/18"
-                    className="mx-auto w-full max-w-51.25 self-center sm:max-w-57.5 lg:max-w-62.5"
-                  />
-                </div>
-              </Reveal>
+                </Reveal>
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
 
-        <PricingSection />
+          <PricingSection />
 
-        {/* ── FAQ ──────────────────────────────────────────── */}
-        <section id="faq" className="border-border/40 border-t">
-          <div className="mx-auto w-full max-w-2xl px-6 py-14 sm:py-20">
-            <Reveal className="mb-10">
-              <Eyebrow>{t("faq.sectionTitle")}</Eyebrow>
-              <h2 className="mt-3 text-2xl font-semibold tracking-tight">
-                {t("faq.sectionHeading")}
-              </h2>
-            </Reveal>
-            <FaqAccordion items={faq} />
-          </div>
-        </section>
-      </main>
+          {/* ── FAQ ──────────────────────────────────────────── */}
+          <section id="faq" className="border-border/40 border-t">
+            <div className="mx-auto w-full max-w-2xl px-6 py-14 sm:py-20">
+              <Reveal className="mb-10">
+                <Eyebrow>{t("faq.sectionTitle")}</Eyebrow>
+                <h2 className="mt-3 text-2xl font-semibold tracking-tight">
+                  {t("faq.sectionHeading")}
+                </h2>
+              </Reveal>
+              <FaqAccordion items={faq} />
+            </div>
+          </section>
+        </main>
 
-      <Footer />
-    </div>
+        <Footer />
+      </div>
+    </LanguageProvider>
   );
 }

--- a/src/app/share/layout.tsx
+++ b/src/app/share/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
+import LanguageProvider from "@/i18n/LanguageProvider";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("share.metadata");
@@ -15,5 +16,9 @@ export default function ShareLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <>{children}</>;
+  return (
+    <LanguageProvider namespaces={["common", "editor", "share"]}>
+      {children}
+    </LanguageProvider>
+  );
 }

--- a/src/app/studio/layout.tsx
+++ b/src/app/studio/layout.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_SOCIAL_IMAGE_HEIGHT,
   DEFAULT_SOCIAL_IMAGE_WIDTH,
 } from "@/lib/seo";
+import LanguageProvider from "@/i18n/LanguageProvider";
 
 export const metadata: Metadata = {
   title: "Drone Race Track Builder",
@@ -45,8 +46,20 @@ export default function StudioLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div style={{ "--radius": "0.375rem" } as React.CSSProperties}>
-      {children}
-    </div>
+    <LanguageProvider
+      namespaces={[
+        "common",
+        "dialogs",
+        "editor",
+        "exportPdf",
+        "inspector",
+        "setupEstimate",
+        "shapes",
+      ]}
+    >
+      <div style={{ "--radius": "0.375rem" } as React.CSSProperties}>
+        {children}
+      </div>
+    </LanguageProvider>
   );
 }

--- a/src/i18n/LanguageProvider.tsx
+++ b/src/i18n/LanguageProvider.tsx
@@ -1,6 +1,6 @@
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale } from "next-intl/server";
-import { isValidLocale } from "@/lib/i18n/locales";
+import { defaultLocale, isValidLocale } from "@/lib/i18n/locales";
 import { pickMessages, type MessageNamespace } from "@/i18n/messages";
 
 type LanguageProviderProps = {
@@ -13,7 +13,7 @@ export default async function LanguageProvider({
   children,
 }: LanguageProviderProps) {
   const rawLocale = await getLocale();
-  const locale = isValidLocale(rawLocale) ? rawLocale : "en";
+  const locale = isValidLocale(rawLocale) ? rawLocale : defaultLocale;
 
   return (
     <NextIntlClientProvider

--- a/src/i18n/LanguageProvider.tsx
+++ b/src/i18n/LanguageProvider.tsx
@@ -1,0 +1,26 @@
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale } from "next-intl/server";
+import { isValidLocale } from "@/lib/i18n/locales";
+import { pickMessages, type MessageNamespace } from "@/i18n/messages";
+
+type LanguageProviderProps = {
+  namespaces: readonly MessageNamespace[];
+  children: React.ReactNode;
+};
+
+export default async function LanguageProvider({
+  namespaces,
+  children,
+}: LanguageProviderProps) {
+  const rawLocale = await getLocale();
+  const locale = isValidLocale(rawLocale) ? rawLocale : "en";
+
+  return (
+    <NextIntlClientProvider
+      locale={locale}
+      messages={pickMessages(locale, namespaces)}
+    >
+      {children}
+    </NextIntlClientProvider>
+  );
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1,0 +1,22 @@
+import * as en from "@lang/en";
+import * as nl from "@lang/nl";
+import { defaultLocale, type SupportedLocale } from "@/lib/i18n/locales";
+
+const catalogs = { en, nl } as const;
+
+export type MessageNamespace = keyof typeof en;
+
+export function getMessagesForLocale(locale: SupportedLocale) {
+  return catalogs[locale] ?? catalogs[defaultLocale];
+}
+
+export function pickMessages(
+  locale: SupportedLocale,
+  namespaces: readonly MessageNamespace[]
+) {
+  const catalog = getMessagesForLocale(locale);
+
+  return Object.fromEntries(
+    namespaces.map((namespace) => [namespace, catalog[namespace]])
+  );
+}

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import * as en from "@lang/en";
 import * as nl from "@lang/nl";
 import { defaultLocale, type SupportedLocale } from "@/lib/i18n/locales";

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,15 +1,8 @@
 import { getRequestConfig } from "next-intl/server";
 import { cookies, headers } from "next/headers";
-import {
-  defaultLocale,
-  getLocaleFromAcceptLanguage,
-  isValidLocale,
-} from "@/lib/i18n/locales";
+import { getLocaleFromAcceptLanguage, isValidLocale } from "@/lib/i18n/locales";
 import { LOCALE_COOKIE } from "@/lib/i18n/locales";
-import * as en from "@lang/en";
-import * as nl from "@lang/nl";
-
-const messages = { en: { ...en }, nl: { ...nl } };
+import { getMessagesForLocale } from "@/i18n/messages";
 
 export default getRequestConfig(async () => {
   const cookieStore = await cookies();
@@ -21,6 +14,6 @@ export default getRequestConfig(async () => {
 
   return {
     locale,
-    messages: messages[locale] ?? messages[defaultLocale],
+    messages: getMessagesForLocale(locale),
   };
 });


### PR DESCRIPTION
## Summary
- add a route-level LanguageProvider that only sends the namespaces each client route needs
- keep the root provider limited to common messages instead of the full locale catalog
- share locale catalog access between next-intl request config and route-scoped providers

## Why
The full EN/NL catalog was being serialized through the root client provider, increasing client/RSC payload after the i18n rollout. Route-scoped message sets keep public, dashboard, share, login, and studio routes from receiving unrelated translations.

## Size notes
- NL full catalog: 91.9 KiB raw JSON
- NL dashboard route payload: 13.6 KiB
- NL share/embed route payload: 16.9 KiB
- NL login route payload: 2.8 KiB
- OpenNext handler after this change: 7,462,731 bytes raw / 1,911,753 bytes gzip

## Validation
- npm run type
- npm run i18n:check
- npm run build
- npx opennextjs-cloudflare build