### PR TITLE
fix: Translate remaining i18n allowlist copy

### DIFF
--- a/lang/en/common.json
+++ b/lang/en/common.json
@@ -34,6 +34,19 @@
     "type": "Type",
     "view": "View"
   },
+  "dataTable": {
+    "filterPlaceholder": "Filter {title}...",
+    "noResults": "No results found.",
+    "selectedCount": "{count} selected",
+    "clearFilters": "Clear filters"
+  },
+  "measurementUnit": {
+    "metric": "Metric",
+    "imperial": "Imperial",
+    "presetAriaLabel": "Measurement preset: {current}. Switch to {next}.",
+    "presetLabel": "Measurement preset: {current}",
+    "description": "Switch displayed distances and compatible inputs."
+  },
   "status": {
     "active": "Active",
     "expired": "Expired",

--- a/lang/en/dialogs.json
+++ b/lang/en/dialogs.json
@@ -423,7 +423,11 @@
   "completeProfile": {
     "title": "Add your name",
     "subtitle": "Give your account a clear display name for cloud projects and sharing.",
+    "displayNameLabel": "Display name",
     "namePlaceholder": "Your name",
+    "description": "This is the name TrackDraw will show for cloud projects and shared layouts.",
+    "descriptionWithEmail": "This is the name TrackDraw will show for cloud projects and shared layouts on {email}.",
+    "skip": "Skip",
     "save": "Save name",
     "saving": "Saving…",
     "nameRequired": "Please enter the name you want TrackDraw to show.",

--- a/lang/en/dialogs.json
+++ b/lang/en/dialogs.json
@@ -385,6 +385,8 @@
       "untitled": "Untitled"
     },
     "account": {
+      "loadingProjects": "Loading account projects...",
+      "loadProjectsFailed": "Could not load account projects",
       "noProjects": "No account projects",
       "noProjectsDesc": "Sync a project to make it available across devices.",
       "conflictWarning": "This project changed on another device while you were signed out",
@@ -418,7 +420,10 @@
       "revokeLinkAriaLabel": "Revoke share link"
     },
     "copyProjectIdSuccess": "Project ID copied",
-    "copyProjectIdAriaLabel": "Copy API project ID"
+    "copyProjectIdFailed": "Could not copy the project ID from this browser.",
+    "copyProjectIdLabel": "API project ID",
+    "copyProjectIdAriaLabel": "Copy API project ID",
+    "copyAction": "Copy"
   },
   "completeProfile": {
     "title": "Add your name",

--- a/lang/en/editor.json
+++ b/lang/en/editor.json
@@ -86,6 +86,10 @@
     "canvas2d": "2D canvas",
     "preview3d": "3D preview"
   },
+  "elementPlacementControl": {
+    "official": "Official",
+    "typeLabel": "{tool} type"
+  },
   "header": {
     "untitledTitle": "Untitled",
     "statusFailed": "Failed",

--- a/lang/en/landing.json
+++ b/lang/en/landing.json
@@ -1,4 +1,14 @@
 {
+  "metadata": {
+    "homeTitle": "TrackDraw · Drone Race Track Builder",
+    "homeSocialTitle": "TrackDraw | Drone Race Track Builder",
+    "homeDescription": "TrackDraw is a drone race track builder for FPV race directors. Design tracks to scale, review track flow in 3D, and share read-only race-day layouts.",
+    "homeSocialDescription": "Use TrackDraw as a drone race track builder to plan FPV layouts to scale, review track flow in 3D, and share read-only race-day plans.",
+    "studioTitle": "Drone Race Track Builder",
+    "studioSocialTitle": "TrackDraw | Drone Race Track Builder",
+    "studioDescription": "Open the TrackDraw drone race track builder to design FPV layouts to scale, add gates and obstacles, and preview track flow in 3D.",
+    "studioSocialDescription": "Design FPV drone race tracks to scale, add gates and obstacles, and preview track flow in 3D."
+  },
   "header": {
     "homeAriaLabel": "Home",
     "homeTooltip": "Back to the main landing page",

--- a/lang/en/login.json
+++ b/lang/en/login.json
@@ -1,4 +1,8 @@
 {
+  "metadata": {
+    "title": "Sign in",
+    "description": "Sign in to TrackDraw with a one-time magic link."
+  },
   "goHome": "Go to homepage",
   "backToStudio": "Back to Studio",
   "pageTitle": "TrackDraw account",

--- a/lang/en/share.json
+++ b/lang/en/share.json
@@ -34,7 +34,13 @@
   },
   "metadata": {
     "title": "View Track",
-    "description": "View this FPV race track designed with TrackDraw."
+    "description": "View this FPV race track designed with TrackDraw.",
+    "expiredTitle": "Expired Track Share",
+    "expiredDescription": "This TrackDraw share link has expired. Ask the sender to publish a fresh link.",
+    "retiredTitle": "Unsupported Track Share",
+    "retiredDescription": "This older TrackDraw share format is no longer supported. Ask the sender to publish a fresh link.",
+    "embedTitle": "Track Embed",
+    "embedDescription": "Embedded TrackDraw read-only track view."
   },
   "embedUnavailable": {
     "temporaryTitle": "Embed unavailable",

--- a/lang/nl/common.json
+++ b/lang/nl/common.json
@@ -34,6 +34,19 @@
     "type": "Type",
     "view": "Weergave"
   },
+  "dataTable": {
+    "filterPlaceholder": "Filter {title}...",
+    "noResults": "Geen resultaten gevonden.",
+    "selectedCount": "{count} geselecteerd",
+    "clearFilters": "Filters wissen"
+  },
+  "measurementUnit": {
+    "metric": "Metrisch",
+    "imperial": "Imperial",
+    "presetAriaLabel": "Meetpreset: {current}. Wissel naar {next}.",
+    "presetLabel": "Meetpreset: {current}",
+    "description": "Wissel weergegeven afstanden en compatibele invoer."
+  },
   "status": {
     "active": "Actief",
     "expired": "Verlopen",

--- a/lang/nl/dialogs.json
+++ b/lang/nl/dialogs.json
@@ -385,6 +385,8 @@
       "untitled": "Naamloos"
     },
     "account": {
+      "loadingProjects": "Accountprojecten laden...",
+      "loadProjectsFailed": "Accountprojecten konden niet worden geladen",
       "noProjects": "Geen accountprojecten",
       "noProjectsDesc": "Synchroniseer een project om het op alle apparaten beschikbaar te maken.",
       "conflictWarning": "Dit project is op een ander apparaat gewijzigd terwijl je niet was aangemeld",
@@ -418,7 +420,10 @@
       "revokeLinkAriaLabel": "Deellink intrekken"
     },
     "copyProjectIdSuccess": "Project-ID gekopieerd",
-    "copyProjectIdAriaLabel": "API-project-ID kopiëren"
+    "copyProjectIdFailed": "Project-ID kon niet vanuit deze browser worden gekopieerd.",
+    "copyProjectIdLabel": "API-project-ID",
+    "copyProjectIdAriaLabel": "API-project-ID kopiëren",
+    "copyAction": "Kopiëren"
   },
   "completeProfile": {
     "title": "Voeg je naam toe",

--- a/lang/nl/dialogs.json
+++ b/lang/nl/dialogs.json
@@ -423,7 +423,11 @@
   "completeProfile": {
     "title": "Voeg je naam toe",
     "subtitle": "Geef je account een duidelijke weergavenaam voor cloudprojecten en delen.",
+    "displayNameLabel": "Weergavenaam",
     "namePlaceholder": "Jouw naam",
+    "description": "Dit is de naam die TrackDraw toont bij cloudprojecten en gedeelde lay-outs.",
+    "descriptionWithEmail": "Dit is de naam die TrackDraw toont bij cloudprojecten en gedeelde lay-outs op {email}.",
+    "skip": "Overslaan",
     "save": "Naam opslaan",
     "saving": "Opslaan…",
     "nameRequired": "Vul de naam in die TrackDraw moet weergeven.",

--- a/lang/nl/editor.json
+++ b/lang/nl/editor.json
@@ -86,6 +86,10 @@
     "canvas2d": "2D-canvas",
     "preview3d": "3D-preview"
   },
+  "elementPlacementControl": {
+    "official": "Officieel",
+    "typeLabel": "{tool}-type"
+  },
   "header": {
     "untitledTitle": "Naamloos",
     "statusFailed": "Mislukt",

--- a/lang/nl/landing.json
+++ b/lang/nl/landing.json
@@ -1,4 +1,14 @@
 {
+  "metadata": {
+    "homeTitle": "TrackDraw · Drone Race Track Builder",
+    "homeSocialTitle": "TrackDraw | Drone Race Track Builder",
+    "homeDescription": "TrackDraw is een drone race track builder voor FPV-raceorganisatoren. Ontwerp tracks op schaal, beoordeel trackflow in 3D en deel alleen-lezen racedaglay-outs.",
+    "homeSocialDescription": "Gebruik TrackDraw als drone race track builder om FPV-lay-outs op schaal te plannen, trackflow in 3D te beoordelen en alleen-lezen racedagplannen te delen.",
+    "studioTitle": "Drone Race Track Builder",
+    "studioSocialTitle": "TrackDraw | Drone Race Track Builder",
+    "studioDescription": "Open de TrackDraw drone race track builder om FPV-lay-outs op schaal te ontwerpen, gates en obstakels toe te voegen en trackflow in 3D te previewen.",
+    "studioSocialDescription": "Ontwerp FPV drone race tracks op schaal, voeg gates en obstakels toe en preview trackflow in 3D."
+  },
   "header": {
     "homeAriaLabel": "Home",
     "homeTooltip": "Terug naar de hoofdpagina",

--- a/lang/nl/login.json
+++ b/lang/nl/login.json
@@ -1,4 +1,8 @@
 {
+  "metadata": {
+    "title": "Inloggen",
+    "description": "Log in bij TrackDraw met een eenmalige magic link."
+  },
   "goHome": "Naar homepage",
   "backToStudio": "Terug naar Studio",
   "pageTitle": "TrackDraw-account",

--- a/lang/nl/share.json
+++ b/lang/nl/share.json
@@ -34,7 +34,13 @@
   },
   "metadata": {
     "title": "Track bekijken",
-    "description": "Bekijk deze FPV-racetrack die met TrackDraw is ontworpen."
+    "description": "Bekijk deze FPV-racetrack die met TrackDraw is ontworpen.",
+    "expiredTitle": "Verlopen trackshare",
+    "expiredDescription": "Deze TrackDraw-deellink is verlopen. Vraag de verzender om een nieuwe link te publiceren.",
+    "retiredTitle": "Niet-ondersteunde trackshare",
+    "retiredDescription": "Dit oudere TrackDraw-shareformaat wordt niet meer ondersteund. Vraag de verzender om een nieuwe link te publiceren.",
+    "embedTitle": "Track embed",
+    "embedDescription": "Ingesloten alleen-lezen TrackDraw-trackweergave."
   },
   "embedUnavailable": {
     "temporaryTitle": "Embed niet beschikbaar",

--- a/scripts/i18n_hardcoded_allowlist.json
+++ b/scripts/i18n_hardcoded_allowlist.json
@@ -117,33 +117,6 @@
     "note": "Developer/debug/technical UI; translate later if exposed to normal users."
   },
   {
-    "file": "src/components/data-table/DataTableFacetFilter.tsx",
-    "kind": "JSX text",
-    "text": "Clear filters",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
-  },
-  {
-    "file": "src/components/data-table/DataTableFacetFilter.tsx",
-    "kind": "JSX text",
-    "text": "No results found.",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
-  },
-  {
-    "file": "src/components/data-table/DataTableFacetFilter.tsx",
-    "kind": "JSX text",
-    "text": "selected",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
     "file": "src/components/dialogs/ExportDialog.tsx",
     "kind": "JSX text",
     "text": "Editable backup or read-only setup handoff.",
@@ -259,24 +232,6 @@
     "group": "technical-token",
     "priority": "exception",
     "note": "Unit, file extension, coordinate label, or visual separator."
-  },
-  {
-    "file": "src/components/dialogs/ProjectManager/AccountTab.tsx",
-    "kind": "JSX text",
-    "text": "Could not load account projects",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
-  },
-  {
-    "file": "src/components/dialogs/ProjectManager/AccountTab.tsx",
-    "kind": "JSX text",
-    "text": "Loading account projects...",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
   },
   {
     "file": "src/components/dialogs/ProjectManager/DeviceTab.tsx",
@@ -486,24 +441,6 @@
     "note": "Visible product UI copy; prioritize replacing with translation keys."
   },
   {
-    "file": "src/components/dialogs/ProjectManager/shared.tsx",
-    "kind": "JSX text",
-    "text": "API project ID",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
-  },
-  {
-    "file": "src/components/dialogs/ProjectManager/shared.tsx",
-    "kind": "JSX text",
-    "text": "Copy",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
-  },
-  {
     "file": "src/components/dialogs/ProjectManager/SharesTab.tsx",
     "kind": "JSX text",
     "text": "Cancel",
@@ -700,24 +637,6 @@
     "group": "product-ui-translate",
     "priority": "medium",
     "note": "Visible product UI copy; translate when touching this surface."
-  },
-  {
-    "file": "src/components/editor/ElementPlacementControl.tsx",
-    "kind": "JSX text",
-    "text": "Official",
-    "count": 2,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
-  },
-  {
-    "file": "src/components/editor/ElementPlacementControl.tsx",
-    "kind": "JSX text",
-    "text": "type",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
   },
   {
     "file": "src/components/editor/Header.tsx",
@@ -934,24 +853,6 @@
     "group": "dev-or-technical-ui",
     "priority": "low",
     "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
-    "file": "src/components/MeasurementUnitToggle.tsx",
-    "kind": "JSX text",
-    "text": "Measurement preset:",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
-  },
-  {
-    "file": "src/components/MeasurementUnitToggle.tsx",
-    "kind": "JSX text",
-    "text": "Switch displayed distances and compatible inputs.",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
   },
   {
     "file": "src/components/ThemeToggle.tsx",

--- a/scripts/i18n_hardcoded_allowlist.json
+++ b/scripts/i18n_hardcoded_allowlist.json
@@ -9,42 +9,6 @@
     "note": "Brand-only alt text is intentionally stable unless the image needs descriptive alt copy."
   },
   {
-    "file": "src/app/embed/layout.tsx",
-    "kind": "metadata property description",
-    "text": "Embedded TrackDraw read-only track view.",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/embed/layout.tsx",
-    "kind": "metadata property title",
-    "text": "Track Embed",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/login/layout.tsx",
-    "kind": "metadata property description",
-    "text": "Sign in to TrackDraw with a one-time magic link.",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/login/layout.tsx",
-    "kind": "metadata property title",
-    "text": "Sign in",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
     "file": "src/app/login/page.tsx",
     "kind": "JSX prop alt",
     "text": "TrackDraw",
@@ -90,87 +54,6 @@
     "note": "Visible product UI copy; translate when touching this surface."
   },
   {
-    "file": "src/app/page.tsx",
-    "kind": "metadata property description",
-    "text": "TrackDraw is a drone race track builder for FPV race directors. Design tracks to scale, review track flow in 3D, and share read-only race-day layouts.",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/page.tsx",
-    "kind": "metadata property description",
-    "text": "Use TrackDraw as a drone race track builder to plan FPV layouts to scale, review track flow in 3D, and share read-only race-day plans.",
-    "count": 2,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/page.tsx",
-    "kind": "metadata property title",
-    "text": "TrackDraw | Drone Race Track Builder",
-    "count": 2,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/share/[token]/layout.tsx",
-    "kind": "metadata property description",
-    "text": "This older TrackDraw share format is no longer supported. Ask the sender to publish a fresh link.",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/share/[token]/layout.tsx",
-    "kind": "metadata property description",
-    "text": "This TrackDraw share link has expired. Ask the sender to publish a fresh link.",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/share/[token]/layout.tsx",
-    "kind": "metadata property description",
-    "text": "View this FPV race track designed with TrackDraw.",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/share/[token]/layout.tsx",
-    "kind": "metadata property title",
-    "text": "Expired Track Share",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/share/[token]/layout.tsx",
-    "kind": "metadata property title",
-    "text": "Unsupported Track Share",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/share/[token]/layout.tsx",
-    "kind": "metadata property title",
-    "text": "View Track",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
     "file": "src/app/share/[token]/not-found.tsx",
     "kind": "JSX prop alt",
     "text": "TrackDraw",
@@ -196,42 +79,6 @@
     "group": "intentional-brand-alt",
     "priority": "exception",
     "note": "Brand-only alt text is intentionally stable unless the image needs descriptive alt copy."
-  },
-  {
-    "file": "src/app/studio/layout.tsx",
-    "kind": "metadata property description",
-    "text": "Design FPV drone race tracks to scale, add gates and obstacles, and preview track flow in 3D.",
-    "count": 2,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/studio/layout.tsx",
-    "kind": "metadata property description",
-    "text": "Open the TrackDraw drone race track builder to design FPV layouts to scale, add gates and obstacles, and preview track flow in 3D.",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/studio/layout.tsx",
-    "kind": "metadata property title",
-    "text": "Drone Race Track Builder",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/studio/layout.tsx",
-    "kind": "metadata property title",
-    "text": "TrackDraw | Drone Race Track Builder",
-    "count": 2,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
   },
   {
     "file": "src/components/canvas/editor/TrackCanvas.tsx",
@@ -295,33 +142,6 @@
     "group": "dev-or-technical-ui",
     "priority": "low",
     "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
-    "file": "src/components/dialogs/CompleteProfileDialog.tsx",
-    "kind": "JSX text",
-    "text": "Display name",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
-  },
-  {
-    "file": "src/components/dialogs/CompleteProfileDialog.tsx",
-    "kind": "JSX text",
-    "text": "Skip",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
-  },
-  {
-    "file": "src/components/dialogs/CompleteProfileDialog.tsx",
-    "kind": "JSX text",
-    "text": "This is the name TrackDraw will show for cloud projects and shared layouts",
-    "count": 1,
-    "group": "product-ui-translate",
-    "priority": "high",
-    "note": "Visible product UI copy; prioritize replacing with translation keys."
   },
   {
     "file": "src/components/dialogs/ExportDialog.tsx",

--- a/scripts/i18n_hardcoded_allowlist.json
+++ b/scripts/i18n_hardcoded_allowlist.json
@@ -1,59 +1,5 @@
 [
   {
-    "file": "src/app/dashboard/api-keys/page.tsx",
-    "kind": "metadata property title",
-    "text": "Dashboard API Keys",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/dashboard/audit/page.tsx",
-    "kind": "metadata property title",
-    "text": "Dashboard Audit",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/dashboard/email-preview/page.tsx",
-    "kind": "metadata property title",
-    "text": "Dashboard Email Preview",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/dashboard/gallery/page.tsx",
-    "kind": "metadata property title",
-    "text": "Dashboard Gallery",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/dashboard/metrics/page.tsx",
-    "kind": "metadata property title",
-    "text": "Dashboard Metrics",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
-    "file": "src/app/dashboard/users/page.tsx",
-    "kind": "metadata property title",
-    "text": "Dashboard Users",
-    "count": 1,
-    "group": "metadata-translate",
-    "priority": "high",
-    "note": "Hardcoded metadata should be localized or generated from translations."
-  },
-  {
     "file": "src/app/embed/EmbedUnavailable.tsx",
     "kind": "JSX prop alt",
     "text": "TrackDraw",

--- a/src/app/dashboard/api-keys/page.tsx
+++ b/src/app/dashboard/api-keys/page.tsx
@@ -8,13 +8,18 @@ import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 import { hasCapability } from "@/lib/server/authorization";
 import { listApiKeysForAdmin } from "@/lib/server/api-keys";
 
-export const metadata: Metadata = {
-  title: "Dashboard API Keys",
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("dashboard");
+  const tCommon = await getTranslations("common");
+
+  return {
+    title: `${tCommon("labels.dashboard")} ${t("pages.apiKeys")}`,
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
 
 export default async function DashboardApiKeysPage() {
   const requestHeaders = new Headers(await headers());

--- a/src/app/dashboard/audit/page.tsx
+++ b/src/app/dashboard/audit/page.tsx
@@ -10,10 +10,15 @@ import { listAuditEvents } from "@/lib/server/audit";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 import { hasCapability } from "@/lib/server/authorization";
 
-export const metadata: Metadata = {
-  title: "Dashboard Audit",
-  robots: { index: false, follow: false },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("dashboard");
+  const tCommon = await getTranslations("common");
+
+  return {
+    title: `${tCommon("labels.dashboard")} ${t("pages.audit")}`,
+    robots: { index: false, follow: false },
+  };
+}
 
 type AuditFilter = "all" | "account" | "gallery";
 

--- a/src/app/dashboard/email-preview/page.tsx
+++ b/src/app/dashboard/email-preview/page.tsx
@@ -13,10 +13,15 @@ import {
 import { hasCapability } from "@/lib/server/authorization";
 import { cn } from "@/lib/utils";
 
-export const metadata: Metadata = {
-  title: "Dashboard Email Preview",
-  robots: { index: false, follow: false },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("dashboard");
+  const tCommon = await getTranslations("common");
+
+  return {
+    title: `${tCommon("labels.dashboard")} ${t("pages.emailPreview")}`,
+    robots: { index: false, follow: false },
+  };
+}
 
 const previewKeys: AuthEmailPreviewKey[] = [
   "magic-link",

--- a/src/app/dashboard/gallery/page.tsx
+++ b/src/app/dashboard/gallery/page.tsx
@@ -8,13 +8,18 @@ import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 import { hasCapability } from "@/lib/server/authorization";
 import { listGalleryEntriesForDashboard } from "@/lib/server/gallery";
 
-export const metadata: Metadata = {
-  title: "Dashboard Gallery",
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("dashboard");
+  const tCommon = await getTranslations("common");
+
+  return {
+    title: `${tCommon("labels.dashboard")} ${t("pages.gallery")}`,
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
 
 export default async function DashboardGalleryPage() {
   const requestHeaders = new Headers(await headers());

--- a/src/app/dashboard/metrics/page.tsx
+++ b/src/app/dashboard/metrics/page.tsx
@@ -21,10 +21,15 @@ import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 import { hasCapability } from "@/lib/server/authorization";
 import { getAdminMetrics, getGrowthByRange } from "@/lib/server/metrics";
 
-export const metadata: Metadata = {
-  title: "Dashboard Metrics",
-  robots: { index: false, follow: false },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("dashboard");
+  const tCommon = await getTranslations("common");
+
+  return {
+    title: `${tCommon("labels.dashboard")} ${t("pages.metrics")}`,
+    robots: { index: false, follow: false },
+  };
+}
 
 type KpiCardProps = {
   label: string;

--- a/src/app/dashboard/users/page.tsx
+++ b/src/app/dashboard/users/page.tsx
@@ -8,13 +8,18 @@ import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 import { hasCapability } from "@/lib/server/authorization";
 import { listUsersForAdmin } from "@/lib/server/users";
 
-export const metadata: Metadata = {
-  title: "Dashboard Users",
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("dashboard");
+  const tCommon = await getTranslations("common");
+
+  return {
+    title: `${tCommon("labels.dashboard")} ${t("pages.users")}`,
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
 
 export default async function DashboardUsersPage() {
   const requestHeaders = new Headers(await headers());

--- a/src/app/embed/layout.tsx
+++ b/src/app/embed/layout.tsx
@@ -1,14 +1,19 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import LanguageProvider from "@/i18n/LanguageProvider";
 
-export const metadata: Metadata = {
-  title: "Track Embed",
-  description: "Embedded TrackDraw read-only track view.",
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("share.metadata");
+
+  return {
+    title: t("embedTitle"),
+    description: t("embedDescription"),
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
 
 export default function EmbedLayout({
   children,

--- a/src/app/login/layout.tsx
+++ b/src/app/login/layout.tsx
@@ -1,14 +1,19 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import LanguageProvider from "@/i18n/LanguageProvider";
 
-export const metadata: Metadata = {
-  title: "Sign in",
-  description: "Sign in to TrackDraw with a one-time magic link.",
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("login.metadata");
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
 
 export default function LoginLayout({
   children,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,38 +16,39 @@ import {
   serializeJsonLd,
 } from "@/lib/seo";
 
-export const metadata: Metadata = {
-  title: {
-    absolute: "TrackDraw · Drone Race Track Builder",
-  },
-  description:
-    "TrackDraw is a drone race track builder for FPV race directors. Design tracks to scale, review track flow in 3D, and share read-only race-day layouts.",
-  keywords: SITE_KEYWORDS,
-  authors: [SITE_AUTHOR],
-  alternates: {
-    canonical: "/",
-  },
-  openGraph: {
-    title: "TrackDraw | Drone Race Track Builder",
-    description:
-      "Use TrackDraw as a drone race track builder to plan FPV layouts to scale, review track flow in 3D, and share read-only race-day plans.",
-    url: "/",
-    images: [
-      {
-        url: DEFAULT_SOCIAL_IMAGE,
-        width: DEFAULT_SOCIAL_IMAGE_WIDTH,
-        height: DEFAULT_SOCIAL_IMAGE_HEIGHT,
-        alt: DEFAULT_OG_IMAGE_ALT,
-      },
-    ],
-  },
-  twitter: {
-    title: "TrackDraw | Drone Race Track Builder",
-    description:
-      "Use TrackDraw as a drone race track builder to plan FPV layouts to scale, review track flow in 3D, and share read-only race-day plans.",
-    images: [DEFAULT_SOCIAL_IMAGE],
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("landing.metadata");
+
+  return {
+    title: {
+      absolute: t("homeTitle"),
+    },
+    description: t("homeDescription"),
+    keywords: SITE_KEYWORDS,
+    authors: [SITE_AUTHOR],
+    alternates: {
+      canonical: "/",
+    },
+    openGraph: {
+      title: t("homeSocialTitle"),
+      description: t("homeSocialDescription"),
+      url: "/",
+      images: [
+        {
+          url: DEFAULT_SOCIAL_IMAGE,
+          width: DEFAULT_SOCIAL_IMAGE_WIDTH,
+          height: DEFAULT_SOCIAL_IMAGE_HEIGHT,
+          alt: DEFAULT_OG_IMAGE_ALT,
+        },
+      ],
+    },
+    twitter: {
+      title: t("homeSocialTitle"),
+      description: t("homeSocialDescription"),
+      images: [DEFAULT_SOCIAL_IMAGE],
+    },
+  };
+}
 import Link from "next/link";
 import { Footer } from "@/components/landing/Footer";
 import { PublicSiteHeader } from "@/components/landing/PublicSiteHeader";

--- a/src/app/share/[token]/layout.tsx
+++ b/src/app/share/[token]/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { getShareDescription, getShareTitle } from "@/lib/share";
 import {
   getGalleryEntryByShareToken,
@@ -51,14 +52,14 @@ function buildShareMetadataDescription(params: {
 export async function generateMetadata({
   params,
 }: ShareTokenLayoutProps): Promise<Metadata> {
+  const t = await getTranslations("share.metadata");
   const { token } = await params;
   const resolvedShare = await resolveShareView(token);
 
   if (resolvedShare.status === "expired") {
     return {
-      title: "Expired Track Share",
-      description:
-        "This TrackDraw share link has expired. Ask the sender to publish a fresh link.",
+      title: t("expiredTitle"),
+      description: t("expiredDescription"),
       robots: {
         index: false,
         follow: true,
@@ -68,9 +69,8 @@ export async function generateMetadata({
 
   if (resolvedShare.status === "retired") {
     return {
-      title: "Unsupported Track Share",
-      description:
-        "This older TrackDraw share format is no longer supported. Ask the sender to publish a fresh link.",
+      title: t("retiredTitle"),
+      description: t("retiredDescription"),
       robots: {
         index: false,
         follow: true,
@@ -80,8 +80,8 @@ export async function generateMetadata({
 
   if (resolvedShare.status !== "available") {
     return {
-      title: "View Track",
-      description: "View this FPV race track designed with TrackDraw.",
+      title: t("title"),
+      description: t("description"),
       robots: {
         index: false,
         follow: true,

--- a/src/app/studio/layout.tsx
+++ b/src/app/studio/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import {
   DEFAULT_OG_IMAGE_ALT,
   DEFAULT_SOCIAL_IMAGE,
@@ -7,38 +8,39 @@ import {
 } from "@/lib/seo";
 import LanguageProvider from "@/i18n/LanguageProvider";
 
-export const metadata: Metadata = {
-  title: "Drone Race Track Builder",
-  description:
-    "Open the TrackDraw drone race track builder to design FPV layouts to scale, add gates and obstacles, and preview track flow in 3D.",
-  alternates: {
-    canonical: "/studio",
-  },
-  openGraph: {
-    title: "TrackDraw | Drone Race Track Builder",
-    description:
-      "Design FPV drone race tracks to scale, add gates and obstacles, and preview track flow in 3D.",
-    url: "/studio",
-    images: [
-      {
-        url: DEFAULT_SOCIAL_IMAGE,
-        width: DEFAULT_SOCIAL_IMAGE_WIDTH,
-        height: DEFAULT_SOCIAL_IMAGE_HEIGHT,
-        alt: DEFAULT_OG_IMAGE_ALT,
-      },
-    ],
-  },
-  twitter: {
-    title: "TrackDraw | Drone Race Track Builder",
-    description:
-      "Design FPV drone race tracks to scale, add gates and obstacles, and preview track flow in 3D.",
-    images: [DEFAULT_SOCIAL_IMAGE],
-  },
-  robots: {
-    index: true,
-    follow: true,
-  },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("landing.metadata");
+
+  return {
+    title: t("studioTitle"),
+    description: t("studioDescription"),
+    alternates: {
+      canonical: "/studio",
+    },
+    openGraph: {
+      title: t("studioSocialTitle"),
+      description: t("studioSocialDescription"),
+      url: "/studio",
+      images: [
+        {
+          url: DEFAULT_SOCIAL_IMAGE,
+          width: DEFAULT_SOCIAL_IMAGE_WIDTH,
+          height: DEFAULT_SOCIAL_IMAGE_HEIGHT,
+          alt: DEFAULT_OG_IMAGE_ALT,
+        },
+      ],
+    },
+    twitter: {
+      title: t("studioSocialTitle"),
+      description: t("studioSocialDescription"),
+      images: [DEFAULT_SOCIAL_IMAGE],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+  };
+}
 
 export default function StudioLayout({
   children,

--- a/src/components/MeasurementUnitToggle.tsx
+++ b/src/components/MeasurementUnitToggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Ruler } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Tooltip,
   TooltipContent,
@@ -18,17 +19,22 @@ export function MeasurementUnitToggle({
   className?: string;
   tooltip?: boolean;
 }) {
+  const t = useTranslations("common.measurementUnit");
   const { unitSystem, setUnitSystem } = useMeasurementUnitSystem();
   const nextUnitSystem = unitSystem === "metric" ? "imperial" : "metric";
-  const label = unitSystem === "metric" ? "Metric" : "Imperial";
-  const nextLabel = nextUnitSystem === "metric" ? "Metric" : "Imperial";
+  const label = unitSystem === "metric" ? t("metric") : t("imperial");
+  const nextLabel = nextUnitSystem === "metric" ? t("metric") : t("imperial");
+  const actionLabel = t("presetAriaLabel", {
+    current: label,
+    next: nextLabel,
+  });
 
   const button = (
     <button
       type="button"
       onClick={() => setUnitSystem(nextUnitSystem)}
-      aria-label={`Measurement preset: ${label}. Switch to ${nextLabel}.`}
-      title={`Measurement preset: ${label}. Switch to ${nextLabel}.`}
+      aria-label={actionLabel}
+      title={actionLabel}
       className={cn(
         "text-muted-foreground hover:bg-muted hover:text-foreground inline-flex h-8 items-center gap-1.5 rounded-md px-2 text-xs transition-colors lg:h-7 lg:px-2",
         className
@@ -45,10 +51,10 @@ export function MeasurementUnitToggle({
     <Tooltip>
       <TooltipTrigger asChild>{button}</TooltipTrigger>
       <TooltipContent>
-        <span className="block font-medium">Measurement preset: {label}</span>
-        <span className="mt-1 block opacity-80">
-          Switch displayed distances and compatible inputs.
+        <span className="block font-medium">
+          {t("presetLabel", { current: label })}
         </span>
+        <span className="mt-1 block opacity-80">{t("description")}</span>
       </TooltipContent>
     </Tooltip>
   );

--- a/src/components/data-table/DataTableFacetFilter.tsx
+++ b/src/components/data-table/DataTableFacetFilter.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { CheckIcon, PlusCircle } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -34,6 +35,7 @@ export default function DataTableFacetFilter<TValue extends string>({
   onChange,
   onClear,
 }: DataTableFacetFilterProps<TValue>) {
+  const t = useTranslations("common.dataTable");
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
 
@@ -88,7 +90,7 @@ export default function DataTableFacetFilter<TValue extends string>({
                   variant="muted"
                   className="h-4 rounded-sm px-1.5 text-[10px] font-medium tracking-normal normal-case"
                 >
-                  {selected.length} selected
+                  {t("selectedCount", { count: selected.length })}
                 </Badge>
               ) : (
                 selected.map((value, index) => (
@@ -110,14 +112,16 @@ export default function DataTableFacetFilter<TValue extends string>({
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder={`Filter ${title.toLowerCase()}...`}
+            placeholder={t("filterPlaceholder", {
+              title: title.toLowerCase(),
+            })}
             className="h-8 shadow-none"
           />
         </div>
         <div className="max-h-72 overflow-y-auto p-1">
           {filteredOptions.length === 0 ? (
             <p className="text-muted-foreground px-2 py-6 text-center text-sm">
-              No results found.
+              {t("noResults")}
             </p>
           ) : (
             filteredOptions.map((option) => {
@@ -164,7 +168,7 @@ export default function DataTableFacetFilter<TValue extends string>({
                 className="hover:bg-muted hover:text-foreground w-full cursor-pointer justify-center"
                 onClick={clearSelection}
               >
-                Clear filters
+                {t("clearFilters")}
               </Button>
             </div>
           </>

--- a/src/components/dialogs/CompleteProfileDialog.tsx
+++ b/src/components/dialogs/CompleteProfileDialog.tsx
@@ -73,7 +73,7 @@ export default function CompleteProfileDialog({
           htmlFor="complete-profile-name"
           className="text-foreground text-sm font-medium"
         >
-          Display name
+          {t("completeProfile.displayNameLabel")}
         </label>
         <input
           id="complete-profile-name"
@@ -94,8 +94,9 @@ export default function CompleteProfileDialog({
       ) : null}
 
       <p className="text-muted-foreground text-sm leading-relaxed">
-        This is the name TrackDraw will show for cloud projects and shared
-        layouts{email ? ` on ${email}` : ""}.
+        {email
+          ? t("completeProfile.descriptionWithEmail", { email })
+          : t("completeProfile.description")}
       </p>
 
       <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
@@ -105,7 +106,7 @@ export default function CompleteProfileDialog({
           onClick={() => onOpenChange(false)}
           disabled={saving}
         >
-          Skip
+          {t("completeProfile.skip")}
         </Button>
         <Button
           type="button"

--- a/src/components/dialogs/ProjectManager/AccountTab.tsx
+++ b/src/components/dialogs/ProjectManager/AccountTab.tsx
@@ -61,7 +61,7 @@ export function ProjectManagerAccountTab({
         role="status"
       >
         <p className="text-muted-foreground px-1 pb-1 text-[11px]">
-          Loading account projects...
+          {t("projectManager.account.loadingProjects")}
         </p>
         <SkeletonCard />
         <SkeletonCard />
@@ -74,7 +74,7 @@ export function ProjectManagerAccountTab({
     return (
       <div className="border-destructive/20 bg-destructive/8 rounded-xl border px-4 py-3">
         <p className="text-foreground text-sm font-medium">
-          Could not load account projects
+          {t("projectManager.account.loadProjectsFailed")}
         </p>
         <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
           {error}

--- a/src/components/dialogs/ProjectManager/shared.tsx
+++ b/src/components/dialogs/ProjectManager/shared.tsx
@@ -106,7 +106,7 @@ export function ProjectIdCopyRow({ projectId }: { projectId: string }) {
       await navigator.clipboard.writeText(projectId);
       toast.success(t("projectManager.copyProjectIdSuccess"));
     } catch {
-      toast.error("Could not copy the project ID from this browser.");
+      toast.error(t("projectManager.copyProjectIdFailed"));
     }
   };
 
@@ -114,7 +114,7 @@ export function ProjectIdCopyRow({ projectId }: { projectId: string }) {
     <div className="border-border/35 mt-2 flex min-w-0 items-center justify-between gap-3 border-t pt-2">
       <div className="min-w-0">
         <p className="text-muted-foreground text-[10px] font-semibold tracking-[0.12em] uppercase">
-          API project ID
+          {t("projectManager.copyProjectIdLabel")}
         </p>
         <p className="text-foreground/85 mt-0.5 truncate font-mono text-[11px]">
           {projectId}
@@ -130,7 +130,7 @@ export function ProjectIdCopyRow({ projectId }: { projectId: string }) {
         aria-label={t("projectManager.copyProjectIdAriaLabel")}
       >
         <Copy className="size-3.5" />
-        Copy
+        {t("projectManager.copyAction")}
       </button>
     </div>
   );

--- a/src/components/editor/ElementPlacementControl.tsx
+++ b/src/components/editor/ElementPlacementControl.tsx
@@ -3,6 +3,7 @@
 import { type CSSProperties, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Check, ChevronDown } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Popover,
   PopoverContent,
@@ -22,6 +23,7 @@ const controlWidthCh = Math.max(
 );
 
 export function ElementPlacementControl() {
+  const t = useTranslations("editor.elementPlacementControl");
   const [open, setOpen] = useState(false);
   const activeTool = useEditor((state) => state.ui.activeTool);
   const activePlacementElementId = useEditor(
@@ -93,7 +95,7 @@ export function ElementPlacementControl() {
                         </span>
                         {activeEntry.official ? (
                           <span className="bg-brand-primary/14 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-[0.06em] uppercase">
-                            Official
+                            {t("official")}
                           </span>
                         ) : null}
                       </span>
@@ -116,7 +118,7 @@ export function ElementPlacementControl() {
               >
                 <div className="px-3 pt-3 pb-1.5">
                   <p className="text-muted-foreground/60 text-[10px] font-semibold tracking-widest uppercase">
-                    {toolLabel} type
+                    {t("typeLabel", { tool: toolLabel })}
                   </p>
                 </div>
                 <div className="max-h-72 space-y-0.5 overflow-y-auto px-1.5 pb-1.5">
@@ -153,7 +155,7 @@ export function ElementPlacementControl() {
                             </span>
                             {entry.official ? (
                               <span className="bg-brand-primary/12 text-brand-primary shrink-0 rounded-full px-1.5 py-0.5 text-[9px] leading-none font-semibold tracking-[0.06em] uppercase">
-                                Official
+                                {t("official")}
                               </span>
                             ) : null}
                           </span>


### PR DESCRIPTION
## Summary
- localize dashboard/public metadata that was still tracked in the hardcoded-copy allowlist
- translate visible profile and shared-control copy in small common components
- reduce the hardcoded-copy allowlist baseline from 161 to 119 known occurrences

## Why
The multilingual rollout left several high-priority hardcoded strings documented in the allowlist. This removes a safe batch of that debt without changing editor behavior.

## Validation
- npm run type
- npm run i18n:check
- node scripts/i18n_hardcoded_scan.mjs
- prettier check on changed files