### PR TITLE
chore: Normalize editor i18n keys

### DIFF
--- a/lang/en/editor.json
+++ b/lang/en/editor.json
@@ -167,11 +167,13 @@
     "tipText": "Select shapes on the canvas, then use <strong>Save preset</strong> in the inspector to add your own."
   },
   "starterOverlay": {
-    "title": "Welcome to TrackDraw",
-    "mobileSubtitle": "Place a few gates, draw the route, check 3D, then share when the track is ready.",
-    "studioEyebrow": "Studio",
-    "desktopDescription": "Design the layout in 2D, review elevation in 3D, and share a read-only link when the track is ready.",
-    "dismissAria": "Dismiss starter dialog",
+    "dialog": {
+      "title": "Welcome to TrackDraw",
+      "mobileSubtitle": "Place a few gates, draw the route, check 3D, then share when the track is ready.",
+      "studioEyebrow": "Studio",
+      "desktopDescription": "Design the layout in 2D, review elevation in 3D, and share a read-only link when the track is ready.",
+      "dismissAria": "Dismiss starter dialog"
+    },
     "hints": {
       "gate": {
         "badge": "Guided",
@@ -211,7 +213,9 @@
     }
   },
   "starterFlow": {
-    "goodFirstSteps": "Good first steps",
+    "intro": {
+      "goodFirstSteps": "Good first steps"
+    },
     "steps": {
       "step1": {
         "title": "Place a few gates and obstacles",
@@ -226,17 +230,25 @@
         "description": "Review the route early and send a read-only link when it is ready."
       }
     },
-    "guidedTitle": "Start with guidance",
-    "guidedDescriptionDesktop": "Open an empty field with `Gate` selected so you can block out the course first. Draw the path once the first obstacles are down.",
-    "guidedDescriptionMobile": "Open an empty field with Gate selected. Draw the path once the first obstacles are down.",
-    "continueEmpty": "Continue with empty canvas",
-    "kbdGate": "places gates",
-    "kbdPath": "starts the route",
-    "kbdFinish": "finishes the path",
-    "starterLayoutsLabel": "Starter layouts",
-    "guidedStartLabel": "Guided start",
-    "emptyStartLabel": "Empty start",
-    "emptyStartDescription": "Skip the guided start and open the empty studio instead."
+    "starterLayouts": {
+      "label": "Starter layouts"
+    },
+    "guided": {
+      "label": "Guided start",
+      "title": "Start with guidance",
+      "descriptionDesktop": "Open an empty field with `Gate` selected so you can block out the course first. Draw the path once the first obstacles are down.",
+      "descriptionMobile": "Open an empty field with Gate selected. Draw the path once the first obstacles are down."
+    },
+    "empty": {
+      "label": "Empty start",
+      "continue": "Continue with empty canvas",
+      "description": "Skip the guided start and open the empty studio instead."
+    },
+    "shortcuts": {
+      "gate": "places gates",
+      "path": "starts the route",
+      "finish": "finishes the path"
+    }
   },
   "saveAsPresetDialog": {
     "title": "Save as preset",
@@ -250,92 +262,146 @@
   },
   "mobilePanels": {
     "viewControls": {
-      "currentMode": "Current mode",
-      "viewModeLabel": "View mode",
-      "fitToField": "Fit to field",
-      "fitToFieldDescription": "Center the current design in view",
-      "snapLabel": "Snap",
-      "snapDescription": "Lock to nearby grid positions and objects",
-      "rulersLabel": "Rulers",
-      "rulersDescription": "Show top and left guides on mobile",
-      "obstacleNumbersLabel": "Obstacle numbers",
-      "obstacleNumbersDescription": "Show path numbers on route obstacles",
-      "flyThroughLabel": "Fly-through",
-      "flyThroughDescriptionAvailable": "Start the race-line preview camera",
-      "flyThroughDescriptionReadOnly": "No route in this shared track",
-      "flyThroughDescriptionDraw": "Draw a path in 2D first to enable this",
-      "gizmoLabel": "Gizmo",
-      "gizmoDescription": "Show the axis helper in 3D preview",
-      "shareSectionLabel": "Share",
-      "editableCopyLabel": "Editable copy",
-      "shareButtonLabel": "Share",
-      "readOnly3dWithPath": "Read-only 3D review with fly-through available for this shared track.",
-      "readOnly3dNoPath": "Read-only 3D review for this shared track. No route is available for fly-through.",
-      "readOnly2dWithPath": "Read-only 2D review for this shared track. Switch to 3D to use fly-through.",
-      "readOnly2dNoPath": "Read-only 2D review for this shared track."
+      "mode": {
+        "current": "Current mode",
+        "viewModeLabel": "View mode"
+      },
+      "controls": {
+        "fitToField": {
+          "label": "Fit to field",
+          "description": "Center the current design in view"
+        },
+        "snap": {
+          "label": "Snap",
+          "description": "Lock to nearby grid positions and objects"
+        },
+        "rulers": {
+          "label": "Rulers",
+          "description": "Show top and left guides on mobile"
+        },
+        "obstacleNumbers": {
+          "label": "Obstacle numbers",
+          "description": "Show path numbers on route obstacles"
+        },
+        "flyThrough": {
+          "label": "Fly-through",
+          "descriptions": {
+            "available": "Start the race-line preview camera",
+            "readOnly": "No route in this shared track",
+            "draw": "Draw a path in 2D first to enable this"
+          }
+        },
+        "gizmo": {
+          "label": "Gizmo",
+          "description": "Show the axis helper in 3D preview"
+        }
+      },
+      "readOnly": {
+        "review3dWithPath": "Read-only 3D review with fly-through available for this shared track.",
+        "review3dNoPath": "Read-only 3D review for this shared track. No route is available for fly-through.",
+        "review2dWithPath": "Read-only 2D review for this shared track. Switch to 3D to use fly-through.",
+        "review2dNoPath": "Read-only 2D review for this shared track."
+      },
+      "share": {
+        "sectionLabel": "Share",
+        "editableCopy": "Editable copy",
+        "shareButton": "Share"
+      }
     },
     "multiSelect": {
-      "title": "Multi-select",
-      "lockedHint": "Locked selection. Unlock before moving or resizing.",
-      "tapHint": "Tap items to add or remove them.",
-      "groupNamePlaceholder": "Group name",
-      "duplicate": "Duplicate",
-      "ungroup": "Ungroup",
-      "group": "Group",
-      "unlock": "Unlock",
-      "lock": "Lock",
-      "delete": "Delete"
+      "header": {
+        "title": "Multi-select",
+        "lockedHint": "Locked selection. Unlock before moving or resizing.",
+        "tapHint": "Tap items to add or remove them."
+      },
+      "fields": {
+        "groupNamePlaceholder": "Group name"
+      },
+      "actions": {
+        "duplicate": "Duplicate",
+        "ungroup": "Ungroup",
+        "group": "Group",
+        "unlock": "Unlock",
+        "lock": "Lock",
+        "delete": "Delete"
+      }
     },
     "pathBuilder": {
-      "title": "Path builder",
-      "loopConnected": "Loop connected · {count} points · {length}",
-      "pointsCount": "{count} points · {length}",
-      "tapToStart": "Tap the canvas to place the first point",
-      "undo": "Undo",
-      "connectEnds": "Connect ends",
-      "finish": "Finish",
-      "cancel": "Cancel"
+      "header": {
+        "title": "Path builder"
+      },
+      "status": {
+        "loopConnected": "Loop connected · {count} points · {length}",
+        "pointsCount": "{count} points · {length}",
+        "tapToStart": "Tap the canvas to place the first point"
+      },
+      "actions": {
+        "undo": "Undo",
+        "connectEnds": "Connect ends",
+        "finish": "Finish",
+        "cancel": "Cancel"
+      }
     },
     "editorPanels": {
-      "quickActionsTitle": "Quick actions",
-      "adjustTitle": "Adjust",
-      "addPointHint": "Add point on selected segment",
-      "deleteWaypointHint": "Delete selected waypoint",
-      "resumeHint": "Resume or adjust this path",
-      "selectionStepHint": "{label} · {step} step",
-      "selectionFallback": "Selection",
-      "addPoint": "Add point",
-      "editPath": "Edit path",
-      "duplicate": "Duplicate",
-      "unlock": "Unlock",
-      "lock": "Lock",
-      "deletePoint": "Delete point",
-      "delete": "Delete",
-      "adjust": "Adjust",
-      "back": "Back",
-      "step": "Step",
-      "left": "Left",
-      "up": "Up",
-      "down": "Down",
-      "right": "Right",
-      "exit": "Exit",
-      "select": "Select",
-      "tools": "Tools",
-      "inspect": "Inspect",
-      "view": "View",
-      "review": "Review",
-      "share": "Share",
-      "editCopy": "Edit copy",
-      "designSettingsHint": "Design settings",
-      "inspectorTitle": "Inspector",
-      "inspectorSubtitleEmpty": "Design settings and placed items",
-      "inspectorSubtitleSelected": "Selection properties and editing",
-      "toolsTitle": "Tools",
-      "toolsSubtitle3d": "Project actions for the current 3D session",
-      "toolsSubtitle2d": "Drawing and editing tools",
-      "viewTitle": "View",
-      "viewSubtitle": "Canvas mode, guides and viewport controls",
-      "preview": "Preview"
+      "quickActions": {
+        "title": "Quick actions",
+        "adjustTitle": "Adjust",
+        "hints": {
+          "addPoint": "Add point on selected segment",
+          "deleteWaypoint": "Delete selected waypoint",
+          "resume": "Resume or adjust this path",
+          "selectionStep": "{label} · {step} step",
+          "selectionFallback": "Selection"
+        },
+        "actions": {
+          "addPoint": "Add point",
+          "editPath": "Edit path",
+          "duplicate": "Duplicate",
+          "unlock": "Unlock",
+          "lock": "Lock",
+          "deletePoint": "Delete point",
+          "delete": "Delete",
+          "adjust": "Adjust",
+          "back": "Back"
+        },
+        "adjust": {
+          "step": "Step",
+          "left": "Left",
+          "up": "Up",
+          "down": "Down",
+          "right": "Right"
+        }
+      },
+      "nav": {
+        "exit": "Exit",
+        "select": "Select",
+        "tools": "Tools",
+        "inspect": "Inspect",
+        "view": "View",
+        "review": "Review",
+        "share": "Share",
+        "editCopy": "Edit copy",
+        "preview": "Preview"
+      },
+      "inspector": {
+        "designSettingsHint": "Design settings",
+        "title": "Inspector",
+        "subtitles": {
+          "empty": "Design settings and placed items",
+          "selected": "Selection properties and editing"
+        }
+      },
+      "tools": {
+        "title": "Tools",
+        "subtitles": {
+          "preview3d": "Project actions for the current 3D session",
+          "canvas2d": "Drawing and editing tools"
+        }
+      },
+      "view": {
+        "title": "View",
+        "subtitle": "Canvas mode, guides and viewport controls"
+      }
     }
   },
   "viewModeSwitch": {

--- a/lang/nl/editor.json
+++ b/lang/nl/editor.json
@@ -167,11 +167,13 @@
     "tipText": "Selecteer vormen op het canvas en gebruik <strong>Opslaan als preset</strong> in de inspector om je eigen preset toe te voegen."
   },
   "starterOverlay": {
-    "title": "Welkom bij TrackDraw",
-    "mobileSubtitle": "Plaats een paar gates, teken de route, controleer in 3D en deel zodra de track klaar is.",
-    "studioEyebrow": "Studio",
-    "desktopDescription": "Ontwerp de layout in 2D, bekijk de hoogte in 3D en deel een alleen-lezen link zodra de track klaar is.",
-    "dismissAria": "Startdialoog sluiten",
+    "dialog": {
+      "title": "Welkom bij TrackDraw",
+      "mobileSubtitle": "Plaats een paar gates, teken de route, controleer in 3D en deel zodra de track klaar is.",
+      "studioEyebrow": "Studio",
+      "desktopDescription": "Ontwerp de layout in 2D, bekijk de hoogte in 3D en deel een alleen-lezen link zodra de track klaar is.",
+      "dismissAria": "Startdialoog sluiten"
+    },
     "hints": {
       "gate": {
         "badge": "Begeleid",
@@ -211,7 +213,9 @@
     }
   },
   "starterFlow": {
-    "goodFirstSteps": "Goede eerste stappen",
+    "intro": {
+      "goodFirstSteps": "Goede eerste stappen"
+    },
     "steps": {
       "step1": {
         "title": "Plaats een paar gates en obstakels",
@@ -226,17 +230,25 @@
         "description": "Bekijk de route vroeg en stuur een alleen-lezen link zodra het klaar is."
       }
     },
-    "guidedTitle": "Start met begeleiding",
-    "guidedDescriptionDesktop": "Open een leeg veld met `Gate` geselecteerd zodat je eerst de baan kunt uitzetten. Teken het pad zodra de eerste obstakels staan.",
-    "guidedDescriptionMobile": "Open een leeg veld met Gate geselecteerd. Teken het pad zodra de eerste obstakels staan.",
-    "continueEmpty": "Doorgaan met leeg canvas",
-    "kbdGate": "plaatst gates",
-    "kbdPath": "start de route",
-    "kbdFinish": "maakt het pad af",
-    "starterLayoutsLabel": "Startlayouts",
-    "guidedStartLabel": "Begeleide start",
-    "emptyStartLabel": "Lege start",
-    "emptyStartDescription": "Sla de begeleide start over en open direct de lege studio."
+    "starterLayouts": {
+      "label": "Startlayouts"
+    },
+    "guided": {
+      "label": "Begeleide start",
+      "title": "Start met begeleiding",
+      "descriptionDesktop": "Open een leeg veld met `Gate` geselecteerd zodat je eerst de baan kunt uitzetten. Teken het pad zodra de eerste obstakels staan.",
+      "descriptionMobile": "Open een leeg veld met Gate geselecteerd. Teken het pad zodra de eerste obstakels staan."
+    },
+    "empty": {
+      "label": "Lege start",
+      "continue": "Doorgaan met leeg canvas",
+      "description": "Sla de begeleide start over en open direct de lege studio."
+    },
+    "shortcuts": {
+      "gate": "plaatst gates",
+      "path": "start de route",
+      "finish": "maakt het pad af"
+    }
   },
   "saveAsPresetDialog": {
     "title": "Opslaan als preset",
@@ -250,92 +262,146 @@
   },
   "mobilePanels": {
     "viewControls": {
-      "currentMode": "Huidige modus",
-      "viewModeLabel": "Weergavemodus",
-      "fitToField": "Passend aan veld",
-      "fitToFieldDescription": "Centreer het huidige ontwerp in beeld",
-      "snapLabel": "Snap",
-      "snapDescription": "Vergrendel naar nabije rasterposities en objecten",
-      "rulersLabel": "Linialen",
-      "rulersDescription": "Toon boven- en linkerlinialen op mobiel",
-      "obstacleNumbersLabel": "Obstakelnummers",
-      "obstacleNumbersDescription": "Toon padnummers op route-obstakels",
-      "flyThroughLabel": "Flythrough",
-      "flyThroughDescriptionAvailable": "Start de race line-previewcamera",
-      "flyThroughDescriptionReadOnly": "Geen route in deze gedeelde track",
-      "flyThroughDescriptionDraw": "Teken eerst een pad in 2D om dit te activeren",
-      "gizmoLabel": "Gizmo",
-      "gizmoDescription": "Toon de as-helper in 3D-preview",
-      "shareSectionLabel": "Delen",
-      "editableCopyLabel": "Bewerkbare kopie",
-      "shareButtonLabel": "Delen",
-      "readOnly3dWithPath": "Alleen-lezen 3D-review met flythrough beschikbaar voor deze gedeelde track.",
-      "readOnly3dNoPath": "Alleen-lezen 3D-review voor deze gedeelde track. Geen route beschikbaar voor flythrough.",
-      "readOnly2dWithPath": "Alleen-lezen 2D-review voor deze gedeelde track. Wissel naar 3D voor flythrough.",
-      "readOnly2dNoPath": "Alleen-lezen 2D-review voor deze gedeelde track."
+      "mode": {
+        "current": "Huidige modus",
+        "viewModeLabel": "Weergavemodus"
+      },
+      "controls": {
+        "fitToField": {
+          "label": "Passend aan veld",
+          "description": "Centreer het huidige ontwerp in beeld"
+        },
+        "snap": {
+          "label": "Snap",
+          "description": "Vergrendel naar nabije rasterposities en objecten"
+        },
+        "rulers": {
+          "label": "Linialen",
+          "description": "Toon boven- en linkerlinialen op mobiel"
+        },
+        "obstacleNumbers": {
+          "label": "Obstakelnummers",
+          "description": "Toon padnummers op route-obstakels"
+        },
+        "flyThrough": {
+          "label": "Flythrough",
+          "descriptions": {
+            "available": "Start de race line-previewcamera",
+            "readOnly": "Geen route in deze gedeelde track",
+            "draw": "Teken eerst een pad in 2D om dit te activeren"
+          }
+        },
+        "gizmo": {
+          "label": "Gizmo",
+          "description": "Toon de as-helper in 3D-preview"
+        }
+      },
+      "readOnly": {
+        "review3dWithPath": "Alleen-lezen 3D-review met flythrough beschikbaar voor deze gedeelde track.",
+        "review3dNoPath": "Alleen-lezen 3D-review voor deze gedeelde track. Geen route beschikbaar voor flythrough.",
+        "review2dWithPath": "Alleen-lezen 2D-review voor deze gedeelde track. Wissel naar 3D voor flythrough.",
+        "review2dNoPath": "Alleen-lezen 2D-review voor deze gedeelde track."
+      },
+      "share": {
+        "sectionLabel": "Delen",
+        "editableCopy": "Bewerkbare kopie",
+        "shareButton": "Delen"
+      }
     },
     "multiSelect": {
-      "title": "Multi-select",
-      "lockedHint": "Vergrendelde selectie. Ontgrendel voor verplaatsen of vergroten.",
-      "tapHint": "Tik op items om ze toe te voegen of te verwijderen.",
-      "groupNamePlaceholder": "Groepsnaam",
-      "duplicate": "Dupliceren",
-      "ungroup": "Groep opheffen",
-      "group": "Groeperen",
-      "unlock": "Ontgrendelen",
-      "lock": "Vergrendelen",
-      "delete": "Verwijderen"
+      "header": {
+        "title": "Multi-select",
+        "lockedHint": "Vergrendelde selectie. Ontgrendel voor verplaatsen of vergroten.",
+        "tapHint": "Tik op items om ze toe te voegen of te verwijderen."
+      },
+      "fields": {
+        "groupNamePlaceholder": "Groepsnaam"
+      },
+      "actions": {
+        "duplicate": "Dupliceren",
+        "ungroup": "Groep opheffen",
+        "group": "Groeperen",
+        "unlock": "Ontgrendelen",
+        "lock": "Vergrendelen",
+        "delete": "Verwijderen"
+      }
     },
     "pathBuilder": {
-      "title": "Path builder",
-      "loopConnected": "Loop verbonden · {count} waypoints · {length}",
-      "pointsCount": "{count} waypoints · {length}",
-      "tapToStart": "Tik op het canvas om het eerste waypoint te plaatsen",
-      "undo": "Ongedaan maken",
-      "connectEnds": "Einden verbinden",
-      "finish": "Afronden",
-      "cancel": "Annuleren"
+      "header": {
+        "title": "Path builder"
+      },
+      "status": {
+        "loopConnected": "Loop verbonden · {count} waypoints · {length}",
+        "pointsCount": "{count} waypoints · {length}",
+        "tapToStart": "Tik op het canvas om het eerste waypoint te plaatsen"
+      },
+      "actions": {
+        "undo": "Ongedaan maken",
+        "connectEnds": "Einden verbinden",
+        "finish": "Afronden",
+        "cancel": "Annuleren"
+      }
     },
     "editorPanels": {
-      "quickActionsTitle": "Snelle acties",
-      "adjustTitle": "Aanpassen",
-      "addPointHint": "Waypoint toevoegen op geselecteerd segment",
-      "deleteWaypointHint": "Geselecteerd waypoint verwijderen",
-      "resumeHint": "Hervat of pas dit pad aan",
-      "selectionStepHint": "{label} · {step} stap",
-      "selectionFallback": "Selectie",
-      "addPoint": "Waypoint toevoegen",
-      "editPath": "Path bewerken",
-      "duplicate": "Dupliceren",
-      "unlock": "Ontgrendelen",
-      "lock": "Vergrendelen",
-      "deletePoint": "Waypoint verwijderen",
-      "delete": "Verwijderen",
-      "adjust": "Aanpassen",
-      "back": "Terug",
-      "step": "Stap",
-      "left": "Links",
-      "up": "Omhoog",
-      "down": "Omlaag",
-      "right": "Rechts",
-      "exit": "Sluiten",
-      "select": "Selecteren",
-      "tools": "Tools",
-      "inspect": "Inspecteren",
-      "view": "Weergave",
-      "review": "Review",
-      "share": "Delen",
-      "editCopy": "Kopie bewerken",
-      "designSettingsHint": "Ontwerpinstellingen",
-      "inspectorTitle": "Inspector",
-      "inspectorSubtitleEmpty": "Ontwerpinstellingen en geplaatste items",
-      "inspectorSubtitleSelected": "Selectie-eigenschappen en bewerken",
-      "toolsTitle": "Tools",
-      "toolsSubtitle3d": "Projectacties voor de huidige 3D-sessie",
-      "toolsSubtitle2d": "Teken- en bewerkingstools",
-      "viewTitle": "Weergave",
-      "viewSubtitle": "Canvasmodus, hulplijnen en viewport-instellingen",
-      "preview": "Preview"
+      "quickActions": {
+        "title": "Snelle acties",
+        "adjustTitle": "Aanpassen",
+        "hints": {
+          "addPoint": "Waypoint toevoegen op geselecteerd segment",
+          "deleteWaypoint": "Geselecteerd waypoint verwijderen",
+          "resume": "Hervat of pas dit pad aan",
+          "selectionStep": "{label} · {step} stap",
+          "selectionFallback": "Selectie"
+        },
+        "actions": {
+          "addPoint": "Waypoint toevoegen",
+          "editPath": "Path bewerken",
+          "duplicate": "Dupliceren",
+          "unlock": "Ontgrendelen",
+          "lock": "Vergrendelen",
+          "deletePoint": "Waypoint verwijderen",
+          "delete": "Verwijderen",
+          "adjust": "Aanpassen",
+          "back": "Terug"
+        },
+        "adjust": {
+          "step": "Stap",
+          "left": "Links",
+          "up": "Omhoog",
+          "down": "Omlaag",
+          "right": "Rechts"
+        }
+      },
+      "nav": {
+        "exit": "Sluiten",
+        "select": "Selecteren",
+        "tools": "Tools",
+        "inspect": "Inspecteren",
+        "view": "Weergave",
+        "review": "Review",
+        "share": "Delen",
+        "editCopy": "Kopie bewerken",
+        "preview": "Preview"
+      },
+      "inspector": {
+        "designSettingsHint": "Ontwerpinstellingen",
+        "title": "Inspector",
+        "subtitles": {
+          "empty": "Ontwerpinstellingen en geplaatste items",
+          "selected": "Selectie-eigenschappen en bewerken"
+        }
+      },
+      "tools": {
+        "title": "Tools",
+        "subtitles": {
+          "preview3d": "Projectacties voor de huidige 3D-sessie",
+          "canvas2d": "Teken- en bewerkingstools"
+        }
+      },
+      "view": {
+        "title": "Weergave",
+        "subtitle": "Canvasmodus, hulplijnen en viewport-instellingen"
+      }
     }
   },
   "viewModeSwitch": {

--- a/src/components/editor/EditorStarterOverlay.tsx
+++ b/src/components/editor/EditorStarterOverlay.tsx
@@ -91,8 +91,8 @@ export function EditorStarterOverlay({
           onOpenChange={(open) => {
             if (!open) onDismissStarter();
           }}
-          title={t("title")}
-          subtitle={t("mobileSubtitle")}
+          title={t("dialog.title")}
+          subtitle={t("dialog.mobileSubtitle")}
           contentClassName="max-h-[96dvh]"
           bodyClassName="space-y-5 pt-3 pb-4"
         >
@@ -112,20 +112,20 @@ export function EditorStarterOverlay({
             <div className="relative">
               <div className="pr-10">
                 <p className="text-muted-foreground text-[11px] font-medium tracking-[0.12em] uppercase">
-                  {t("studioEyebrow")}
+                  {t("dialog.studioEyebrow")}
                 </p>
                 <p className="text-foreground mt-2 text-[1.25rem] font-semibold tracking-[-0.02em]">
-                  {t("title")}
+                  {t("dialog.title")}
                 </p>
                 <p className="text-muted-foreground mt-2 text-sm leading-relaxed">
-                  {t("desktopDescription")}
+                  {t("dialog.desktopDescription")}
                 </p>
               </div>
               <button
                 type="button"
                 onClick={onDismissStarter}
                 className="text-muted-foreground/75 hover:text-foreground hover:bg-muted absolute top-0 right-0 cursor-pointer rounded-full p-1.5 transition-colors"
-                aria-label={t("dismissAria")}
+                aria-label={t("dialog.dismissAria")}
               >
                 <X className="size-4" />
               </button>

--- a/src/components/editor/StarterFlow.tsx
+++ b/src/components/editor/StarterFlow.tsx
@@ -29,7 +29,7 @@ export function StarterSteps({ mobile = false }: { mobile?: boolean }) {
             : "text-muted-foreground text-[11px] font-semibold tracking-widest uppercase"
         }
       >
-        {t("goodFirstSteps")}
+        {t("intro.goodFirstSteps")}
       </p>
       <ol className={mobile ? "space-y-3" : "mt-3 space-y-3"}>
         {STARTER_STEP_IDS.map((id, index) => {
@@ -149,10 +149,10 @@ export function StarterActions({
             </div>
             <div className="min-w-0 flex-1">
               <p className="text-foreground text-sm font-medium">
-                {t("guidedTitle")}
+                {t("guided.title")}
               </p>
               <p className="text-muted-foreground mt-1 text-xs leading-5">
-                {t("guidedDescriptionDesktop")}
+                {t("guided.descriptionDesktop")}
               </p>
             </div>
             <div className="flex h-full items-center self-stretch">
@@ -165,15 +165,15 @@ export function StarterActions({
             onClick={onBlank}
             className="text-muted-foreground hover:text-foreground mt-3 w-full cursor-pointer text-center text-sm underline-offset-2 transition-colors hover:underline"
           >
-            {t("continueEmpty")}
+            {t("empty.continue")}
           </button>
         </div>
         <p className="text-muted-foreground mt-5 hidden flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] sm:flex">
-          <Kbd>G</Kbd> {t("kbdGate")}
+          <Kbd>G</Kbd> {t("shortcuts.gate")}
           <span className="text-muted-foreground/60">·</span>
-          <Kbd>P</Kbd> {t("kbdPath")}
+          <Kbd>P</Kbd> {t("shortcuts.path")}
           <span className="text-muted-foreground/60">·</span>
-          <Kbd>Enter</Kbd> {t("kbdFinish")}
+          <Kbd>Enter</Kbd> {t("shortcuts.finish")}
         </p>
       </>
     );
@@ -184,7 +184,7 @@ export function StarterActions({
       <div className="space-y-2.5">
         <div>
           <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-            {t("starterLayoutsLabel")}
+            {t("starterLayouts.label")}
           </p>
           <div className="space-y-2">
             {starterLayouts.map((layout) => (
@@ -212,7 +212,7 @@ export function StarterActions({
         </div>
 
         <p className="text-muted-foreground/60 pt-1 text-[11px] font-semibold tracking-widest uppercase">
-          {t("guidedStartLabel")}
+          {t("guided.label")}
         </p>
 
         <button
@@ -225,17 +225,17 @@ export function StarterActions({
           </div>
           <div className="min-w-0 flex-1">
             <p className="text-foreground text-[13px] font-medium">
-              {t("guidedTitle")}
+              {t("guided.title")}
             </p>
             <p className="text-muted-foreground mt-1 text-[11px] leading-5">
-              {t("guidedDescriptionMobile")}
+              {t("guided.descriptionMobile")}
             </p>
           </div>
           <ChevronRight className="text-muted-foreground/45 mt-0.5 size-4 shrink-0" />
         </button>
 
         <p className="text-muted-foreground/60 pt-1 text-[11px] font-semibold tracking-widest uppercase">
-          {t("emptyStartLabel")}
+          {t("empty.label")}
         </p>
 
         <button
@@ -248,10 +248,10 @@ export function StarterActions({
           </div>
           <div className="min-w-0 flex-1">
             <p className="text-foreground text-[13px] font-medium">
-              {t("continueEmpty")}
+              {t("empty.continue")}
             </p>
             <p className="text-muted-foreground mt-1 text-[11px] leading-5">
-              {t("emptyStartDescription")}
+              {t("empty.description")}
             </p>
           </div>
         </button>

--- a/src/components/editor/mobile/EditorMobilePanels.tsx
+++ b/src/components/editor/mobile/EditorMobilePanels.tsx
@@ -173,17 +173,19 @@ function MobileQuickActionsOverlay({
       <div className="flex items-start justify-between gap-3 px-1 pb-2">
         <div className="min-w-0">
           <p className="truncate text-[11px] font-semibold tracking-[0.08em] text-white/92 uppercase">
-            {expanded ? t("adjustTitle") : t("quickActionsTitle")}
+            {expanded ? t("quickActions.adjustTitle") : t("quickActions.title")}
           </p>
           <p className="truncate text-[11px] text-white/70">
             {canAddWaypoint
-              ? t("addPointHint")
+              ? t("quickActions.hints.addPoint")
               : canDeleteWaypoint
-                ? t("deleteWaypointHint")
+                ? t("quickActions.hints.deleteWaypoint")
                 : canResumePathEditing
-                  ? t("resumeHint")
-                  : t("selectionStepHint", {
-                      label: singleSelectedShapeLabel ?? t("selectionFallback"),
+                  ? t("quickActions.hints.resume")
+                  : t("quickActions.hints.selectionStep", {
+                      label:
+                        singleSelectedShapeLabel ??
+                        t("quickActions.hints.selectionFallback"),
                       step: mobilePrecisionStepLabel,
                     })}
           </p>
@@ -200,7 +202,7 @@ function MobileQuickActionsOverlay({
               className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
             >
               <Plus className="size-4" />
-              <span>{t("addPoint")}</span>
+              <span>{t("quickActions.actions.addPoint")}</span>
             </button>
           ) : canResumePathEditing ? (
             <button
@@ -210,7 +212,7 @@ function MobileQuickActionsOverlay({
               className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
             >
               <PencilLine className="size-4" />
-              <span>{t("editPath")}</span>
+              <span>{t("quickActions.actions.editPath")}</span>
             </button>
           ) : (
             <button
@@ -220,7 +222,7 @@ function MobileQuickActionsOverlay({
               className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
             >
               <Copy className="size-4" />
-              <span>{t("duplicate")}</span>
+              <span>{t("quickActions.actions.duplicate")}</span>
             </button>
           )}
           <button
@@ -233,7 +235,11 @@ function MobileQuickActionsOverlay({
             ) : (
               <Lock className="size-4" />
             )}
-            <span>{selectionLocked ? t("unlock") : t("lock")}</span>
+            <span>
+              {selectionLocked
+                ? t("quickActions.actions.unlock")
+                : t("quickActions.actions.lock")}
+            </span>
           </button>
           <button
             type="button"
@@ -242,7 +248,11 @@ function MobileQuickActionsOverlay({
             className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-rose-300 transition-colors hover:bg-rose-400/12 hover:text-rose-200 disabled:text-white/35"
           >
             <Trash2 className="size-4" />
-            <span>{canDeleteWaypoint ? t("deletePoint") : t("delete")}</span>
+            <span>
+              {canDeleteWaypoint
+                ? t("quickActions.actions.deletePoint")
+                : t("quickActions.actions.delete")}
+            </span>
           </button>
           <button
             type="button"
@@ -251,7 +261,7 @@ function MobileQuickActionsOverlay({
             className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <SlidersHorizontal className="size-4" />
-            <span>{t("adjust")}</span>
+            <span>{t("quickActions.actions.adjust")}</span>
           </button>
         </div>
       ) : (
@@ -262,7 +272,7 @@ function MobileQuickActionsOverlay({
             className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/62 transition-colors hover:bg-white/10 hover:text-white"
           >
             <ArrowLeft className="size-4" />
-            <span>{t("back")}</span>
+            <span>{t("quickActions.actions.back")}</span>
           </button>
           <button
             type="button"
@@ -283,7 +293,7 @@ function MobileQuickActionsOverlay({
             <span>+15°</span>
           </button>
           <div className="flex items-center justify-center text-[9px] font-medium tracking-[0.08em] text-white/35 uppercase">
-            {t("step")}
+            {t("quickActions.adjust.step")}
           </div>
           <button
             type="button"
@@ -292,7 +302,7 @@ function MobileQuickActionsOverlay({
             className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <ArrowLeft className="size-4" />
-            <span>{t("left")}</span>
+            <span>{t("quickActions.adjust.left")}</span>
           </button>
           <button
             type="button"
@@ -301,7 +311,7 @@ function MobileQuickActionsOverlay({
             className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <ArrowUp className="size-4" />
-            <span>{t("up")}</span>
+            <span>{t("quickActions.adjust.up")}</span>
           </button>
           <button
             type="button"
@@ -310,7 +320,7 @@ function MobileQuickActionsOverlay({
             className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <ArrowDown className="size-4" />
-            <span>{t("down")}</span>
+            <span>{t("quickActions.adjust.down")}</span>
           </button>
           <button
             type="button"
@@ -319,7 +329,7 @@ function MobileQuickActionsOverlay({
             className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <ArrowRight className="size-4" />
-            <span>{t("right")}</span>
+            <span>{t("quickActions.adjust.right")}</span>
           </button>
         </div>
       )}
@@ -470,7 +480,7 @@ export function EditorMobilePanels({
   const inspectorHint =
     selectedCount > 0
       ? tStatusBar("selected", { count: selectedCount })
-      : t("designSettingsHint");
+      : t("inspector.designSettingsHint");
   const handleMobileSelectButton = () => {
     if (mobileMultiSelectEnabled) {
       onExitMobileMultiSelect();
@@ -506,14 +516,16 @@ export function EditorMobilePanels({
               )}
             >
               <SquareMousePointer className="size-3.5" />
-              <span>{mobileMultiSelectEnabled ? t("exit") : t("select")}</span>
+              <span>
+                {mobileMultiSelectEnabled ? t("nav.exit") : t("nav.select")}
+              </span>
             </button>
             <button
               onClick={openToolsDrawer}
               className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5"
             >
               <LayoutGrid className="size-3.5" />
-              <span>{t("tools")}</span>
+              <span>{t("nav.tools")}</span>
             </button>
             <div className="min-w-0 flex-[1.25]">
               <div className="mx-auto flex max-w-34 flex-col items-center justify-center rounded-[0.95rem] border border-white/10 bg-white/8 px-1.5 py-1 text-center">
@@ -530,14 +542,14 @@ export function EditorMobilePanels({
               className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5"
             >
               <SlidersHorizontal className="size-3.5" />
-              <span>{t("inspect")}</span>
+              <span>{t("nav.inspect")}</span>
             </button>
             <button
               onClick={openViewDrawer}
               className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5"
             >
               <Scan className="size-3.5" />
-              <span>{t("view")}</span>
+              <span>{t("nav.view")}</span>
             </button>
           </motion.div>
         </div>
@@ -562,21 +574,21 @@ export function EditorMobilePanels({
               className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
             >
               <Scan className="size-3.5" />
-              <span>{t("review")}</span>
+              <span>{t("nav.review")}</span>
             </button>
             <button
               onClick={onShare}
               className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
             >
               <Share2 className="size-3.5" />
-              <span>{t("share")}</span>
+              <span>{t("nav.share")}</span>
             </button>
             <Link
               href={studioHref}
               className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
             >
               <ArrowRight className="size-3.5" />
-              <span>{t("editCopy")}</span>
+              <span>{t("nav.editCopy")}</span>
             </Link>
           </motion.div>
         </div>
@@ -674,11 +686,11 @@ export function EditorMobilePanels({
           onOpenChange={(open) => {
             if (!open) onCloseInspector();
           }}
-          title={t("inspectorTitle")}
+          title={t("inspector.title")}
           subtitle={
             selectedCount === 0
-              ? t("inspectorSubtitleEmpty")
-              : t("inspectorSubtitleSelected")
+              ? t("inspector.subtitles.empty")
+              : t("inspector.subtitles.selected")
           }
           contentClassName="h-[82dvh] max-h-[92dvh] min-h-[72dvh] overscroll-contain"
           bodyClassName="bg-card min-h-0 touch-pan-y overscroll-y-contain [-webkit-overflow-scrolling:touch] p-0"
@@ -697,8 +709,12 @@ export function EditorMobilePanels({
         <MobileDrawer
           open={mobileToolsOpen}
           onOpenChange={onSetMobileToolsOpen}
-          title={t("toolsTitle")}
-          subtitle={tab === "3d" ? t("toolsSubtitle3d") : t("toolsSubtitle2d")}
+          title={t("tools.title")}
+          subtitle={
+            tab === "3d"
+              ? t("tools.subtitles.preview3d")
+              : t("tools.subtitles.canvas2d")
+          }
           bodyClassName="space-y-4 pt-3 pb-4"
         >
           <ToolsControls
@@ -719,8 +735,8 @@ export function EditorMobilePanels({
         <MobileDrawer
           open={mobileViewOpen}
           onOpenChange={onSetMobileViewOpen}
-          title={t("viewTitle")}
-          subtitle={t("viewSubtitle")}
+          title={t("view.title")}
+          subtitle={t("view.subtitle")}
           bodyClassName="space-y-5 pt-3 pb-4"
         >
           <ViewControls
@@ -750,8 +766,8 @@ export function EditorMobilePanels({
         <MobileDrawer
           open={readOnlyMenuOpen}
           onOpenChange={onSetReadOnlyMenuOpen}
-          title={t("viewTitle")}
-          subtitle={t("viewSubtitle")}
+          title={t("view.title")}
+          subtitle={t("view.subtitle")}
           bodyClassName="space-y-5 pt-3 pb-4"
         >
           <ViewControls

--- a/src/components/editor/mobile/MultiSelectOverlay.tsx
+++ b/src/components/editor/mobile/MultiSelectOverlay.tsx
@@ -47,12 +47,12 @@ export function MultiSelectOverlay({
           <p className="truncate text-[11px] font-semibold tracking-[0.08em] text-white/92 uppercase">
             {selectedCount > 0
               ? tStatusBar("selected", { count: selectedCount })
-              : t("title")}
+              : t("header.title")}
           </p>
           <p className="truncate text-[11px] text-white/70">
             {selectionLocked && selectedCount > 0
-              ? t("lockedHint")
-              : t("tapHint")}
+              ? t("header.lockedHint")
+              : t("header.tapHint")}
           </p>
         </div>
       </div>
@@ -62,7 +62,7 @@ export function MultiSelectOverlay({
           <Input
             value={selectedGroupName ?? ""}
             onChange={(event) => onSetGroupName(event.target.value)}
-            placeholder={t("groupNamePlaceholder")}
+            placeholder={t("fields.groupNamePlaceholder")}
             className="h-9 rounded-[0.9rem] border-white/12 bg-white/8 px-3 text-[12px] text-white placeholder:text-white/38"
           />
         </div>
@@ -76,7 +76,7 @@ export function MultiSelectOverlay({
           className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
         >
           <Copy className="size-4" />
-          <span>{t("duplicate")}</span>
+          <span>{t("actions.duplicate")}</span>
         </button>
         <button
           type="button"
@@ -89,7 +89,9 @@ export function MultiSelectOverlay({
           ) : (
             <Group className="size-4" />
           )}
-          <span>{canUngroupSelection ? t("ungroup") : t("group")}</span>
+          <span>
+            {canUngroupSelection ? t("actions.ungroup") : t("actions.group")}
+          </span>
         </button>
         <button
           type="button"
@@ -102,7 +104,7 @@ export function MultiSelectOverlay({
           ) : (
             <Lock className="size-4" />
           )}
-          <span>{selectionLocked ? t("unlock") : t("lock")}</span>
+          <span>{selectionLocked ? t("actions.unlock") : t("actions.lock")}</span>
         </button>
         <button
           type="button"
@@ -111,7 +113,7 @@ export function MultiSelectOverlay({
           className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-rose-300 transition-colors hover:bg-rose-400/12 hover:text-rose-200 disabled:text-white/35"
         >
           <Trash2 className="size-4" />
-          <span>{t("delete")}</span>
+          <span>{t("actions.delete")}</span>
         </button>
       </div>
     </motion.div>

--- a/src/components/editor/mobile/MultiSelectOverlay.tsx
+++ b/src/components/editor/mobile/MultiSelectOverlay.tsx
@@ -104,7 +104,9 @@ export function MultiSelectOverlay({
           ) : (
             <Lock className="size-4" />
           )}
-          <span>{selectionLocked ? t("actions.unlock") : t("actions.lock")}</span>
+          <span>
+            {selectionLocked ? t("actions.unlock") : t("actions.lock")}
+          </span>
         </button>
         <button
           type="button"

--- a/src/components/editor/mobile/PathBuilderOverlay.tsx
+++ b/src/components/editor/mobile/PathBuilderOverlay.tsx
@@ -39,20 +39,20 @@ export function PathBuilderOverlay({
       <div className="flex items-start justify-between gap-3 px-1 pb-2">
         <div className="min-w-0">
           <p className="truncate text-[11px] font-semibold tracking-[0.08em] text-white/92 uppercase">
-            {t("title")}
+            {t("header.title")}
           </p>
           <p className="truncate text-[11px] text-white/70">
             {draftPathClosed
-              ? t("loopConnected", {
+              ? t("status.loopConnected", {
                   count: draftPathPointCount,
                   length: lengthLabel,
                 })
               : draftPathPointCount > 0
-                ? t("pointsCount", {
+                ? t("status.pointsCount", {
                     count: draftPathPointCount,
                     length: lengthLabel,
                   })
-                : t("tapToStart")}
+                : t("status.tapToStart")}
           </p>
         </div>
       </div>
@@ -65,7 +65,7 @@ export function PathBuilderOverlay({
           className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/78 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
         >
           <ArrowRight className="size-4 rotate-180" />
-          <span>{t("undo")}</span>
+          <span>{t("actions.undo")}</span>
         </button>
         <button
           type="button"
@@ -74,7 +74,7 @@ export function PathBuilderOverlay({
           className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/78 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
         >
           <Link2 className="size-4" />
-          <span>{t("connectEnds")}</span>
+          <span>{t("actions.connectEnds")}</span>
         </button>
         <button
           type="button"
@@ -83,7 +83,7 @@ export function PathBuilderOverlay({
           className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/78 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
         >
           <PencilLine className="size-4" />
-          <span>{t("finish")}</span>
+          <span>{t("actions.finish")}</span>
         </button>
         <button
           type="button"
@@ -91,7 +91,7 @@ export function PathBuilderOverlay({
           className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-rose-300 transition-colors hover:bg-rose-400/12 hover:text-rose-200"
         >
           <X className="size-4" />
-          <span>{t("cancel")}</span>
+          <span>{t("actions.cancel")}</span>
         </button>
       </div>
     </motion.div>

--- a/src/components/editor/mobile/ToolsControls.tsx
+++ b/src/components/editor/mobile/ToolsControls.tsx
@@ -81,7 +81,7 @@ export function ToolsControls({
       {tab === "2d" && (
         <div>
           <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-            {t("mobilePanels.editorPanels.tools")}
+            {t("mobilePanels.editorPanels.nav.tools")}
           </p>
 
           {/* Catalog tools — active one auto-expands with type list */}

--- a/src/components/editor/mobile/ViewControls.tsx
+++ b/src/components/editor/mobile/ViewControls.tsx
@@ -99,17 +99,17 @@ export function ViewControls({
     ? `${inspectorHint}. ${saveStatusLabel}.`
     : tab === "3d"
       ? hasPath
-        ? t("readOnly3dWithPath")
-        : t("readOnly3dNoPath")
+        ? t("readOnly.review3dWithPath")
+        : t("readOnly.review3dNoPath")
       : hasPath
-        ? t("readOnly2dWithPath")
-        : t("readOnly2dNoPath");
+        ? t("readOnly.review2dWithPath")
+        : t("readOnly.review2dNoPath");
 
   return (
     <>
       <div>
         <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-          {readOnly ? saveStatusLabel : t("currentMode")}
+          {readOnly ? saveStatusLabel : t("mode.current")}
         </p>
         <div className="border-border/50 bg-muted/18 rounded-2xl border px-3 py-3">
           <p className="text-foreground text-sm font-medium">
@@ -122,7 +122,7 @@ export function ViewControls({
       </div>
       <div>
         <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-          {t("viewModeLabel")}
+          {t("mode.viewModeLabel")}
         </p>
         <ViewModeSwitch
           value={tab}
@@ -137,9 +137,11 @@ export function ViewControls({
           className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground mt-2.5 flex w-full items-center justify-between rounded-2xl border px-3 py-2.5 text-left transition-colors"
         >
           <div>
-            <p className="text-[11px] font-medium">{t("fitToField")}</p>
+            <p className="text-[11px] font-medium">
+              {t("controls.fitToField.label")}
+            </p>
             <p className="text-muted-foreground/75 pt-0.5 text-[11px]">
-              {t("fitToFieldDescription")}
+              {t("controls.fitToField.description")}
             </p>
           </div>
           <Scan className="size-4" />
@@ -157,9 +159,11 @@ export function ViewControls({
                 )}
               >
                 <div>
-                  <p className="text-[11px] font-medium">{t("snapLabel")}</p>
+                  <p className="text-[11px] font-medium">
+                    {t("controls.snap.label")}
+                  </p>
                   <p className="text-muted-foreground/75 pt-0.5 text-[11px]">
-                    {t("snapDescription")}
+                    {t("controls.snap.description")}
                   </p>
                 </div>
                 <div
@@ -175,14 +179,14 @@ export function ViewControls({
               </button>
             )}
             <ToggleRow
-              title={t("rulersLabel")}
-              description={t("rulersDescription")}
+              title={t("controls.rulers.label")}
+              description={t("controls.rulers.description")}
               enabled={mobileRulersEnabled}
               onClick={() => onSetMobileRulersEnabled(!mobileRulersEnabled)}
             />
             <ToggleRow
-              title={t("obstacleNumbersLabel")}
-              description={t("obstacleNumbersDescription")}
+              title={t("controls.obstacleNumbers.label")}
+              description={t("controls.obstacleNumbers.description")}
               enabled={mobileObstacleNumbersEnabled}
               onClick={() =>
                 onSetMobileObstacleNumbersEnabled(!mobileObstacleNumbersEnabled)
@@ -206,21 +210,21 @@ export function ViewControls({
             >
               <div>
                 <p className="text-[11px] font-medium">
-                  {t("flyThroughLabel")}
+                  {t("controls.flyThrough.label")}
                 </p>
                 <p className="text-muted-foreground/75 pt-0.5 text-[11px]">
                   {hasPath
-                    ? t("flyThroughDescriptionAvailable")
+                    ? t("controls.flyThrough.descriptions.available")
                     : readOnly
-                      ? t("flyThroughDescriptionReadOnly")
-                      : t("flyThroughDescriptionDraw")}
+                      ? t("controls.flyThrough.descriptions.readOnly")
+                      : t("controls.flyThrough.descriptions.draw")}
                 </p>
               </div>
               <Play className="size-4" />
             </button>
             <ToggleRow
-              title={t("gizmoLabel")}
-              description={t("gizmoDescription")}
+              title={t("controls.gizmo.label")}
+              description={t("controls.gizmo.description")}
               enabled={mobileGizmoEnabled}
               onClick={() => onSetMobileGizmoEnabled(!mobileGizmoEnabled)}
             />
@@ -230,7 +234,7 @@ export function ViewControls({
       {readOnly && showShareActions ? (
         <div>
           <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-            {t("shareSectionLabel")}
+            {t("share.sectionLabel")}
           </p>
           <div className="grid grid-cols-2 gap-2">
             <Link
@@ -239,7 +243,7 @@ export function ViewControls({
             >
               <ArrowRight className="size-4" />
               <span className="text-[11px] leading-none font-medium">
-                {t("editableCopyLabel")}
+                {t("share.editableCopy")}
               </span>
             </Link>
             <button
@@ -248,7 +252,7 @@ export function ViewControls({
             >
               <Share2 className="size-4" />
               <span className="text-[11px] leading-none font-medium">
-                {t("shareButtonLabel")}
+                {t("share.shareButton")}
               </span>
             </button>
           </div>

--- a/src/components/editor/viewer/MobilePanels.tsx
+++ b/src/components/editor/viewer/MobilePanels.tsx
@@ -75,7 +75,7 @@ export default function MobilePanels({
             )}
           >
             <Scan className="size-3.5" />
-            <span>{embedMode ? t("view") : t("preview")}</span>
+            <span>{embedMode ? t("nav.view") : t("nav.preview")}</span>
           </button>
           {!embedMode ? (
             <button
@@ -83,7 +83,7 @@ export default function MobilePanels({
               className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-lg px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
             >
               <Share2 className="size-3.5" />
-              <span>{t("share")}</span>
+              <span>{t("nav.share")}</span>
             </button>
           ) : null}
           {!embedMode ? (
@@ -92,7 +92,7 @@ export default function MobilePanels({
               className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-lg px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
             >
               <ArrowRight className="size-3.5" />
-              <span>{t("editCopy")}</span>
+              <span>{t("nav.editCopy")}</span>
             </Link>
           ) : null}
         </div>
@@ -101,8 +101,8 @@ export default function MobilePanels({
       <MobileDrawer
         open={readOnlyMenuOpen}
         onOpenChange={onSetReadOnlyMenuOpen}
-        title={t("viewTitle")}
-        subtitle={t("viewSubtitle")}
+        title={t("view.title")}
+        subtitle={t("view.subtitle")}
         bodyClassName="space-y-5 pt-3 pb-4"
       >
         <ViewControls


### PR DESCRIPTION
## Summary

- normalize larger editor i18n groups for starter overlay, starter flow, and mobile panels
- group mobile view controls, quick actions, path builder, multi-select, read-only share actions, drawer titles, and shortcuts by purpose
- update editor/mobile/viewer components to use the nested key paths without changing EN/NL wording

## Issue

Part of #517.

## Validation

- `npm run i18n:check`
- `npm run i18n:scan-hardcoded`
- `npm run type`
- `npm run lint`