### PR TITLE
chore: Normalize inspector i18n keys

### DIFF
--- a/lang/en/inspector.json
+++ b/lang/en/inspector.json
@@ -121,63 +121,93 @@
     "noItemsMatchFilter": "No items match this filter."
   },
   "layout": {
-    "mapReferenceTitle": "Map reference",
-    "opacityLabel": "Opacity",
-    "mapRotationLabel": "Rotation",
-    "removeMapTitle": "Remove map reference",
-    "editMapTitle": "Edit map reference",
-    "addMapTitle": "Add map reference",
-    "editLabel": "Edit",
-    "addMapLabel": "Add map",
-    "showMapTitle": "Show map reference",
-    "hideMapTitle": "Hide map reference",
-    "showLabel": "Show",
-    "routeNumberingTitle": "Route numbering",
-    "inventoryTitle": "Inventory",
-    "fieldTitle": "Field",
-    "unitsLabel": "Units",
-    "renderScaleLabel": "Render scale",
-    "renderScaleTooltip": "Internal canvas density in pixels per meter",
-    "titlePlaceholder": "Untitled Track",
-    "projectSubtitle": "Tune the project title, field setup, and available obstacle stock.",
-    "layoutTitle": "Current layout",
-    "layoutSubtitle": "Review placed items, route numbering, and buildability for the current layout.",
-    "emptyLayoutTitle": "No items placed yet",
-    "emptyLayoutDescription": "Add a few objects on the canvas to review the layout and compare it against your inventory.",
-    "statusBuildable": "Buildable",
-    "statusShort": "Short",
-    "missingLabel": "Missing",
-    "typesLabel": "Types",
-    "inventoryDescription": "TrackDraw compares the current layout against the obstacle stock saved in this project.",
-    "needCountSuffix": "need {count}",
-    "stockOk": "ok",
-    "pxPerMeterAriaLabel": "pixels per meter, internal canvas scale",
-    "itemsCountMeta": "{count} items",
-    "buildableMeta": "buildable",
-    "shortItemsMeta": "{count, plural, one {short 1 item} other {short {count} items}}",
-    "stockCoveredMeta": "stock covered",
-    "typesShortMeta": "{count, plural, one {1 type short} other {{count} types short}}",
-    "numberedMeta": "{count} numbered",
-    "numberingIdleMeta": "numbering idle",
-    "numberingNeedsReviewMeta": "numbering needs review"
+    "mapReference": {
+      "title": "Map reference",
+      "fields": {
+        "opacity": "Opacity",
+        "rotation": "Rotation"
+      },
+      "actions": {
+        "removeTitle": "Remove map reference",
+        "editTitle": "Edit map reference",
+        "addTitle": "Add map reference",
+        "edit": "Edit",
+        "add": "Add map",
+        "showTitle": "Show map reference",
+        "hideTitle": "Hide map reference",
+        "show": "Show"
+      }
+    },
+    "sections": {
+      "routeNumbering": "Route numbering",
+      "inventory": "Inventory",
+      "field": "Field"
+    },
+    "field": {
+      "unitsLabel": "Units",
+      "renderScaleLabel": "Render scale",
+      "renderScaleTooltip": "Internal canvas density in pixels per meter",
+      "pxPerMeterAriaLabel": "pixels per meter, internal canvas scale"
+    },
+    "project": {
+      "titlePlaceholder": "Untitled Track",
+      "subtitle": "Tune the project title, field setup, and available obstacle stock."
+    },
+    "overview": {
+      "title": "Current layout",
+      "subtitle": "Review placed items, route numbering, and buildability for the current layout.",
+      "emptyTitle": "No items placed yet",
+      "emptyDescription": "Add a few objects on the canvas to review the layout and compare it against your inventory."
+    },
+    "inventory": {
+      "status": {
+        "buildable": "Buildable",
+        "short": "Short"
+      },
+      "labels": {
+        "missing": "Missing",
+        "types": "Types"
+      },
+      "description": "TrackDraw compares the current layout against the obstacle stock saved in this project.",
+      "needCountSuffix": "need {count}",
+      "stockOk": "ok"
+    },
+    "meta": {
+      "itemsCount": "{count} items",
+      "buildable": "buildable",
+      "shortItems": "{count, plural, one {short 1 item} other {short {count} items}}",
+      "stockCovered": "stock covered",
+      "typesShort": "{count, plural, one {1 type short} other {{count} types short}}",
+      "numbered": "{count} numbered",
+      "numberingIdle": "numbering idle",
+      "numberingNeedsReview": "numbering needs review"
+    }
   },
   "routeNumbering": {
-    "numberedLabel": "Numbered",
-    "issuesLabel": "Issues",
-    "statusReady": "Ready",
-    "statusPartial": "Needs review",
-    "statusNoRouteMatches": "No matches",
-    "statusMissingRoute": "Missing route",
-    "statusNoNumberedObstacles": "No route obstacles",
-    "statusEmpty": "Empty",
-    "messageReady": "{count, plural, one {1 route obstacle numbered.} other {{count} route obstacles numbered.}}",
-    "messagePartial": "{mapped} of {total} route obstacles are numbered.",
-    "messageNoRouteMatches": "{count, plural, one {1 route obstacle found, but none sit close enough to the race line.} other {{count} route obstacles found, but none sit close enough to the race line.}}",
-    "messageMissingRoute": "{count, plural, one {1 route obstacle needs a race line before numbering can be derived.} other {{count} route obstacles need a race line before numbering can be derived.}}",
-    "messageNoNumberedObstacles": "Gates, ladders, and dive gates will appear in route numbering.",
-    "messageEmpty": "Add route obstacles and a race line to derive numbering.",
-    "offRoutePrefix": "Off route: {names}",
-    "moreSuffix": " +{count} more"
+    "status": {
+      "ready": "Ready",
+      "partial": "Needs review",
+      "noRouteMatches": "No matches",
+      "missingRoute": "Missing route",
+      "noNumberedObstacles": "No route obstacles",
+      "empty": "Empty"
+    },
+    "messages": {
+      "ready": "{count, plural, one {1 route obstacle numbered.} other {{count} route obstacles numbered.}}",
+      "partial": "{mapped} of {total} route obstacles are numbered.",
+      "noRouteMatches": "{count, plural, one {1 route obstacle found, but none sit close enough to the race line.} other {{count} route obstacles found, but none sit close enough to the race line.}}",
+      "missingRoute": "{count, plural, one {1 route obstacle needs a race line before numbering can be derived.} other {{count} route obstacles need a race line before numbering can be derived.}}",
+      "noNumberedObstacles": "Gates, ladders, and dive gates will appear in route numbering.",
+      "empty": "Add route obstacles and a race line to derive numbering."
+    },
+    "issues": {
+      "offRoutePrefix": "Off route: {names}",
+      "moreSuffix": " +{count} more"
+    },
+    "meta": {
+      "numbered": "Numbered",
+      "issues": "Issues"
+    }
   },
   "elevationChart": {
     "noRouteSelected": "No race line selected",

--- a/lang/nl/inspector.json
+++ b/lang/nl/inspector.json
@@ -121,63 +121,93 @@
     "noItemsMatchFilter": "Geen items komen overeen met dit filter."
   },
   "layout": {
-    "mapReferenceTitle": "Kaartverwijzing",
-    "opacityLabel": "Transparantie",
-    "mapRotationLabel": "Rotatie",
-    "removeMapTitle": "Kaartverwijzing verwijderen",
-    "editMapTitle": "Kaartverwijzing bewerken",
-    "addMapTitle": "Kaartverwijzing toevoegen",
-    "editLabel": "Bewerken",
-    "addMapLabel": "Kaart toevoegen",
-    "showMapTitle": "Kaartverwijzing weergeven",
-    "hideMapTitle": "Kaartverwijzing verbergen",
-    "showLabel": "Weergeven",
-    "routeNumberingTitle": "Routenummering",
-    "inventoryTitle": "Inventaris",
-    "fieldTitle": "Veld",
-    "unitsLabel": "Eenheden",
-    "renderScaleLabel": "Renderschaal",
-    "renderScaleTooltip": "Interne canvasdichtheid in pixels per meter",
-    "titlePlaceholder": "Naamloze track",
-    "projectSubtitle": "Stel de projecttitel, veldconfiguratie en beschikbaar obstakels in.",
-    "layoutTitle": "Huidige indeling",
-    "layoutSubtitle": "Bekijk geplaatste items, routenummering en bouweigenschappen van de huidige indeling.",
-    "emptyLayoutTitle": "Nog geen items geplaatst",
-    "emptyLayoutDescription": "Voeg een paar objecten toe op het canvas om de indeling te bekijken en te vergelijken met je inventaris.",
-    "statusBuildable": "Bouwbaar",
-    "statusShort": "Tekort",
-    "missingLabel": "Ontbreekt",
-    "typesLabel": "Types",
-    "inventoryDescription": "TrackDraw vergelijkt de huidige indeling met de obstakelvoorraad die in dit project is opgeslagen.",
-    "needCountSuffix": "nodig {count}",
-    "stockOk": "ok",
-    "pxPerMeterAriaLabel": "pixels per meter, interne canvasschaal",
-    "itemsCountMeta": "{count} items",
-    "buildableMeta": "bouwbaar",
-    "shortItemsMeta": "{count, plural, one {tekort 1 item} other {tekort {count} items}}",
-    "stockCoveredMeta": "voorraad gedekt",
-    "typesShortMeta": "{count, plural, one {1 type tekort} other {{count} types tekort}}",
-    "numberedMeta": "{count} genummerd",
-    "numberingIdleMeta": "nummering inactief",
-    "numberingNeedsReviewMeta": "nummering vereist controle"
+    "mapReference": {
+      "title": "Kaartverwijzing",
+      "fields": {
+        "opacity": "Transparantie",
+        "rotation": "Rotatie"
+      },
+      "actions": {
+        "removeTitle": "Kaartverwijzing verwijderen",
+        "editTitle": "Kaartverwijzing bewerken",
+        "addTitle": "Kaartverwijzing toevoegen",
+        "edit": "Bewerken",
+        "add": "Kaart toevoegen",
+        "showTitle": "Kaartverwijzing weergeven",
+        "hideTitle": "Kaartverwijzing verbergen",
+        "show": "Weergeven"
+      }
+    },
+    "sections": {
+      "routeNumbering": "Routenummering",
+      "inventory": "Inventaris",
+      "field": "Veld"
+    },
+    "field": {
+      "unitsLabel": "Eenheden",
+      "renderScaleLabel": "Renderschaal",
+      "renderScaleTooltip": "Interne canvasdichtheid in pixels per meter",
+      "pxPerMeterAriaLabel": "pixels per meter, interne canvasschaal"
+    },
+    "project": {
+      "titlePlaceholder": "Naamloze track",
+      "subtitle": "Stel de projecttitel, veldconfiguratie en beschikbaar obstakels in."
+    },
+    "overview": {
+      "title": "Huidige indeling",
+      "subtitle": "Bekijk geplaatste items, routenummering en bouweigenschappen van de huidige indeling.",
+      "emptyTitle": "Nog geen items geplaatst",
+      "emptyDescription": "Voeg een paar objecten toe op het canvas om de indeling te bekijken en te vergelijken met je inventaris."
+    },
+    "inventory": {
+      "status": {
+        "buildable": "Bouwbaar",
+        "short": "Tekort"
+      },
+      "labels": {
+        "missing": "Ontbreekt",
+        "types": "Types"
+      },
+      "description": "TrackDraw vergelijkt de huidige indeling met de obstakelvoorraad die in dit project is opgeslagen.",
+      "needCountSuffix": "nodig {count}",
+      "stockOk": "ok"
+    },
+    "meta": {
+      "itemsCount": "{count} items",
+      "buildable": "bouwbaar",
+      "shortItems": "{count, plural, one {tekort 1 item} other {tekort {count} items}}",
+      "stockCovered": "voorraad gedekt",
+      "typesShort": "{count, plural, one {1 type tekort} other {{count} types tekort}}",
+      "numbered": "{count} genummerd",
+      "numberingIdle": "nummering inactief",
+      "numberingNeedsReview": "nummering vereist controle"
+    }
   },
   "routeNumbering": {
-    "numberedLabel": "Genummerd",
-    "issuesLabel": "Problemen",
-    "statusReady": "Gereed",
-    "statusPartial": "Controle nodig",
-    "statusNoRouteMatches": "Geen overeenkomsten",
-    "statusMissingRoute": "Route ontbreekt",
-    "statusNoNumberedObstacles": "Geen route-obstakels",
-    "statusEmpty": "Leeg",
-    "messageReady": "{count, plural, one {1 route-obstakel genummerd.} other {{count} route-obstakels genummerd.}}",
-    "messagePartial": "{mapped} van {total} route-obstakels zijn genummerd.",
-    "messageNoRouteMatches": "{count, plural, one {1 route-obstakel gevonden, maar geen ligt dicht genoeg bij de race line.} other {{count} route-obstakels gevonden, maar geen ligt dicht genoeg bij de race line.}}",
-    "messageMissingRoute": "{count, plural, one {1 route-obstakel heeft een race line nodig voordat nummering kan worden afgeleid.} other {{count} route-obstakels hebben een race line nodig voordat nummering kan worden afgeleid.}}",
-    "messageNoNumberedObstacles": "Gates, ladders en dive gates verschijnen in de routenummering.",
-    "messageEmpty": "Voeg route-obstakels en een race line toe om nummering af te leiden.",
-    "offRoutePrefix": "Niet op route: {names}",
-    "moreSuffix": " +{count} meer"
+    "status": {
+      "ready": "Gereed",
+      "partial": "Controle nodig",
+      "noRouteMatches": "Geen overeenkomsten",
+      "missingRoute": "Route ontbreekt",
+      "noNumberedObstacles": "Geen route-obstakels",
+      "empty": "Leeg"
+    },
+    "messages": {
+      "ready": "{count, plural, one {1 route-obstakel genummerd.} other {{count} route-obstakels genummerd.}}",
+      "partial": "{mapped} van {total} route-obstakels zijn genummerd.",
+      "noRouteMatches": "{count, plural, one {1 route-obstakel gevonden, maar geen ligt dicht genoeg bij de race line.} other {{count} route-obstakels gevonden, maar geen ligt dicht genoeg bij de race line.}}",
+      "missingRoute": "{count, plural, one {1 route-obstakel heeft een race line nodig voordat nummering kan worden afgeleid.} other {{count} route-obstakels hebben een race line nodig voordat nummering kan worden afgeleid.}}",
+      "noNumberedObstacles": "Gates, ladders en dive gates verschijnen in de routenummering.",
+      "empty": "Voeg route-obstakels en een race line toe om nummering af te leiden."
+    },
+    "issues": {
+      "offRoutePrefix": "Niet op route: {names}",
+      "moreSuffix": " +{count} meer"
+    },
+    "meta": {
+      "numbered": "Genummerd",
+      "issues": "Problemen"
+    }
   },
   "elevationChart": {
     "noRouteSelected": "Geen race line geselecteerd",

--- a/lang/nl/inspector.json
+++ b/lang/nl/inspector.json
@@ -151,7 +151,7 @@
     },
     "project": {
       "titlePlaceholder": "Naamloze track",
-      "subtitle": "Stel de projecttitel, veldconfiguratie en beschikbaar obstakels in."
+      "subtitle": "Stel de projecttitel, veldconfiguratie en beschikbare obstakels in."
     },
     "overview": {
       "title": "Huidige indeling",

--- a/src/components/inspector/views/project-layout.tsx
+++ b/src/components/inspector/views/project-layout.tsx
@@ -70,11 +70,11 @@ function MapReferenceSection({
     "inline-flex h-11 items-center justify-center gap-1.5 rounded-lg border border-brand-primary/30 bg-brand-primary/8 px-2.5 text-xs font-medium text-brand-primary transition-colors hover:bg-brand-primary/12 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8 lg:text-[11px]";
 
   return (
-    <Section title={t("layout.mapReferenceTitle")}>
+    <Section title={t("layout.mapReference.title")}>
       <div className="space-y-3">
         {reference ? (
           <>
-            <Row label={t("layout.opacityLabel")}>
+            <Row label={t("layout.mapReference.fields.opacity")}>
               <div className="flex min-w-0 items-center gap-2">
                 <input
                   type="range"
@@ -92,7 +92,7 @@ function MapReferenceSection({
                 </span>
               </div>
             </Row>
-            <Row label={t("layout.mapRotationLabel")}>
+            <Row label={t("layout.mapReference.fields.rotation")}>
               <Num
                 value={reference.rotationDeg}
                 onChange={setMapReferenceRotation}
@@ -113,17 +113,23 @@ function MapReferenceSection({
           <button
             type="button"
             title={
-              reference ? t("layout.editMapTitle") : t("layout.addMapTitle")
+              reference
+                ? t("layout.mapReference.actions.editTitle")
+                : t("layout.mapReference.actions.addTitle")
             }
             aria-label={
-              reference ? t("layout.editMapTitle") : t("layout.addMapTitle")
+              reference
+                ? t("layout.mapReference.actions.editTitle")
+                : t("layout.mapReference.actions.addTitle")
             }
             className={actionBtnPrimaryClass}
             onClick={() => setDialogOpen(true)}
           >
             <MapPinned className="size-4 lg:size-3" />
             <span>
-              {reference ? t("layout.editLabel") : t("layout.addMapLabel")}
+              {reference
+                ? t("layout.mapReference.actions.edit")
+                : t("layout.mapReference.actions.add")}
             </span>
           </button>
           {reference ? (
@@ -132,13 +138,13 @@ function MapReferenceSection({
                 type="button"
                 title={
                   reference.visible === false
-                    ? t("layout.showMapTitle")
-                    : t("layout.hideMapTitle")
+                    ? t("layout.mapReference.actions.showTitle")
+                    : t("layout.mapReference.actions.hideTitle")
                 }
                 aria-label={
                   reference.visible === false
-                    ? t("layout.showMapTitle")
-                    : t("layout.hideMapTitle")
+                    ? t("layout.mapReference.actions.showTitle")
+                    : t("layout.mapReference.actions.hideTitle")
                 }
                 className={actionBtnClass}
                 onClick={() =>
@@ -152,14 +158,14 @@ function MapReferenceSection({
                 )}
                 <span>
                   {reference.visible === false
-                    ? t("layout.showLabel")
+                    ? t("layout.mapReference.actions.show")
                     : tCommon("actions.hide")}
                 </span>
               </button>
               <button
                 type="button"
-                title={t("layout.removeMapTitle")}
-                aria-label={t("layout.removeMapTitle")}
+                title={t("layout.mapReference.actions.removeTitle")}
+                aria-label={t("layout.mapReference.actions.removeTitle")}
                 className={`${actionBtnClass} border-red-500/20 bg-red-500/6 text-red-500 hover:bg-red-500/12`}
                 onClick={clearMapReference}
               >
@@ -211,40 +217,40 @@ function RouteNumberingOverview({
     report.status === "no-numbered-obstacles";
   const statusLabel =
     report.status === "ready"
-      ? t("routeNumbering.statusReady")
+      ? t("routeNumbering.status.ready")
       : report.status === "partial"
-        ? t("routeNumbering.statusPartial")
+        ? t("routeNumbering.status.partial")
         : report.status === "no-route-matches"
-          ? t("routeNumbering.statusNoRouteMatches")
+          ? t("routeNumbering.status.noRouteMatches")
           : report.status === "missing-route"
-            ? t("routeNumbering.statusMissingRoute")
+            ? t("routeNumbering.status.missingRoute")
             : report.status === "no-numbered-obstacles"
-              ? t("routeNumbering.statusNoNumberedObstacles")
-              : t("routeNumbering.statusEmpty");
+              ? t("routeNumbering.status.noNumberedObstacles")
+              : t("routeNumbering.status.empty");
   const message =
     report.status === "ready"
-      ? t("routeNumbering.messageReady", {
+      ? t("routeNumbering.messages.ready", {
           count: report.mappedObstacleCount,
         })
       : report.status === "partial"
-        ? t("routeNumbering.messagePartial", {
+        ? t("routeNumbering.messages.partial", {
             mapped: report.mappedObstacleCount,
             total: report.totalNumberedObstacleCount,
           })
         : report.status === "no-route-matches"
-          ? t("routeNumbering.messageNoRouteMatches", {
+          ? t("routeNumbering.messages.noRouteMatches", {
               count: report.totalNumberedObstacleCount,
             })
           : report.status === "missing-route"
-            ? t("routeNumbering.messageMissingRoute", {
+            ? t("routeNumbering.messages.missingRoute", {
                 count: report.totalNumberedObstacleCount,
               })
             : report.status === "no-numbered-obstacles"
-              ? t("routeNumbering.messageNoNumberedObstacles")
-              : t("routeNumbering.messageEmpty");
+              ? t("routeNumbering.messages.noNumberedObstacles")
+              : t("routeNumbering.messages.empty");
 
   return (
-    <Section title={t("layout.routeNumberingTitle")}>
+    <Section title={t("layout.sections.routeNumbering")}>
       <div className="space-y-2">
         <div className="grid grid-cols-3 gap-2">
           <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
@@ -257,7 +263,7 @@ function RouteNumberingOverview({
           </div>
           <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
             <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
-              {t("routeNumbering.numberedLabel")}
+              {t("routeNumbering.meta.numbered")}
             </p>
             <p className="text-foreground text-[12px] font-semibold">
               {report.mappedObstacleCount}/{report.totalNumberedObstacleCount}
@@ -265,7 +271,7 @@ function RouteNumberingOverview({
           </div>
           <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
             <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
-              {t("routeNumbering.issuesLabel")}
+              {t("routeNumbering.meta.issues")}
             </p>
             <p className="text-foreground text-[12px] font-semibold">
               {report.issueCount}
@@ -282,11 +288,13 @@ function RouteNumberingOverview({
           <p className="text-[11px] leading-relaxed">{message}</p>
           {issueNames.length > 0 ? (
             <p className="mt-1 text-[10px] leading-relaxed opacity-80">
-              {t("routeNumbering.offRoutePrefix", {
+              {t("routeNumbering.issues.offRoutePrefix", {
                 names: issueNames.join(", "),
               })}
               {extraIssueCount > 0
-                ? t("routeNumbering.moreSuffix", { count: extraIssueCount })
+                ? t("routeNumbering.issues.moreSuffix", {
+                    count: extraIssueCount,
+                  })
                 : ""}
             </p>
           ) : null}
@@ -363,7 +371,7 @@ export function ProjectLayoutInspectorView({
   };
 
   const inventoryContent = (
-    <Section title={t("layout.inventoryTitle")}>
+    <Section title={t("layout.sections.inventory")}>
       <div className="space-y-3">
         <div className="grid grid-cols-3 gap-2">
           <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
@@ -372,13 +380,13 @@ export function ProjectLayoutInspectorView({
             </p>
             <p className="text-foreground text-[12px] font-semibold">
               {totalMissing === 0
-                ? t("layout.statusBuildable")
-                : t("layout.statusShort")}
+                ? t("layout.inventory.status.buildable")
+                : t("layout.inventory.status.short")}
             </p>
           </div>
           <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
             <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
-              {t("layout.missingLabel")}
+              {t("layout.inventory.labels.missing")}
             </p>
             <p className="text-foreground text-[12px] font-semibold">
               {totalMissing}
@@ -386,7 +394,7 @@ export function ProjectLayoutInspectorView({
           </div>
           <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
             <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
-              {t("layout.typesLabel")}
+              {t("layout.inventory.labels.types")}
             </p>
             <p className="text-foreground text-[12px] font-semibold">
               {kindsMissing}
@@ -394,7 +402,7 @@ export function ProjectLayoutInspectorView({
           </div>
         </div>
         <p className="text-muted-foreground/70 text-[11px] leading-relaxed">
-          {t("layout.inventoryDescription")}
+          {t("layout.inventory.description")}
         </p>
         <div className="space-y-1">
           {inventoryKinds.map((kind) => {
@@ -414,7 +422,7 @@ export function ProjectLayoutInspectorView({
                     />
                   </div>
                   <span className="text-muted-foreground/65 shrink-0 text-[10px] font-medium tracking-[0.08em] uppercase">
-                    {t("layout.needCountSuffix", {
+                    {t("layout.inventory.needCountSuffix", {
                       count: comparison?.required ?? 0,
                     })}
                   </span>
@@ -425,7 +433,9 @@ export function ProjectLayoutInspectorView({
                         : "shrink-0 rounded-md border border-emerald-500/20 bg-emerald-500/8 px-2 py-1 font-mono text-[10px] font-medium text-emerald-500"
                     }
                   >
-                    {missing > 0 ? `-${missing}` : t("layout.stockOk")}
+                    {missing > 0
+                      ? `-${missing}`
+                      : t("layout.inventory.stockOk")}
                   </span>
                 </div>
               </Row>
@@ -439,10 +449,10 @@ export function ProjectLayoutInspectorView({
   const projectContent = (
     <>
       <InspectorLead
-        title={design.title.trim() || t("layout.titlePlaceholder")}
-        subtitle={t("layout.projectSubtitle")}
+        title={design.title.trim() || t("layout.project.titlePlaceholder")}
+        subtitle={t("layout.project.subtitle")}
         meta={[
-          t("layout.itemsCountMeta", { count: shapes.length }),
+          t("layout.meta.itemsCount", { count: shapes.length }),
           formatFieldSize(design.field.width, design.field.height, unitSystem),
           `grid ${formatMeasurement(design.field.gridStep, unitSystem, {
             precision: 1,
@@ -463,12 +473,12 @@ export function ProjectLayoutInspectorView({
             }
           }}
           onChange={(event) => updateDesignMeta({ title: event.target.value })}
-          placeholder={t("layout.titlePlaceholder")}
+          placeholder={t("layout.project.titlePlaceholder")}
           className="bg-muted/40 border-border/40 focus-visible:border-border/80 focus-visible:ring-ring/20 h-8 rounded-md px-2.5 text-sm shadow-none focus-visible:ring-1 lg:h-7 lg:px-2 lg:text-[11px]"
         />
       </div>
-      <Section title={t("layout.fieldTitle")}>
-        <Row label={t("layout.unitsLabel")}>
+      <Section title={t("layout.sections.field")}>
+        <Row label={t("layout.field.unitsLabel")}>
           <MeasurementUnitToggle />
         </Row>
         <Row label={t("dimensions.widthLabel", { unit: fieldUnitLabel })}>
@@ -495,10 +505,10 @@ export function ProjectLayoutInspectorView({
             minMeters={0.5}
           />
         </Row>
-        <Row label={t("layout.renderScaleLabel")}>
+        <Row label={t("layout.field.renderScaleLabel")}>
           <div
             className="flex min-w-0 items-center gap-2"
-            title={t("layout.renderScaleTooltip")}
+            title={t("layout.field.renderScaleTooltip")}
           >
             <div className="min-w-0 flex-1">
               <Num
@@ -510,7 +520,7 @@ export function ProjectLayoutInspectorView({
             </div>
             <span
               className="text-muted-foreground/65 shrink-0 text-[10px] font-medium tracking-[0.08em] uppercase"
-              aria-label={t("layout.pxPerMeterAriaLabel")}
+              aria-label={t("layout.field.pxPerMeterAriaLabel")}
             >
               px/m
             </span>
@@ -524,24 +534,24 @@ export function ProjectLayoutInspectorView({
   const layoutContent = (
     <>
       <InspectorLead
-        title={t("layout.layoutTitle")}
-        subtitle={t("layout.layoutSubtitle")}
+        title={t("layout.overview.title")}
+        subtitle={t("layout.overview.subtitle")}
         meta={[
-          t("layout.itemsCountMeta", { count: shapes.length }),
+          t("layout.meta.itemsCount", { count: shapes.length }),
           totalMissing === 0
-            ? t("layout.buildableMeta")
-            : t("layout.shortItemsMeta", { count: totalMissing }),
+            ? t("layout.meta.buildable")
+            : t("layout.meta.shortItems", { count: totalMissing }),
           kindsMissing > 0
-            ? t("layout.typesShortMeta", { count: kindsMissing })
-            : t("layout.stockCoveredMeta"),
+            ? t("layout.meta.typesShort", { count: kindsMissing })
+            : t("layout.meta.stockCovered"),
           obstacleNumberingReport.status === "ready"
-            ? t("layout.numberedMeta", {
+            ? t("layout.meta.numbered", {
                 count: obstacleNumberingReport.mappedObstacleCount,
               })
             : obstacleNumberingReport.status === "no-numbered-obstacles" ||
                 obstacleNumberingReport.status === "empty"
-              ? t("layout.numberingIdleMeta")
-              : t("layout.numberingNeedsReviewMeta"),
+              ? t("layout.meta.numberingIdle")
+              : t("layout.meta.numberingNeedsReview"),
         ]}
       />
       <div className="space-y-4">
@@ -566,10 +576,10 @@ export function ProjectLayoutInspectorView({
         ) : (
           <div className="border-border/40 rounded-lg border border-dashed px-3 py-4 text-center">
             <p className="text-foreground/75 text-[11px] font-medium">
-              {t("layout.emptyLayoutTitle")}
+              {t("layout.overview.emptyTitle")}
             </p>
             <p className="text-muted-foreground/70 mt-1 text-[11px] leading-relaxed">
-              {t("layout.emptyLayoutDescription")}
+              {t("layout.overview.emptyDescription")}
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary

- normalize larger inspector i18n groups for project/layout copy and route numbering
- group map reference, field, inventory, overview, metadata, route numbering statuses, messages, meta labels, and issue copy by purpose
- update the project/layout inspector to use the nested key paths without changing EN/NL wording

## Issue

Part of #517.

## Validation

- `npm run i18n:check`
- `npm run i18n:scan-hardcoded`
- `npm run type`
- `npm run lint`