### PR TITLE
chore: Normalize dialog i18n keys

### DIFF
--- a/lang/en/dialogs.json
+++ b/lang/en/dialogs.json
@@ -125,28 +125,46 @@
     }
   },
   "export": {
-    "dialogTitle": "Export",
-    "dialogSubtitle": "Export the current track as visual assets, project handoff files, or simulator-ready outputs.",
-    "darkTheme": "Dark",
-    "lightTheme": "Light",
-    "enableRouteNumbers": "Enable route numbers in export",
-    "disableRouteNumbers": "Disable route numbers in export",
-    "enableRouteNumbersMobile": "Enable route numbers",
-    "disableRouteNumbersMobile": "Disable route numbers",
-    "filenameLabel": "Filename",
-    "themeLabel": "Theme",
-    "routeNumbersLabel": "Route numbers",
-    "routeNumbersHint": "In 2D exports",
-    "switchTo3dView": "Switch to 3D view",
-    "openRequiredView": "Open required view",
-    "exportFormatAriaLabel": "Export {label}",
-    "view3dUnavailable": "3D view not available — open the 3D tab first",
-    "canvasNotReady": "Canvas not ready",
-    "exported": "Exported",
-    "webmRenderingBackground": "Cinematic FPV is rendering in the background…",
-    "webmRenderingProgress": "Rendering cinematic FPV… {status}",
-    "webmReady": "Cinematic FPV export ready",
-    "webmProgressLabel": "Rendering fly-through… video {duration}",
+    "dialog": {
+      "title": "Export",
+      "subtitle": "Export the current track as visual assets, project handoff files, or simulator-ready outputs."
+    },
+    "fields": {
+      "filename": {
+        "label": "Filename"
+      }
+    },
+    "theme": {
+      "label": "Theme",
+      "dark": "Dark",
+      "light": "Light"
+    },
+    "routeNumbers": {
+      "label": "Route numbers",
+      "hint": "In 2D exports",
+      "enable": "Enable route numbers in export",
+      "disable": "Disable route numbers in export",
+      "enableMobile": "Enable route numbers",
+      "disableMobile": "Disable route numbers"
+    },
+    "actions": {
+      "switchTo3dView": "Switch to 3D view",
+      "openRequiredView": "Open required view"
+    },
+    "aria": {
+      "exportFormat": "Export {label}"
+    },
+    "messages": {
+      "view3dUnavailable": "3D view not available — open the 3D tab first",
+      "canvasNotReady": "Canvas not ready",
+      "exported": "Exported"
+    },
+    "webm": {
+      "renderingBackground": "Cinematic FPV is rendering in the background…",
+      "renderingProgress": "Rendering cinematic FPV… {status}",
+      "ready": "Cinematic FPV export ready",
+      "progressLabel": "Rendering fly-through… video {duration}"
+    },
     "sections": {
       "visualExports": {
         "title": "Visual Exports",

--- a/lang/en/dialogs.json
+++ b/lang/en/dialogs.json
@@ -1,96 +1,148 @@
 {
   "account": {
-    "navSecurity": "Security",
-    "navApiKeys": "API keys",
-    "navDanger": "Danger zone",
-    "panelProfile": {
-      "title": "Your profile",
-      "description": "Manage the name shown across your TrackDraw account."
+    "dialog": {
+      "eyebrow": "Studio",
+      "mobileSubtitle": "Manage your TrackDraw account."
     },
-    "panelSecurity": {
-      "title": "Security",
-      "description": "Manage sign-in methods, account email, and passkeys for your TrackDraw account."
+    "nav": {
+      "security": "Security",
+      "apiKeys": "API keys",
+      "danger": "Danger zone"
     },
-    "panelApiKeys": {
-      "title": "API keys",
-      "description": "Create and revoke expiring keys for external TrackDraw integrations."
+    "panels": {
+      "profile": {
+        "title": "Your profile",
+        "description": "Manage the name shown across your TrackDraw account."
+      },
+      "security": {
+        "title": "Security",
+        "description": "Manage sign-in methods, account email, and passkeys for your TrackDraw account."
+      },
+      "apiKeys": {
+        "title": "API keys",
+        "description": "Create and revoke expiring keys for external TrackDraw integrations."
+      },
+      "danger": {
+        "title": "Danger zone",
+        "description": "Destructive and irreversible account actions."
+      }
     },
-    "panelDanger": {
-      "title": "Danger zone",
-      "description": "Destructive and irreversible account actions."
-    },
-    "dialogEyebrow": "Studio",
-    "dialogMobileSubtitle": "Manage your TrackDraw account.",
     "profile": {
-      "displayNameLabel": "Display name",
-      "displayNamePlaceholder": "Your name",
-      "languageDescription": "Changes apply immediately",
-      "saving": "Saving...",
-      "noAccountEmail": "TrackDraw account"
+      "displayName": {
+        "label": "Display name",
+        "placeholder": "Your name"
+      },
+      "language": {
+        "description": "Changes apply immediately"
+      },
+      "status": {
+        "saving": "Saving..."
+      },
+      "fallback": {
+        "noAccountEmail": "TrackDraw account"
+      }
     },
     "security": {
-      "emailAddress": "Email address",
-      "newEmail": "New email",
-      "emailPlaceholder": "name@example.com",
-      "emailChangeDescription": "After saving, we will send a confirmation to your current email address first. Once confirmed, you will verify the new one.",
-      "changeEmail": "Change email",
-      "passkeysTitle": "Passkeys",
-      "passkeysDescription": "Add a passkey for faster sign-in on supported devices.",
-      "savingEmail": "Saving...",
-      "addPasskey": "Add passkey",
-      "addingPasskey": "Adding...",
-      "devAuthUnavailable": "Passkeys are not available in `npm run dev`. Use `npm run preview` to test the real auth flow locally.",
-      "reauthTitle": "Sign in again to continue",
-      "reauthDescription": "Passkey setup requires a recent sign-in. You can stay signed in for normal work, but this security action needs confirmation.",
-      "signInAgain": "Sign in again",
-      "unsupportedBrowser": "This browser does not currently expose WebAuthn here, so passkey setup is unavailable on this device.",
-      "loadingPasskeys": "Loading passkeys...",
-      "emptyTitle": "No passkeys yet",
-      "emptyDescription": "Add one to make sign-in quicker on your trusted devices.",
-      "addedDate": "Added {date}",
-      "synced": "synced",
-      "renameAriaLabel": "Rename passkey",
-      "removingAriaLabel": "Removing passkey",
-      "removeAriaLabel": "Remove passkey",
-      "removing": "Removing...",
-      "removeTooltip": "Remove from account",
-      "passkeyNamePlaceholder": "Passkey name",
-      "unnamedPasskey": "Unnamed passkey",
-      "renameDescription": "This only changes how the passkey is labeled in your TrackDraw account.",
-      "saveName": "Save name"
+      "email": {
+        "address": "Email address",
+        "newEmail": "New email",
+        "placeholder": "name@example.com",
+        "changeDescription": "After saving, we will send a confirmation to your current email address first. Once confirmed, you will verify the new one.",
+        "change": "Change email",
+        "saving": "Saving..."
+      },
+      "passkeys": {
+        "title": "Passkeys",
+        "description": "Add a passkey for faster sign-in on supported devices.",
+        "add": "Add passkey",
+        "adding": "Adding...",
+        "devAuthUnavailable": "Passkeys are not available in `npm run dev`. Use `npm run preview` to test the real auth flow locally.",
+        "unsupportedBrowser": "This browser does not currently expose WebAuthn here, so passkey setup is unavailable on this device.",
+        "loading": "Loading passkeys...",
+        "addedDate": "Added {date}",
+        "status": {
+          "synced": "synced"
+        },
+        "reauth": {
+          "title": "Sign in again to continue",
+          "description": "Passkey setup requires a recent sign-in. You can stay signed in for normal work, but this security action needs confirmation.",
+          "action": "Sign in again"
+        },
+        "empty": {
+          "title": "No passkeys yet",
+          "description": "Add one to make sign-in quicker on your trusted devices."
+        },
+        "aria": {
+          "rename": "Rename passkey",
+          "removing": "Removing passkey",
+          "remove": "Remove passkey"
+        },
+        "actions": {
+          "removing": "Removing...",
+          "removeTooltip": "Remove from account",
+          "saveName": "Save name"
+        },
+        "fields": {
+          "namePlaceholder": "Passkey name"
+        },
+        "fallback": {
+          "unnamed": "Unnamed passkey"
+        },
+        "rename": {
+          "description": "This only changes how the passkey is labeled in your TrackDraw account."
+        }
+      }
     },
     "apiKeys": {
-      "keyNameLabel": "Key name",
-      "expiryDays": "{days} days",
-      "expiryYear": "1 year",
-      "namePlaceholder": "Overlay integration",
-      "create": "Create",
-      "createdTitle": "API key created",
-      "createdDescription": "This secret is shown once. Store it before closing this dialog.",
-      "activeTitle": "Active API keys",
-      "descriptionPrefix": "Read-only keys for trusted integrations.",
-      "docsLink": "API docs",
-      "refreshAriaLabel": "Refresh API keys",
-      "loading": "Loading API keys...",
-      "emptyTitle": "No API keys yet",
-      "emptyDescription": "Create one when a trusted integration needs read-only access to your account projects.",
-      "unnamedKey": "Unnamed API key",
-      "expiresOn": "Expires {date}",
-      "lastUsed": "Last used {date}",
-      "revokeConfirmTitle": "Revoke API key?",
-      "revokeTooltip": "Revoke",
-      "revokeAriaLabel": "Revoke {name}",
-      "revokeWarningExpiring": "This key stops working.",
-      "revokeWarningNonExpiring": "Integrations using this key lose read-only access.",
-      "revoking": "Revoking...",
-      "revoke": "Revoke"
+      "form": {
+        "keyNameLabel": "Key name",
+        "expiryDays": "{days} days",
+        "expiryYear": "1 year",
+        "namePlaceholder": "Overlay integration",
+        "create": "Create"
+      },
+      "created": {
+        "title": "API key created",
+        "description": "This secret is shown once. Store it before closing this dialog."
+      },
+      "active": {
+        "title": "Active API keys",
+        "descriptionPrefix": "Read-only keys for trusted integrations.",
+        "docsLink": "API docs",
+        "refreshAriaLabel": "Refresh API keys",
+        "loading": "Loading API keys..."
+      },
+      "empty": {
+        "title": "No API keys yet",
+        "description": "Create one when a trusted integration needs read-only access to your account projects."
+      },
+      "fallback": {
+        "unnamed": "Unnamed API key"
+      },
+      "meta": {
+        "expiresOn": "Expires {date}",
+        "lastUsed": "Last used {date}"
+      },
+      "revoke": {
+        "confirmTitle": "Revoke API key?",
+        "tooltip": "Revoke",
+        "ariaLabel": "Revoke {name}",
+        "warningExpiring": "This key stops working.",
+        "warningNonExpiring": "Integrations using this key lose read-only access.",
+        "revoking": "Revoking...",
+        "action": "Revoke"
+      }
     },
     "danger": {
       "description": "Deleting your account removes account projects, published links, API keys, and other account-backed data. Export anything account-backed that you want to keep before continuing.",
-      "typeToConfirm": "Type DELETE to confirm",
-      "deletePlaceholder": "DELETE",
-      "deleting": "Deleting...",
-      "deleteAccount": "Delete account"
+      "confirm": {
+        "label": "Type DELETE to confirm",
+        "placeholder": "DELETE"
+      },
+      "actions": {
+        "deleting": "Deleting...",
+        "deleteAccount": "Delete account"
+      }
     },
     "shared": {
       "loading": "Loading account...",
@@ -241,85 +293,219 @@
     "backupFirst": "Back up current project first"
   },
   "share": {
-    "dialogEyebrow": "Studio",
-    "dialogEyebrowExisting": "Shared track",
-    "dialogTitle": "Share",
-    "dialogMobileSubtitle": "Share a read-only review link for this track",
-    "navShareLink": "Share link",
-    "navShare": "Share",
-    "navEmbed": "Embed",
-    "navGallery": "Gallery",
-    "currentSharedLink": "Current shared link",
-    "readOnlyReviewOn": "Read-only {view} review on {hostname}",
-    "primaryAction": {
-      "updateLink": "Update link",
-      "copyLink": "Copy link",
-      "createLink": "Create link",
-      "createNewLink": "Create new link"
+    "dialog": {
+      "eyebrow": "Studio",
+      "existingEyebrow": "Shared track",
+      "title": "Share",
+      "mobileSubtitle": "Share a read-only review link for this track"
     },
-    "gallery": {
-      "loading": "Loading current state",
-      "featured": "Featured in gallery",
-      "listed": "Listed in gallery",
-      "hiddenByModeration": "Hidden by moderation",
-      "linkOnly": "Link only",
-      "noPublishedLink": "No published link",
-      "checkingStatus": "Checking the current gallery status.",
-      "featuredDesc": "Visible in the public gallery and pinned near the top.",
-      "listedDesc": "Visible in the public gallery.",
-      "hiddenDesc": "Hidden by moderation. The direct link still works until it is revoked.",
-      "linkOnlyDesc": "Share link only. Not visible in the public gallery.",
-      "noLinkDesc": "Create a share link first.",
-      "checking": "Checking",
-      "noLink": "No link",
-      "expiresInDays": "Expires in {days} days",
-      "noExpiry": "No expiry",
-      "visibility": "Visibility",
+    "nav": {
       "shareLink": "Share link",
-      "publishFirstTitle": "Publish before listing",
-      "publishFirstDescription": "The gallery uses the current published snapshot, so a share link is required before this track can be listed.",
-      "createShareFirst": "Create share link first",
-      "moderationLockTitle": "Moderation lock",
-      "moderationLockDescription": "This track is hidden from the gallery by moderation. The direct share link can still work until it is revoked.",
-      "detailsTitle": "Gallery details",
-      "listTitle": "List in gallery",
-      "detailsDescription": "Update the title and description shown on the public gallery card.",
-      "listDescription": "Add a title, description and generated preview for public browsing.",
-      "titlePlaceholder": "Track title",
-      "descriptionPlaceholder": "Short description for the gallery card",
-      "authorLabel": "Author",
-      "noDisplayName": "no display name set",
-      "generatingPreview": "Generating preview...",
-      "previewReady": "Preview ready",
-      "refreshShareFirst": "Update the share link first so the gallery uses the latest snapshot.",
-      "titleRequired": "Add a title before saving.",
-      "descriptionLength": "Use {min}-{max} characters for the description.",
-      "displayNameRequired": "Set an account display name first.",
-      "noMetadataChanges": "Update the title or description to save changes.",
-      "addToGallery": "Add to gallery",
-      "cardTitle": "Gallery card",
-      "cardDescription": "Review or update the public title and description for this track.",
-      "untitled": "Untitled",
-      "noDescription": "No gallery description set.",
-      "editDetails": "Edit details",
-      "viewGallery": "View gallery",
-      "removeConfirm": "Remove from the public gallery? The share link itself will continue to work until it is revoked.",
-      "removeFromGallery": "Remove from gallery",
-      "readyTitle": "Ready to list",
-      "readyDescription": "Add this published snapshot to the public gallery with its own title, description and preview."
+      "share": "Share",
+      "embed": "Embed",
+      "gallery": "Gallery"
+    },
+    "currentLink": {
+      "title": "Current shared link",
+      "readOnlyReviewOn": "Read-only {view} review on {hostname}"
     },
     "content": {
-      "shareTitle": "Share link",
-      "shareDescExisting": "Copy or resend this published read-only link, or open Studio to make your own editable copy.",
-      "shareDescAccount": "Create or update the durable read-only link for this account project.",
-      "shareDescSeparate": "Create a separate durable read-only link for this editable copy or local track.",
-      "shareDescAnon": "Create a temporary read-only snapshot link and control how long it stays active.",
-      "galleryTitle": "Gallery visibility",
-      "galleryDesc": "Manage how this published link appears in the public gallery.",
-      "embedTitle": "Embed",
-      "embedDesc": "Copy iframe code for an account-published track that stays live until revoked.",
-      "actionsDescExisting": "Use the current published link in other apps or reopen it in a new tab.",
-      "actionsDesc": "Open, resend, revoke, or export this share without changing the track itself."
+      "share": {
+        "title": "Share link",
+        "description": {
+          "existing": "Copy or resend this published read-only link, or open Studio to make your own editable copy.",
+          "account": "Create or update the durable read-only link for this account project.",
+          "separate": "Create a separate durable read-only link for this editable copy or local track.",
+          "anonymous": "Create a temporary read-only snapshot link and control how long it stays active."
+        }
+      },
+      "gallery": {
+        "title": "Gallery visibility",
+        "description": "Manage how this published link appears in the public gallery."
+      },
+      "embed": {
+        "title": "Embed",
+        "description": "Copy iframe code for an account-published track that stays live until revoked."
+      },
+      "actions": {
+        "descriptionExisting": "Use the current published link in other apps or reopen it in a new tab.",
+        "description": "Open, resend, revoke, or export this share without changing the track itself."
+      }
+    },
+    "link": {
+      "expiry": {
+        "days": "{days} days",
+        "label": "Link expires after",
+        "description": "Temporary snapshots stay available until they expire."
+      },
+      "titles": {
+        "savedProject": "Saved project link",
+        "newShare": "New share link",
+        "separatePublished": "Separate published link",
+        "temporary": "Temporary link",
+        "noSavedProject": "No saved project link yet",
+        "noSeparate": "No separate link yet",
+        "noTemporary": "No temporary link yet"
+      },
+      "descriptions": {
+        "savedProject": "This saved account project uses one durable read-only link. Updating it keeps the same URL with the latest design.",
+        "newShare": "This editable copy gets its own durable read-only link. It will not update another project's published link.",
+        "createSavedProject": "Create one durable URL for this account project. Future updates can keep the same link.",
+        "createSeparate": "Create a durable URL for this copy without changing any earlier share.",
+        "createTemporary": "Choose when it expires and create a read-only snapshot."
+      },
+      "lifetime": {
+        "published": "Published link on {hostname}, stays live until revoked",
+        "temporary": "Read-only snapshot on {hostname}, expires in {days} days"
+      },
+      "warnings": {
+        "outdatedDesign": "This link no longer reflects the latest design.",
+        "outdatedExpiry": "This link no longer reflects the latest expiry selection."
+      }
+    },
+    "embed": {
+      "iframeTitle": "TrackDraw track embed",
+      "code": {
+        "title": "Embed code",
+        "description": "Account-published tracks can be embedded on club or event sites.",
+        "label": "Iframe code",
+        "selectedViewDescription": "Includes the selected initial view.",
+        "copy": "Copy code"
+      },
+      "state": {
+        "loading": "Loading embed state…"
+      },
+      "publish": {
+        "title": "Publish before embedding",
+        "description": "Embeds use the durable account-published link, so create the published link before copying iframe code.",
+        "action": "Create published link"
+      },
+      "temporary": {
+        "title": "Temporary links cannot be embedded",
+        "description": "Sign in and publish this track from your account to create a durable embed."
+      },
+      "refresh": {
+        "message": "Update the published link first so the embed uses the latest design.",
+        "action": "Update link"
+      },
+      "initialView": {
+        "label": "Initial view",
+        "options": {
+          "layout2d": {
+            "label": "2D layout",
+            "description": "Open as the flat field plan"
+          },
+          "preview3d": {
+            "label": "3D preview",
+            "description": "Open in the orbit review"
+          }
+        }
+      }
+    },
+    "gallery": {
+      "status": {
+        "loading": "Loading current state",
+        "featured": "Featured in gallery",
+        "listed": "Listed in gallery",
+        "hiddenByModeration": "Hidden by moderation",
+        "linkOnly": "Link only",
+        "noPublishedLink": "No published link",
+        "checking": "Checking",
+        "noLink": "No link",
+        "expiresInDays": "Expires in {days} days",
+        "noExpiry": "No expiry"
+      },
+      "descriptions": {
+        "checking": "Checking the current gallery status.",
+        "featured": "Visible in the public gallery and pinned near the top.",
+        "listed": "Visible in the public gallery.",
+        "hidden": "Hidden by moderation. The direct link still works until it is revoked.",
+        "linkOnly": "Share link only. Not visible in the public gallery.",
+        "noLink": "Create a share link first."
+      },
+      "labels": {
+        "visibility": "Visibility",
+        "shareLink": "Share link",
+        "author": "Author"
+      },
+      "publishFirst": {
+        "title": "Publish before listing",
+        "description": "The gallery uses the current published snapshot, so a share link is required before this track can be listed.",
+        "action": "Create share link first"
+      },
+      "moderation": {
+        "title": "Moderation lock",
+        "description": "This track is hidden from the gallery by moderation. The direct share link can still work until it is revoked."
+      },
+      "details": {
+        "title": "Gallery details",
+        "description": "Update the title and description shown on the public gallery card.",
+        "edit": "Edit details"
+      },
+      "list": {
+        "title": "List in gallery",
+        "description": "Add a title, description and generated preview for public browsing.",
+        "add": "Add to gallery",
+        "readyTitle": "Ready to list",
+        "readyDescription": "Add this published snapshot to the public gallery with its own title, description and preview."
+      },
+      "fields": {
+        "titlePlaceholder": "Track title",
+        "descriptionPlaceholder": "Short description for the gallery card"
+      },
+      "validation": {
+        "titleRequired": "Add a title before saving.",
+        "descriptionLength": "Use {min}-{max} characters for the description.",
+        "displayNameRequired": "Set an account display name first.",
+        "noMetadataChanges": "Update the title or description to save changes.",
+        "refreshShareFirst": "Update the share link first so the gallery uses the latest snapshot."
+      },
+      "preview": {
+        "generating": "Generating preview...",
+        "ready": "Preview ready"
+      },
+      "card": {
+        "title": "Gallery card",
+        "description": "Review or update the public title and description for this track.",
+        "untitled": "Untitled",
+        "noDescription": "No gallery description set.",
+        "viewGallery": "View gallery"
+      },
+      "remove": {
+        "confirm": "Remove from the public gallery? The share link itself will continue to work until it is revoked.",
+        "action": "Remove from gallery"
+      },
+      "fallback": {
+        "noDisplayName": "no display name set"
+      }
+    },
+    "actions": {
+      "primary": {
+        "updateLink": "Update link",
+        "copyLink": "Copy link",
+        "createLink": "Create link",
+        "createNewLink": "Create new link"
+      },
+      "copyLink": "Copy link",
+      "revoke": "Revoke",
+      "share": {
+        "existingDescription": "This page is already the published read-only review link. Share it as-is, or open Studio if you want an editable copy.",
+        "withPathDescription": "Shared links open as read-only review pages. This link opens straight into {view} review, and the route is ready for fly-through.",
+        "withoutPathDescription": "Shared links open as read-only review pages. Add a path first if you want reviewers to use fly-through and elevation review."
+      },
+      "nativeShare": {
+        "title": "Share via...",
+        "description": "Send to apps or contacts"
+      },
+      "openInTab": {
+        "label": "Open in tab",
+        "reopenCurrent": "Reopen the current shared link in a new tab",
+        "previewLink": "Preview the share link in a new window"
+      },
+      "exportJson": {
+        "label": "Export JSON instead",
+        "description": "Editable backup for reopening in TrackDraw"
+      }
     },
     "errors": {
       "createFailed": "Failed to create share link",
@@ -338,88 +524,36 @@
       "galleryListed": "Track listed in gallery",
       "galleryUpdated": "Gallery details updated",
       "linkRevoked": "Link revoked"
-    },
-    "link": {
-      "expiryDays": "{days} days",
-      "savedProjectTitle": "Saved project link",
-      "newShareTitle": "New share link",
-      "savedProjectDescription": "This saved account project uses one durable read-only link. Updating it keeps the same URL with the latest design.",
-      "newShareDescription": "This editable copy gets its own durable read-only link. It will not update another project's published link.",
-      "separatePublishedTitle": "Separate published link",
-      "temporaryTitle": "Temporary link",
-      "noSavedProjectTitle": "No saved project link yet",
-      "noSeparateTitle": "No separate link yet",
-      "noTemporaryTitle": "No temporary link yet",
-      "lifetimePublished": "Published link on {hostname}, stays live until revoked",
-      "lifetimeTemporary": "Read-only snapshot on {hostname}, expires in {days} days",
-      "createSavedProject": "Create one durable URL for this account project. Future updates can keep the same link.",
-      "createSeparate": "Create a durable URL for this copy without changing any earlier share.",
-      "createTemporary": "Choose when it expires and create a read-only snapshot.",
-      "outdatedDesign": "This link no longer reflects the latest design.",
-      "outdatedExpiry": "This link no longer reflects the latest expiry selection."
-    },
-    "embed": {
-      "iframeTitle": "TrackDraw track embed",
-      "codeTitle": "Embed code",
-      "codeDescription": "Account-published tracks can be embedded on club or event sites.",
-      "loadingState": "Loading embed state…",
-      "publishBeforeEmbedding": "Publish before embedding",
-      "publishBeforeEmbeddingDescription": "Embeds use the durable account-published link, so create the published link before copying iframe code.",
-      "createPublishedLink": "Create published link",
-      "temporaryLinksCannotEmbed": "Temporary links cannot be embedded",
-      "temporaryLinksCannotEmbedDescription": "Sign in and publish this track from your account to create a durable embed.",
-      "refreshFirst": "Update the published link first so the embed uses the latest design.",
-      "updateLink": "Update link",
-      "initialView": "Initial view",
-      "iframeCodeLabel": "Iframe code",
-      "iframeCodeDescription": "Includes the selected initial view.",
-      "copyCode": "Copy code",
-      "layout2dLabel": "2D layout",
-      "layout2dDescription": "Open as the flat field plan",
-      "preview3dLabel": "3D preview",
-      "preview3dDescription": "Open in the orbit review"
-    },
-    "actions": {
-      "existingDescription": "This page is already the published read-only review link. Share it as-is, or open Studio if you want an editable copy.",
-      "withPathDescription": "Shared links open as read-only review pages. This link opens straight into {view} review, and the route is ready for fly-through.",
-      "withoutPathDescription": "Shared links open as read-only review pages. Add a path first if you want reviewers to use fly-through and elevation review.",
-      "nativeShareTitle": "Share via...",
-      "nativeShareDescription": "Send to apps or contacts",
-      "openInTab": "Open in tab",
-      "reopenCurrent": "Reopen the current shared link in a new tab",
-      "previewLink": "Preview the share link in a new window",
-      "exportJson": "Export JSON instead",
-      "exportJsonDescription": "Editable backup for reopening in TrackDraw"
-    },
-    "labels": {
-      "copyLink": "Copy link",
-      "linkExpiresAfter": "Link expires after",
-      "temporarySnapshotsExpire": "Temporary snapshots stay available until they expire.",
-      "revoke": "Revoke"
     }
   },
   "projectManager": {
-    "dialogEyebrow": "Studio",
-    "dialogTitle": "Projects",
-    "dialogMobileSubtitle": "Open, rename, sync or restore.",
-    "navThisDevice": "This device",
-    "navShares": "Shares",
-    "navSnapshots": "Snapshots",
-    "panelDevice": {
-      "label": "On this device",
-      "description": "Local copies saved on this device. Synced projects can also appear in Account."
+    "dialog": {
+      "eyebrow": "Studio",
+      "title": "Projects",
+      "mobileSubtitle": "Open, rename, sync or restore."
     },
-    "panelAccount": {
-      "label": "Account projects",
-      "description": "Account copies available on your signed-in devices. Open one here to refresh this browser."
+    "nav": {
+      "thisDevice": "This device",
+      "shares": "Shares",
+      "snapshots": "Snapshots"
     },
-    "panelSnapshots": {
-      "label": "Snapshots",
-      "description": "Earlier saved states of the current project. Restore any point to roll back changes."
-    },
-    "panelShares": {
-      "label": "Published shares",
-      "description": "Active share links published from your account. Copy, open or revoke them here."
+    "panels": {
+      "device": {
+        "label": "On this device",
+        "description": "Local copies saved on this device. Synced projects can also appear in Account."
+      },
+      "account": {
+        "label": "Account projects",
+        "description": "Account copies available on your signed-in devices. Open one here to refresh this browser."
+      },
+      "snapshots": {
+        "label": "Snapshots",
+        "description": "Earlier saved states of the current project. Restore any point to roll back changes."
+      },
+      "shares": {
+        "label": "Published shares",
+        "description": "Active share links published from your account. Copy, open or revoke them here."
+      }
     },
     "device": {
       "sync": {
@@ -499,58 +633,96 @@
       }
     },
     "account": {
-      "loadingProjects": "Loading account projects...",
-      "loadProjectsFailed": "Could not load account projects",
-      "noProjects": "No account projects",
-      "noProjectsDesc": "Sync a project to make it available across devices.",
-      "conflictWarning": "This project changed on another device while you were signed out",
-      "syncError": "Could not sync the latest changes",
-      "resolveConflictFirst": "Resolve the version conflict first",
-      "retrySync": "Retry sync",
-      "syncPendingChanges": "Sync pending changes",
-      "syncing": "Syncing",
-      "reviewNeeded": "Review needed",
-      "syncFailed": "Sync failed",
-      "synced": "Synced",
-      "untitled": "Untitled"
+      "status": {
+        "loadingProjects": "Loading account projects...",
+        "syncing": "Syncing",
+        "reviewNeeded": "Review needed",
+        "failed": "Sync failed",
+        "synced": "Synced"
+      },
+      "empty": {
+        "noProjects": "No account projects",
+        "description": "Sync a project to make it available across devices."
+      },
+      "messages": {
+        "loadFailed": "Could not load account projects",
+        "conflictWarning": "This project changed on another device while you were signed out",
+        "syncError": "Could not sync the latest changes",
+        "resolveConflictFirst": "Resolve the version conflict first"
+      },
+      "actions": {
+        "retrySync": "Retry sync",
+        "syncPendingChanges": "Sync pending changes"
+      },
+      "fallback": {
+        "untitled": "Untitled"
+      }
     },
     "restore": {
-      "noSnapshots": "No snapshots yet",
-      "noSnapshotsDesc": "Snapshots are created automatically when you open or replace a project.",
-      "noSnapshotsDesktopDesc": "Press <kbdMeta>⌘S</kbdMeta> / <kbdCtrl>Ctrl S</kbdCtrl> or use the save button in the header.",
-      "restoreTitle": "Restore this snapshot",
-      "deleteTitle": "Delete snapshot",
-      "restoreSnapshotConfirm": "Restore this snapshot?",
-      "restoreAction": "Restore",
-      "restoreSnapshotAriaLabel": "Restore {title}",
-      "deleteSnapshotAriaLabel": "Delete {title}",
-      "snapshotFallback": "snapshot",
-      "activeBadge": "active",
-      "untitled": "Untitled"
+      "empty": {
+        "noSnapshots": "No snapshots yet",
+        "description": "Snapshots are created automatically when you open or replace a project.",
+        "desktopDescription": "Press <kbdMeta>⌘S</kbdMeta> / <kbdCtrl>Ctrl S</kbdCtrl> or use the save button in the header."
+      },
+      "actions": {
+        "restoreTitle": "Restore this snapshot",
+        "deleteTitle": "Delete snapshot",
+        "restore": "Restore"
+      },
+      "aria": {
+        "restoreSnapshot": "Restore {title}",
+        "deleteSnapshot": "Delete {title}"
+      },
+      "confirm": {
+        "restoreSnapshot": "Restore this snapshot?"
+      },
+      "status": {
+        "active": "active"
+      },
+      "fallback": {
+        "snapshot": "snapshot",
+        "untitled": "Untitled"
+      }
     },
     "shares": {
-      "loadingPublishedShares": "Loading published shares...",
-      "readOnlyReviewLinks": "Shares are read-only review links. Export JSON when someone needs an editable TrackDraw backup.",
-      "noShares": "No active shares",
-      "noSharesDesc": "Account-published links stay live until revoked. Temporary anonymous links expire automatically and are not managed here.",
-      "publishedStatus": "published",
-      "expiredStatus": "expired",
-      "expiresInDays": "{days, plural, one {1 day left} other {# days left}}",
-      "publishedLifetime": "read-only published link, live until revoked",
-      "temporaryLifetime": "read-only temporary link, {expiresIn}",
-      "copyLink": "Copy link",
-      "openTab": "Open in new tab",
-      "revokeLink": "Revoke link",
-      "copyLinkAriaLabel": "Copy share link",
-      "openTabAriaLabel": "Open share link",
-      "revokeLinkAriaLabel": "Revoke share link",
-      "revokeLinkConfirm": "Revoke this link?"
+      "status": {
+        "loadingPublishedShares": "Loading published shares...",
+        "published": "published",
+        "expired": "expired",
+        "expiresInDays": "{days, plural, one {1 day left} other {# days left}}"
+      },
+      "messages": {
+        "readOnlyReviewLinks": "Shares are read-only review links. Export JSON when someone needs an editable TrackDraw backup."
+      },
+      "empty": {
+        "noShares": "No active shares",
+        "description": "Account-published links stay live until revoked. Temporary anonymous links expire automatically and are not managed here."
+      },
+      "lifetime": {
+        "published": "read-only published link, live until revoked",
+        "temporary": "read-only temporary link, {expiresIn}"
+      },
+      "actions": {
+        "copyLink": "Copy link",
+        "openTab": "Open in new tab",
+        "revokeLink": "Revoke link"
+      },
+      "aria": {
+        "copyLink": "Copy share link",
+        "openTab": "Open share link",
+        "revokeLink": "Revoke share link"
+      },
+      "confirm": {
+        "revokeLink": "Revoke this link?"
+      }
     },
-    "copyProjectIdSuccess": "Project ID copied",
-    "copyProjectIdFailed": "Could not copy the project ID from this browser.",
-    "copyProjectIdLabel": "API project ID",
-    "copyProjectIdAriaLabel": "Copy API project ID",
-    "copyAction": "Copy"
+    "projectIdCopy": {
+      "success": "Project ID copied",
+      "failed": "Could not copy the project ID from this browser.",
+      "label": "API project ID",
+      "ariaLabel": "Copy API project ID",
+      "action": "Copy"
+    }
   },
   "completeProfile": {
     "title": "Add your name",

--- a/lang/nl/dialogs.json
+++ b/lang/nl/dialogs.json
@@ -125,28 +125,46 @@
     }
   },
   "export": {
-    "dialogTitle": "Exporteren",
-    "dialogSubtitle": "Exporteer de huidige track als visuele bestanden, projectoverdracht of simulatorklare output.",
-    "darkTheme": "Donker",
-    "lightTheme": "Licht",
-    "enableRouteNumbers": "Routenummers inschakelen in export",
-    "disableRouteNumbers": "Routenummers uitschakelen in export",
-    "enableRouteNumbersMobile": "Routenummers inschakelen",
-    "disableRouteNumbersMobile": "Routenummers uitschakelen",
-    "filenameLabel": "Bestandsnaam",
-    "themeLabel": "Thema",
-    "routeNumbersLabel": "Routenummers",
-    "routeNumbersHint": "In 2D-exports",
-    "switchTo3dView": "Naar 3D-weergave",
-    "openRequiredView": "Vereiste weergave openen",
-    "exportFormatAriaLabel": "{label} exporteren",
-    "view3dUnavailable": "3D-weergave niet beschikbaar — open eerst de 3D-tab",
-    "canvasNotReady": "Canvas is nog niet klaar",
-    "exported": "Geëxporteerd",
-    "webmRenderingBackground": "Cinematic FPV wordt op de achtergrond gerenderd…",
-    "webmRenderingProgress": "Cinematic FPV renderen… {status}",
-    "webmReady": "Cinematic FPV-export is klaar",
-    "webmProgressLabel": "Fly-through video renderen… {duration}",
+    "dialog": {
+      "title": "Exporteren",
+      "subtitle": "Exporteer de huidige track als visuele bestanden, projectoverdracht of simulatorklare output."
+    },
+    "fields": {
+      "filename": {
+        "label": "Bestandsnaam"
+      }
+    },
+    "theme": {
+      "label": "Thema",
+      "dark": "Donker",
+      "light": "Licht"
+    },
+    "routeNumbers": {
+      "label": "Routenummers",
+      "hint": "In 2D-exports",
+      "enable": "Routenummers inschakelen in export",
+      "disable": "Routenummers uitschakelen in export",
+      "enableMobile": "Routenummers inschakelen",
+      "disableMobile": "Routenummers uitschakelen"
+    },
+    "actions": {
+      "switchTo3dView": "Naar 3D-weergave",
+      "openRequiredView": "Vereiste weergave openen"
+    },
+    "aria": {
+      "exportFormat": "{label} exporteren"
+    },
+    "messages": {
+      "view3dUnavailable": "3D-weergave niet beschikbaar — open eerst de 3D-tab",
+      "canvasNotReady": "Canvas is nog niet klaar",
+      "exported": "Geëxporteerd"
+    },
+    "webm": {
+      "renderingBackground": "Cinematic FPV wordt op de achtergrond gerenderd…",
+      "renderingProgress": "Cinematic FPV renderen… {status}",
+      "ready": "Cinematic FPV-export is klaar",
+      "progressLabel": "Fly-through video renderen… {duration}"
+    },
     "sections": {
       "visualExports": {
         "title": "Visuele exports",

--- a/lang/nl/dialogs.json
+++ b/lang/nl/dialogs.json
@@ -1,96 +1,148 @@
 {
   "account": {
-    "navSecurity": "Beveiliging",
-    "navApiKeys": "API-sleutels",
-    "navDanger": "Gevaarzone",
-    "panelProfile": {
-      "title": "Jouw profiel",
-      "description": "Beheer de naam die zichtbaar is in je TrackDraw-account."
+    "dialog": {
+      "eyebrow": "Studio",
+      "mobileSubtitle": "Beheer je TrackDraw-account."
     },
-    "panelSecurity": {
-      "title": "Beveiliging",
-      "description": "Beheer aanmeldmethoden, e-mailadres en passkeys voor je TrackDraw-account."
+    "nav": {
+      "security": "Beveiliging",
+      "apiKeys": "API-sleutels",
+      "danger": "Gevaarzone"
     },
-    "panelApiKeys": {
-      "title": "API-sleutels",
-      "description": "Maak tijdelijke sleutels aan voor externe TrackDraw-integraties en trek ze in."
+    "panels": {
+      "profile": {
+        "title": "Jouw profiel",
+        "description": "Beheer de naam die zichtbaar is in je TrackDraw-account."
+      },
+      "security": {
+        "title": "Beveiliging",
+        "description": "Beheer aanmeldmethoden, e-mailadres en passkeys voor je TrackDraw-account."
+      },
+      "apiKeys": {
+        "title": "API-sleutels",
+        "description": "Maak tijdelijke sleutels aan voor externe TrackDraw-integraties en trek ze in."
+      },
+      "danger": {
+        "title": "Gevaarzone",
+        "description": "Destructieve en onomkeerbare accountacties."
+      }
     },
-    "panelDanger": {
-      "title": "Gevaarzone",
-      "description": "Destructieve en onomkeerbare accountacties."
-    },
-    "dialogEyebrow": "Studio",
-    "dialogMobileSubtitle": "Beheer je TrackDraw-account.",
     "profile": {
-      "displayNameLabel": "Weergavenaam",
-      "displayNamePlaceholder": "Jouw naam",
-      "languageDescription": "Wijzigingen worden direct toegepast",
-      "saving": "Opslaan...",
-      "noAccountEmail": "TrackDraw-account"
+      "displayName": {
+        "label": "Weergavenaam",
+        "placeholder": "Jouw naam"
+      },
+      "language": {
+        "description": "Wijzigingen worden direct toegepast"
+      },
+      "status": {
+        "saving": "Opslaan..."
+      },
+      "fallback": {
+        "noAccountEmail": "TrackDraw-account"
+      }
     },
     "security": {
-      "emailAddress": "E-mailadres",
-      "newEmail": "Nieuw e-mailadres",
-      "emailPlaceholder": "naam@voorbeeld.nl",
-      "emailChangeDescription": "Na het opslaan sturen we eerst een bevestiging naar je huidige e-mailadres. Daarna verifieer je het nieuwe adres.",
-      "changeEmail": "E-mailadres wijzigen",
-      "passkeysTitle": "Passkeys",
-      "passkeysDescription": "Voeg een passkey toe om sneller in te loggen op ondersteunde apparaten.",
-      "savingEmail": "Opslaan...",
-      "addPasskey": "Passkey toevoegen",
-      "addingPasskey": "Toevoegen...",
-      "devAuthUnavailable": "Passkeys zijn niet beschikbaar in `npm run dev`. Gebruik `npm run preview` om de echte auth-flow lokaal te testen.",
-      "reauthTitle": "Log opnieuw in om door te gaan",
-      "reauthDescription": "Voor het instellen van een passkey is een recente login nodig. Je kunt ingelogd blijven voor normaal werk, maar deze beveiligingsactie vraagt om bevestiging.",
-      "signInAgain": "Opnieuw inloggen",
-      "unsupportedBrowser": "Deze browser stelt WebAuthn hier momenteel niet beschikbaar, waardoor passkey-instelling op dit apparaat niet mogelijk is.",
-      "loadingPasskeys": "Passkeys laden...",
-      "emptyTitle": "Nog geen passkeys",
-      "emptyDescription": "Voeg er een toe om sneller in te loggen op je vertrouwde apparaten.",
-      "addedDate": "Toegevoegd op {date}",
-      "synced": "gesynchroniseerd",
-      "renameAriaLabel": "Passkey hernoemen",
-      "removingAriaLabel": "Passkey verwijderen",
-      "removeAriaLabel": "Passkey verwijderen",
-      "removing": "Verwijderen...",
-      "removeTooltip": "Uit account verwijderen",
-      "passkeyNamePlaceholder": "Naam passkey",
-      "unnamedPasskey": "Naamloze passkey",
-      "renameDescription": "Dit wijzigt alleen hoe de passkey in je TrackDraw-account wordt weergegeven.",
-      "saveName": "Naam opslaan"
+      "email": {
+        "address": "E-mailadres",
+        "newEmail": "Nieuw e-mailadres",
+        "placeholder": "naam@voorbeeld.nl",
+        "changeDescription": "Na het opslaan sturen we eerst een bevestiging naar je huidige e-mailadres. Daarna verifieer je het nieuwe adres.",
+        "change": "E-mailadres wijzigen",
+        "saving": "Opslaan..."
+      },
+      "passkeys": {
+        "title": "Passkeys",
+        "description": "Voeg een passkey toe om sneller in te loggen op ondersteunde apparaten.",
+        "add": "Passkey toevoegen",
+        "adding": "Toevoegen...",
+        "devAuthUnavailable": "Passkeys zijn niet beschikbaar in `npm run dev`. Gebruik `npm run preview` om de echte auth-flow lokaal te testen.",
+        "unsupportedBrowser": "Deze browser stelt WebAuthn hier momenteel niet beschikbaar, waardoor passkey-instelling op dit apparaat niet mogelijk is.",
+        "loading": "Passkeys laden...",
+        "addedDate": "Toegevoegd op {date}",
+        "status": {
+          "synced": "gesynchroniseerd"
+        },
+        "reauth": {
+          "title": "Log opnieuw in om door te gaan",
+          "description": "Voor het instellen van een passkey is een recente login nodig. Je kunt ingelogd blijven voor normaal werk, maar deze beveiligingsactie vraagt om bevestiging.",
+          "action": "Opnieuw inloggen"
+        },
+        "empty": {
+          "title": "Nog geen passkeys",
+          "description": "Voeg er een toe om sneller in te loggen op je vertrouwde apparaten."
+        },
+        "aria": {
+          "rename": "Passkey hernoemen",
+          "removing": "Passkey verwijderen",
+          "remove": "Passkey verwijderen"
+        },
+        "actions": {
+          "removing": "Verwijderen...",
+          "removeTooltip": "Uit account verwijderen",
+          "saveName": "Naam opslaan"
+        },
+        "fields": {
+          "namePlaceholder": "Naam passkey"
+        },
+        "fallback": {
+          "unnamed": "Naamloze passkey"
+        },
+        "rename": {
+          "description": "Dit wijzigt alleen hoe de passkey in je TrackDraw-account wordt weergegeven."
+        }
+      }
     },
     "apiKeys": {
-      "keyNameLabel": "Sleutelnaam",
-      "expiryDays": "{days} dagen",
-      "expiryYear": "1 jaar",
-      "namePlaceholder": "Overlay-integratie",
-      "create": "Aanmaken",
-      "createdTitle": "API-sleutel aangemaakt",
-      "createdDescription": "Dit geheim wordt één keer getoond. Bewaar het voordat je dit venster sluit.",
-      "activeTitle": "Actieve API-sleutels",
-      "descriptionPrefix": "Alleen-lezen sleutels voor vertrouwde integraties.",
-      "docsLink": "API-docs",
-      "refreshAriaLabel": "API-sleutels verversen",
-      "loading": "API-sleutels laden...",
-      "emptyTitle": "Nog geen API-sleutels",
-      "emptyDescription": "Maak er een aan wanneer een vertrouwde integratie alleen-lezen toegang nodig heeft tot je accountprojecten.",
-      "unnamedKey": "Naamloze API-sleutel",
-      "expiresOn": "Verloopt op {date}",
-      "lastUsed": "Laatst gebruikt {date}",
-      "revokeConfirmTitle": "API-sleutel intrekken?",
-      "revokeTooltip": "Intrekken",
-      "revokeAriaLabel": "{name} intrekken",
-      "revokeWarningExpiring": "Deze sleutel stopt met werken.",
-      "revokeWarningNonExpiring": "Integraties die deze sleutel gebruiken verliezen leestoegang.",
-      "revoking": "Intrekken...",
-      "revoke": "Intrekken"
+      "form": {
+        "keyNameLabel": "Sleutelnaam",
+        "expiryDays": "{days} dagen",
+        "expiryYear": "1 jaar",
+        "namePlaceholder": "Overlay-integratie",
+        "create": "Aanmaken"
+      },
+      "created": {
+        "title": "API-sleutel aangemaakt",
+        "description": "Dit geheim wordt één keer getoond. Bewaar het voordat je dit venster sluit."
+      },
+      "active": {
+        "title": "Actieve API-sleutels",
+        "descriptionPrefix": "Alleen-lezen sleutels voor vertrouwde integraties.",
+        "docsLink": "API-docs",
+        "refreshAriaLabel": "API-sleutels verversen",
+        "loading": "API-sleutels laden..."
+      },
+      "empty": {
+        "title": "Nog geen API-sleutels",
+        "description": "Maak er een aan wanneer een vertrouwde integratie alleen-lezen toegang nodig heeft tot je accountprojecten."
+      },
+      "fallback": {
+        "unnamed": "Naamloze API-sleutel"
+      },
+      "meta": {
+        "expiresOn": "Verloopt op {date}",
+        "lastUsed": "Laatst gebruikt {date}"
+      },
+      "revoke": {
+        "confirmTitle": "API-sleutel intrekken?",
+        "tooltip": "Intrekken",
+        "ariaLabel": "{name} intrekken",
+        "warningExpiring": "Deze sleutel stopt met werken.",
+        "warningNonExpiring": "Integraties die deze sleutel gebruiken verliezen leestoegang.",
+        "revoking": "Intrekken...",
+        "action": "Intrekken"
+      }
     },
     "danger": {
       "description": "Het verwijderen van je account verwijdert accountprojecten, gepubliceerde links, API-keys en andere accountgebonden data. Exporteer wat je wilt behouden voordat je doorgaat.",
-      "typeToConfirm": "Typ DELETE om te bevestigen",
-      "deletePlaceholder": "DELETE",
-      "deleting": "Verwijderen...",
-      "deleteAccount": "Account verwijderen"
+      "confirm": {
+        "label": "Typ DELETE om te bevestigen",
+        "placeholder": "DELETE"
+      },
+      "actions": {
+        "deleting": "Verwijderen...",
+        "deleteAccount": "Account verwijderen"
+      }
     },
     "shared": {
       "loading": "Account laden...",
@@ -241,85 +293,219 @@
     "backupFirst": "Eerst back-up van huidig project maken"
   },
   "share": {
-    "dialogEyebrow": "Studio",
-    "dialogEyebrowExisting": "Gedeelde track",
-    "dialogTitle": "Delen",
-    "dialogMobileSubtitle": "Deel een alleen-lezen reviewlink voor deze track",
-    "navShareLink": "Deellink",
-    "navShare": "Delen",
-    "navEmbed": "Embed",
-    "navGallery": "Galerij",
-    "currentSharedLink": "Huidige gedeelde link",
-    "readOnlyReviewOn": "Alleen-lezen {view}-review op {hostname}",
-    "primaryAction": {
-      "updateLink": "Link bijwerken",
-      "copyLink": "Link kopiëren",
-      "createLink": "Link aanmaken",
-      "createNewLink": "Nieuwe link aanmaken"
+    "dialog": {
+      "eyebrow": "Studio",
+      "existingEyebrow": "Gedeelde track",
+      "title": "Delen",
+      "mobileSubtitle": "Deel een alleen-lezen reviewlink voor deze track"
     },
-    "gallery": {
-      "loading": "Huidige status laden",
-      "featured": "Uitgelicht in galerij",
-      "listed": "Vermeld in galerij",
-      "hiddenByModeration": "Verborgen door moderatie",
-      "linkOnly": "Alleen link",
-      "noPublishedLink": "Geen gepubliceerde link",
-      "checkingStatus": "Huidige galerijstatus controleren.",
-      "featuredDesc": "Zichtbaar in de publieke galerij en bovenaan geplaatst.",
-      "listedDesc": "Zichtbaar in de publieke galerij.",
-      "hiddenDesc": "Verborgen door moderatie. De directe link werkt nog totdat deze wordt ingetrokken.",
-      "linkOnlyDesc": "Alleen deellink. Niet zichtbaar in de publieke galerij.",
-      "noLinkDesc": "Maak eerst een deellink aan.",
-      "checking": "Controleren",
-      "noLink": "Geen link",
-      "expiresInDays": "Verloopt over {days} dagen",
-      "noExpiry": "Geen verloopdatum",
-      "visibility": "Zichtbaarheid",
+    "nav": {
       "shareLink": "Deellink",
-      "publishFirstTitle": "Publiceer voordat je vermeldt",
-      "publishFirstDescription": "De galerij gebruikt de huidige gepubliceerde snapshot, dus er is een deellink nodig voordat deze track vermeld kan worden.",
-      "createShareFirst": "Eerst deellink aanmaken",
-      "moderationLockTitle": "Moderatieblokkade",
-      "moderationLockDescription": "Deze track is door moderatie verborgen uit de galerij. De directe deellink kan nog werken totdat die wordt ingetrokken.",
-      "detailsTitle": "Galerijgegevens",
-      "listTitle": "In galerij plaatsen",
-      "detailsDescription": "Werk de titel en beschrijving bij die op de publieke galerijkaart staan.",
-      "listDescription": "Voeg een titel, beschrijving en gegenereerde preview toe voor publieke weergave.",
-      "titlePlaceholder": "Tracktitel",
-      "descriptionPlaceholder": "Korte beschrijving voor de galerijkaart",
-      "authorLabel": "Auteur",
-      "noDisplayName": "geen weergavenaam ingesteld",
-      "generatingPreview": "Preview genereren...",
-      "previewReady": "Preview klaar",
-      "refreshShareFirst": "Werk eerst de deellink bij zodat de galerij de nieuwste snapshot gebruikt.",
-      "titleRequired": "Voeg een titel toe voordat je opslaat.",
-      "descriptionLength": "Gebruik {min}-{max} tekens voor de beschrijving.",
-      "displayNameRequired": "Stel eerst een accountweergavenaam in.",
-      "noMetadataChanges": "Werk de titel of beschrijving bij om wijzigingen op te slaan.",
-      "addToGallery": "Toevoegen aan galerij",
-      "cardTitle": "Galerijkaart",
-      "cardDescription": "Bekijk of wijzig de publieke titel en beschrijving voor deze track.",
-      "untitled": "Naamloos",
-      "noDescription": "Geen galerijbeschrijving ingesteld.",
-      "editDetails": "Gegevens bewerken",
-      "viewGallery": "Galerij bekijken",
-      "removeConfirm": "Verwijderen uit de publieke galerij? De deellink zelf blijft werken totdat die wordt ingetrokken.",
-      "removeFromGallery": "Uit galerij verwijderen",
-      "readyTitle": "Klaar om te vermelden",
-      "readyDescription": "Voeg deze gepubliceerde snapshot toe aan de publieke galerij met een eigen titel, beschrijving en preview."
+      "share": "Delen",
+      "embed": "Embed",
+      "gallery": "Galerij"
+    },
+    "currentLink": {
+      "title": "Huidige gedeelde link",
+      "readOnlyReviewOn": "Alleen-lezen {view}-review op {hostname}"
     },
     "content": {
-      "shareTitle": "Deellink",
-      "shareDescExisting": "Kopieer of stuur deze gepubliceerde alleen-lezenlink opnieuw, of open Studio om een eigen bewerkbare kopie te maken.",
-      "shareDescAccount": "Maak de duurzame alleen-lezenlink voor dit accountproject aan of werk hem bij.",
-      "shareDescSeparate": "Maak een aparte duurzame alleen-lezenlink aan voor deze bewerkbare kopie of lokale track.",
-      "shareDescAnon": "Maak een tijdelijke alleen-lezen snapshotlink aan en bepaal hoe lang die actief blijft.",
-      "galleryTitle": "Zichtbaarheid galerij",
-      "galleryDesc": "Beheer hoe deze gepubliceerde link in de publieke galerij verschijnt.",
-      "embedTitle": "Embed",
-      "embedDesc": "Kopieer iframe-code voor een accountgepubliceerde track die actief blijft totdat ingetrokken.",
-      "actionsDescExisting": "Gebruik de huidige gepubliceerde link in andere apps of open hem in een nieuw tabblad.",
-      "actionsDesc": "Open, stuur opnieuw, trek in of exporteer dit gedeelde item zonder de track te wijzigen."
+      "share": {
+        "title": "Deellink",
+        "description": {
+          "existing": "Kopieer of stuur deze gepubliceerde alleen-lezenlink opnieuw, of open Studio om een eigen bewerkbare kopie te maken.",
+          "account": "Maak de duurzame alleen-lezenlink voor dit accountproject aan of werk hem bij.",
+          "separate": "Maak een aparte duurzame alleen-lezenlink aan voor deze bewerkbare kopie of lokale track.",
+          "anonymous": "Maak een tijdelijke alleen-lezen snapshotlink aan en bepaal hoe lang die actief blijft."
+        }
+      },
+      "gallery": {
+        "title": "Zichtbaarheid galerij",
+        "description": "Beheer hoe deze gepubliceerde link in de publieke galerij verschijnt."
+      },
+      "embed": {
+        "title": "Embed",
+        "description": "Kopieer iframe-code voor een accountgepubliceerde track die actief blijft totdat ingetrokken."
+      },
+      "actions": {
+        "descriptionExisting": "Gebruik de huidige gepubliceerde link in andere apps of open hem in een nieuw tabblad.",
+        "description": "Open, stuur opnieuw, trek in of exporteer dit gedeelde item zonder de track te wijzigen."
+      }
+    },
+    "link": {
+      "expiry": {
+        "days": "{days} dagen",
+        "label": "Link verloopt na",
+        "description": "Tijdelijke snapshots blijven beschikbaar totdat ze verlopen."
+      },
+      "titles": {
+        "savedProject": "Opgeslagen projectlink",
+        "newShare": "Nieuwe deellink",
+        "separatePublished": "Aparte gepubliceerde link",
+        "temporary": "Tijdelijke link",
+        "noSavedProject": "Nog geen opgeslagen projectlink",
+        "noSeparate": "Nog geen aparte link",
+        "noTemporary": "Nog geen tijdelijke link"
+      },
+      "descriptions": {
+        "savedProject": "Dit opgeslagen accountproject gebruikt één duurzame alleen-lezen link. Bijwerken houdt dezelfde URL met het nieuwste ontwerp.",
+        "newShare": "Deze bewerkbare kopie krijgt een eigen duurzame alleen-lezen link. Die wijzigt geen eerder gepubliceerde projectlink.",
+        "createSavedProject": "Maak één duurzame URL voor dit accountproject. Toekomstige updates kunnen dezelfde link houden.",
+        "createSeparate": "Maak een duurzame URL voor deze kopie zonder eerdere shares te wijzigen.",
+        "createTemporary": "Kies wanneer hij verloopt en maak een alleen-lezen snapshot."
+      },
+      "lifetime": {
+        "published": "Gepubliceerde link op {hostname}, blijft live totdat die wordt ingetrokken",
+        "temporary": "Alleen-lezen snapshot op {hostname}, verloopt over {days} dagen"
+      },
+      "warnings": {
+        "outdatedDesign": "Deze link bevat niet meer het nieuwste ontwerp.",
+        "outdatedExpiry": "Deze link gebruikt niet meer de nieuwste verloopkeuze."
+      }
+    },
+    "embed": {
+      "iframeTitle": "TrackDraw track embed",
+      "code": {
+        "title": "Embedcode",
+        "description": "Accountgepubliceerde tracks kunnen worden ingesloten op club- of eventsites.",
+        "label": "Iframe-code",
+        "selectedViewDescription": "Inclusief de geselecteerde startweergave.",
+        "copy": "Code kopiëren"
+      },
+      "state": {
+        "loading": "Embedstatus laden…"
+      },
+      "publish": {
+        "title": "Publiceer voor embedden",
+        "description": "Embeds gebruiken de duurzame accountgepubliceerde link, dus maak de gepubliceerde link aan voordat je iframe-code kopieert.",
+        "action": "Gepubliceerde link aanmaken"
+      },
+      "temporary": {
+        "title": "Tijdelijke links kunnen niet worden embedded",
+        "description": "Meld je aan en publiceer deze track vanuit je account om een duurzame embed te maken."
+      },
+      "refresh": {
+        "message": "Werk eerst de gepubliceerde link bij zodat de embed het nieuwste ontwerp gebruikt.",
+        "action": "Link bijwerken"
+      },
+      "initialView": {
+        "label": "Startweergave",
+        "options": {
+          "layout2d": {
+            "label": "2D-layout",
+            "description": "Open als plat veldplan"
+          },
+          "preview3d": {
+            "label": "3D-preview",
+            "description": "Open in de orbit-review"
+          }
+        }
+      }
+    },
+    "gallery": {
+      "status": {
+        "loading": "Huidige status laden",
+        "featured": "Uitgelicht in galerij",
+        "listed": "Vermeld in galerij",
+        "hiddenByModeration": "Verborgen door moderatie",
+        "linkOnly": "Alleen link",
+        "noPublishedLink": "Geen gepubliceerde link",
+        "checking": "Controleren",
+        "noLink": "Geen link",
+        "expiresInDays": "Verloopt over {days} dagen",
+        "noExpiry": "Geen verloopdatum"
+      },
+      "descriptions": {
+        "checking": "Huidige galerijstatus controleren.",
+        "featured": "Zichtbaar in de publieke galerij en bovenaan geplaatst.",
+        "listed": "Zichtbaar in de publieke galerij.",
+        "hidden": "Verborgen door moderatie. De directe link werkt nog totdat deze wordt ingetrokken.",
+        "linkOnly": "Alleen deellink. Niet zichtbaar in de publieke galerij.",
+        "noLink": "Maak eerst een deellink aan."
+      },
+      "labels": {
+        "visibility": "Zichtbaarheid",
+        "shareLink": "Deellink",
+        "author": "Auteur"
+      },
+      "publishFirst": {
+        "title": "Publiceer voordat je vermeldt",
+        "description": "De galerij gebruikt de huidige gepubliceerde snapshot, dus er is een deellink nodig voordat deze track vermeld kan worden.",
+        "action": "Eerst deellink aanmaken"
+      },
+      "moderation": {
+        "title": "Moderatieblokkade",
+        "description": "Deze track is door moderatie verborgen uit de galerij. De directe deellink kan nog werken totdat die wordt ingetrokken."
+      },
+      "details": {
+        "title": "Galerijgegevens",
+        "description": "Werk de titel en beschrijving bij die op de publieke galerijkaart staan.",
+        "edit": "Gegevens bewerken"
+      },
+      "list": {
+        "title": "In galerij plaatsen",
+        "description": "Voeg een titel, beschrijving en gegenereerde preview toe voor publieke weergave.",
+        "add": "Toevoegen aan galerij",
+        "readyTitle": "Klaar om te vermelden",
+        "readyDescription": "Voeg deze gepubliceerde snapshot toe aan de publieke galerij met een eigen titel, beschrijving en preview."
+      },
+      "fields": {
+        "titlePlaceholder": "Tracktitel",
+        "descriptionPlaceholder": "Korte beschrijving voor de galerijkaart"
+      },
+      "validation": {
+        "titleRequired": "Voeg een titel toe voordat je opslaat.",
+        "descriptionLength": "Gebruik {min}-{max} tekens voor de beschrijving.",
+        "displayNameRequired": "Stel eerst een accountweergavenaam in.",
+        "noMetadataChanges": "Werk de titel of beschrijving bij om wijzigingen op te slaan.",
+        "refreshShareFirst": "Werk eerst de deellink bij zodat de galerij de nieuwste snapshot gebruikt."
+      },
+      "preview": {
+        "generating": "Preview genereren...",
+        "ready": "Preview klaar"
+      },
+      "card": {
+        "title": "Galerijkaart",
+        "description": "Bekijk of wijzig de publieke titel en beschrijving voor deze track.",
+        "untitled": "Naamloos",
+        "noDescription": "Geen galerijbeschrijving ingesteld.",
+        "viewGallery": "Galerij bekijken"
+      },
+      "remove": {
+        "confirm": "Verwijderen uit de publieke galerij? De deellink zelf blijft werken totdat die wordt ingetrokken.",
+        "action": "Uit galerij verwijderen"
+      },
+      "fallback": {
+        "noDisplayName": "geen weergavenaam ingesteld"
+      }
+    },
+    "actions": {
+      "primary": {
+        "updateLink": "Link bijwerken",
+        "copyLink": "Link kopiëren",
+        "createLink": "Link aanmaken",
+        "createNewLink": "Nieuwe link aanmaken"
+      },
+      "copyLink": "Link kopiëren",
+      "revoke": "Intrekken",
+      "share": {
+        "existingDescription": "Deze pagina is al de gepubliceerde alleen-lezen reviewlink. Deel hem zo, of open Studio als je een bewerkbare kopie wilt.",
+        "withPathDescription": "Gedeelde links openen als alleen-lezen reviewpagina's. Deze link opent direct in {view}-review en de route is klaar voor fly-through.",
+        "withoutPathDescription": "Gedeelde links openen als alleen-lezen reviewpagina's. Voeg eerst een pad toe als reviewers fly-through en hoogtereview moeten gebruiken."
+      },
+      "nativeShare": {
+        "title": "Delen via...",
+        "description": "Stuur naar apps of contacten"
+      },
+      "openInTab": {
+        "label": "Openen in tabblad",
+        "reopenCurrent": "Open de huidige gedeelde link opnieuw in een nieuw tabblad",
+        "previewLink": "Bekijk de deellink in een nieuw venster"
+      },
+      "exportJson": {
+        "label": "JSON exporteren",
+        "description": "Bewerkbare back-up om opnieuw te openen in TrackDraw"
+      }
     },
     "errors": {
       "createFailed": "Deellink aanmaken mislukt",
@@ -338,88 +524,36 @@
       "galleryListed": "Track vermeld in galerij",
       "galleryUpdated": "Galerij bijgewerkt",
       "linkRevoked": "Link ingetrokken"
-    },
-    "link": {
-      "expiryDays": "{days} dagen",
-      "savedProjectTitle": "Opgeslagen projectlink",
-      "newShareTitle": "Nieuwe deellink",
-      "savedProjectDescription": "Dit opgeslagen accountproject gebruikt één duurzame alleen-lezen link. Bijwerken houdt dezelfde URL met het nieuwste ontwerp.",
-      "newShareDescription": "Deze bewerkbare kopie krijgt een eigen duurzame alleen-lezen link. Die wijzigt geen eerder gepubliceerde projectlink.",
-      "separatePublishedTitle": "Aparte gepubliceerde link",
-      "temporaryTitle": "Tijdelijke link",
-      "noSavedProjectTitle": "Nog geen opgeslagen projectlink",
-      "noSeparateTitle": "Nog geen aparte link",
-      "noTemporaryTitle": "Nog geen tijdelijke link",
-      "lifetimePublished": "Gepubliceerde link op {hostname}, blijft live totdat die wordt ingetrokken",
-      "lifetimeTemporary": "Alleen-lezen snapshot op {hostname}, verloopt over {days} dagen",
-      "createSavedProject": "Maak één duurzame URL voor dit accountproject. Toekomstige updates kunnen dezelfde link houden.",
-      "createSeparate": "Maak een duurzame URL voor deze kopie zonder eerdere shares te wijzigen.",
-      "createTemporary": "Kies wanneer hij verloopt en maak een alleen-lezen snapshot.",
-      "outdatedDesign": "Deze link bevat niet meer het nieuwste ontwerp.",
-      "outdatedExpiry": "Deze link gebruikt niet meer de nieuwste verloopkeuze."
-    },
-    "embed": {
-      "iframeTitle": "TrackDraw track embed",
-      "codeTitle": "Embedcode",
-      "codeDescription": "Accountgepubliceerde tracks kunnen worden ingesloten op club- of eventsites.",
-      "loadingState": "Embedstatus laden…",
-      "publishBeforeEmbedding": "Publiceer voor embedden",
-      "publishBeforeEmbeddingDescription": "Embeds gebruiken de duurzame accountgepubliceerde link, dus maak de gepubliceerde link aan voordat je iframe-code kopieert.",
-      "createPublishedLink": "Gepubliceerde link aanmaken",
-      "temporaryLinksCannotEmbed": "Tijdelijke links kunnen niet worden embedded",
-      "temporaryLinksCannotEmbedDescription": "Meld je aan en publiceer deze track vanuit je account om een duurzame embed te maken.",
-      "refreshFirst": "Werk eerst de gepubliceerde link bij zodat de embed het nieuwste ontwerp gebruikt.",
-      "updateLink": "Link bijwerken",
-      "initialView": "Startweergave",
-      "iframeCodeLabel": "Iframe-code",
-      "iframeCodeDescription": "Inclusief de geselecteerde startweergave.",
-      "copyCode": "Code kopiëren",
-      "layout2dLabel": "2D-layout",
-      "layout2dDescription": "Open als plat veldplan",
-      "preview3dLabel": "3D-preview",
-      "preview3dDescription": "Open in de orbit-review"
-    },
-    "actions": {
-      "existingDescription": "Deze pagina is al de gepubliceerde alleen-lezen reviewlink. Deel hem zo, of open Studio als je een bewerkbare kopie wilt.",
-      "withPathDescription": "Gedeelde links openen als alleen-lezen reviewpagina's. Deze link opent direct in {view}-review en de route is klaar voor fly-through.",
-      "withoutPathDescription": "Gedeelde links openen als alleen-lezen reviewpagina's. Voeg eerst een pad toe als reviewers fly-through en hoogtereview moeten gebruiken.",
-      "nativeShareTitle": "Delen via...",
-      "nativeShareDescription": "Stuur naar apps of contacten",
-      "openInTab": "Openen in tabblad",
-      "reopenCurrent": "Open de huidige gedeelde link opnieuw in een nieuw tabblad",
-      "previewLink": "Bekijk de deellink in een nieuw venster",
-      "exportJson": "JSON exporteren",
-      "exportJsonDescription": "Bewerkbare back-up om opnieuw te openen in TrackDraw"
-    },
-    "labels": {
-      "copyLink": "Link kopiëren",
-      "linkExpiresAfter": "Link verloopt na",
-      "temporarySnapshotsExpire": "Tijdelijke snapshots blijven beschikbaar totdat ze verlopen.",
-      "revoke": "Intrekken"
     }
   },
   "projectManager": {
-    "dialogEyebrow": "Studio",
-    "dialogTitle": "Projecten",
-    "dialogMobileSubtitle": "Openen, hernoemen, synchroniseren of herstellen.",
-    "navThisDevice": "Dit apparaat",
-    "navShares": "Gedeeld",
-    "navSnapshots": "Snapshots",
-    "panelDevice": {
-      "label": "Op dit apparaat",
-      "description": "Lokale kopieën op dit apparaat. Gesynchroniseerde projecten kunnen ook onder Account verschijnen."
+    "dialog": {
+      "eyebrow": "Studio",
+      "title": "Projecten",
+      "mobileSubtitle": "Openen, hernoemen, synchroniseren of herstellen."
     },
-    "panelAccount": {
-      "label": "Accountprojecten",
-      "description": "Accountkopieën beschikbaar op je aangemelde apparaten. Open er een hier om deze browser te vernieuwen."
+    "nav": {
+      "thisDevice": "Dit apparaat",
+      "shares": "Gedeeld",
+      "snapshots": "Snapshots"
     },
-    "panelSnapshots": {
-      "label": "Snapshots",
-      "description": "Eerdere opgeslagen versies van het huidige project. Herstel elk punt om wijzigingen terug te draaien."
-    },
-    "panelShares": {
-      "label": "Gepubliceerde gedeelde items",
-      "description": "Actieve deellinks die vanuit je account zijn gepubliceerd. Kopieer, open of trek ze hier in."
+    "panels": {
+      "device": {
+        "label": "Op dit apparaat",
+        "description": "Lokale kopieën op dit apparaat. Gesynchroniseerde projecten kunnen ook onder Account verschijnen."
+      },
+      "account": {
+        "label": "Accountprojecten",
+        "description": "Accountkopieën beschikbaar op je aangemelde apparaten. Open er een hier om deze browser te vernieuwen."
+      },
+      "snapshots": {
+        "label": "Snapshots",
+        "description": "Eerdere opgeslagen versies van het huidige project. Herstel elk punt om wijzigingen terug te draaien."
+      },
+      "shares": {
+        "label": "Gepubliceerde gedeelde items",
+        "description": "Actieve deellinks die vanuit je account zijn gepubliceerd. Kopieer, open of trek ze hier in."
+      }
     },
     "device": {
       "sync": {
@@ -499,58 +633,96 @@
       }
     },
     "account": {
-      "loadingProjects": "Accountprojecten laden...",
-      "loadProjectsFailed": "Accountprojecten konden niet worden geladen",
-      "noProjects": "Geen accountprojecten",
-      "noProjectsDesc": "Synchroniseer een project om het op alle apparaten beschikbaar te maken.",
-      "conflictWarning": "Dit project is op een ander apparaat gewijzigd terwijl je niet was aangemeld",
-      "syncError": "Laatste wijzigingen konden niet worden gesynchroniseerd",
-      "resolveConflictFirst": "Los eerst het versieconflict op",
-      "retrySync": "Synchronisatie opnieuw proberen",
-      "syncPendingChanges": "Openstaande wijzigingen synchroniseren",
-      "syncing": "Synchroniseren",
-      "reviewNeeded": "Beoordeling vereist",
-      "syncFailed": "Synchronisatie mislukt",
-      "synced": "Gesynchroniseerd",
-      "untitled": "Naamloos"
+      "status": {
+        "loadingProjects": "Accountprojecten laden...",
+        "syncing": "Synchroniseren",
+        "reviewNeeded": "Beoordeling vereist",
+        "failed": "Synchronisatie mislukt",
+        "synced": "Gesynchroniseerd"
+      },
+      "empty": {
+        "noProjects": "Geen accountprojecten",
+        "description": "Synchroniseer een project om het op alle apparaten beschikbaar te maken."
+      },
+      "messages": {
+        "loadFailed": "Accountprojecten konden niet worden geladen",
+        "conflictWarning": "Dit project is op een ander apparaat gewijzigd terwijl je niet was aangemeld",
+        "syncError": "Laatste wijzigingen konden niet worden gesynchroniseerd",
+        "resolveConflictFirst": "Los eerst het versieconflict op"
+      },
+      "actions": {
+        "retrySync": "Synchronisatie opnieuw proberen",
+        "syncPendingChanges": "Openstaande wijzigingen synchroniseren"
+      },
+      "fallback": {
+        "untitled": "Naamloos"
+      }
     },
     "restore": {
-      "noSnapshots": "Nog geen snapshots",
-      "noSnapshotsDesc": "Snapshots worden automatisch aangemaakt wanneer je een project opent of vervangt.",
-      "noSnapshotsDesktopDesc": "Druk op <kbdMeta>⌘S</kbdMeta> / <kbdCtrl>Ctrl S</kbdCtrl> of gebruik de opslagknop in de header.",
-      "restoreTitle": "Dit snapshot herstellen",
-      "deleteTitle": "Snapshot verwijderen",
-      "restoreSnapshotConfirm": "Dit snapshot herstellen?",
-      "restoreAction": "Herstellen",
-      "restoreSnapshotAriaLabel": "{title} herstellen",
-      "deleteSnapshotAriaLabel": "{title} verwijderen",
-      "snapshotFallback": "snapshot",
-      "activeBadge": "actief",
-      "untitled": "Naamloos"
+      "empty": {
+        "noSnapshots": "Nog geen snapshots",
+        "description": "Snapshots worden automatisch aangemaakt wanneer je een project opent of vervangt.",
+        "desktopDescription": "Druk op <kbdMeta>⌘S</kbdMeta> / <kbdCtrl>Ctrl S</kbdCtrl> of gebruik de opslagknop in de header."
+      },
+      "actions": {
+        "restoreTitle": "Dit snapshot herstellen",
+        "deleteTitle": "Snapshot verwijderen",
+        "restore": "Herstellen"
+      },
+      "aria": {
+        "restoreSnapshot": "{title} herstellen",
+        "deleteSnapshot": "{title} verwijderen"
+      },
+      "confirm": {
+        "restoreSnapshot": "Dit snapshot herstellen?"
+      },
+      "status": {
+        "active": "actief"
+      },
+      "fallback": {
+        "snapshot": "snapshot",
+        "untitled": "Naamloos"
+      }
     },
     "shares": {
-      "loadingPublishedShares": "Gepubliceerde shares laden...",
-      "readOnlyReviewLinks": "Shares zijn alleen-lezen reviewlinks. Exporteer JSON wanneer iemand een bewerkbare TrackDraw-back-up nodig heeft.",
-      "noShares": "Geen actieve gedeelde items",
-      "noSharesDesc": "Accountgepubliceerde links blijven actief totdat ze worden ingetrokken. Tijdelijke anonieme links verlopen automatisch en worden hier niet beheerd.",
-      "publishedStatus": "gepubliceerd",
-      "expiredStatus": "verlopen",
-      "expiresInDays": "{days, plural, one {1 dag over} other {# dagen over}}",
-      "publishedLifetime": "alleen-lezen gepubliceerde link, live tot intrekking",
-      "temporaryLifetime": "alleen-lezen tijdelijke link, {expiresIn}",
-      "copyLink": "Link kopiëren",
-      "openTab": "Openen in nieuw tabblad",
-      "revokeLink": "Link intrekken",
-      "copyLinkAriaLabel": "Deellink kopiëren",
-      "openTabAriaLabel": "Deellink openen",
-      "revokeLinkAriaLabel": "Deellink intrekken",
-      "revokeLinkConfirm": "Deze link intrekken?"
+      "status": {
+        "loadingPublishedShares": "Gepubliceerde shares laden...",
+        "published": "gepubliceerd",
+        "expired": "verlopen",
+        "expiresInDays": "{days, plural, one {1 dag over} other {# dagen over}}"
+      },
+      "messages": {
+        "readOnlyReviewLinks": "Shares zijn alleen-lezen reviewlinks. Exporteer JSON wanneer iemand een bewerkbare TrackDraw-back-up nodig heeft."
+      },
+      "empty": {
+        "noShares": "Geen actieve gedeelde items",
+        "description": "Accountgepubliceerde links blijven actief totdat ze worden ingetrokken. Tijdelijke anonieme links verlopen automatisch en worden hier niet beheerd."
+      },
+      "lifetime": {
+        "published": "alleen-lezen gepubliceerde link, live tot intrekking",
+        "temporary": "alleen-lezen tijdelijke link, {expiresIn}"
+      },
+      "actions": {
+        "copyLink": "Link kopiëren",
+        "openTab": "Openen in nieuw tabblad",
+        "revokeLink": "Link intrekken"
+      },
+      "aria": {
+        "copyLink": "Deellink kopiëren",
+        "openTab": "Deellink openen",
+        "revokeLink": "Deellink intrekken"
+      },
+      "confirm": {
+        "revokeLink": "Deze link intrekken?"
+      }
     },
-    "copyProjectIdSuccess": "Project-ID gekopieerd",
-    "copyProjectIdFailed": "Project-ID kon niet vanuit deze browser worden gekopieerd.",
-    "copyProjectIdLabel": "API-project-ID",
-    "copyProjectIdAriaLabel": "API-project-ID kopiëren",
-    "copyAction": "Kopiëren"
+    "projectIdCopy": {
+      "success": "Project-ID gekopieerd",
+      "failed": "Project-ID kon niet vanuit deze browser worden gekopieerd.",
+      "label": "API-project-ID",
+      "ariaLabel": "API-project-ID kopiëren",
+      "action": "Kopiëren"
+    }
   },
   "completeProfile": {
     "title": "Voeg je naam toe",

--- a/src/components/dialogs/AccountDialog/ApiKeysView.tsx
+++ b/src/components/dialogs/AccountDialog/ApiKeysView.tsx
@@ -119,7 +119,7 @@ export function AccountApiKeysView({
             id="api-key-name-label"
             className="order-1 block text-sm font-medium"
           >
-            {t("account.apiKeys.keyNameLabel")}
+            {t("account.apiKeys.form.keyNameLabel")}
           </span>
           <span
             id="api-key-expiry-label"
@@ -135,7 +135,7 @@ export function AccountApiKeysView({
             value={apiKeyName}
             onChange={(event) => onApiKeyNameChange(event.target.value)}
             className="order-2 h-8 rounded-lg px-2.5 shadow-none sm:order-4"
-            placeholder={t("account.apiKeys.namePlaceholder")}
+            placeholder={t("account.apiKeys.form.namePlaceholder")}
             maxLength={64}
           />
 
@@ -152,16 +152,16 @@ export function AccountApiKeysView({
               </SelectTrigger>
               <SelectContent align="start">
                 <SelectItem value="7">
-                  {t("account.apiKeys.expiryDays", { days: 7 })}
+                  {t("account.apiKeys.form.expiryDays", { days: 7 })}
                 </SelectItem>
                 <SelectItem value="30">
-                  {t("account.apiKeys.expiryDays", { days: 30 })}
+                  {t("account.apiKeys.form.expiryDays", { days: 30 })}
                 </SelectItem>
                 <SelectItem value="90">
-                  {t("account.apiKeys.expiryDays", { days: 90 })}
+                  {t("account.apiKeys.form.expiryDays", { days: 90 })}
                 </SelectItem>
                 <SelectItem value="365">
-                  {t("account.apiKeys.expiryYear")}
+                  {t("account.apiKeys.form.expiryYear")}
                 </SelectItem>
               </SelectContent>
             </Select>
@@ -181,7 +181,7 @@ export function AccountApiKeysView({
             ) : (
               <Plus className="size-4" />
             )}
-            {t("account.apiKeys.create")}
+            {t("account.apiKeys.form.create")}
           </Button>
         </div>
 
@@ -189,10 +189,10 @@ export function AccountApiKeysView({
           <div className="space-y-3 rounded-2xl border border-emerald-500/25 bg-emerald-500/8 px-4 py-4">
             <div>
               <p className="text-sm font-medium text-emerald-700 dark:text-emerald-300">
-                {t("account.apiKeys.createdTitle")}
+                {t("account.apiKeys.created.title")}
               </p>
               <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-                {t("account.apiKeys.createdDescription")}
+                {t("account.apiKeys.created.description")}
               </p>
             </div>
             <div
@@ -222,7 +222,7 @@ export function AccountApiKeysView({
         <div className="space-y-1.5">
           <div className="flex items-center justify-between gap-3">
             <p className="text-sm font-medium">
-              {t("account.apiKeys.activeTitle")}
+              {t("account.apiKeys.active.title")}
             </p>
             <Button
               type="button"
@@ -230,7 +230,7 @@ export function AccountApiKeysView({
               onClick={onRefreshApiKeys}
               disabled={apiKeysLoading}
               className="text-muted-foreground hover:text-foreground hover:bg-muted h-7 w-7 shrink-0 rounded-lg px-0"
-              aria-label={t("account.apiKeys.refreshAriaLabel")}
+              aria-label={t("account.apiKeys.active.refreshAriaLabel")}
             >
               <RefreshCw
                 className={cn("size-4", apiKeysLoading && "animate-spin")}
@@ -239,14 +239,14 @@ export function AccountApiKeysView({
           </div>
           <div>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              {t("account.apiKeys.descriptionPrefix")}{" "}
+              {t("account.apiKeys.active.descriptionPrefix")}{" "}
               <Link
                 href="/api/docs"
                 target="_blank"
                 rel="noreferrer"
                 className="text-foreground inline-flex items-center gap-1 font-medium underline-offset-4 hover:underline"
               >
-                {t("account.apiKeys.docsLink")}
+                {t("account.apiKeys.active.docsLink")}
                 <ExternalLink className="size-3" />
               </Link>
             </p>
@@ -256,7 +256,7 @@ export function AccountApiKeysView({
         {apiKeysLoading ? (
           <div className="text-muted-foreground flex items-center gap-2 text-sm">
             <LoaderCircle className="size-4 animate-spin" />
-            {t("account.apiKeys.loading")}
+            {t("account.apiKeys.active.loading")}
           </div>
         ) : apiKeys.length === 0 ? (
           <div className="bg-muted/20 border-border/60 rounded-2xl border px-4 py-4">
@@ -266,10 +266,10 @@ export function AccountApiKeysView({
               </span>
               <div className="min-w-0">
                 <p className="text-sm font-medium">
-                  {t("account.apiKeys.emptyTitle")}
+                  {t("account.apiKeys.empty.title")}
                 </p>
                 <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-                  {t("account.apiKeys.emptyDescription")}
+                  {t("account.apiKeys.empty.description")}
                 </p>
               </div>
             </div>
@@ -294,16 +294,16 @@ export function AccountApiKeysView({
                         <div className="min-w-0">
                           <p className="truncate text-sm font-medium">
                             {apiKey.name?.trim() ||
-                              t("account.apiKeys.unnamedKey")}
+                              t("account.apiKeys.fallback.unnamed")}
                           </p>
                           <div className="mt-1 flex flex-wrap gap-1.5">
                             <span className="border-border/50 bg-background/60 text-muted-foreground inline-flex rounded-md border px-1.5 py-0.5 text-[11px]">
-                              {t("account.apiKeys.expiresOn", {
+                              {t("account.apiKeys.meta.expiresOn", {
                                 date: formatDate(apiKey.expiresAt),
                               })}
                             </span>
                             <span className="border-border/50 bg-background/60 text-muted-foreground inline-flex rounded-md border px-1.5 py-0.5 text-[11px]">
-                              {t("account.apiKeys.lastUsed", {
+                              {t("account.apiKeys.meta.lastUsed", {
                                 date: formatDate(apiKey.lastRequest),
                               })}
                             </span>
@@ -311,16 +311,18 @@ export function AccountApiKeysView({
                         </div>
                       </div>
 
-                      <ActionTooltip label={t("account.apiKeys.revokeTooltip")}>
+                      <ActionTooltip
+                        label={t("account.apiKeys.revoke.tooltip")}
+                      >
                         <button
                           type="button"
                           onClick={() => setConfirmRevokeKeyId(apiKey.id)}
                           disabled={isDeleting}
                           className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 flex size-8 shrink-0 cursor-pointer items-center justify-center rounded-lg opacity-100 transition-colors disabled:pointer-events-none disabled:opacity-50"
-                          aria-label={t("account.apiKeys.revokeAriaLabel", {
+                          aria-label={t("account.apiKeys.revoke.ariaLabel", {
                             name:
                               apiKey.name?.trim() ||
-                              t("account.apiKeys.unnamedKey"),
+                              t("account.apiKeys.fallback.unnamed"),
                           })}
                         >
                           {isDeleting ? (
@@ -344,12 +346,12 @@ export function AccountApiKeysView({
                       >
                         <div className="min-w-0 flex-1">
                           <p className="text-foreground truncate text-sm font-medium">
-                            {t("account.apiKeys.revokeConfirmTitle")}
+                            {t("account.apiKeys.revoke.confirmTitle")}
                           </p>
                           <p className="text-muted-foreground truncate text-[11px]">
                             {isMobile
-                              ? t("account.apiKeys.revokeWarningExpiring")
-                              : t("account.apiKeys.revokeWarningNonExpiring")}
+                              ? t("account.apiKeys.revoke.warningExpiring")
+                              : t("account.apiKeys.revoke.warningNonExpiring")}
                           </p>
                         </div>
                         <div className="flex shrink-0 items-center gap-1">
@@ -363,8 +365,8 @@ export function AccountApiKeysView({
                             className="bg-destructive/10 hover:bg-destructive/20 text-destructive disabled:text-destructive/60 cursor-pointer rounded-lg px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-not-allowed"
                           >
                             {isDeleting
-                              ? t("account.apiKeys.revoking")
-                              : t("account.apiKeys.revoke")}
+                              ? t("account.apiKeys.revoke.revoking")
+                              : t("account.apiKeys.revoke.action")}
                           </button>
                           <button
                             type="button"

--- a/src/components/dialogs/AccountDialog/DangerView.tsx
+++ b/src/components/dialogs/AccountDialog/DangerView.tsx
@@ -44,13 +44,13 @@ export function AccountDangerView({
       <div className="space-y-3">
         <label className="block">
           <span className="mb-2 block text-sm font-medium">
-            {t("account.danger.typeToConfirm")}
+            {t("account.danger.confirm.label")}
           </span>
           <Input
             type="text"
             value={deleteConfirmation}
             onChange={(event) => onDeleteConfirmationChange(event.target.value)}
-            placeholder={t("account.danger.deletePlaceholder")}
+            placeholder={t("account.danger.confirm.placeholder")}
             className="h-8 rounded-lg px-2.5 shadow-none"
           />
         </label>
@@ -68,8 +68,8 @@ export function AccountDangerView({
             className="h-8 rounded-lg px-2.5"
           >
             {deleting
-              ? t("account.danger.deleting")
-              : t("account.danger.deleteAccount")}
+              ? t("account.danger.actions.deleting")
+              : t("account.danger.actions.deleteAccount")}
           </Button>
         </div>
       </div>

--- a/src/components/dialogs/AccountDialog/ProfileView.tsx
+++ b/src/components/dialogs/AccountDialog/ProfileView.tsx
@@ -66,7 +66,7 @@ export function AccountProfileView({
             {getDisplayName(user)}
           </p>
           <p className="text-muted-foreground mt-0.5 text-sm">
-            {user.email ?? t("account.profile.noAccountEmail")}
+            {user.email ?? t("account.profile.fallback.noAccountEmail")}
           </p>
         </div>
       </div>
@@ -74,14 +74,14 @@ export function AccountProfileView({
       <div className="border-border/60 space-y-4 border-t pt-5">
         <label className="block">
           <span className="mb-2 block text-sm font-medium">
-            {t("account.profile.displayNameLabel")}
+            {t("account.profile.displayName.label")}
           </span>
           <Input
             type="text"
             autoComplete="name"
             value={name}
             onChange={(event) => onNameChange(event.target.value)}
-            placeholder={t("account.profile.displayNamePlaceholder")}
+            placeholder={t("account.profile.displayName.placeholder")}
             className="h-8 rounded-lg px-2.5 shadow-none"
           />
         </label>
@@ -99,7 +99,7 @@ export function AccountProfileView({
             className={cn("h-8 rounded-lg px-2.5", isMobile && "w-full")}
           >
             {saving
-              ? t("account.profile.saving")
+              ? t("account.profile.status.saving")
               : tCommon("actions.saveChanges")}
           </Button>
           <Button
@@ -127,7 +127,7 @@ export function AccountProfileView({
         <div>
           <p className="text-sm font-medium">{tCommon("labels.language")}</p>
           <p className="text-muted-foreground mt-0.5 text-xs">
-            {t("account.profile.languageDescription")}
+            {t("account.profile.language.description")}
           </p>
         </div>
         <LanguagePicker variant="full" className="w-40" />

--- a/src/components/dialogs/AccountDialog/SecurityView.tsx
+++ b/src/components/dialogs/AccountDialog/SecurityView.tsx
@@ -101,10 +101,10 @@ export function AccountSecurityView({
       <div className="border-border/60 space-y-4 border-b pb-5">
         <div className="space-y-1">
           <p className="text-sm font-medium">
-            {t("account.security.emailAddress")}
+            {t("account.security.email.address")}
           </p>
           <p className="text-muted-foreground truncate text-sm">
-            {user.email ?? t("account.profile.noAccountEmail")}
+            {user.email ?? t("account.profile.fallback.noAccountEmail")}
           </p>
         </div>
 
@@ -113,20 +113,20 @@ export function AccountSecurityView({
             <div className="bg-muted/20 border-border/60 space-y-4 rounded-2xl border px-4 py-4">
               <label className="block">
                 <span className="text-muted-foreground mb-2 block text-xs font-medium tracking-[0.01em]">
-                  {t("account.security.newEmail")}
+                  {t("account.security.email.newEmail")}
                 </span>
                 <Input
                   type="email"
                   autoComplete="email"
                   value={email}
                   onChange={(event) => onEmailChange(event.target.value)}
-                  placeholder={t("account.security.emailPlaceholder")}
+                  placeholder={t("account.security.email.placeholder")}
                   className="h-8 rounded-lg px-2.5 shadow-none"
                 />
               </label>
 
               <p className="text-muted-foreground text-sm leading-relaxed">
-                {t("account.security.emailChangeDescription")}
+                {t("account.security.email.changeDescription")}
               </p>
 
               <div
@@ -154,7 +154,7 @@ export function AccountSecurityView({
                   className={cn("h-8 rounded-lg px-2.5", isMobile && "w-full")}
                 >
                   {changingEmail
-                    ? t("account.security.savingEmail")
+                    ? t("account.security.email.saving")
                     : tCommon("actions.save")}
                 </Button>
               </div>
@@ -169,7 +169,7 @@ export function AccountSecurityView({
               }}
               className={cn("h-8 rounded-lg px-2.5", isMobile && "w-full")}
             >
-              {t("account.security.changeEmail")}
+              {t("account.security.email.change")}
             </Button>
           )}
         </div>
@@ -184,10 +184,10 @@ export function AccountSecurityView({
         >
           <div className="min-w-0">
             <p className="text-sm font-medium">
-              {t("account.security.passkeysTitle")}
+              {t("account.security.passkeys.title")}
             </p>
             <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-              {t("account.security.passkeysDescription")}
+              {t("account.security.passkeys.description")}
             </p>
           </div>
           <Button
@@ -205,25 +205,25 @@ export function AccountSecurityView({
             )}
           >
             {passkeyLoading
-              ? t("account.security.addingPasskey")
-              : t("account.security.addPasskey")}
+              ? t("account.security.passkeys.adding")
+              : t("account.security.passkeys.add")}
           </Button>
         </div>
 
         {isDevAuthShimEnabled() ? (
           <div className="bg-muted/20 border-border/60 rounded-2xl border px-4 py-3">
             <p className="text-muted-foreground text-sm leading-relaxed">
-              {t("account.security.devAuthUnavailable")}
+              {t("account.security.passkeys.devAuthUnavailable")}
             </p>
           </div>
         ) : passkeyReauthRequired ? (
           <div className="border-brand-primary/25 bg-brand-primary/8 space-y-3 rounded-2xl border px-4 py-4">
             <div>
               <p className="text-sm font-medium">
-                {t("account.security.reauthTitle")}
+                {t("account.security.passkeys.reauth.title")}
               </p>
               <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-                {t("account.security.reauthDescription")}
+                {t("account.security.passkeys.reauth.description")}
               </p>
             </div>
             <Button
@@ -232,19 +232,19 @@ export function AccountSecurityView({
               onClick={onPasskeyReauthenticate}
               className={cn("h-8 rounded-lg px-2.5", isMobile && "w-full")}
             >
-              {t("account.security.signInAgain")}
+              {t("account.security.passkeys.reauth.action")}
             </Button>
           </div>
         ) : !passkeySupported ? (
           <div className="bg-muted/20 border-border/60 rounded-2xl border px-4 py-3">
             <p className="text-muted-foreground text-sm leading-relaxed">
-              {t("account.security.unsupportedBrowser")}
+              {t("account.security.passkeys.unsupportedBrowser")}
             </p>
           </div>
         ) : passkeysLoading ? (
           <div className="text-muted-foreground flex items-center gap-2 text-sm">
             <LoaderCircle className="size-4 animate-spin" />
-            {t("account.security.loadingPasskeys")}
+            {t("account.security.passkeys.loading")}
           </div>
         ) : passkeys.length === 0 ? (
           <div className="bg-muted/20 border-border/60 rounded-2xl border px-4 py-4">
@@ -254,10 +254,10 @@ export function AccountSecurityView({
               </span>
               <div className="min-w-0">
                 <p className="text-sm font-medium">
-                  {t("account.security.emptyTitle")}
+                  {t("account.security.passkeys.empty.title")}
                 </p>
                 <p className="text-muted-foreground mt-1 text-sm leading-relaxed">
-                  {t("account.security.emptyDescription")}
+                  {t("account.security.passkeys.empty.description")}
                 </p>
               </div>
             </div>
@@ -291,14 +291,14 @@ export function AccountSecurityView({
                         <div className="min-w-0">
                           <p className="truncate text-sm font-medium">
                             {passkey.name?.trim() ||
-                              t("account.security.unnamedPasskey")}
+                              t("account.security.passkeys.fallback.unnamed")}
                           </p>
                           <p className="text-muted-foreground text-xs">
-                            {t("account.security.addedDate", {
+                            {t("account.security.passkeys.addedDate", {
                               date: createdAt,
                             })}
                             {passkey.backedUp
-                              ? ` · ${t("account.security.synced")}`
+                              ? ` · ${t("account.security.passkeys.status.synced")}`
                               : ""}
                           </p>
                         </div>
@@ -314,7 +314,9 @@ export function AccountSecurityView({
                               variant="ghost"
                               size="icon"
                               className={isMobile ? undefined : "size-7"}
-                              aria-label={t("account.security.renameAriaLabel")}
+                              aria-label={t(
+                                "account.security.passkeys.aria.rename"
+                              )}
                               onClick={() =>
                                 onEditingPasskeyIdChange(passkey.id)
                               }
@@ -335,8 +337,8 @@ export function AccountSecurityView({
                             size="icon"
                             aria-label={
                               isDeleting
-                                ? t("account.security.removingAriaLabel")
-                                : t("account.security.removeAriaLabel")
+                                ? t("account.security.passkeys.aria.removing")
+                                : t("account.security.passkeys.aria.remove")
                             }
                             onClick={() => onDeletePasskey(passkey.id)}
                             disabled={isDeleting || passkeyLoading}
@@ -351,8 +353,10 @@ export function AccountSecurityView({
                         </TooltipTrigger>
                         <TooltipContent>
                           {isDeleting
-                            ? t("account.security.removing")
-                            : t("account.security.removeTooltip")}
+                            ? t("account.security.passkeys.actions.removing")
+                            : t(
+                                "account.security.passkeys.actions.removeTooltip"
+                              )}
                         </TooltipContent>
                       </Tooltip>
                     </div>
@@ -370,13 +374,13 @@ export function AccountSecurityView({
                           }))
                         }
                         placeholder={t(
-                          "account.security.passkeyNamePlaceholder"
+                          "account.security.passkeys.fields.namePlaceholder"
                         )}
                         className="h-8 rounded-lg px-2.5 shadow-none"
                       />
 
                       <p className="text-muted-foreground text-xs leading-relaxed">
-                        {t("account.security.renameDescription")}
+                        {t("account.security.passkeys.rename.description")}
                       </p>
 
                       <div
@@ -405,7 +409,7 @@ export function AccountSecurityView({
                           disabled={passkeyLoading || !draftName.trim()}
                           className="h-8 rounded-lg px-2.5"
                         >
-                          {t("account.security.saveName")}
+                          {t("account.security.passkeys.actions.saveName")}
                         </Button>
                       </div>
                     </div>

--- a/src/components/dialogs/AccountDialog/index.tsx
+++ b/src/components/dialogs/AccountDialog/index.tsx
@@ -570,17 +570,17 @@ export default function AccountDialog({
     },
     {
       id: "security" as AccountDialogView,
-      label: t("account.navSecurity"),
+      label: t("account.nav.security"),
       icon: <ShieldCheck className="size-4" />,
     },
     {
       id: "apiKeys" as AccountDialogView,
-      label: t("account.navApiKeys"),
+      label: t("account.nav.apiKeys"),
       icon: <Braces className="size-4" />,
     },
     {
       id: "danger" as AccountDialogView,
-      label: t("account.navDanger"),
+      label: t("account.nav.danger"),
       icon: <ShieldAlert className="size-4" />,
       tone: "danger" as const,
     },
@@ -591,23 +591,23 @@ export default function AccountDialog({
     { title: string; description: string; content: React.ReactNode }
   > = {
     profile: {
-      title: t("account.panelProfile.title"),
-      description: t("account.panelProfile.description"),
+      title: t("account.panels.profile.title"),
+      description: t("account.panels.profile.description"),
       content: profileContent,
     },
     security: {
-      title: t("account.panelSecurity.title"),
-      description: t("account.panelSecurity.description"),
+      title: t("account.panels.security.title"),
+      description: t("account.panels.security.description"),
       content: securityContent,
     },
     apiKeys: {
-      title: t("account.panelApiKeys.title"),
-      description: t("account.panelApiKeys.description"),
+      title: t("account.panels.apiKeys.title"),
+      description: t("account.panels.apiKeys.description"),
       content: apiKeysContent,
     },
     danger: {
-      title: t("account.panelDanger.title"),
-      description: t("account.panelDanger.description"),
+      title: t("account.panels.danger.title"),
+      description: t("account.panels.danger.description"),
       content: dangerContent,
     },
   };
@@ -618,9 +618,9 @@ export default function AccountDialog({
     <SidebarDialog
       open={open}
       onOpenChange={onOpenChange}
-      eyebrow={t("account.dialogEyebrow")}
+      eyebrow={t("account.dialog.eyebrow")}
       title={tCommon("labels.account")}
-      mobileSubtitle={t("account.dialogMobileSubtitle")}
+      mobileSubtitle={t("account.dialog.mobileSubtitle")}
       navItems={navItems}
       activeItem={view}
       onItemChange={(id) => {

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -337,8 +337,8 @@ export default function ExportDialog({
 
       toast.success(
         warningText
-          ? `${options?.successMessage ?? t("export.exported")}. ${warningText}`
-          : (options?.successMessage ?? t("export.exported")),
+          ? `${options?.successMessage ?? t("export.messages.exported")}. ${warningText}`
+          : (options?.successMessage ?? t("export.messages.exported")),
         options?.toastId !== undefined ? { id: options.toastId } : undefined
       );
       if (!options?.closeOnStart) {
@@ -365,7 +365,7 @@ export default function ExportDialog({
         {/* Filename */}
         <label className="flex min-w-0 flex-1 cursor-text flex-col gap-1.5 px-4 py-3">
           <span className="text-muted-foreground text-[10px] font-semibold tracking-[0.12em] uppercase select-none">
-            {t("export.filenameLabel")}
+            {t("export.fields.filename.label")}
           </span>
           <input
             type="text"
@@ -379,7 +379,7 @@ export default function ExportDialog({
         {/* Theme */}
         <div className="flex shrink-0 flex-col gap-1.5 px-4 py-3">
           <span className="text-muted-foreground text-[10px] font-semibold tracking-[0.12em] uppercase select-none">
-            {t("export.themeLabel")}
+            {t("export.theme.label")}
           </span>
           <div className="flex items-center gap-3">
             <button
@@ -394,7 +394,7 @@ export default function ExportDialog({
               )}
             >
               <Moon className="size-3.5 shrink-0" />
-              {t("export.darkTheme")}
+              {t("export.theme.dark")}
             </button>
             <button
               type="button"
@@ -413,7 +413,7 @@ export default function ExportDialog({
                   exportTheme === "light" ? "text-amber-500" : ""
                 )}
               />
-              {t("export.lightTheme")}
+              {t("export.theme.light")}
             </button>
           </div>
         </div>
@@ -422,10 +422,10 @@ export default function ExportDialog({
         <div className="flex shrink-0 items-center gap-3 px-4 py-3">
           <div className="flex flex-col gap-1.5">
             <span className="text-muted-foreground text-[10px] font-semibold tracking-[0.12em] uppercase select-none">
-              {t("export.routeNumbersLabel")}
+              {t("export.routeNumbers.label")}
             </span>
             <span className="text-muted-foreground/45 text-[10px]">
-              {t("export.routeNumbersHint")}
+              {t("export.routeNumbers.hint")}
             </span>
           </div>
           <button
@@ -438,8 +438,8 @@ export default function ExportDialog({
             aria-pressed={includeObstacleNumbers}
             aria-label={
               includeObstacleNumbers
-                ? t("export.disableRouteNumbers")
-                : t("export.enableRouteNumbers")
+                ? t("export.routeNumbers.disable")
+                : t("export.routeNumbers.enable")
             }
           >
             <span className="bg-background block size-4 rounded-full shadow-xs" />
@@ -503,7 +503,7 @@ export default function ExportDialog({
             lockedAction={
               activeTab !== "3d" && onRequest3DView
                 ? {
-                    label: t("export.switchTo3dView"),
+                    label: t("export.actions.switchTo3dView"),
                     onClick: onRequest3DView,
                   }
                 : undefined
@@ -511,7 +511,8 @@ export default function ExportDialog({
             onExport={() =>
               run("3d", () => {
                 const dataUrl = preview3DRef?.current?.screenshot();
-                if (!dataUrl) throw new Error(t("export.view3dUnavailable"));
+                if (!dataUrl)
+                  throw new Error(t("export.messages.view3dUnavailable"));
                 const a = document.createElement("a");
                 a.href = dataUrl;
                 a.download = `${safeName({
@@ -559,7 +560,8 @@ export default function ExportDialog({
             onExport={() =>
               run("race-day-pdf", async () => {
                 const stage = canvasRef.current?.getStage();
-                if (!stage) throw new Error(t("export.canvasNotReady"));
+                if (!stage)
+                  throw new Error(t("export.messages.canvasNotReady"));
                 const { exportPdf } = await import("@/lib/export/exportPdf");
                 const shareUrl = await getRacePackShareUrl();
                 await exportPdf(
@@ -608,7 +610,7 @@ export default function ExportDialog({
                   webmToastIdRef.current = toastId;
                   setWebmProgress(null);
                   webmStartTimeRef.current = Date.now();
-                  toast.loading(t("export.webmRenderingBackground"), {
+                  toast.loading(t("export.webm.renderingBackground"), {
                     id: toastId,
                   });
                   const { exportFlythrough } =
@@ -621,7 +623,7 @@ export default function ExportDialog({
                       (progress) => {
                         setWebmProgress(progress);
                         toast.loading(
-                          t("export.webmRenderingProgress", {
+                          t("export.webm.renderingProgress", {
                             status: getFlythroughStatusText(
                               progress,
                               webmStartTimeRef.current
@@ -639,7 +641,7 @@ export default function ExportDialog({
                 },
                 {
                   closeOnStart: true,
-                  successMessage: t("export.webmReady"),
+                  successMessage: t("export.webm.ready"),
                   toastId: "webm-flythrough-export",
                 }
               )
@@ -660,7 +662,7 @@ export default function ExportDialog({
           <div className="mt-3 space-y-1.5">
             <div className="text-muted-foreground flex justify-between text-[10px]">
               <span>
-                {t("export.webmProgressLabel", {
+                {t("export.webm.progressLabel", {
                   duration: formatDuration(webmProgress.videoDurationSeconds),
                 })}
               </span>
@@ -698,8 +700,8 @@ export default function ExportDialog({
             color="bg-sky-500/15 text-sky-400"
             description={t("export.formats.image.descriptionShort")}
             isBusy={busy === "png"}
-            lockedLabel={t("export.openRequiredView")}
-            exportAriaLabel={t("export.exportFormatAriaLabel", {
+            lockedLabel={t("export.actions.openRequiredView")}
+            exportAriaLabel={t("export.aria.exportFormat", {
               label: t("export.formats.image.label"),
             })}
             onAction={() =>
@@ -721,8 +723,8 @@ export default function ExportDialog({
             color="bg-purple-500/15 text-purple-400"
             description={t("export.formats.vector.descriptionShort")}
             isBusy={busy === "svg"}
-            lockedLabel={t("export.openRequiredView")}
-            exportAriaLabel={t("export.exportFormatAriaLabel", {
+            lockedLabel={t("export.actions.openRequiredView")}
+            exportAriaLabel={t("export.aria.exportFormat", {
               label: t("export.formats.vector.label"),
             })}
             onAction={() =>
@@ -744,8 +746,8 @@ export default function ExportDialog({
             description={t("export.formats.render3d.descriptionShort")}
             isBusy={busy === "3d"}
             locked={activeTab !== "3d"}
-            lockedLabel={t("export.switchTo3dView")}
-            exportAriaLabel={t("export.exportFormatAriaLabel", {
+            lockedLabel={t("export.actions.switchTo3dView")}
+            exportAriaLabel={t("export.aria.exportFormat", {
               label: t("export.formats.render3d.label"),
             })}
             onAction={
@@ -755,7 +757,7 @@ export default function ExportDialog({
                     run("3d", () => {
                       const dataUrl = preview3DRef?.current?.screenshot();
                       if (!dataUrl)
-                        throw new Error(t("export.view3dUnavailable"));
+                        throw new Error(t("export.messages.view3dUnavailable"));
                       const a = document.createElement("a");
                       a.href = dataUrl;
                       a.download = `${safeName({ view: "3d", theme: currentTheme })}.png`;
@@ -778,8 +780,8 @@ export default function ExportDialog({
             color="bg-emerald-500/15 text-emerald-400"
             description={t("export.formats.projectFile.descriptionShort")}
             isBusy={busy === "json"}
-            lockedLabel={t("export.openRequiredView")}
-            exportAriaLabel={t("export.exportFormatAriaLabel", {
+            lockedLabel={t("export.actions.openRequiredView")}
+            exportAriaLabel={t("export.aria.exportFormat", {
               label: t("export.formats.projectFile.label"),
             })}
             onAction={() =>
@@ -796,14 +798,15 @@ export default function ExportDialog({
             color="bg-red-500/15 text-red-400"
             description={t("export.formats.racePack.descriptionShort")}
             isBusy={busy === "race-day-pdf"}
-            lockedLabel={t("export.openRequiredView")}
-            exportAriaLabel={t("export.exportFormatAriaLabel", {
+            lockedLabel={t("export.actions.openRequiredView")}
+            exportAriaLabel={t("export.aria.exportFormat", {
               label: t("export.formats.racePack.label"),
             })}
             onAction={() =>
               run("race-day-pdf", async () => {
                 const stage = canvasRef.current?.getStage();
-                if (!stage) throw new Error(t("export.canvasNotReady"));
+                if (!stage)
+                  throw new Error(t("export.messages.canvasNotReady"));
                 const { exportPdf } = await import("@/lib/export/exportPdf");
                 const shareUrl = await getRacePackShareUrl();
                 await exportPdf(
@@ -837,8 +840,8 @@ export default function ExportDialog({
             color="bg-violet-500/15 text-violet-400"
             description={t("export.formats.cinematicFpv.descriptionShort")}
             isBusy={busy === "webm"}
-            lockedLabel={t("export.openRequiredView")}
-            exportAriaLabel={t("export.exportFormatAriaLabel", {
+            lockedLabel={t("export.actions.openRequiredView")}
+            exportAriaLabel={t("export.aria.exportFormat", {
               label: t("export.formats.cinematicFpv.label"),
             })}
             onAction={() =>
@@ -850,7 +853,7 @@ export default function ExportDialog({
                   webmToastIdRef.current = toastId;
                   setWebmProgress(null);
                   webmStartTimeRef.current = Date.now();
-                  toast.loading(t("export.webmRenderingBackground"), {
+                  toast.loading(t("export.webm.renderingBackground"), {
                     id: toastId,
                   });
                   const { exportFlythrough } =
@@ -863,7 +866,7 @@ export default function ExportDialog({
                       (progress) => {
                         setWebmProgress(progress);
                         toast.loading(
-                          t("export.webmRenderingProgress", {
+                          t("export.webm.renderingProgress", {
                             status: getFlythroughStatusText(
                               progress,
                               webmStartTimeRef.current
@@ -881,7 +884,7 @@ export default function ExportDialog({
                 },
                 {
                   closeOnStart: true,
-                  successMessage: t("export.webmReady"),
+                  successMessage: t("export.webm.ready"),
                   toastId: "webm-flythrough-export",
                 }
               )
@@ -894,8 +897,8 @@ export default function ExportDialog({
             color="bg-lime-500/15 text-lime-400"
             description={t("export.formats.velocidrone.descriptionShort")}
             isBusy={busy === "trk"}
-            lockedLabel={t("export.openRequiredView")}
-            exportAriaLabel={t("export.exportFormatAriaLabel", {
+            lockedLabel={t("export.actions.openRequiredView")}
+            exportAriaLabel={t("export.aria.exportFormat", {
               label: t("export.formats.velocidrone.label"),
             })}
             onAction={() =>
@@ -912,15 +915,15 @@ export default function ExportDialog({
       <MobileDrawer
         open={open}
         onOpenChange={onOpenChange}
-        title={t("export.dialogTitle")}
-        subtitle={t("export.dialogSubtitle")}
+        title={t("export.dialog.title")}
+        subtitle={t("export.dialog.subtitle")}
         contentClassName="data-[vaul-drawer-direction=bottom]:mt-12 data-[vaul-drawer-direction=bottom]:max-h-[90dvh]"
         pinnedContent={
           <div className="border-border/40 space-y-2.5 border-b px-4 pt-2 pb-3">
             {/* Filename */}
             <label className="border-border/50 bg-muted/25 flex cursor-text items-center gap-2.5 rounded-xl border px-3.5 py-2.5">
               <span className="text-muted-foreground shrink-0 text-[11px] font-medium select-none">
-                {t("export.filenameLabel")}
+                {t("export.fields.filename.label")}
               </span>
               <input
                 type="text"
@@ -945,7 +948,7 @@ export default function ExportDialog({
                   )}
                 >
                   <Moon className="size-3.5 shrink-0" />
-                  {t("export.darkTheme")}
+                  {t("export.theme.dark")}
                 </button>
                 <button
                   type="button"
@@ -964,12 +967,12 @@ export default function ExportDialog({
                       exportTheme === "light" ? "text-amber-500" : ""
                     )}
                   />
-                  {t("export.lightTheme")}
+                  {t("export.theme.light")}
                 </button>
               </div>
               <div className="flex items-center gap-2.5">
                 <span className="text-muted-foreground text-[11px] font-medium select-none">
-                  {t("export.routeNumbersLabel")}
+                  {t("export.routeNumbers.label")}
                 </span>
                 <button
                   type="button"
@@ -985,8 +988,8 @@ export default function ExportDialog({
                   aria-pressed={includeObstacleNumbers}
                   aria-label={
                     includeObstacleNumbers
-                      ? t("export.disableRouteNumbersMobile")
-                      : t("export.enableRouteNumbersMobile")
+                      ? t("export.routeNumbers.disableMobile")
+                      : t("export.routeNumbers.enableMobile")
                   }
                 >
                   <span className="bg-background block size-5 rounded-full shadow-xs" />
@@ -1005,8 +1008,8 @@ export default function ExportDialog({
     <DesktopModal
       open={open}
       onOpenChange={onOpenChange}
-      title={t("export.dialogTitle")}
-      subtitle={t("export.dialogSubtitle")}
+      title={t("export.dialog.title")}
+      subtitle={t("export.dialog.subtitle")}
       maxWidth="max-w-2xl"
       panelClassName="px-7 py-7"
     >

--- a/src/components/dialogs/ProjectManager/AccountTab.tsx
+++ b/src/components/dialogs/ProjectManager/AccountTab.tsx
@@ -61,7 +61,7 @@ export function ProjectManagerAccountTab({
         role="status"
       >
         <p className="text-muted-foreground px-1 pb-1 text-[11px]">
-          {t("projectManager.account.loadingProjects")}
+          {t("projectManager.account.status.loadingProjects")}
         </p>
         <SkeletonCard />
         <SkeletonCard />
@@ -74,7 +74,7 @@ export function ProjectManagerAccountTab({
     return (
       <div className="border-destructive/20 bg-destructive/8 rounded-xl border px-4 py-3">
         <p className="text-foreground text-sm font-medium">
-          {t("projectManager.account.loadProjectsFailed")}
+          {t("projectManager.account.messages.loadFailed")}
         </p>
         <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
           {error}
@@ -87,8 +87,8 @@ export function ProjectManagerAccountTab({
     return (
       <EmptyState
         icon={<Cloud className="size-6" />}
-        title={t("projectManager.account.noProjects")}
-        description={t("projectManager.account.noProjectsDesc")}
+        title={t("projectManager.account.empty.noProjects")}
+        description={t("projectManager.account.empty.description")}
       />
     );
   }
@@ -108,11 +108,12 @@ export function ProjectManagerAccountTab({
           ? `Latest local copy saved ${formatRelativeTime(syncMeta.fallbackSavedAt)}`
           : null;
         const metaLine = hasConflict
-          ? (syncMeta?.error ?? t("projectManager.account.conflictWarning"))
+          ? (syncMeta?.error ??
+            t("projectManager.account.messages.conflictWarning"))
           : hasSyncFailure
             ? (fallbackLine ??
               syncMeta?.error ??
-              t("projectManager.account.syncError"))
+              t("projectManager.account.messages.syncError"))
             : hasPendingChanges
               ? `${itemLabel(proj.shapeCount)} · account copy waiting to sync`
               : `${itemLabel(proj.shapeCount)} · account copy synced ${formatRelativeTime(lastSyncedAt)}`;
@@ -138,7 +139,7 @@ export function ProjectManagerAccountTab({
             <ProjectAvatar id={proj.id} title={proj.title || "?"} />
             <div className="min-w-0 flex-1">
               <p className="text-foreground truncate text-sm font-medium">
-                {proj.title || t("projectManager.account.untitled")}
+                {proj.title || t("projectManager.account.fallback.untitled")}
               </p>
               <div className="mt-1 flex flex-wrap items-center gap-1.5">
                 {isCurrent ? <CurrentBadge /> : null}
@@ -157,14 +158,14 @@ export function ProjectManagerAccountTab({
                   )}
                 >
                   {isSyncing
-                    ? t("projectManager.account.syncing")
+                    ? t("projectManager.account.status.syncing")
                     : hasConflict
-                      ? t("projectManager.account.reviewNeeded")
+                      ? t("projectManager.account.status.reviewNeeded")
                       : hasPendingChanges
                         ? tCommon("status.pending")
                         : hasSyncFailure
-                          ? t("projectManager.account.syncFailed")
-                          : t("projectManager.account.synced")}
+                          ? t("projectManager.account.status.failed")
+                          : t("projectManager.account.status.synced")}
                 </span>
               </div>
               <p
@@ -206,10 +207,12 @@ export function ProjectManagerAccountTab({
                   }
                   title={
                     hasConflict
-                      ? t("projectManager.account.resolveConflictFirst")
+                      ? t(
+                          "projectManager.account.messages.resolveConflictFirst"
+                        )
                       : hasSyncFailure
-                        ? t("projectManager.account.retrySync")
-                        : t("projectManager.account.syncPendingChanges")
+                        ? t("projectManager.account.actions.retrySync")
+                        : t("projectManager.account.actions.syncPendingChanges")
                   }
                 >
                   {hasConflict || hasSyncFailure ? (

--- a/src/components/dialogs/ProjectManager/RestoreTab.tsx
+++ b/src/components/dialogs/ProjectManager/RestoreTab.tsx
@@ -39,13 +39,13 @@ export function ProjectManagerRestoreTab({
     return (
       <EmptyState
         icon={<Clock className="size-6" />}
-        title={t("projectManager.restore.noSnapshots")}
+        title={t("projectManager.restore.empty.noSnapshots")}
         description={
           isMobile ? (
-            t("projectManager.restore.noSnapshotsDesc")
+            t("projectManager.restore.empty.description")
           ) : (
             <>
-              {t.rich("projectManager.restore.noSnapshotsDesktopDesc", {
+              {t.rich("projectManager.restore.empty.desktopDescription", {
                 kbdMeta: (chunks) => <Kbd>{chunks}</Kbd>,
                 kbdCtrl: (chunks) => <Kbd>{chunks}</Kbd>,
               })}
@@ -61,7 +61,7 @@ export function ProjectManagerRestoreTab({
       {restorePoints.map((r) => {
         const isActive = r.id === activeRestorePointId;
         const snapshotTitle =
-          r.designTitle || t("projectManager.restore.snapshotFallback");
+          r.designTitle || t("projectManager.restore.fallback.snapshot");
         return (
           <div
             key={r.id}
@@ -78,11 +78,12 @@ export function ProjectManagerRestoreTab({
             <div className="min-w-0 flex-1">
               <div className="flex min-w-0 items-center gap-1.5">
                 <p className="text-foreground truncate text-sm font-medium">
-                  {r.designTitle || t("projectManager.restore.untitled")}
+                  {r.designTitle ||
+                    t("projectManager.restore.fallback.untitled")}
                 </p>
                 {isActive && (
                   <CurrentBadge
-                    label={t("projectManager.restore.activeBadge")}
+                    label={t("projectManager.restore.status.active")}
                   />
                 )}
               </div>
@@ -94,13 +95,12 @@ export function ProjectManagerRestoreTab({
               {onRestorePoint && (
                 <button
                   type="button"
-                  aria-label={t(
-                    "projectManager.restore.restoreSnapshotAriaLabel",
-                    { title: snapshotTitle }
-                  )}
+                  aria-label={t("projectManager.restore.aria.restoreSnapshot", {
+                    title: snapshotTitle,
+                  })}
                   onClick={() => setConfirmRestoreId(r.id)}
                   className="text-muted-foreground hover:text-foreground hover:bg-muted flex size-8 cursor-pointer items-center justify-center rounded-lg transition-colors"
-                  title={t("projectManager.restore.restoreTitle")}
+                  title={t("projectManager.restore.actions.restoreTitle")}
                 >
                   <RotateCcw className="size-3.5" />
                 </button>
@@ -108,13 +108,12 @@ export function ProjectManagerRestoreTab({
               {onDeleteRestorePoint && (
                 <button
                   type="button"
-                  aria-label={t(
-                    "projectManager.restore.deleteSnapshotAriaLabel",
-                    { title: snapshotTitle }
-                  )}
+                  aria-label={t("projectManager.restore.aria.deleteSnapshot", {
+                    title: snapshotTitle,
+                  })}
                   onClick={() => onDeleteRestorePoint(r.id)}
                   className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 flex size-8 cursor-pointer items-center justify-center rounded-lg transition-colors"
-                  title={t("projectManager.restore.deleteTitle")}
+                  title={t("projectManager.restore.actions.deleteTitle")}
                 >
                   <Trash2 className="size-3.5" />
                 </button>
@@ -131,7 +130,7 @@ export function ProjectManagerRestoreTab({
                   onClick={(e) => e.stopPropagation()}
                 >
                   <p className="text-foreground truncate text-sm font-medium">
-                    {t("projectManager.restore.restoreSnapshotConfirm")}
+                    {t("projectManager.restore.confirm.restoreSnapshot")}
                   </p>
                   <div className="flex shrink-0 items-center gap-1">
                     <button
@@ -142,7 +141,7 @@ export function ProjectManagerRestoreTab({
                       }}
                       className="bg-foreground text-background hover:bg-foreground/90 cursor-pointer rounded-lg px-3 py-1.5 text-xs font-medium transition-colors"
                     >
-                      {t("projectManager.restore.restoreAction")}
+                      {t("projectManager.restore.actions.restore")}
                     </button>
                     <button
                       onClick={() => setConfirmRestoreId(null)}

--- a/src/components/dialogs/ProjectManager/SharesTab.tsx
+++ b/src/components/dialogs/ProjectManager/SharesTab.tsx
@@ -16,12 +16,12 @@ function formatExpiresIn(
   iso: string | null,
   t: (key: string, values?: Record<string, string | number | Date>) => string
 ): string {
-  if (!iso) return t("projectManager.shares.publishedStatus");
+  if (!iso) return t("projectManager.shares.status.published");
   const days = Math.ceil(
     (new Date(iso).getTime() - Date.now()) / (1000 * 60 * 60 * 24)
   );
-  if (days <= 0) return t("projectManager.shares.expiredStatus");
-  return t("projectManager.shares.expiresInDays", { days });
+  if (days <= 0) return t("projectManager.shares.status.expired");
+  return t("projectManager.shares.status.expiresInDays", { days });
 }
 
 interface ProjectManagerSharesTabProps {
@@ -53,7 +53,7 @@ export function ProjectManagerSharesTab({
         role="status"
       >
         <p className="text-muted-foreground px-1 pb-1 text-[11px]">
-          {t("projectManager.shares.loadingPublishedShares")}
+          {t("projectManager.shares.status.loadingPublishedShares")}
         </p>
         <SkeletonCard />
         <SkeletonCard />
@@ -65,8 +65,8 @@ export function ProjectManagerSharesTab({
     return (
       <EmptyState
         icon={<Link2 className="size-6" />}
-        title={t("projectManager.shares.noShares")}
-        description={t("projectManager.shares.noSharesDesc")}
+        title={t("projectManager.shares.empty.noShares")}
+        description={t("projectManager.shares.empty.description")}
       />
     );
   }
@@ -74,7 +74,7 @@ export function ProjectManagerSharesTab({
   return (
     <div className="space-y-2">
       <p className="text-muted-foreground px-1 pb-1 text-[11px] leading-relaxed">
-        {t("projectManager.shares.readOnlyReviewLinks")}
+        {t("projectManager.shares.messages.readOnlyReviewLinks")}
       </p>
       {shares.map((share) => {
         const shareUrl = `${typeof window !== "undefined" ? window.location.origin : ""}/share/${encodeURIComponent(share.token)}`;
@@ -84,8 +84,8 @@ export function ProjectManagerSharesTab({
         const displayTitle = projectTitle ?? share.title;
         const lifetimeLabel =
           share.shareType === "published"
-            ? t("projectManager.shares.publishedLifetime")
-            : t("projectManager.shares.temporaryLifetime", {
+            ? t("projectManager.shares.lifetime.published")
+            : t("projectManager.shares.lifetime.temporary", {
                 expiresIn: formatExpiresIn(share.expiresAt, t),
               });
 
@@ -109,10 +109,12 @@ export function ProjectManagerSharesTab({
               className="flex shrink-0 items-center gap-0.5"
               onClick={(e) => e.stopPropagation()}
             >
-              <DesktopActionTooltip label={t("projectManager.shares.copyLink")}>
+              <DesktopActionTooltip
+                label={t("projectManager.shares.actions.copyLink")}
+              >
                 <button
                   type="button"
-                  aria-label={t("projectManager.shares.copyLinkAriaLabel")}
+                  aria-label={t("projectManager.shares.aria.copyLink")}
                   onClick={async () => {
                     await navigator.clipboard.writeText(shareUrl);
                     setCopiedToken(share.token);
@@ -127,10 +129,12 @@ export function ProjectManagerSharesTab({
                   )}
                 </button>
               </DesktopActionTooltip>
-              <DesktopActionTooltip label={t("projectManager.shares.openTab")}>
+              <DesktopActionTooltip
+                label={t("projectManager.shares.actions.openTab")}
+              >
                 <button
                   type="button"
-                  aria-label={t("projectManager.shares.openTabAriaLabel")}
+                  aria-label={t("projectManager.shares.aria.openTab")}
                   onClick={() =>
                     window.open(shareUrl, "_blank", "noopener,noreferrer")
                   }
@@ -141,11 +145,11 @@ export function ProjectManagerSharesTab({
               </DesktopActionTooltip>
               {onRevoke && (
                 <DesktopActionTooltip
-                  label={t("projectManager.shares.revokeLink")}
+                  label={t("projectManager.shares.actions.revokeLink")}
                 >
                   <button
                     type="button"
-                    aria-label={t("projectManager.shares.revokeLinkAriaLabel")}
+                    aria-label={t("projectManager.shares.aria.revokeLink")}
                     onClick={() => setConfirmRevokeToken(share.token)}
                     className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 flex size-8 cursor-pointer items-center justify-center rounded-lg opacity-100 transition-colors md:opacity-0 md:group-hover:opacity-100"
                   >
@@ -165,7 +169,7 @@ export function ProjectManagerSharesTab({
                   onClick={(e) => e.stopPropagation()}
                 >
                   <p className="text-foreground truncate text-sm font-medium">
-                    {t("projectManager.shares.revokeLinkConfirm")}
+                    {t("projectManager.shares.confirm.revokeLink")}
                   </p>
                   <div className="flex shrink-0 items-center gap-1">
                     <button
@@ -175,7 +179,7 @@ export function ProjectManagerSharesTab({
                       }}
                       className="bg-destructive/10 hover:bg-destructive/20 text-destructive cursor-pointer rounded-lg px-3 py-1.5 text-xs font-medium transition-colors"
                     >
-                      {t("projectManager.shares.revokeLink")}
+                      {t("projectManager.shares.actions.revokeLink")}
                     </button>
                     <button
                       onClick={() => setConfirmRevokeToken(null)}

--- a/src/components/dialogs/ProjectManager/index.tsx
+++ b/src/components/dialogs/ProjectManager/index.tsx
@@ -95,7 +95,7 @@ export default function ProjectManagerDialog({
   const navItems: NavItem[] = [
     {
       id: "device",
-      label: t("projectManager.navThisDevice"),
+      label: t("projectManager.nav.thisDevice"),
       icon: <FolderOpen className="size-4" />,
       count: projects.length,
     },
@@ -109,7 +109,7 @@ export default function ProjectManagerDialog({
           },
           {
             id: "shares",
-            label: t("projectManager.navShares"),
+            label: t("projectManager.nav.shares"),
             icon: <Link2 className="size-4" />,
             count: accountShares.length,
           },
@@ -117,7 +117,7 @@ export default function ProjectManagerDialog({
       : []),
     {
       id: "restore",
-      label: t("projectManager.navSnapshots"),
+      label: t("projectManager.nav.snapshots"),
       icon: <Clock className="size-4" />,
       count: restorePoints.length,
     },
@@ -130,20 +130,20 @@ export default function ProjectManagerDialog({
 
   const viewMeta: Record<View, { label: string; description: string }> = {
     device: {
-      label: t("projectManager.panelDevice.label"),
-      description: t("projectManager.panelDevice.description"),
+      label: t("projectManager.panels.device.label"),
+      description: t("projectManager.panels.device.description"),
     },
     account: {
-      label: t("projectManager.panelAccount.label"),
-      description: t("projectManager.panelAccount.description"),
+      label: t("projectManager.panels.account.label"),
+      description: t("projectManager.panels.account.description"),
     },
     restore: {
-      label: t("projectManager.panelSnapshots.label"),
-      description: t("projectManager.panelSnapshots.description"),
+      label: t("projectManager.panels.snapshots.label"),
+      description: t("projectManager.panels.snapshots.description"),
     },
     shares: {
-      label: t("projectManager.panelShares.label"),
-      description: t("projectManager.panelShares.description"),
+      label: t("projectManager.panels.shares.label"),
+      description: t("projectManager.panels.shares.description"),
     },
   };
 
@@ -207,9 +207,9 @@ export default function ProjectManagerDialog({
     <SidebarDialog
       open={open}
       onOpenChange={onOpenChange}
-      eyebrow={t("projectManager.dialogEyebrow")}
-      title={t("projectManager.dialogTitle")}
-      mobileSubtitle={t("projectManager.dialogMobileSubtitle")}
+      eyebrow={t("projectManager.dialog.eyebrow")}
+      title={t("projectManager.dialog.title")}
+      mobileSubtitle={t("projectManager.dialog.mobileSubtitle")}
       navItems={navItems.map((item) => ({
         id: item.id,
         label: item.label,

--- a/src/components/dialogs/ProjectManager/shared.tsx
+++ b/src/components/dialogs/ProjectManager/shared.tsx
@@ -104,9 +104,9 @@ export function ProjectIdCopyRow({ projectId }: { projectId: string }) {
   const copyProjectId = async () => {
     try {
       await navigator.clipboard.writeText(projectId);
-      toast.success(t("projectManager.copyProjectIdSuccess"));
+      toast.success(t("projectManager.projectIdCopy.success"));
     } catch {
-      toast.error(t("projectManager.copyProjectIdFailed"));
+      toast.error(t("projectManager.projectIdCopy.failed"));
     }
   };
 
@@ -114,7 +114,7 @@ export function ProjectIdCopyRow({ projectId }: { projectId: string }) {
     <div className="border-border/35 mt-2 flex min-w-0 items-center justify-between gap-3 border-t pt-2">
       <div className="min-w-0">
         <p className="text-muted-foreground text-[10px] font-semibold tracking-[0.12em] uppercase">
-          {t("projectManager.copyProjectIdLabel")}
+          {t("projectManager.projectIdCopy.label")}
         </p>
         <p className="text-foreground/85 mt-0.5 truncate font-mono text-[11px]">
           {projectId}
@@ -127,10 +127,10 @@ export function ProjectIdCopyRow({ projectId }: { projectId: string }) {
           void copyProjectId();
         }}
         className="text-muted-foreground hover:text-foreground flex shrink-0 items-center gap-1.5 text-[11px] font-medium transition-colors"
-        aria-label={t("projectManager.copyProjectIdAriaLabel")}
+        aria-label={t("projectManager.projectIdCopy.ariaLabel")}
       >
         <Copy className="size-3.5" />
-        {t("projectManager.copyAction")}
+        {t("projectManager.projectIdCopy.action")}
       </button>
     </div>
   );

--- a/src/components/dialogs/ShareDialog.tsx
+++ b/src/components/dialogs/ShareDialog.tsx
@@ -747,13 +747,13 @@ export default function ShareDialog({
 
   const primaryActionLabel = share
     ? linkNeedsRefresh
-      ? t("share.primaryAction.updateLink")
-      : t("share.primaryAction.copyLink")
+      ? t("share.actions.primary.updateLink")
+      : t("share.actions.primary.copyLink")
     : isAccountProjectShare
-      ? t("share.primaryAction.createLink")
+      ? t("share.actions.primary.createLink")
       : isAuthenticated
-        ? t("share.primaryAction.createNewLink")
-        : t("share.primaryAction.createLink");
+        ? t("share.actions.primary.createNewLink")
+        : t("share.actions.primary.createLink");
   const PrimaryIcon = share
     ? linkNeedsRefresh
       ? Link2
@@ -768,47 +768,49 @@ export default function ShareDialog({
     : () => handlePublish();
 
   const galleryStateLabel = !loadDone
-    ? t("share.gallery.loading")
+    ? t("share.gallery.status.loading")
     : share?.galleryState === "featured"
-      ? t("share.gallery.featured")
+      ? t("share.gallery.status.featured")
       : share?.galleryState === "listed"
-        ? t("share.gallery.listed")
+        ? t("share.gallery.status.listed")
         : share?.galleryState === "hidden"
-          ? t("share.gallery.hiddenByModeration")
+          ? t("share.gallery.status.hiddenByModeration")
           : share
-            ? t("share.gallery.linkOnly")
-            : t("share.gallery.noPublishedLink");
+            ? t("share.gallery.status.linkOnly")
+            : t("share.gallery.status.noPublishedLink");
 
   const galleryStateDesc = !loadDone
-    ? t("share.gallery.checkingStatus")
+    ? t("share.gallery.descriptions.checking")
     : share?.galleryState === "featured"
-      ? t("share.gallery.featuredDesc")
+      ? t("share.gallery.descriptions.featured")
       : share?.galleryState === "listed"
-        ? t("share.gallery.listedDesc")
+        ? t("share.gallery.descriptions.listed")
         : share?.galleryState === "hidden"
-          ? t("share.gallery.hiddenDesc")
+          ? t("share.gallery.descriptions.hidden")
           : share
-            ? t("share.gallery.linkOnlyDesc")
-            : t("share.gallery.noLinkDesc");
+            ? t("share.gallery.descriptions.linkOnly")
+            : t("share.gallery.descriptions.noLink");
 
   const galleryVisibilityValue = !loadDone
-    ? t("share.gallery.checking")
+    ? t("share.gallery.status.checking")
     : share?.galleryState === "featured"
-      ? t("share.gallery.featured")
+      ? t("share.gallery.status.featured")
       : share?.galleryState === "listed"
-        ? t("share.gallery.listed")
+        ? t("share.gallery.status.listed")
         : share?.galleryState === "hidden"
-          ? t("share.gallery.hiddenByModeration")
+          ? t("share.gallery.status.hiddenByModeration")
           : share
-            ? t("share.gallery.linkOnly")
-            : t("share.gallery.noLink");
+            ? t("share.gallery.status.linkOnly")
+            : t("share.gallery.status.noLink");
   const galleryShareLinkValue = !share
-    ? t("share.gallery.noLink")
+    ? t("share.gallery.status.noLink")
     : share.shareType === "published"
       ? tCommon("status.published")
       : share.expiresInDays === null
-        ? t("share.gallery.noExpiry")
-        : t("share.gallery.expiresInDays", { days: share.expiresInDays });
+        ? t("share.gallery.status.noExpiry")
+        : t("share.gallery.status.expiresInDays", {
+            days: share.expiresInDays,
+          });
   const GalleryStatusIcon = !loadDone
     ? Loader2
     : share?.galleryState === "featured"
@@ -832,7 +834,7 @@ export default function ShareDialog({
     ? [
         {
           id: "share",
-          label: t("share.navShareLink"),
+          label: t("share.nav.shareLink"),
           icon: <Link2 className="size-4" />,
         },
         {
@@ -844,14 +846,14 @@ export default function ShareDialog({
     : [
         {
           id: "share",
-          label: t("share.navShare"),
+          label: t("share.nav.share"),
           icon: <Link2 className="size-4" />,
         },
         ...(showEmbedSection
           ? [
               {
                 id: "embed",
-                label: t("share.navEmbed"),
+                label: t("share.nav.embed"),
                 icon: <Code2 className="size-4" />,
               },
             ]
@@ -860,7 +862,7 @@ export default function ShareDialog({
           ? [
               {
                 id: "gallery",
-                label: t("share.navGallery"),
+                label: t("share.nav.gallery"),
                 icon: <ImageIcon className="size-4" />,
               },
             ]
@@ -879,28 +881,28 @@ export default function ShareDialog({
 
   const contentMeta: Record<Tab, { title: string; description: string }> = {
     share: {
-      title: t("share.content.shareTitle"),
+      title: t("share.content.share.title"),
       description: existingShareMode
-        ? t("share.content.shareDescExisting")
+        ? t("share.content.share.description.existing")
         : isAuthenticated
           ? isAccountProjectShare
-            ? t("share.content.shareDescAccount")
-            : t("share.content.shareDescSeparate")
-          : t("share.content.shareDescAnon"),
+            ? t("share.content.share.description.account")
+            : t("share.content.share.description.separate")
+          : t("share.content.share.description.anonymous"),
     },
     gallery: {
-      title: t("share.content.galleryTitle"),
-      description: t("share.content.galleryDesc"),
+      title: t("share.content.gallery.title"),
+      description: t("share.content.gallery.description"),
     },
     embed: {
-      title: t("share.content.embedTitle"),
-      description: t("share.content.embedDesc"),
+      title: t("share.content.embed.title"),
+      description: t("share.content.embed.description"),
     },
     actions: {
       title: tCommon("labels.actions"),
       description: existingShareMode
-        ? t("share.content.actionsDescExisting")
-        : t("share.content.actionsDesc"),
+        ? t("share.content.actions.descriptionExisting")
+        : t("share.content.actions.description"),
     },
   };
 
@@ -915,11 +917,11 @@ export default function ShareDialog({
         onOpenChange={onOpenChange}
         eyebrow={
           existingShareMode
-            ? t("share.dialogEyebrowExisting")
-            : t("share.dialogEyebrow")
+            ? t("share.dialog.existingEyebrow")
+            : t("share.dialog.eyebrow")
         }
-        title={t("share.dialogTitle")}
-        mobileSubtitle={t("share.dialogMobileSubtitle")}
+        title={t("share.dialog.title")}
+        mobileSubtitle={t("share.dialog.mobileSubtitle")}
         navItems={navItems}
         activeItem={resolvedTab}
         onItemChange={(id) => setActiveTab(id as Tab)}
@@ -936,10 +938,10 @@ export default function ShareDialog({
                   </div>
                   <div className="min-w-0">
                     <p className="text-foreground text-sm font-medium">
-                      {t("share.currentSharedLink")}
+                      {t("share.currentLink.title")}
                     </p>
                     <p className="text-muted-foreground text-[11px]">
-                      {t("share.readOnlyReviewOn", {
+                      {t("share.currentLink.readOnlyReviewOn", {
                         view: currentView.toUpperCase(),
                         hostname,
                       })}
@@ -963,7 +965,7 @@ export default function ShareDialog({
                   ) : (
                     <Copy className="size-4" />
                   )}
-                  {t("share.labels.copyLink")}
+                  {t("share.actions.copyLink")}
                 </Button>
               </div>
             ) : (
@@ -972,10 +974,10 @@ export default function ShareDialog({
                   <div className="space-y-3">
                     <div>
                       <p className="text-foreground text-sm font-medium">
-                        {t("share.labels.linkExpiresAfter")}
+                        {t("share.link.expiry.label")}
                       </p>
                       <p className="text-muted-foreground mt-1 text-[11px]">
-                        {t("share.labels.temporarySnapshotsExpire")}
+                        {t("share.link.expiry.description")}
                       </p>
                     </div>
                     <div className="grid grid-cols-3 gap-2">
@@ -990,7 +992,7 @@ export default function ShareDialog({
                               "border-foreground/15 bg-muted text-foreground"
                           )}
                         >
-                          {t("share.link.expiryDays", { days: option.value })}
+                          {t("share.link.expiry.days", { days: option.value })}
                         </button>
                       ))}
                     </div>
@@ -999,13 +1001,13 @@ export default function ShareDialog({
                   <div className="border-border/60 bg-muted/18 rounded-xl border px-3 py-3">
                     <p className="text-foreground text-sm font-medium">
                       {isAccountProjectShare
-                        ? t("share.link.savedProjectTitle")
-                        : t("share.link.newShareTitle")}
+                        ? t("share.link.titles.savedProject")
+                        : t("share.link.titles.newShare")}
                     </p>
                     <p className="text-muted-foreground mt-1 text-[12px] leading-relaxed">
                       {isAccountProjectShare
-                        ? t("share.link.savedProjectDescription")
-                        : t("share.link.newShareDescription")}
+                        ? t("share.link.descriptions.savedProject")
+                        : t("share.link.descriptions.newShare")}
                     </p>
                   </div>
                 )}
@@ -1020,28 +1022,28 @@ export default function ShareDialog({
                         {share
                           ? share.shareType === "published"
                             ? isAccountProjectShare
-                              ? t("share.link.savedProjectTitle")
-                              : t("share.link.separatePublishedTitle")
-                            : t("share.link.temporaryTitle")
+                              ? t("share.link.titles.savedProject")
+                              : t("share.link.titles.separatePublished")
+                            : t("share.link.titles.temporary")
                           : isAuthenticated
                             ? isAccountProjectShare
-                              ? t("share.link.noSavedProjectTitle")
-                              : t("share.link.noSeparateTitle")
-                            : t("share.link.noTemporaryTitle")}
+                              ? t("share.link.titles.noSavedProject")
+                              : t("share.link.titles.noSeparate")
+                            : t("share.link.titles.noTemporary")}
                       </p>
                       <p className="text-muted-foreground text-[11px]">
                         {share
                           ? share.expiresInDays === null
-                            ? t("share.link.lifetimePublished", { hostname })
-                            : t("share.link.lifetimeTemporary", {
+                            ? t("share.link.lifetime.published", { hostname })
+                            : t("share.link.lifetime.temporary", {
                                 hostname,
                                 days: share.expiresInDays,
                               })
                           : isAuthenticated
                             ? isAccountProjectShare
-                              ? t("share.link.createSavedProject")
-                              : t("share.link.createSeparate")
-                            : t("share.link.createTemporary")}
+                              ? t("share.link.descriptions.createSavedProject")
+                              : t("share.link.descriptions.createSeparate")
+                            : t("share.link.descriptions.createTemporary")}
                       </p>
                     </div>
                   </div>
@@ -1059,8 +1061,8 @@ export default function ShareDialog({
                       <Share2 className="mt-0.5 size-3.5 shrink-0" />
                       <span className="leading-relaxed">
                         {shareNeedsRefresh
-                          ? t("share.link.outdatedDesign")
-                          : t("share.link.outdatedExpiry")}
+                          ? t("share.link.warnings.outdatedDesign")
+                          : t("share.link.warnings.outdatedExpiry")}
                       </span>
                     </div>
                   ) : null}
@@ -1092,7 +1094,7 @@ export default function ShareDialog({
                             className={cn(shareDialogButtonClassName, "w-full")}
                           >
                             <RefreshCw className="size-4" />
-                            {t("share.primaryAction.updateLink")}
+                            {t("share.actions.primary.updateLink")}
                           </Button>
                         ) : null}
                         <Button
@@ -1102,7 +1104,7 @@ export default function ShareDialog({
                           className={cn(shareDialogButtonClassName, "w-full")}
                         >
                           <Ban className="size-4" />
-                          {t("share.labels.revoke")}
+                          {t("share.actions.revoke")}
                         </Button>
                       </>
                     ) : null}
@@ -1119,7 +1121,7 @@ export default function ShareDialog({
               <div className="flex items-center gap-2">
                 <Loader2 className="text-muted-foreground size-4 animate-spin" />
                 <p className="text-muted-foreground text-sm">
-                  {t("share.embed.loadingState")}
+                  {t("share.embed.state.loading")}
                 </p>
               </div>
             ) : !share ? (
@@ -1130,10 +1132,10 @@ export default function ShareDialog({
                   </div>
                   <div className="min-w-0">
                     <p className="text-foreground text-sm font-medium">
-                      {t("share.embed.publishBeforeEmbedding")}
+                      {t("share.embed.publish.title")}
                     </p>
                     <p className="text-muted-foreground mt-1 text-[12px] leading-relaxed">
-                      {t("share.embed.publishBeforeEmbeddingDescription")}
+                      {t("share.embed.publish.description")}
                     </p>
                   </div>
                 </div>
@@ -1147,16 +1149,16 @@ export default function ShareDialog({
                   ) : (
                     <Link2 className="size-4" />
                   )}
-                  {t("share.embed.createPublishedLink")}
+                  {t("share.embed.publish.action")}
                 </Button>
               </div>
             ) : share.shareType !== "published" ? (
               <div className="space-y-2">
                 <p className="text-foreground text-sm font-medium">
-                  {t("share.embed.temporaryLinksCannotEmbed")}
+                  {t("share.embed.temporary.title")}
                 </p>
                 <p className="text-muted-foreground text-[12px] leading-relaxed">
-                  {t("share.embed.temporaryLinksCannotEmbedDescription")}
+                  {t("share.embed.temporary.description")}
                 </p>
               </div>
             ) : linkNeedsRefresh ? (
@@ -1164,7 +1166,7 @@ export default function ShareDialog({
                 <div className="flex items-start gap-2 rounded-lg border border-amber-500/25 bg-amber-500/8 px-3 py-2.5 text-xs text-amber-400">
                   <Share2 className="mt-0.5 size-3.5 shrink-0" />
                   <span className="leading-relaxed">
-                    {t("share.embed.refreshFirst")}
+                    {t("share.embed.refresh.message")}
                   </span>
                 </div>
                 <Button
@@ -1177,7 +1179,7 @@ export default function ShareDialog({
                   ) : (
                     <RefreshCw className="size-4" />
                   )}
-                  {t("share.embed.updateLink")}
+                  {t("share.embed.refresh.action")}
                 </Button>
               </div>
             ) : iframeCode ? (
@@ -1188,31 +1190,39 @@ export default function ShareDialog({
                   </div>
                   <div className="min-w-0">
                     <p className="text-foreground text-sm font-medium">
-                      {t("share.embed.codeTitle")}
+                      {t("share.embed.code.title")}
                     </p>
                     <p className="text-muted-foreground text-[11px]">
-                      {t("share.embed.codeDescription")}
+                      {t("share.embed.code.description")}
                     </p>
                   </div>
                 </div>
 
                 <div className="space-y-2">
                   <p className="text-muted-foreground text-[11px] font-medium">
-                    {t("share.embed.initialView")}
+                    {t("share.embed.initialView.label")}
                   </p>
                   <div className="grid grid-cols-1 gap-2 min-[420px]:grid-cols-2">
                     {(
                       [
                         {
                           view: "2d",
-                          label: t("share.embed.layout2dLabel"),
-                          description: t("share.embed.layout2dDescription"),
+                          label: t(
+                            "share.embed.initialView.options.layout2d.label"
+                          ),
+                          description: t(
+                            "share.embed.initialView.options.layout2d.description"
+                          ),
                           icon: Route,
                         },
                         {
                           view: "3d",
-                          label: t("share.embed.preview3dLabel"),
-                          description: t("share.embed.preview3dDescription"),
+                          label: t(
+                            "share.embed.initialView.options.preview3d.label"
+                          ),
+                          description: t(
+                            "share.embed.initialView.options.preview3d.description"
+                          ),
                           icon: Orbit,
                         },
                       ] as const
@@ -1259,10 +1269,10 @@ export default function ShareDialog({
                   <div className="flex flex-col gap-2 min-[520px]:flex-row min-[520px]:items-center min-[520px]:justify-between">
                     <div>
                       <p className="text-muted-foreground text-[11px] font-medium">
-                        {t("share.embed.iframeCodeLabel")}
+                        {t("share.embed.code.label")}
                       </p>
                       <p className="text-muted-foreground/75 mt-0.5 text-[10px]">
-                        {t("share.embed.iframeCodeDescription")}
+                        {t("share.embed.code.selectedViewDescription")}
                       </p>
                     </div>
                     <Button
@@ -1279,7 +1289,7 @@ export default function ShareDialog({
                       ) : (
                         <Copy className="size-4" />
                       )}
-                      {t("share.embed.copyCode")}
+                      {t("share.embed.code.copy")}
                     </Button>
                   </div>
                   <textarea
@@ -1322,7 +1332,7 @@ export default function ShareDialog({
               <div className="grid grid-cols-1 gap-2 min-[380px]:grid-cols-2">
                 <div className="bg-background/55 rounded-lg px-3 py-2">
                   <p className="text-muted-foreground text-[10px] font-medium tracking-[0.12em] uppercase">
-                    {t("share.gallery.visibility")}
+                    {t("share.gallery.labels.visibility")}
                   </p>
                   <p className="text-foreground mt-0.5 text-xs font-medium">
                     {galleryVisibilityValue}
@@ -1330,7 +1340,7 @@ export default function ShareDialog({
                 </div>
                 <div className="bg-background/55 rounded-lg px-3 py-2">
                   <p className="text-muted-foreground text-[10px] font-medium tracking-[0.12em] uppercase">
-                    {t("share.gallery.shareLink")}
+                    {t("share.gallery.labels.shareLink")}
                   </p>
                   <p className="text-foreground mt-0.5 text-xs font-medium">
                     {galleryShareLinkValue}
@@ -1343,10 +1353,10 @@ export default function ShareDialog({
               <div className="border-border/60 bg-muted/12 space-y-3 rounded-xl border p-3">
                 <div>
                   <p className="text-foreground text-sm font-medium">
-                    {t("share.gallery.publishFirstTitle")}
+                    {t("share.gallery.publishFirst.title")}
                   </p>
                   <p className="text-muted-foreground mt-1 text-[12px] leading-relaxed">
-                    {t("share.gallery.publishFirstDescription")}
+                    {t("share.gallery.publishFirst.description")}
                   </p>
                 </div>
                 <Button
@@ -1354,16 +1364,16 @@ export default function ShareDialog({
                   onClick={() => setActiveTab("share")}
                   className={cn(shareDialogButtonClassName, "w-full")}
                 >
-                  {t("share.gallery.createShareFirst")}
+                  {t("share.gallery.publishFirst.action")}
                 </Button>
               </div>
             ) : blockedByModeration ? (
               <div className="border-destructive/25 bg-destructive/8 space-y-1.5 rounded-xl border p-3">
                 <p className="text-destructive text-sm font-medium">
-                  {t("share.gallery.moderationLockTitle")}
+                  {t("share.gallery.moderation.title")}
                 </p>
                 <p className="text-destructive text-[11px] leading-relaxed">
-                  {t("share.gallery.moderationLockDescription")}
+                  {t("share.gallery.moderation.description")}
                 </p>
               </div>
             ) : showGalleryForm ? (
@@ -1371,13 +1381,13 @@ export default function ShareDialog({
                 <div>
                   <p className="text-foreground text-sm font-medium">
                     {isGalleryVisible
-                      ? t("share.gallery.detailsTitle")
-                      : t("share.gallery.listTitle")}
+                      ? t("share.gallery.details.title")
+                      : t("share.gallery.list.title")}
                   </p>
                   <p className="text-muted-foreground mt-1 text-[12px] leading-relaxed">
                     {isGalleryVisible
-                      ? t("share.gallery.detailsDescription")
-                      : t("share.gallery.listDescription")}
+                      ? t("share.gallery.details.description")
+                      : t("share.gallery.list.description")}
                   </p>
                 </div>
 
@@ -1389,7 +1399,7 @@ export default function ShareDialog({
                     value={galleryTitleInput}
                     onChange={(e) => setGalleryTitleInput(e.target.value)}
                     className="border-border bg-background/70 text-foreground focus:ring-ring/40 w-full min-w-0 rounded-lg border px-3 py-2 text-sm outline-hidden focus:ring-1"
-                    placeholder={t("share.gallery.titlePlaceholder")}
+                    placeholder={t("share.gallery.fields.titlePlaceholder")}
                   />
                 </label>
 
@@ -1403,7 +1413,9 @@ export default function ShareDialog({
                     maxLength={GALLERY_DESCRIPTION_MAX_LENGTH}
                     rows={3}
                     className="border-border bg-background/70 text-foreground focus:ring-ring/40 w-full min-w-0 resize-none rounded-lg border px-3 py-2 text-sm outline-hidden focus:ring-1"
-                    placeholder={t("share.gallery.descriptionPlaceholder")}
+                    placeholder={t(
+                      "share.gallery.fields.descriptionPlaceholder"
+                    )}
                   />
                   <span className="text-muted-foreground mt-1 block text-right text-[10px]">
                     {galleryDescriptionInput.length}/
@@ -1414,13 +1426,13 @@ export default function ShareDialog({
                 {!isGalleryVisible ? (
                   <div className="space-y-2">
                     <p className="text-muted-foreground text-[11px]">
-                      {t("share.gallery.authorLabel")}:{" "}
+                      {t("share.gallery.labels.author")}:{" "}
                       <span
                         className={displayNameValid ? "" : "text-destructive"}
                       >
                         {displayNameValid
                           ? displayName
-                          : t("share.gallery.noDisplayName")}
+                          : t("share.gallery.fallback.noDisplayName")}
                       </span>
                     </p>
 
@@ -1429,14 +1441,14 @@ export default function ShareDialog({
                         <>
                           <Loader2 className="text-muted-foreground size-3.5 animate-spin" />
                           <span className="text-muted-foreground text-[11px]">
-                            {t("share.gallery.generatingPreview")}
+                            {t("share.gallery.preview.generating")}
                           </span>
                         </>
                       ) : (
                         <>
                           <Check className="size-3.5 text-emerald-500" />
                           <span className="text-muted-foreground text-[11px]">
-                            {t("share.gallery.previewReady")}
+                            {t("share.gallery.preview.ready")}
                           </span>
                         </>
                       )}
@@ -1446,26 +1458,26 @@ export default function ShareDialog({
 
                 {!isGalleryVisible && shareNeedsRefresh ? (
                   <p className="text-muted-foreground text-[11px]">
-                    {t("share.gallery.refreshShareFirst")}
+                    {t("share.gallery.validation.refreshShareFirst")}
                   </p>
                 ) : !galleryTitleValid ? (
                   <p className="text-destructive text-[11px]">
-                    {t("share.gallery.titleRequired")}
+                    {t("share.gallery.validation.titleRequired")}
                   </p>
                 ) : !galleryDescriptionValid ? (
                   <p className="text-destructive text-[11px]">
-                    {t("share.gallery.descriptionLength", {
+                    {t("share.gallery.validation.descriptionLength", {
                       min: GALLERY_DESCRIPTION_MIN_LENGTH,
                       max: GALLERY_DESCRIPTION_MAX_LENGTH,
                     })}
                   </p>
                 ) : !isGalleryVisible && !displayNameValid ? (
                   <p className="text-destructive text-[11px]">
-                    {t("share.gallery.displayNameRequired")}
+                    {t("share.gallery.validation.displayNameRequired")}
                   </p>
                 ) : isGalleryVisible && !hasGalleryMetadataChanges ? (
                   <p className="text-muted-foreground text-[11px]">
-                    {t("share.gallery.noMetadataChanges")}
+                    {t("share.gallery.validation.noMetadataChanges")}
                   </p>
                 ) : null}
 
@@ -1494,7 +1506,7 @@ export default function ShareDialog({
                   >
                     {isGalleryVisible
                       ? tCommon("actions.saveChanges")
-                      : t("share.gallery.addToGallery")}
+                      : t("share.gallery.list.add")}
                   </Button>
                 </div>
               </div>
@@ -1505,10 +1517,10 @@ export default function ShareDialog({
                     <>
                       <div>
                         <p className="text-foreground text-sm font-medium">
-                          {t("share.gallery.cardTitle")}
+                          {t("share.gallery.card.title")}
                         </p>
                         <p className="text-muted-foreground mt-1 text-[12px] leading-relaxed">
-                          {t("share.gallery.cardDescription")}
+                          {t("share.gallery.card.description")}
                         </p>
                       </div>
                       <dl className="space-y-2 text-[12px]">
@@ -1519,7 +1531,7 @@ export default function ShareDialog({
                           <dd className="text-foreground truncate font-medium">
                             {share.galleryTitle ||
                               design.title ||
-                              t("share.gallery.untitled")}
+                              t("share.gallery.card.untitled")}
                           </dd>
                         </div>
                         <div className="space-y-0.5 min-[420px]:grid min-[420px]:grid-cols-[4.5rem_1fr] min-[420px]:gap-3 min-[420px]:space-y-0">
@@ -1528,7 +1540,7 @@ export default function ShareDialog({
                           </dt>
                           <dd className="text-muted-foreground line-clamp-2 leading-relaxed">
                             {share.galleryDescription ||
-                              t("share.gallery.noDescription")}
+                              t("share.gallery.card.noDescription")}
                           </dd>
                         </div>
                       </dl>
@@ -1541,7 +1553,7 @@ export default function ShareDialog({
                           disabled={busy}
                           className={shareDialogButtonClassName}
                         >
-                          {t("share.gallery.editDetails")}
+                          {t("share.gallery.details.edit")}
                         </Button>
                         <Button
                           variant="outline"
@@ -1549,14 +1561,14 @@ export default function ShareDialog({
                           asChild
                         >
                           <Link href="/gallery">
-                            {t("share.gallery.viewGallery")}
+                            {t("share.gallery.card.viewGallery")}
                           </Link>
                         </Button>
                       </div>
                       {confirmRemoveFromGallery ? (
                         <div className="border-border/60 flex flex-col gap-2 border-t pt-3">
                           <p className="text-muted-foreground text-[11px] leading-relaxed">
-                            {t("share.gallery.removeConfirm")}
+                            {t("share.gallery.remove.confirm")}
                           </p>
                           <div className="flex flex-col-reverse gap-2 min-[380px]:flex-row min-[380px]:justify-end">
                             <Button
@@ -1599,7 +1611,7 @@ export default function ShareDialog({
                             )}
                           >
                             <Trash2 className="size-4" />
-                            {t("share.gallery.removeFromGallery")}
+                            {t("share.gallery.remove.action")}
                           </Button>
                         </div>
                       )}
@@ -1608,15 +1620,15 @@ export default function ShareDialog({
                     <>
                       <div>
                         <p className="text-foreground text-sm font-medium">
-                          {t("share.gallery.readyTitle")}
+                          {t("share.gallery.list.readyTitle")}
                         </p>
                         <p className="text-muted-foreground mt-1 text-[12px] leading-relaxed">
-                          {t("share.gallery.readyDescription")}
+                          {t("share.gallery.list.readyDescription")}
                         </p>
                       </div>
                       {shareNeedsRefresh ? (
                         <p className="text-muted-foreground text-[11px] leading-relaxed">
-                          {t("share.gallery.refreshShareFirst")}
+                          {t("share.gallery.validation.refreshShareFirst")}
                         </p>
                       ) : null}
                       <div className="border-border/60 flex border-t pt-3 min-[520px]:justify-end">
@@ -1631,7 +1643,7 @@ export default function ShareDialog({
                             "w-full min-[520px]:w-auto"
                           )}
                         >
-                          {t("share.gallery.addToGallery")}
+                          {t("share.gallery.list.add")}
                         </Button>
                       </div>
                     </>
@@ -1648,12 +1660,12 @@ export default function ShareDialog({
               <Share2 className="text-muted-foreground mt-0.5 size-3.5 shrink-0" />
               <p className="text-muted-foreground leading-relaxed">
                 {existingShareMode
-                  ? t("share.actions.existingDescription")
+                  ? t("share.actions.share.existingDescription")
                   : hasPath
-                    ? t("share.actions.withPathDescription", {
+                    ? t("share.actions.share.withPathDescription", {
                         view: currentView.toUpperCase(),
                       })
-                    : t("share.actions.withoutPathDescription")}
+                    : t("share.actions.share.withoutPathDescription")}
               </p>
             </div>
 
@@ -1673,10 +1685,10 @@ export default function ShareDialog({
                   </div>
                   <div className="min-w-0 flex-1">
                     <p className="text-foreground text-sm font-medium">
-                      {t("share.actions.nativeShareTitle")}
+                      {t("share.actions.nativeShare.title")}
                     </p>
                     <p className="text-muted-foreground text-[11px]">
-                      {t("share.actions.nativeShareDescription")}
+                      {t("share.actions.nativeShare.description")}
                     </p>
                   </div>
                 </button>
@@ -1707,12 +1719,12 @@ export default function ShareDialog({
                   </div>
                   <div className="min-w-0 flex-1">
                     <p className="text-foreground text-sm font-medium">
-                      {t("share.actions.openInTab")}
+                      {t("share.actions.openInTab.label")}
                     </p>
                     <p className="text-muted-foreground text-[11px]">
                       {existingShareMode
-                        ? t("share.actions.reopenCurrent")
-                        : t("share.actions.previewLink")}
+                        ? t("share.actions.openInTab.reopenCurrent")
+                        : t("share.actions.openInTab.previewLink")}
                     </p>
                   </div>
                 </button>
@@ -1728,10 +1740,10 @@ export default function ShareDialog({
                   </div>
                   <div className="min-w-0 flex-1">
                     <p className="text-foreground text-sm font-medium">
-                      {t("share.actions.exportJson")}
+                      {t("share.actions.exportJson.label")}
                     </p>
                     <p className="text-muted-foreground text-[11px]">
-                      {t("share.actions.exportJsonDescription")}
+                      {t("share.actions.exportJson.description")}
                     </p>
                   </div>
                 </button>


### PR DESCRIPTION
## Summary

- normalize dialog i18n key structure across `dialogs.share`, `dialogs.export`, `dialogs.projectManager`, and `dialogs.account`
- group related copy by feature and purpose, including dialog/nav/panels, link/embed/gallery, status, empty states, aria labels, actions, messages, and fallback copy
- update dialog components to use the new nested key paths while keeping existing EN/NL wording and FPV terminology intact

## Issue

Part of #517.

## Validation

- `npm run i18n:check`
- `npm run i18n:scan-hardcoded`
- `npm run type`
- `npm run lint`