### PR TITLE
chore: Normalize remaining i18n keys

### DIFF
--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -33,25 +33,43 @@
   },
   "overview": {
     "kpi": {
-      "totalUsers": "Total users",
-      "totalUsersSub": "+{count} this month",
-      "vsPrevMonth": "vs prev month",
-      "activeProjects": "Active projects",
-      "activeProjectsSub": "non-archived",
-      "activeShares": "Active shares",
-      "activeSharesSub": "live share links",
-      "gallery": "Gallery",
-      "gallerySub": "{featured} featured · {hidden} hidden"
+      "totalUsers": {
+        "label": "Total users",
+        "sub": "+{count} this month"
+      },
+      "activeProjects": {
+        "label": "Active projects",
+        "sub": "non-archived"
+      },
+      "activeShares": {
+        "label": "Active shares",
+        "sub": "live share links"
+      },
+      "gallery": {
+        "label": "Gallery",
+        "sub": "{featured} featured · {hidden} hidden"
+      },
+      "comparison": {
+        "vsPrevMonth": "vs prev month"
+      }
     },
-    "recentActivity": "Recent activity",
-    "recentSignups": "Recent sign-ups",
-    "galleryCardTitle": "Gallery",
-    "viewAll": "View all",
-    "noRecentActivity": "No recent activity",
-    "noRecentSignups": "No recent sign-ups",
-    "noGalleryEntries": "No gallery entries yet",
-    "untitled": "Untitled",
-    "unknownOwner": "Unknown",
+    "sections": {
+      "recentActivity": "Recent activity",
+      "recentSignups": "Recent sign-ups",
+      "gallery": "Gallery"
+    },
+    "actions": {
+      "viewAll": "View all"
+    },
+    "empty": {
+      "recentActivity": "No recent activity",
+      "recentSignups": "No recent sign-ups",
+      "galleryEntries": "No gallery entries yet"
+    },
+    "fallback": {
+      "untitled": "Untitled",
+      "unknownOwner": "Unknown"
+    },
     "galleryState": {
       "featured": "Featured",
       "hidden": "Hidden",
@@ -75,27 +93,47 @@
     }
   },
   "overviewCards": {
-    "galleryEntries": "Gallery entries",
-    "galleryEntriesHelper": "All dashboard-managed entries",
-    "featured": "Featured",
-    "featuredHelper": "Pinned in the featured section",
-    "hidden": "Hidden",
-    "hiddenHelper": "Removed from public discovery",
-    "totalAccounts": "Total accounts",
-    "totalAccountsHelper": "Tracked user records"
+    "cards": {
+      "galleryEntries": {
+        "label": "Gallery entries",
+        "helper": "All dashboard-managed entries"
+      },
+      "featured": {
+        "label": "Featured",
+        "helper": "Pinned in the featured section"
+      },
+      "hidden": {
+        "label": "Hidden",
+        "helper": "Removed from public discovery"
+      },
+      "totalAccounts": {
+        "label": "Total accounts",
+        "helper": "Tracked user records"
+      }
+    }
   },
   "metrics": {
     "kpi": {
-      "totalUsers": "Total users",
-      "totalUsersSub": "+{count} this month",
-      "activeUsers30d": "Active users (30d)",
-      "activeUsers30dSub": "{pct}% of total",
-      "projects": "Projects",
-      "projectsSub": "non-archived · {archived} archived",
-      "activeShares": "Active shares",
-      "activeSharesSub": "{revoked} revoked",
-      "activeApiKeys": "Active API keys",
-      "activeApiKeysSub": "{total} total"
+      "totalUsers": {
+        "label": "Total users",
+        "sub": "+{count} this month"
+      },
+      "activeUsers30d": {
+        "label": "Active users (30d)",
+        "sub": "{pct}% of total"
+      },
+      "projects": {
+        "label": "Projects",
+        "sub": "non-archived · {archived} archived"
+      },
+      "activeShares": {
+        "label": "Active shares",
+        "sub": "{revoked} revoked"
+      },
+      "activeApiKeys": {
+        "label": "Active API keys",
+        "sub": "{total} total"
+      }
     },
     "userPopulation": {
       "title": "User population",
@@ -160,8 +198,10 @@
     }
   },
   "users": {
-    "searchPlaceholder": "Search by name or email...",
-    "role": "Role",
+    "filters": {
+      "searchPlaceholder": "Search by name or email...",
+      "role": "Role"
+    },
     "table": {
       "user": "User",
       "projects": "Projects",
@@ -169,42 +209,64 @@
       "joined": "Joined",
       "lastLogin": "Last login"
     },
-    "you": "(you)",
-    "unnamedUser": "Unnamed user",
-    "emptyMessage": "No users found.",
-    "showing": "Showing {filtered} of {total} accounts.",
-    "loadFailed": "Failed to load user context.",
-    "copySuccess": "{label} copied.",
-    "copyFailed": "Could not copy {label}.",
-    "updateFailed": "Could not update the selected role.",
-    "updateSuccess": "Updated {name} to {role}.",
+    "selfBadge": "(you)",
+    "fallback": {
+      "unnamedUser": "Unnamed user"
+    },
+    "empty": {
+      "default": "No users found."
+    },
+    "status": {
+      "showing": "Showing {filtered} of {total} accounts."
+    },
+    "messages": {
+      "loadFailed": "Failed to load user context.",
+      "copySuccess": "{label} copied.",
+      "copyFailed": "Could not copy {label}.",
+      "updateFailed": "Could not update the selected role.",
+      "updateSuccess": "Updated {name} to {role}."
+    },
     "panel": {
-      "loading": "Loading…",
+      "status": {
+        "loading": "Loading…"
+      },
       "stats": {
         "projects": "Projects",
         "shares": "Shares",
         "gallery": "Gallery",
         "apiKeys": "API keys"
       },
-      "accountSection": "Account",
-      "memberSince": "Member since",
-      "lastLogin": "Last login",
-      "role": "Role",
-      "userId": "User ID",
-      "copyUserId": "Copy user ID",
-      "changeRole": "Change role",
-      "cannotChangeOwnRole": "Cannot change own role",
-      "save": "Save",
-      "recentActivitySection": "Recent activity",
-      "noAuditEvents": "No audit events recorded.",
-      "actor": "Actor",
-      "target": "Target",
-      "viewFullAuditTrail": "View full audit trail"
+      "sections": {
+        "account": "Account",
+        "recentActivity": "Recent activity"
+      },
+      "fields": {
+        "memberSince": "Member since",
+        "lastLogin": "Last login",
+        "role": "Role",
+        "userId": "User ID"
+      },
+      "actions": {
+        "copyUserId": "Copy user ID",
+        "changeRole": "Change role",
+        "save": "Save",
+        "viewFullAuditTrail": "View full audit trail"
+      },
+      "messages": {
+        "cannotChangeOwnRole": "Cannot change own role",
+        "noAuditEvents": "No audit events recorded."
+      },
+      "relation": {
+        "actor": "Actor",
+        "target": "Target"
+      }
     }
   },
   "apiKeys": {
-    "searchPlaceholder": "Search key name or owner...",
-    "status": "Status",
+    "filters": {
+      "searchPlaceholder": "Search key name or owner...",
+      "status": "Status"
+    },
     "statusValues": {
       "active": "Active",
       "expired": "Expired",
@@ -218,45 +280,66 @@
       "lastUsed": "Last used",
       "expires": "Expires"
     },
-    "emptyMessage": "No API keys found.",
-    "emptyFilteredMessage": "No API keys match the current filters.",
-    "showing": "Showing {filtered} of {total} API keys.",
-    "off": "Off",
-    "minutesUnit": "{count} min",
-    "hoursUnit": "{count} hr",
+    "empty": {
+      "default": "No API keys found.",
+      "filtered": "No API keys match the current filters."
+    },
+    "status": {
+      "showing": "Showing {filtered} of {total} API keys.",
+      "off": "Off"
+    },
+    "units": {
+      "minutes": "{count} min",
+      "hours": "{count} hr"
+    },
     "panel": {
       "title": "API Key",
-      "selectRow": "Select a key row to inspect its details.",
-      "requests": "Requests",
-      "remaining": "Remaining",
-      "rateLimit": "Rate limit",
-      "keySection": "Key",
-      "status": "Status",
-      "prefix": "Prefix",
-      "permissions": "Permissions",
-      "created": "Created",
-      "expires": "Expires",
-      "lastUsed": "Last used",
-      "ownerSection": "Owner",
-      "name": "Name",
-      "email": "Email",
-      "userId": "User ID"
+      "empty": {
+        "selectRow": "Select a key row to inspect its details."
+      },
+      "stats": {
+        "requests": "Requests",
+        "remaining": "Remaining",
+        "rateLimit": "Rate limit"
+      },
+      "sections": {
+        "key": "Key",
+        "owner": "Owner"
+      },
+      "fields": {
+        "status": "Status",
+        "prefix": "Prefix",
+        "permissions": "Permissions",
+        "created": "Created",
+        "expires": "Expires",
+        "lastUsed": "Last used",
+        "name": "Name",
+        "email": "Email",
+        "userId": "User ID"
+      }
     }
   },
   "audit": {
-    "searchPlaceholder": "Search event, actor, target or entity...",
-    "category": "Category",
+    "filters": {
+      "searchPlaceholder": "Search event, actor, target or entity...",
+      "category": "Category",
+      "event": "Event",
+      "actor": "Actor"
+    },
     "categoryValues": {
       "Account": "Account",
       "Gallery": "Gallery",
       "System": "System"
     },
-    "event": "Event",
-    "actor": "Actor",
-    "target": "Target",
-    "entity": "Entity",
-    "when": "When",
-    "sortAriaLabel": "Sort audit events by {label}",
+    "labels": {
+      "actor": "Actor",
+      "target": "Target",
+      "entity": "Entity",
+      "when": "When"
+    },
+    "aria": {
+      "sort": "Sort audit events by {label}"
+    },
     "stats": {
       "visibleEvents": "Visible events",
       "visibleEventsHelper": "Matching the latest audit window",
@@ -274,7 +357,9 @@
       "details": "Details",
       "noEvents": "No audit events match the current filters."
     },
-    "unknownUser": "Unknown user",
+    "fallback": {
+      "unknownUser": "Unknown user"
+    },
     "eventTitles": {
       "accountRoleChanged": "Role changed",
       "galleryEntryFeatured": "Gallery entry featured",
@@ -288,17 +373,21 @@
       "galleryEntry": "Gallery entry",
       "account": "Account"
     },
-    "share": "Share {token}",
-    "entityId": "ID {id}"
+    "entity": {
+      "share": "Share {token}",
+      "id": "ID {id}"
+    }
   },
   "gallery": {
-    "searchPlaceholder": "Search title, description or owner...",
-    "state": "State",
+    "filters": {
+      "searchPlaceholder": "Search title, description or owner...",
+      "state": "State",
+      "share": "Share"
+    },
     "stateValues": {
       "unlisted": "Unlisted (regular shares)",
       "unlistedBadge": "Unlisted"
     },
-    "share": "Share",
     "shareValues": {
       "active": "Active",
       "expired": "Expired",
@@ -311,37 +400,57 @@
       "share": "Share",
       "published": "Published"
     },
-    "feature": "Feature",
-    "unfeature": "Unfeature",
-    "hide": "Hide",
-    "restore": "Restore",
-    "delete": "Delete",
-    "manageRestricted": "Only moderators and admins can update gallery entries.",
-    "deleteRestricted": "Only moderators and admins can delete gallery entries.",
-    "updateFailed": "Failed to update gallery entry.",
-    "updateSuccess": "Gallery entry {action}d.",
-    "deleteFailed": "Failed to delete gallery entry.",
-    "deleteSuccess": "Gallery entry deleted.",
-    "copyLinkSuccess": "Share link copied.",
-    "copyLinkFailed": "Could not copy the share link.",
-    "copySuccess": "{label} copied.",
-    "copyFailed": "Could not copy {label}.",
-    "openActions": "Open gallery entry actions",
-    "rowAriaLabel": "Inspect {title}",
-    "emptyMessage": "No gallery entries yet.",
-    "emptyFilteredMessage": "No gallery entries match the current filters.",
-    "cleanupNotice": "Changes apply immediately to the public gallery. {expired} expired and {revoked} revoked linked shares are visible here for operator cleanup.",
-    "showing": "Showing {filtered} of {total} gallery entries.",
-    "revokedOn": "Revoked {date}",
-    "expiredOn": "Expired {date}",
-    "expiresOn": "Expires {date}",
-    "noExpiry": "No expiry",
-    "notSet": "Not set",
-    "notAvailable": "Not available",
-    "elementCount": "{count, plural, one {# element} other {# elements}}",
-    "embedUnavailableTemporary": "Temporary shares cannot be embedded",
-    "embedUnavailableRevoked": "Share has been revoked",
-    "embedUnavailableExpired": "Share has expired",
+    "actions": {
+      "feature": "Feature",
+      "unfeature": "Unfeature",
+      "hide": "Hide",
+      "restore": "Restore",
+      "delete": "Delete",
+      "open": "Open gallery entry actions"
+    },
+    "restrictions": {
+      "manage": "Only moderators and admins can update gallery entries.",
+      "delete": "Only moderators and admins can delete gallery entries."
+    },
+    "messages": {
+      "updateFailed": "Failed to update gallery entry.",
+      "updateSuccess": "Gallery entry {action}d.",
+      "deleteFailed": "Failed to delete gallery entry.",
+      "deleteSuccess": "Gallery entry deleted.",
+      "copyLinkSuccess": "Share link copied.",
+      "copyLinkFailed": "Could not copy the share link.",
+      "copySuccess": "{label} copied.",
+      "copyFailed": "Could not copy {label}."
+    },
+    "aria": {
+      "row": "Inspect {title}"
+    },
+    "empty": {
+      "default": "No gallery entries yet.",
+      "filtered": "No gallery entries match the current filters."
+    },
+    "status": {
+      "cleanupNotice": "Changes apply immediately to the public gallery. {expired} expired and {revoked} revoked linked shares are visible here for operator cleanup.",
+      "showing": "Showing {filtered} of {total} gallery entries."
+    },
+    "lifecycle": {
+      "revokedOn": "Revoked {date}",
+      "expiredOn": "Expired {date}",
+      "expiresOn": "Expires {date}",
+      "noExpiry": "No expiry"
+    },
+    "fallback": {
+      "notSet": "Not set",
+      "notAvailable": "Not available"
+    },
+    "meta": {
+      "elementCount": "{count, plural, one {# element} other {# elements}}"
+    },
+    "embed": {
+      "unavailableTemporary": "Temporary shares cannot be embedded",
+      "unavailableRevoked": "Share has been revoked",
+      "unavailableExpired": "Share has expired"
+    },
     "inspect": {
       "title": "Inspect public gallery readiness and share lifecycle.",
       "previewReady": "Preview ready",

--- a/lang/en/landing.json
+++ b/lang/en/landing.json
@@ -81,58 +81,84 @@
       "subtitle": "Build the track on a field that matches reality.",
       "description": "Start with the field dimensions, then place the elements crews already recognize. That makes the first version of the plan useful immediately, instead of just being a rough sketch.",
       "screenshotAlt": "TrackDraw 2D layout editor with obstacle library and track plan",
-      "bullet1": "Scale-accurate field dimensions",
-      "bullet2": "Gates, flags, cones, start pads and larger features",
-      "bullet3": "Race line and labels for briefing clarity"
+      "bullets": [
+        "Scale-accurate field dimensions",
+        "Gates, flags, cones, start pads and larger features",
+        "Race line and labels for briefing clarity"
+      ]
     },
     "fineTune": {
       "title": "Fine-Tune",
       "subtitle": "Keep editing when the venue forces a change.",
       "description": "A good plan changes cleanly. Inspector controls and mobile-friendly editing make it possible to adjust object properties, reposition items and keep the design usable even when the real venue refuses to stay static.",
       "screenshotAlt": "TrackDraw mobile editor with settings panel open",
-      "bullet1": "Inspector controls for dimensions, rotation and color",
-      "bullet2": "Touch-friendly editing on phones and tablets",
-      "bullet3": "Fast adjustments without leaving the main plan"
+      "bullets": [
+        "Inspector controls for dimensions, rotation and color",
+        "Touch-friendly editing on phones and tablets",
+        "Fast adjustments without leaving the main plan"
+      ]
     },
     "preview": {
       "title": "3D Preview",
       "subtitle": "Walk the track before you build it.",
       "description": "One click switches from the flat 2D plan to a live 3D scene. Assign elevation to each waypoint on the race line to model the full vertical profile. Catch dangerous approaches before a single peg is in the ground.",
       "screenshotAlt": "TrackDraw 3D preview showing track flow and elevation",
-      "bullet1": "Live 3D rendered directly from your 2D design",
-      "bullet2": "Per-waypoint altitude on the race line",
-      "bullet3": "Elevation graph in the inspector panel"
+      "bullets": [
+        "Live 3D rendered directly from your 2D design",
+        "Per-waypoint altitude on the race line",
+        "Elevation graph in the inspector panel"
+      ]
     },
     "handOff": {
       "title": "Hand-Off",
       "subtitle": "Give pilots and crew the same current version.",
       "description": "A plan only matters if other people can open it. Shared read-only links and exports turn the layout into something pilots can review, crew can print and organizers can reuse later.",
       "screenshotAlt": "TrackDraw read-only shared view open on mobile",
-      "bullet1": "Read-only links that open on any device",
-      "bullet2": "PDF, PNG and SVG for briefing and print workflows",
-      "bullet3": "JSON export to archive and reuse layouts later",
-      "gallery": "Browse the gallery for inspiration"
+      "gallery": "Browse the gallery for inspiration",
+      "bullets": [
+        "Read-only links that open on any device",
+        "PDF, PNG and SVG for briefing and print workflows",
+        "JSON export to archive and reuse layouts later"
+      ]
     }
   },
   "faq": {
     "sectionTitle": "FAQ",
     "sectionHeading": "Good to know.",
-    "q1": "Is TrackDraw a drone race track builder?",
-    "a1": "Yes. TrackDraw is a browser-based drone race track builder for FPV race directors who need scale-accurate layouts, 3D review, sharing, and export in one workflow.",
-    "q2": "What is the best way to plan an FPV race track?",
-    "a2": "Start with the field dimensions, place the obstacles you actually have, then review the route in 3D before sharing or exporting the plan. TrackDraw is built around that exact sequence.",
-    "q3": "Can pilots review the layout without an account?",
-    "a3": "Yes. Share links open in read-only mode on any device, no account or app needed. Send it to pilots, judges, or crew and everyone sees the same published version.",
-    "q4": "Does it work on a tablet at the venue?",
-    "a4": "Yes. The editor is touch-friendly, so quick adjustments on a phone or tablet are practical when the real venue forces a change.",
-    "q5": "What export formats are available?",
-    "a5": "PDF, PNG, SVG, JSON, and a cinematic FPV video export. That covers printed race briefs, shareable visuals, reusable project files, and motion-led route review.",
-    "q6": "Do I need an account to get started?",
-    "a6": "No. Open the studio and start designing right away. Creating an account adds cloud storage, durable published links, gallery publishing, and embeds.",
-    "q7": "Can I reuse a layout for a future event?",
-    "a7": "Yes. Save parts of a layout as named presets and place them again in one click. To reuse a full project, export it as JSON and import it at the start of a new event.",
-    "q8": "Can TrackDraw help catch route problems before race day?",
-    "a8": "Yes. The 3D preview and route review warnings help surface uneven spacing, rhythm breaks, and alignment issues before you share the layout or start building it."
+    "items": [
+      {
+        "question": "Is TrackDraw a drone race track builder?",
+        "answer": "Yes. TrackDraw is a browser-based drone race track builder for FPV race directors who need scale-accurate layouts, 3D review, sharing, and export in one workflow."
+      },
+      {
+        "question": "What is the best way to plan an FPV race track?",
+        "answer": "Start with the field dimensions, place the obstacles you actually have, then review the route in 3D before sharing or exporting the plan. TrackDraw is built around that exact sequence."
+      },
+      {
+        "question": "Can pilots review the layout without an account?",
+        "answer": "Yes. Share links open in read-only mode on any device, no account or app needed. Send it to pilots, judges, or crew and everyone sees the same published version."
+      },
+      {
+        "question": "Does it work on a tablet at the venue?",
+        "answer": "Yes. The editor is touch-friendly, so quick adjustments on a phone or tablet are practical when the real venue forces a change."
+      },
+      {
+        "question": "What export formats are available?",
+        "answer": "PDF, PNG, SVG, JSON, and a cinematic FPV video export. That covers printed race briefs, shareable visuals, reusable project files, and motion-led route review."
+      },
+      {
+        "question": "Do I need an account to get started?",
+        "answer": "No. Open the studio and start designing right away. Creating an account adds cloud storage, durable published links, gallery publishing, and embeds."
+      },
+      {
+        "question": "Can I reuse a layout for a future event?",
+        "answer": "Yes. Save parts of a layout as named presets and place them again in one click. To reuse a full project, export it as JSON and import it at the start of a new event."
+      },
+      {
+        "question": "Can TrackDraw help catch route problems before race day?",
+        "answer": "Yes. The 3D preview and route review warnings help surface uneven spacing, rhythm breaks, and alignment issues before you share the layout or start building it."
+      }
+    ]
   },
   "pricing": {
     "sectionEyebrow": "Plans",

--- a/lang/nl/dashboard.json
+++ b/lang/nl/dashboard.json
@@ -33,25 +33,43 @@
   },
   "overview": {
     "kpi": {
-      "totalUsers": "Totaal gebruikers",
-      "totalUsersSub": "+{count} deze maand",
-      "vsPrevMonth": "t.o.v. vorige maand",
-      "activeProjects": "Actieve projecten",
-      "activeProjectsSub": "niet-gearchiveerd",
-      "activeShares": "Actieve shares",
-      "activeSharesSub": "live deellinks",
-      "gallery": "Galerij",
-      "gallerySub": "{featured} uitgelicht · {hidden} verborgen"
+      "totalUsers": {
+        "label": "Totaal gebruikers",
+        "sub": "+{count} deze maand"
+      },
+      "activeProjects": {
+        "label": "Actieve projecten",
+        "sub": "niet-gearchiveerd"
+      },
+      "activeShares": {
+        "label": "Actieve shares",
+        "sub": "live deellinks"
+      },
+      "gallery": {
+        "label": "Galerij",
+        "sub": "{featured} uitgelicht · {hidden} verborgen"
+      },
+      "comparison": {
+        "vsPrevMonth": "t.o.v. vorige maand"
+      }
     },
-    "recentActivity": "Recente activiteit",
-    "recentSignups": "Recente aanmeldingen",
-    "galleryCardTitle": "Galerij",
-    "viewAll": "Alles bekijken",
-    "noRecentActivity": "Geen recente activiteit",
-    "noRecentSignups": "Geen recente aanmeldingen",
-    "noGalleryEntries": "Nog geen galerij-items",
-    "untitled": "Naamloos",
-    "unknownOwner": "Onbekend",
+    "sections": {
+      "recentActivity": "Recente activiteit",
+      "recentSignups": "Recente aanmeldingen",
+      "gallery": "Galerij"
+    },
+    "actions": {
+      "viewAll": "Alles bekijken"
+    },
+    "empty": {
+      "recentActivity": "Geen recente activiteit",
+      "recentSignups": "Geen recente aanmeldingen",
+      "galleryEntries": "Nog geen galerij-items"
+    },
+    "fallback": {
+      "untitled": "Naamloos",
+      "unknownOwner": "Onbekend"
+    },
     "galleryState": {
       "featured": "Uitgelicht",
       "hidden": "Verborgen",
@@ -75,27 +93,47 @@
     }
   },
   "overviewCards": {
-    "galleryEntries": "Galerij-items",
-    "galleryEntriesHelper": "Alle dashboard-beheerde items",
-    "featured": "Uitgelicht",
-    "featuredHelper": "Vastgezet in de uitgelichte sectie",
-    "hidden": "Verborgen",
-    "hiddenHelper": "Verwijderd uit publieke ontdekking",
-    "totalAccounts": "Totaal accounts",
-    "totalAccountsHelper": "Bijgehouden gebruikersrecords"
+    "cards": {
+      "galleryEntries": {
+        "label": "Galerij-items",
+        "helper": "Alle dashboard-beheerde items"
+      },
+      "featured": {
+        "label": "Uitgelicht",
+        "helper": "Vastgezet in de uitgelichte sectie"
+      },
+      "hidden": {
+        "label": "Verborgen",
+        "helper": "Verwijderd uit publieke ontdekking"
+      },
+      "totalAccounts": {
+        "label": "Totaal accounts",
+        "helper": "Bijgehouden gebruikersrecords"
+      }
+    }
   },
   "metrics": {
     "kpi": {
-      "totalUsers": "Totaal gebruikers",
-      "totalUsersSub": "+{count} deze maand",
-      "activeUsers30d": "Actieve gebruikers (30d)",
-      "activeUsers30dSub": "{pct}% van totaal",
-      "projects": "Projecten",
-      "projectsSub": "niet-gearchiveerd · {archived} gearchiveerd",
-      "activeShares": "Actieve shares",
-      "activeSharesSub": "{revoked} ingetrokken",
-      "activeApiKeys": "Actieve API-sleutels",
-      "activeApiKeysSub": "{total} totaal"
+      "totalUsers": {
+        "label": "Totaal gebruikers",
+        "sub": "+{count} deze maand"
+      },
+      "activeUsers30d": {
+        "label": "Actieve gebruikers (30d)",
+        "sub": "{pct}% van totaal"
+      },
+      "projects": {
+        "label": "Projecten",
+        "sub": "niet-gearchiveerd · {archived} gearchiveerd"
+      },
+      "activeShares": {
+        "label": "Actieve shares",
+        "sub": "{revoked} ingetrokken"
+      },
+      "activeApiKeys": {
+        "label": "Actieve API-sleutels",
+        "sub": "{total} totaal"
+      }
     },
     "userPopulation": {
       "title": "Gebruikerspopulatie",
@@ -160,8 +198,10 @@
     }
   },
   "users": {
-    "searchPlaceholder": "Zoek op naam of e-mail...",
-    "role": "Rol",
+    "filters": {
+      "searchPlaceholder": "Zoek op naam of e-mail...",
+      "role": "Rol"
+    },
     "table": {
       "user": "Gebruiker",
       "projects": "Projecten",
@@ -169,42 +209,64 @@
       "joined": "Lid sinds",
       "lastLogin": "Laatste login"
     },
-    "you": "(jij)",
-    "unnamedUser": "Naamloze gebruiker",
-    "emptyMessage": "Geen gebruikers gevonden.",
-    "showing": "{filtered} van {total} accounts weergegeven.",
-    "loadFailed": "Gebruikerscontext laden mislukt.",
-    "copySuccess": "{label} gekopieerd.",
-    "copyFailed": "Kon {label} niet kopiëren.",
-    "updateFailed": "Kon de geselecteerde rol niet bijwerken.",
-    "updateSuccess": "{name} bijgewerkt naar {role}.",
+    "selfBadge": "(jij)",
+    "fallback": {
+      "unnamedUser": "Naamloze gebruiker"
+    },
+    "empty": {
+      "default": "Geen gebruikers gevonden."
+    },
+    "status": {
+      "showing": "{filtered} van {total} accounts weergegeven."
+    },
+    "messages": {
+      "loadFailed": "Gebruikerscontext laden mislukt.",
+      "copySuccess": "{label} gekopieerd.",
+      "copyFailed": "Kon {label} niet kopiëren.",
+      "updateFailed": "Kon de geselecteerde rol niet bijwerken.",
+      "updateSuccess": "{name} bijgewerkt naar {role}."
+    },
     "panel": {
-      "loading": "Laden…",
+      "status": {
+        "loading": "Laden…"
+      },
       "stats": {
         "projects": "Projecten",
         "shares": "Shares",
         "gallery": "Galerij",
         "apiKeys": "API-sleutels"
       },
-      "accountSection": "Account",
-      "memberSince": "Lid sinds",
-      "lastLogin": "Laatste login",
-      "role": "Rol",
-      "userId": "Gebruikers-ID",
-      "copyUserId": "Gebruikers-ID kopiëren",
-      "changeRole": "Rol wijzigen",
-      "cannotChangeOwnRole": "Kan eigen rol niet wijzigen",
-      "save": "Opslaan",
-      "recentActivitySection": "Recente activiteit",
-      "noAuditEvents": "Geen audit-events vastgelegd.",
-      "actor": "Actor",
-      "target": "Doel",
-      "viewFullAuditTrail": "Volledig audit-overzicht bekijken"
+      "sections": {
+        "account": "Account",
+        "recentActivity": "Recente activiteit"
+      },
+      "fields": {
+        "memberSince": "Lid sinds",
+        "lastLogin": "Laatste login",
+        "role": "Rol",
+        "userId": "Gebruikers-ID"
+      },
+      "actions": {
+        "copyUserId": "Gebruikers-ID kopiëren",
+        "changeRole": "Rol wijzigen",
+        "save": "Opslaan",
+        "viewFullAuditTrail": "Volledig audit-overzicht bekijken"
+      },
+      "messages": {
+        "cannotChangeOwnRole": "Kan eigen rol niet wijzigen",
+        "noAuditEvents": "Geen audit-events vastgelegd."
+      },
+      "relation": {
+        "actor": "Actor",
+        "target": "Doel"
+      }
     }
   },
   "apiKeys": {
-    "searchPlaceholder": "Zoek op sleutelnaam of eigenaar...",
-    "status": "Status",
+    "filters": {
+      "searchPlaceholder": "Zoek op sleutelnaam of eigenaar...",
+      "status": "Status"
+    },
     "statusValues": {
       "active": "Actief",
       "expired": "Verlopen",
@@ -218,45 +280,66 @@
       "lastUsed": "Laatst gebruikt",
       "expires": "Verloopt"
     },
-    "emptyMessage": "Geen API-sleutels gevonden.",
-    "emptyFilteredMessage": "Geen API-sleutels voldoen aan de huidige filters.",
-    "showing": "{filtered} van {total} API-sleutels weergegeven.",
-    "off": "Uit",
-    "minutesUnit": "{count} min",
-    "hoursUnit": "{count} uur",
+    "empty": {
+      "default": "Geen API-sleutels gevonden.",
+      "filtered": "Geen API-sleutels voldoen aan de huidige filters."
+    },
+    "status": {
+      "showing": "{filtered} van {total} API-sleutels weergegeven.",
+      "off": "Uit"
+    },
+    "units": {
+      "minutes": "{count} min",
+      "hours": "{count} uur"
+    },
     "panel": {
       "title": "API-sleutel",
-      "selectRow": "Selecteer een sleutelrij om de details te bekijken.",
-      "requests": "Aanvragen",
-      "remaining": "Resterend",
-      "rateLimit": "Rate limit",
-      "keySection": "Sleutel",
-      "status": "Status",
-      "prefix": "Prefix",
-      "permissions": "Permissies",
-      "created": "Aangemaakt",
-      "expires": "Verloopt",
-      "lastUsed": "Laatst gebruikt",
-      "ownerSection": "Eigenaar",
-      "name": "Naam",
-      "email": "E-mail",
-      "userId": "Gebruikers-ID"
+      "empty": {
+        "selectRow": "Selecteer een sleutelrij om de details te bekijken."
+      },
+      "stats": {
+        "requests": "Aanvragen",
+        "remaining": "Resterend",
+        "rateLimit": "Rate limit"
+      },
+      "sections": {
+        "key": "Sleutel",
+        "owner": "Eigenaar"
+      },
+      "fields": {
+        "status": "Status",
+        "prefix": "Prefix",
+        "permissions": "Permissies",
+        "created": "Aangemaakt",
+        "expires": "Verloopt",
+        "lastUsed": "Laatst gebruikt",
+        "name": "Naam",
+        "email": "E-mail",
+        "userId": "Gebruikers-ID"
+      }
     }
   },
   "audit": {
-    "searchPlaceholder": "Zoek op event, actor, doel of entiteit...",
-    "category": "Categorie",
+    "filters": {
+      "searchPlaceholder": "Zoek op event, actor, doel of entiteit...",
+      "category": "Categorie",
+      "event": "Event",
+      "actor": "Actor"
+    },
     "categoryValues": {
       "Account": "Account",
       "Gallery": "Galerij",
       "System": "Systeem"
     },
-    "event": "Event",
-    "actor": "Actor",
-    "target": "Doel",
-    "entity": "Entiteit",
-    "when": "Wanneer",
-    "sortAriaLabel": "Sorteer audit-events op {label}",
+    "labels": {
+      "actor": "Actor",
+      "target": "Doel",
+      "entity": "Entiteit",
+      "when": "Wanneer"
+    },
+    "aria": {
+      "sort": "Sorteer audit-events op {label}"
+    },
     "stats": {
       "visibleEvents": "Zichtbare events",
       "visibleEventsHelper": "Binnen het laatste audit-venster",
@@ -274,7 +357,9 @@
       "details": "Details",
       "noEvents": "Geen audit-events voldoen aan de huidige filters."
     },
-    "unknownUser": "Onbekende gebruiker",
+    "fallback": {
+      "unknownUser": "Onbekende gebruiker"
+    },
     "eventTitles": {
       "accountRoleChanged": "Rol gewijzigd",
       "galleryEntryFeatured": "Galerij-item uitgelicht",
@@ -288,17 +373,21 @@
       "galleryEntry": "Galerij-item",
       "account": "Account"
     },
-    "share": "Share {token}",
-    "entityId": "ID {id}"
+    "entity": {
+      "share": "Share {token}",
+      "id": "ID {id}"
+    }
   },
   "gallery": {
-    "searchPlaceholder": "Zoek op titel, beschrijving of eigenaar...",
-    "state": "Status",
+    "filters": {
+      "searchPlaceholder": "Zoek op titel, beschrijving of eigenaar...",
+      "state": "Status",
+      "share": "Share"
+    },
     "stateValues": {
       "unlisted": "Niet vermeld (gewone shares)",
       "unlistedBadge": "Niet vermeld"
     },
-    "share": "Share",
     "shareValues": {
       "active": "Actief",
       "expired": "Verlopen",
@@ -311,37 +400,57 @@
       "share": "Share",
       "published": "Gepubliceerd"
     },
-    "feature": "Uitlichten",
-    "unfeature": "Niet meer uitlichten",
-    "hide": "Verbergen",
-    "restore": "Herstellen",
-    "delete": "Verwijderen",
-    "manageRestricted": "Alleen moderators en admins kunnen galerij-items bijwerken.",
-    "deleteRestricted": "Alleen moderators en admins kunnen galerij-items verwijderen.",
-    "updateFailed": "Galerij-item bijwerken mislukt.",
-    "updateSuccess": "Galerij-item {action}.",
-    "deleteFailed": "Galerij-item verwijderen mislukt.",
-    "deleteSuccess": "Galerij-item verwijderd.",
-    "copyLinkSuccess": "Deellink gekopieerd.",
-    "copyLinkFailed": "Kon de deellink niet kopiëren.",
-    "copySuccess": "{label} gekopieerd.",
-    "copyFailed": "Kon {label} niet kopiëren.",
-    "openActions": "Galerij-itemacties openen",
-    "rowAriaLabel": "Bekijk {title}",
-    "emptyMessage": "Nog geen galerij-items.",
-    "emptyFilteredMessage": "Geen galerij-items voldoen aan de huidige filters.",
-    "cleanupNotice": "Wijzigingen worden direct toegepast op de publieke galerij. {expired} verlopen en {revoked} ingetrokken gekoppelde shares zijn hier zichtbaar voor opschoning door operators.",
-    "showing": "{filtered} van {total} galerij-items weergegeven.",
-    "revokedOn": "Ingetrokken op {date}",
-    "expiredOn": "Verlopen op {date}",
-    "expiresOn": "Verloopt op {date}",
-    "noExpiry": "Geen vervaldatum",
-    "notSet": "Niet ingesteld",
-    "notAvailable": "Niet beschikbaar",
-    "elementCount": "{count, plural, one {# element} other {# elementen}}",
-    "embedUnavailableTemporary": "Tijdelijke shares kunnen niet worden ingesloten",
-    "embedUnavailableRevoked": "Share is ingetrokken",
-    "embedUnavailableExpired": "Share is verlopen",
+    "actions": {
+      "feature": "Uitlichten",
+      "unfeature": "Niet meer uitlichten",
+      "hide": "Verbergen",
+      "restore": "Herstellen",
+      "delete": "Verwijderen",
+      "open": "Galerij-itemacties openen"
+    },
+    "restrictions": {
+      "manage": "Alleen moderators en admins kunnen galerij-items bijwerken.",
+      "delete": "Alleen moderators en admins kunnen galerij-items verwijderen."
+    },
+    "messages": {
+      "updateFailed": "Galerij-item bijwerken mislukt.",
+      "updateSuccess": "Galerij-item {action}.",
+      "deleteFailed": "Galerij-item verwijderen mislukt.",
+      "deleteSuccess": "Galerij-item verwijderd.",
+      "copyLinkSuccess": "Deellink gekopieerd.",
+      "copyLinkFailed": "Kon de deellink niet kopiëren.",
+      "copySuccess": "{label} gekopieerd.",
+      "copyFailed": "Kon {label} niet kopiëren."
+    },
+    "aria": {
+      "row": "Bekijk {title}"
+    },
+    "empty": {
+      "default": "Nog geen galerij-items.",
+      "filtered": "Geen galerij-items voldoen aan de huidige filters."
+    },
+    "status": {
+      "cleanupNotice": "Wijzigingen worden direct toegepast op de publieke galerij. {expired} verlopen en {revoked} ingetrokken gekoppelde shares zijn hier zichtbaar voor opschoning door operators.",
+      "showing": "{filtered} van {total} galerij-items weergegeven."
+    },
+    "lifecycle": {
+      "revokedOn": "Ingetrokken op {date}",
+      "expiredOn": "Verlopen op {date}",
+      "expiresOn": "Verloopt op {date}",
+      "noExpiry": "Geen vervaldatum"
+    },
+    "fallback": {
+      "notSet": "Niet ingesteld",
+      "notAvailable": "Niet beschikbaar"
+    },
+    "meta": {
+      "elementCount": "{count, plural, one {# element} other {# elementen}}"
+    },
+    "embed": {
+      "unavailableTemporary": "Tijdelijke shares kunnen niet worden ingesloten",
+      "unavailableRevoked": "Share is ingetrokken",
+      "unavailableExpired": "Share is verlopen"
+    },
     "inspect": {
       "title": "Bekijk de gereedheid voor publieke galerij en de share-levenscyclus.",
       "previewReady": "Preview gereed",

--- a/lang/nl/landing.json
+++ b/lang/nl/landing.json
@@ -81,58 +81,84 @@
       "subtitle": "Bouw de track op een veld dat overeenkomt met de realiteit.",
       "description": "Begin met de veldafmetingen en plaats de elementen die crews al herkennen. Dat maakt de eerste versie van het plan direct bruikbaar, in plaats van alleen maar een ruwe schets.",
       "screenshotAlt": "TrackDraw 2D-layouteditor met obstacle library en trackplan",
-      "bullet1": "Veldafmetingen op ware schaal",
-      "bullet2": "Gates, flags, cones, startpads en grotere elementen",
-      "bullet3": "Race line en labels voor briefingduidelijkheid"
+      "bullets": [
+        "Veldafmetingen op ware schaal",
+        "Gates, flags, cones, startpads en grotere elementen",
+        "Race line en labels voor briefingduidelijkheid"
+      ]
     },
     "fineTune": {
       "title": "Verfijnen",
       "subtitle": "Blijf bewerken wanneer de locatie een wijziging vereist.",
       "description": "Een goed plan past zich netjes aan. Inspector-bedieningselementen en mobielvriendelijk bewerken maken het mogelijk om objecteigenschappen aan te passen, items te herpositioneren en het ontwerp bruikbaar te houden, zelfs wanneer de echte locatie weigert statisch te blijven.",
       "screenshotAlt": "TrackDraw mobiele editor met instellingenpaneel geopend",
-      "bullet1": "Inspector-bedieningselementen voor afmetingen, rotatie en kleur",
-      "bullet2": "Touch-vriendelijk bewerken op telefoons en tablets",
-      "bullet3": "Snelle aanpassingen zonder het hoofdplan te verlaten"
+      "bullets": [
+        "Inspector-bedieningselementen voor afmetingen, rotatie en kleur",
+        "Touch-vriendelijk bewerken op telefoons en tablets",
+        "Snelle aanpassingen zonder het hoofdplan te verlaten"
+      ]
     },
     "preview": {
       "title": "3D-preview",
       "subtitle": "Loop door de track voor je hem bouwt.",
       "description": "Eén klik schakelt van het platte 2D-plan naar een live 3D-scène. Wijs hoogte toe aan elk waypoint op de race line om het volledige verticale profiel te modelleren. Ontdek gevaarlijke benaderingen voordat er één enkele paal in de grond staat.",
       "screenshotAlt": "TrackDraw 3D-preview met track flow en hoogte",
-      "bullet1": "Live 3D rechtstreeks gerenderd vanuit je 2D-ontwerp",
-      "bullet2": "Hoogte per waypoint op de race line",
-      "bullet3": "Hoogtegrafiek in het inspectorpaneel"
+      "bullets": [
+        "Live 3D rechtstreeks gerenderd vanuit je 2D-ontwerp",
+        "Hoogte per waypoint op de race line",
+        "Hoogtegrafiek in het inspectorpaneel"
+      ]
     },
     "handOff": {
       "title": "Overdracht",
       "subtitle": "Geef piloten en crew dezelfde actuele versie.",
       "description": "Een plan is alleen waardevol als andere mensen het kunnen openen. Alleen-lezen links en exports maken de lay-out tot iets wat piloten kunnen bekijken, crew kan afdrukken en organisatoren later opnieuw kunnen gebruiken.",
       "screenshotAlt": "TrackDraw alleen-lezen gedeelde weergave geopend op mobiel",
-      "bullet1": "Alleen-lezen links die op elk apparaat openen",
-      "bullet2": "PDF, PNG en SVG voor briefing- en afdrukworkflows",
-      "bullet3": "JSON-export om lay-outs te archiveren en later opnieuw te gebruiken",
-      "gallery": "Bekijk de galerij voor inspiratie"
+      "gallery": "Bekijk de galerij voor inspiratie",
+      "bullets": [
+        "Alleen-lezen links die op elk apparaat openen",
+        "PDF, PNG en SVG voor briefing- en afdrukworkflows",
+        "JSON-export om lay-outs te archiveren en later opnieuw te gebruiken"
+      ]
     }
   },
   "faq": {
     "sectionTitle": "FAQ",
     "sectionHeading": "Goed om te weten.",
-    "q1": "Is TrackDraw een drone race track builder?",
-    "a1": "Ja. TrackDraw is een browsergebaseerde drone race track builder voor FPV-raceorganisatoren die schaalnauwkeurige lay-outs, 3D-review, delen en exporteren in één workflow nodig hebben.",
-    "q2": "Wat is de beste manier om een FPV-racetrack te plannen?",
-    "a2": "Begin met de veldafmetingen, plaats de obstakels die je daadwerkelijk hebt, en bekijk de route dan in 3D voor je het plan deelt of exporteert. TrackDraw is gebouwd rond precies die volgorde.",
-    "q3": "Kunnen piloten de lay-out bekijken zonder een account?",
-    "a3": "Ja. Deellinks openen in alleen-lezen modus op elk apparaat, geen account of app vereist. Stuur hem naar piloten, judges of crew en iedereen ziet dezelfde gepubliceerde versie.",
-    "q4": "Werkt het op een tablet op de locatie?",
-    "a4": "Ja. De editor is touch-vriendelijk, dus snelle aanpassingen op een telefoon of tablet zijn praktisch wanneer de echte locatie een wijziging vereist.",
-    "q5": "Welke exportformaten zijn beschikbaar?",
-    "a5": "PDF, PNG, SVG, JSON en een cinematic FPV-video-export. Dat dekt gedrukte race-briefings, deelbare visuals, herbruikbare projectbestanden en een visuele routereview.",
-    "q6": "Heb ik een account nodig om te beginnen?",
-    "a6": "Nee. Open de studio en begin meteen met ontwerpen. Een account aanmaken voegt cloudopslag, duurzame gepubliceerde links, galerijpublicatie en embeds toe.",
-    "q7": "Kan ik een lay-out hergebruiken voor een toekomstig evenement?",
-    "a7": "Ja. Sla delen van een lay-out op als benoemde presets en plaats ze opnieuw met één klik. Om een volledig project te hergebruiken, exporteer het als JSON en importeer het aan het begin van een nieuw evenement.",
-    "q8": "Kan TrackDraw helpen routeproblemen te ontdekken voor de racedag?",
-    "a8": "Ja. De 3D-preview en routebeoordelingswaarschuwingen helpen ongelijkmatige afstanden, ritmeproblemen en uitlijningsproblemen op te sporen voordat je de lay-out deelt of begint met bouwen."
+    "items": [
+      {
+        "question": "Is TrackDraw een drone race track builder?",
+        "answer": "Ja. TrackDraw is een browsergebaseerde drone race track builder voor FPV-raceorganisatoren die schaalnauwkeurige lay-outs, 3D-review, delen en exporteren in één workflow nodig hebben."
+      },
+      {
+        "question": "Wat is de beste manier om een FPV-racetrack te plannen?",
+        "answer": "Begin met de veldafmetingen, plaats de obstakels die je daadwerkelijk hebt, en bekijk de route dan in 3D voor je het plan deelt of exporteert. TrackDraw is gebouwd rond precies die volgorde."
+      },
+      {
+        "question": "Kunnen piloten de lay-out bekijken zonder een account?",
+        "answer": "Ja. Deellinks openen in alleen-lezen modus op elk apparaat, geen account of app vereist. Stuur hem naar piloten, judges of crew en iedereen ziet dezelfde gepubliceerde versie."
+      },
+      {
+        "question": "Werkt het op een tablet op de locatie?",
+        "answer": "Ja. De editor is touch-vriendelijk, dus snelle aanpassingen op een telefoon of tablet zijn praktisch wanneer de echte locatie een wijziging vereist."
+      },
+      {
+        "question": "Welke exportformaten zijn beschikbaar?",
+        "answer": "PDF, PNG, SVG, JSON en een cinematic FPV-video-export. Dat dekt gedrukte race-briefings, deelbare visuals, herbruikbare projectbestanden en een visuele routereview."
+      },
+      {
+        "question": "Heb ik een account nodig om te beginnen?",
+        "answer": "Nee. Open de studio en begin meteen met ontwerpen. Een account aanmaken voegt cloudopslag, duurzame gepubliceerde links, galerijpublicatie en embeds toe."
+      },
+      {
+        "question": "Kan ik een lay-out hergebruiken voor een toekomstig evenement?",
+        "answer": "Ja. Sla delen van een lay-out op als benoemde presets en plaats ze opnieuw met één klik. Om een volledig project te hergebruiken, exporteer het als JSON en importeer het aan het begin van een nieuw evenement."
+      },
+      {
+        "question": "Kan TrackDraw helpen routeproblemen te ontdekken voor de racedag?",
+        "answer": "Ja. De 3D-preview en routebeoordelingswaarschuwingen helpen ongelijkmatige afstanden, ritmeproblemen en uitlijningsproblemen op te sporen voordat je de lay-out deelt of begint met bouwen."
+      }
+    ]
   },
   "pricing": {
     "sectionEyebrow": "Plannen",

--- a/src/app/dashboard/metrics/page.tsx
+++ b/src/app/dashboard/metrics/page.tsx
@@ -154,9 +154,9 @@ export default async function DashboardMetricsPage() {
         {/* KPI strip */}
         <div className="grid grid-cols-2 gap-3 xl:grid-cols-5">
           <KpiCard
-            label={tMetrics("kpi.totalUsers")}
+            label={tMetrics("kpi.totalUsers.label")}
             value={metrics.users.total}
-            sub={tMetrics("kpi.totalUsersSub", {
+            sub={tMetrics("kpi.totalUsers.sub", {
               count: metrics.users.newThisMonth,
             })}
             icon={Users}
@@ -164,9 +164,9 @@ export default async function DashboardMetricsPage() {
             iconTone="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
           />
           <KpiCard
-            label={tMetrics("kpi.activeUsers30d")}
+            label={tMetrics("kpi.activeUsers30d.label")}
             value={metrics.users.activeLastThirtyDays}
-            sub={tMetrics("kpi.activeUsers30dSub", {
+            sub={tMetrics("kpi.activeUsers30d.sub", {
               pct:
                 metrics.users.total > 0
                   ? Math.round(
@@ -181,9 +181,9 @@ export default async function DashboardMetricsPage() {
             iconTone="bg-sky-500/10 text-sky-600 dark:text-sky-400"
           />
           <KpiCard
-            label={tMetrics("kpi.projects")}
+            label={tMetrics("kpi.projects.label")}
             value={metrics.projects.active}
-            sub={tMetrics("kpi.projectsSub", {
+            sub={tMetrics("kpi.projects.sub", {
               archived: metrics.projects.archived,
             })}
             icon={FolderOpen}
@@ -191,9 +191,9 @@ export default async function DashboardMetricsPage() {
             iconTone="bg-violet-500/10 text-violet-600 dark:text-violet-400"
           />
           <KpiCard
-            label={tMetrics("kpi.activeShares")}
+            label={tMetrics("kpi.activeShares.label")}
             value={metrics.shares.totalActive}
-            sub={tMetrics("kpi.activeSharesSub", {
+            sub={tMetrics("kpi.activeShares.sub", {
               revoked: metrics.shares.revoked,
             })}
             icon={Link2}
@@ -201,9 +201,9 @@ export default async function DashboardMetricsPage() {
             iconTone="bg-orange-500/10 text-orange-600 dark:text-orange-400"
           />
           <KpiCard
-            label={tMetrics("kpi.activeApiKeys")}
+            label={tMetrics("kpi.activeApiKeys.label")}
             value={metrics.apiKeys.active}
-            sub={tMetrics("kpi.activeApiKeysSub", {
+            sub={tMetrics("kpi.activeApiKeys.sub", {
               total: metrics.apiKeys.total,
             })}
             icon={KeyRound}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -206,7 +206,7 @@ function RecentAuditEvents({
   if (events.length === 0) {
     return (
       <p className="text-muted-foreground py-6 text-center text-xs">
-        {t("noRecentActivity")}
+        {t("empty.recentActivity")}
       </p>
     );
   }
@@ -255,7 +255,7 @@ function RecentSignups({
   if (users.length === 0) {
     return (
       <p className="text-muted-foreground py-6 text-center text-xs">
-        {t("noRecentSignups")}
+        {t("empty.recentSignups")}
       </p>
     );
   }
@@ -321,7 +321,7 @@ function RecentGalleryEntries({
   if (entries.length === 0) {
     return (
       <p className="text-muted-foreground py-6 text-center text-xs">
-        {t("noGalleryEntries")}
+        {t("empty.galleryEntries")}
       </p>
     );
   }
@@ -343,10 +343,14 @@ function RecentGalleryEntries({
             </div>
             <div className="min-w-0 flex-1">
               <p className="truncate text-sm font-medium">
-                {entry.galleryTitle || entry.shareTitle || t("untitled")}
+                {entry.galleryTitle ||
+                  entry.shareTitle ||
+                  t("fallback.untitled")}
               </p>
               <p className="text-muted-foreground truncate text-xs">
-                {entry.ownerName ?? entry.ownerEmail ?? t("unknownOwner")}
+                {entry.ownerName ??
+                  entry.ownerEmail ??
+                  t("fallback.unknownOwner")}
               </p>
             </div>
             <span
@@ -393,16 +397,16 @@ export default async function DashboardPage() {
         <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
           <Reveal>
             <KpiCard
-              label={t("kpi.totalUsers")}
+              label={t("kpi.totalUsers.label")}
               value={overviewStats.totalUsers}
-              sub={t("kpi.totalUsersSub", {
+              sub={t("kpi.totalUsers.sub", {
                 count: overviewStats.newUsersThisMonth,
               })}
               trend={{
                 current: overviewStats.newUsersThisMonth,
                 previous: overviewStats.newUsersLastMonth,
               }}
-              vsPrevMonthLabel={t("kpi.vsPrevMonth")}
+              vsPrevMonthLabel={t("kpi.comparison.vsPrevMonth")}
               icon={Users}
               accent="bg-emerald-500"
               iconTone="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
@@ -410,9 +414,9 @@ export default async function DashboardPage() {
           </Reveal>
           <Reveal delay={0.04}>
             <KpiCard
-              label={t("kpi.activeProjects")}
+              label={t("kpi.activeProjects.label")}
               value={overviewStats.activeProjects}
-              sub={t("kpi.activeProjectsSub")}
+              sub={t("kpi.activeProjects.sub")}
               icon={FolderOpen}
               accent="bg-violet-500"
               iconTone="bg-violet-500/10 text-violet-600 dark:text-violet-400"
@@ -420,9 +424,9 @@ export default async function DashboardPage() {
           </Reveal>
           <Reveal delay={0.08}>
             <KpiCard
-              label={t("kpi.activeShares")}
+              label={t("kpi.activeShares.label")}
               value={overviewStats.activeShares}
-              sub={t("kpi.activeSharesSub")}
+              sub={t("kpi.activeShares.sub")}
               icon={Link2}
               accent="bg-orange-500"
               iconTone="bg-orange-500/10 text-orange-600 dark:text-orange-400"
@@ -430,9 +434,9 @@ export default async function DashboardPage() {
           </Reveal>
           <Reveal delay={0.12}>
             <KpiCard
-              label={t("kpi.gallery")}
+              label={t("kpi.gallery.label")}
               value={galleryStats.total}
-              sub={t("kpi.gallerySub", {
+              sub={t("kpi.gallery.sub", {
                 featured: galleryStats.featured,
                 hidden: galleryStats.hidden,
               })}
@@ -449,13 +453,15 @@ export default async function DashboardPage() {
         >
           <Reveal className="bg-card rounded-xl border p-4">
             <div className="mb-3 flex items-center justify-between">
-              <p className="text-sm font-medium">{t("recentActivity")}</p>
+              <p className="text-sm font-medium">
+                {t("sections.recentActivity")}
+              </p>
               {canReadAudit && (
                 <Link
                   href="/dashboard/audit"
                   className="text-muted-foreground hover:text-foreground text-xs transition-colors"
                 >
-                  {t("viewAll")}
+                  {t("actions.viewAll")}
                 </Link>
               )}
             </div>
@@ -470,13 +476,15 @@ export default async function DashboardPage() {
               <div className="mb-3 flex items-center justify-between">
                 <div className="flex items-center gap-1.5">
                   <UserPlus className="text-muted-foreground size-3.5" />
-                  <p className="text-sm font-medium">{t("recentSignups")}</p>
+                  <p className="text-sm font-medium">
+                    {t("sections.recentSignups")}
+                  </p>
                 </div>
                 <Link
                   href="/dashboard/users"
                   className="text-muted-foreground hover:text-foreground text-xs transition-colors"
                 >
-                  {t("viewAll")}
+                  {t("actions.viewAll")}
                 </Link>
               </div>
               <RecentSignups
@@ -493,12 +501,12 @@ export default async function DashboardPage() {
             delay={canReadUsers ? 0.08 : 0.04}
           >
             <div className="mb-3 flex items-center justify-between">
-              <p className="text-sm font-medium">{t("galleryCardTitle")}</p>
+              <p className="text-sm font-medium">{t("sections.gallery")}</p>
               <Link
                 href="/dashboard/gallery"
                 className="text-muted-foreground hover:text-foreground text-xs transition-colors"
               >
-                {t("viewAll")}
+                {t("actions.viewAll")}
               </Link>
             </div>
             <RecentGalleryEntries

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -158,16 +158,12 @@ function LandingVideo({ className = "" }: { className?: string }) {
 export default async function Home() {
   const t = await getTranslations("landing");
 
-  const faq = [
-    { q: t("faq.q1"), a: t("faq.a1") },
-    { q: t("faq.q2"), a: t("faq.a2") },
-    { q: t("faq.q3"), a: t("faq.a3") },
-    { q: t("faq.q4"), a: t("faq.a4") },
-    { q: t("faq.q5"), a: t("faq.a5") },
-    { q: t("faq.q6"), a: t("faq.a6") },
-    { q: t("faq.q7"), a: t("faq.a7") },
-    { q: t("faq.q8"), a: t("faq.a8") },
-  ];
+  const faq = (
+    t.raw("faq.items") as Array<{ question: string; answer: string }>
+  ).map((item) => ({
+    q: item.question,
+    a: item.answer,
+  }));
 
   const features = [
     {
@@ -448,19 +444,17 @@ export default async function Home() {
                         {t("workflow.layout.description")}
                       </p>
                       <ul className="mt-5 space-y-2.5">
-                        {[
-                          t("workflow.layout.bullet1"),
-                          t("workflow.layout.bullet2"),
-                          t("workflow.layout.bullet3"),
-                        ].map((b) => (
-                          <li
-                            key={b}
-                            className="text-muted-foreground flex items-center gap-2.5 text-sm"
-                          >
-                            <CheckCircle2 className="text-brand-primary size-3.5 shrink-0" />{" "}
-                            {b}
-                          </li>
-                        ))}
+                        {(t.raw("workflow.layout.bullets") as string[]).map(
+                          (b) => (
+                            <li
+                              key={b}
+                              className="text-muted-foreground flex items-center gap-2.5 text-sm"
+                            >
+                              <CheckCircle2 className="text-brand-primary size-3.5 shrink-0" />{" "}
+                              {b}
+                            </li>
+                          )
+                        )}
                       </ul>
                     </div>
                   </div>
@@ -480,19 +474,17 @@ export default async function Home() {
                         {t("workflow.fineTune.description")}
                       </p>
                       <ul className="mt-5 space-y-2.5">
-                        {[
-                          t("workflow.fineTune.bullet1"),
-                          t("workflow.fineTune.bullet2"),
-                          t("workflow.fineTune.bullet3"),
-                        ].map((b) => (
-                          <li
-                            key={b}
-                            className="text-muted-foreground flex items-center gap-2.5 text-sm"
-                          >
-                            <CheckCircle2 className="size-3.5 shrink-0 text-emerald-400" />{" "}
-                            {b}
-                          </li>
-                        ))}
+                        {(t.raw("workflow.fineTune.bullets") as string[]).map(
+                          (b) => (
+                            <li
+                              key={b}
+                              className="text-muted-foreground flex items-center gap-2.5 text-sm"
+                            >
+                              <CheckCircle2 className="size-3.5 shrink-0 text-emerald-400" />{" "}
+                              {b}
+                            </li>
+                          )
+                        )}
                       </ul>
                     </div>
                     <Screenshot
@@ -528,19 +520,17 @@ export default async function Home() {
                         {t("workflow.preview.description")}
                       </p>
                       <ul className="mt-5 space-y-2.5">
-                        {[
-                          t("workflow.preview.bullet1"),
-                          t("workflow.preview.bullet2"),
-                          t("workflow.preview.bullet3"),
-                        ].map((b) => (
-                          <li
-                            key={b}
-                            className="text-muted-foreground flex items-center gap-2.5 text-sm"
-                          >
-                            <CheckCircle2 className="size-3.5 shrink-0 text-purple-400" />{" "}
-                            {b}
-                          </li>
-                        ))}
+                        {(t.raw("workflow.preview.bullets") as string[]).map(
+                          (b) => (
+                            <li
+                              key={b}
+                              className="text-muted-foreground flex items-center gap-2.5 text-sm"
+                            >
+                              <CheckCircle2 className="size-3.5 shrink-0 text-purple-400" />{" "}
+                              {b}
+                            </li>
+                          )
+                        )}
                       </ul>
                     </div>
                   </div>
@@ -560,19 +550,17 @@ export default async function Home() {
                         {t("workflow.handOff.description")}
                       </p>
                       <ul className="mt-5 space-y-2.5">
-                        {[
-                          t("workflow.handOff.bullet1"),
-                          t("workflow.handOff.bullet2"),
-                          t("workflow.handOff.bullet3"),
-                        ].map((b) => (
-                          <li
-                            key={b}
-                            className="text-muted-foreground flex items-center gap-2.5 text-sm"
-                          >
-                            <CheckCircle2 className="text-brand-secondary size-3.5 shrink-0" />{" "}
-                            {b}
-                          </li>
-                        ))}
+                        {(t.raw("workflow.handOff.bullets") as string[]).map(
+                          (b) => (
+                            <li
+                              key={b}
+                              className="text-muted-foreground flex items-center gap-2.5 text-sm"
+                            >
+                              <CheckCircle2 className="text-brand-secondary size-3.5 shrink-0" />{" "}
+                              {b}
+                            </li>
+                          )
+                        )}
                       </ul>
                       <Link
                         href="/gallery"

--- a/src/components/dashboard/ApiKeysManager.tsx
+++ b/src/components/dashboard/ApiKeysManager.tsx
@@ -98,8 +98,8 @@ function formatRateLimitWindow(
 ) {
   if (ms === null) return "—";
   const minutes = ms / 1000 / 60;
-  if (minutes < 60) return t("minutesUnit", { count: minutes });
-  return t("hoursUnit", { count: minutes / 60 });
+  if (minutes < 60) return t("units.minutes", { count: minutes });
+  return t("units.hours", { count: minutes / 60 });
 }
 
 function formatPermissions(permissions: AdminApiKey["permissions"]) {
@@ -269,7 +269,7 @@ export default function DashboardApiKeysManager({
   }));
 
   const emptyMessage =
-    initialKeys.length === 0 ? t("emptyMessage") : t("emptyFilteredMessage");
+    initialKeys.length === 0 ? t("empty.default") : t("empty.filtered");
 
   const inspectStatus = inspectKey ? getApiKeyStatus(inspectKey) : null;
 
@@ -278,10 +278,10 @@ export default function DashboardApiKeysManager({
       <DataTableToolbar
         searchValue={globalFilter}
         onSearchChange={setGlobalFilter}
-        searchPlaceholder={t("searchPlaceholder")}
+        searchPlaceholder={t("filters.searchPlaceholder")}
       >
         <DataTableFacetFilter
-          title={t("status")}
+          title={t("filters.status")}
           selected={selectedStatuses}
           options={statusFilterOptions}
           onChange={setSelectedStatuses}
@@ -299,7 +299,7 @@ export default function DashboardApiKeysManager({
       />
 
       <p className="text-muted-foreground text-xs">
-        {t("showing", {
+        {t("status.showing", {
           filtered: filteredRows.length,
           total: initialKeys.length,
         })}
@@ -335,21 +335,21 @@ export default function DashboardApiKeysManager({
               <div className="grid grid-cols-3 divide-x border-b">
                 {[
                   {
-                    label: t("panel.requests"),
+                    label: t("panel.stats.requests"),
                     value: inspectKey.requestCount.toLocaleString(),
                   },
                   {
-                    label: t("panel.remaining"),
+                    label: t("panel.stats.remaining"),
                     value:
                       inspectKey.remaining !== null
                         ? inspectKey.remaining.toLocaleString()
                         : "—",
                   },
                   {
-                    label: t("panel.rateLimit"),
+                    label: t("panel.stats.rateLimit"),
                     value: inspectKey.rateLimitEnabled
                       ? `${inspectKey.rateLimitMax ?? "—"}/${formatRateLimitWindow(inspectKey.rateLimitTimeWindowMs, t as (key: string, values?: Record<string, unknown>) => string)}`
-                      : t("off"),
+                      : t("status.off"),
                   },
                 ].map(({ label, value }) => (
                   <div key={label} className="px-4 py-3 text-center">
@@ -365,12 +365,12 @@ export default function DashboardApiKeysManager({
 
               <div className="space-y-0 px-6 py-5">
                 <p className="text-muted-foreground mb-3 text-[10px] font-medium tracking-wide uppercase">
-                  {t("panel.keySection")}
+                  {t("panel.sections.key")}
                 </p>
                 <dl className="space-y-2">
                   {[
                     {
-                      label: t("panel.status"),
+                      label: t("panel.fields.status"),
                       value: (
                         <Badge variant={getStatusVariant(inspectStatus)}>
                           {getStatusLabel(inspectStatus, t)}
@@ -378,7 +378,7 @@ export default function DashboardApiKeysManager({
                       ),
                     },
                     {
-                      label: t("panel.prefix"),
+                      label: t("panel.fields.prefix"),
                       value: (
                         <span className="font-mono text-xs">
                           {inspectKey.prefix ?? "—"}
@@ -387,7 +387,7 @@ export default function DashboardApiKeysManager({
                       ),
                     },
                     {
-                      label: t("panel.permissions"),
+                      label: t("panel.fields.permissions"),
                       value: (
                         <span className="text-xs">
                           {formatPermissions(inspectKey.permissions)}
@@ -395,15 +395,15 @@ export default function DashboardApiKeysManager({
                       ),
                     },
                     {
-                      label: t("panel.created"),
+                      label: t("panel.fields.created"),
                       value: formatDate(inspectKey.createdAt),
                     },
                     {
-                      label: t("panel.expires"),
+                      label: t("panel.fields.expires"),
                       value: formatDate(inspectKey.expiresAt),
                     },
                     {
-                      label: t("panel.lastUsed"),
+                      label: t("panel.fields.lastUsed"),
                       value: formatDateTime(inspectKey.lastRequest),
                     },
                   ].map(({ label, value }) => (
@@ -422,20 +422,20 @@ export default function DashboardApiKeysManager({
 
               <div className="border-t px-6 py-5">
                 <p className="text-muted-foreground mb-3 text-[10px] font-medium tracking-wide uppercase">
-                  {t("panel.ownerSection")}
+                  {t("panel.sections.owner")}
                 </p>
                 <dl className="space-y-2">
                   {[
                     {
-                      label: t("panel.name"),
+                      label: t("panel.fields.name"),
                       value: inspectKey.ownerName ?? "—",
                     },
                     {
-                      label: t("panel.email"),
+                      label: t("panel.fields.email"),
                       value: inspectKey.ownerEmail ?? "—",
                     },
                     {
-                      label: t("panel.userId"),
+                      label: t("panel.fields.userId"),
                       value: (
                         <span className="font-mono text-xs">
                           {inspectKey.ownerUserId}
@@ -462,7 +462,7 @@ export default function DashboardApiKeysManager({
                 <KeyRound className="size-4" />
                 {t("panel.title")}
               </SheetTitle>
-              <SheetDescription>{t("panel.selectRow")}</SheetDescription>
+              <SheetDescription>{t("panel.empty.selectRow")}</SheetDescription>
             </SheetHeader>
           )}
         </SheetContent>

--- a/src/components/dashboard/GalleryManager.tsx
+++ b/src/components/dashboard/GalleryManager.tsx
@@ -166,17 +166,17 @@ function formatDate(value: string | null) {
 function getShareLifecycleDetail(entry: DashboardGalleryEntry, t: Translate) {
   const state = getShareLifecycleState(entry);
   if (state === "revoked")
-    return t("revokedOn", { date: formatDate(entry.shareRevokedAt) });
+    return t("lifecycle.revokedOn", { date: formatDate(entry.shareRevokedAt) });
   if (state === "expired")
-    return t("expiredOn", { date: formatDate(entry.shareExpiresAt) });
+    return t("lifecycle.expiredOn", { date: formatDate(entry.shareExpiresAt) });
   if (entry.shareExpiresAt)
-    return t("expiresOn", { date: formatDate(entry.shareExpiresAt) });
-  return t("noExpiry");
+    return t("lifecycle.expiresOn", { date: formatDate(entry.shareExpiresAt) });
+  return t("lifecycle.noExpiry");
 }
 
 function formatFieldSize(entry: DashboardGalleryEntry, t: Translate) {
   if (entry.fieldWidth == null || entry.fieldHeight == null) {
-    return t("notSet");
+    return t("fallback.notSet");
   }
 
   return formatMeasurementFieldSize(
@@ -187,8 +187,8 @@ function formatFieldSize(entry: DashboardGalleryEntry, t: Translate) {
 }
 
 function formatElementCount(entry: DashboardGalleryEntry, t: Translate) {
-  if (entry.shapeCount == null) return t("notAvailable");
-  return t("elementCount", { count: entry.shapeCount });
+  if (entry.shapeCount == null) return t("fallback.notAvailable");
+  return t("meta.elementCount", { count: entry.shapeCount });
 }
 
 function getPreviewImageUrl(entry: DashboardGalleryEntry) {
@@ -208,10 +208,10 @@ function getEmbedAvailable(entry: DashboardGalleryEntry) {
 }
 
 function getEmbedUnavailableReason(entry: DashboardGalleryEntry, t: Translate) {
-  if (entry.shareType !== "published") return t("embedUnavailableTemporary");
+  if (entry.shareType !== "published") return t("embed.unavailableTemporary");
   const state = getShareLifecycleState(entry);
-  if (state === "revoked") return t("embedUnavailableRevoked");
-  if (state === "expired") return t("embedUnavailableExpired");
+  if (state === "revoked") return t("embed.unavailableRevoked");
+  if (state === "expired") return t("embed.unavailableExpired");
   return null;
 }
 
@@ -388,7 +388,7 @@ export default function DashboardGalleryManager({
     action: GalleryUpdateAction
   ) => {
     if (!canManageGallery) {
-      toast.error(t("manageRestricted"));
+      toast.error(t("restrictions.manage"));
       return;
     }
 
@@ -411,7 +411,9 @@ export default function DashboardGalleryManager({
 
       if (!response.ok || !payload.ok) {
         throw new Error(
-          payload.ok ? t("updateFailed") : (payload.error ?? t("updateFailed"))
+          payload.ok
+            ? t("messages.updateFailed")
+            : (payload.error ?? t("messages.updateFailed"))
         );
       }
 
@@ -423,9 +425,11 @@ export default function DashboardGalleryManager({
         )
       );
 
-      toast.success(t("updateSuccess", { action }));
+      toast.success(t("messages.updateSuccess", { action }));
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : t("updateFailed"));
+      toast.error(
+        error instanceof Error ? error.message : t("messages.updateFailed")
+      );
     } finally {
       setPendingShareToken(null);
     }
@@ -433,7 +437,7 @@ export default function DashboardGalleryManager({
 
   const deleteEntry = async (shareToken: string) => {
     if (!canManageGallery) {
-      toast.error(t("deleteRestricted"));
+      toast.error(t("restrictions.delete"));
       return;
     }
 
@@ -452,7 +456,9 @@ export default function DashboardGalleryManager({
 
       if (!response.ok || !payload.ok) {
         throw new Error(
-          payload.ok ? t("deleteFailed") : (payload.error ?? t("deleteFailed"))
+          payload.ok
+            ? t("messages.deleteFailed")
+            : (payload.error ?? t("messages.deleteFailed"))
         );
       }
 
@@ -460,9 +466,11 @@ export default function DashboardGalleryManager({
         previous.filter((entry) => entry.shareToken !== shareToken)
       );
       setDeleteCandidate(null);
-      toast.success(t("deleteSuccess"));
+      toast.success(t("messages.deleteSuccess"));
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : t("deleteFailed"));
+      toast.error(
+        error instanceof Error ? error.message : t("messages.deleteFailed")
+      );
     } finally {
       setPendingShareToken(null);
     }
@@ -473,18 +481,18 @@ export default function DashboardGalleryManager({
 
     try {
       await navigator.clipboard.writeText(href);
-      toast.success(t("copyLinkSuccess"));
+      toast.success(t("messages.copyLinkSuccess"));
     } catch {
-      toast.error(t("copyLinkFailed"));
+      toast.error(t("messages.copyLinkFailed"));
     }
   };
 
   const copyToClipboard = async (value: string, label: string) => {
     try {
       await navigator.clipboard.writeText(value);
-      toast.success(t("copySuccess", { label }));
+      toast.success(t("messages.copySuccess", { label }));
     } catch {
-      toast.error(t("copyFailed", { label }));
+      toast.error(t("messages.copyFailed", { label }));
     }
   };
 
@@ -492,12 +500,12 @@ export default function DashboardGalleryManager({
     return entry.galleryState !== "featured"
       ? {
           action: "feature" as const,
-          label: t("feature"),
+          label: t("actions.feature"),
           icon: Sparkles,
         }
       : {
           action: "unfeature" as const,
-          label: t("unfeature"),
+          label: t("actions.unfeature"),
           icon: StarOff,
         };
   }
@@ -506,12 +514,12 @@ export default function DashboardGalleryManager({
     return entry.galleryState !== "hidden"
       ? {
           action: "hide" as const,
-          label: t("hide"),
+          label: t("actions.hide"),
           icon: EyeOff,
         }
       : {
           action: "restore" as const,
-          label: t("restore"),
+          label: t("actions.restore"),
           icon: Eye,
         };
   }
@@ -667,14 +675,14 @@ export default function DashboardGalleryManager({
                   <VisibilityIcon className="size-4" />
                 </Button>
               </ActionTooltip>
-              <ActionTooltip label={t("delete")}>
+              <ActionTooltip label={t("actions.delete")}>
                 <Button
                   type="button"
                   variant="ghost"
                   size="icon"
                   className="text-destructive hover:bg-muted hover:text-destructive size-7"
                   disabled={isPending || !canManageGallery}
-                  aria-label={`${t("delete")} ${entry.galleryTitle}`}
+                  aria-label={`${t("actions.delete")} ${entry.galleryTitle}`}
                   onClick={() => setDeleteCandidate(entry)}
                 >
                   <Trash2 className="size-4" />
@@ -688,7 +696,7 @@ export default function DashboardGalleryManager({
                   size="sm"
                   className="text-muted-foreground hover:text-foreground ml-auto size-8 p-0 md:hidden"
                   disabled={isPending || !canManageGallery}
-                  aria-label={t("openActions")}
+                  aria-label={t("actions.open")}
                 >
                   {isPending ? (
                     <Loader2 className="size-4 animate-spin" />
@@ -720,7 +728,7 @@ export default function DashboardGalleryManager({
                   className="text-destructive focus:text-destructive"
                 >
                   <Trash2 className="size-4" />
-                  {t("delete")}
+                  {t("actions.delete")}
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -792,7 +800,7 @@ export default function DashboardGalleryManager({
     (entry) => getShareLifecycleState(entry) === "revoked"
   ).length;
   const emptyMessage =
-    entries.length === 0 ? t("emptyMessage") : t("emptyFilteredMessage");
+    entries.length === 0 ? t("empty.default") : t("empty.filtered");
   const inspectShareLifecycle = inspectCandidate
     ? getShareLifecycleState(inspectCandidate)
     : null;
@@ -808,16 +816,16 @@ export default function DashboardGalleryManager({
       <DataTableToolbar
         searchValue={globalFilter}
         onSearchChange={setGlobalFilter}
-        searchPlaceholder={t("searchPlaceholder")}
+        searchPlaceholder={t("filters.searchPlaceholder")}
       >
         <DataTableFacetFilter
-          title={t("state")}
+          title={t("filters.state")}
           selected={selectedGalleryStates}
           options={stateFilterOptions}
           onChange={setSelectedGalleryStates}
         />
         <DataTableFacetFilter
-          title={t("share")}
+          title={t("filters.share")}
           selected={selectedShareLifecycles}
           options={shareFilterOptions}
           onChange={setSelectedShareLifecycles}
@@ -825,7 +833,7 @@ export default function DashboardGalleryManager({
       </DataTableToolbar>
 
       <p className="text-muted-foreground text-xs">
-        {t("cleanupNotice", {
+        {t("status.cleanupNotice", {
           expired: expiredShareCount,
           revoked: revokedShareCount,
         })}
@@ -840,12 +848,15 @@ export default function DashboardGalleryManager({
         emptyClassName="py-8"
         onRowClick={(row) => setInspectCandidate(row.original)}
         getRowAriaLabel={(row) =>
-          t("rowAriaLabel", { title: row.original.galleryTitle })
+          t("aria.row", { title: row.original.galleryTitle })
         }
       />
 
       <p className="text-muted-foreground text-xs">
-        {t("showing", { filtered: filteredRows.length, total: entries.length })}
+        {t("status.showing", {
+          filtered: filteredRows.length,
+          total: entries.length,
+        })}
       </p>
 
       <Dialog
@@ -1008,7 +1019,7 @@ export default function DashboardGalleryManager({
                                 {getEmbedUnavailableReason(
                                   inspectCandidate,
                                   t as unknown as Translate
-                                ) ?? t("notAvailable")}
+                                ) ?? t("fallback.notAvailable")}
                               </span>
                             )
                           }

--- a/src/components/dashboard/OverviewCards.tsx
+++ b/src/components/dashboard/OverviewCards.tsx
@@ -61,27 +61,27 @@ export default async function DashboardOverviewCards({
   const cards: KpiCardConfig[] = [
     {
       key: "gallery-total",
-      label: t("galleryEntries"),
+      label: t("cards.galleryEntries.label"),
       value: galleryStats.total,
-      helper: t("galleryEntriesHelper"),
+      helper: t("cards.galleryEntries.helper"),
       icon: ImageIcon,
       accent: "bg-sky-500",
       iconTone: "bg-sky-500/10 text-sky-600 dark:text-sky-400",
     },
     {
       key: "gallery-featured",
-      label: t("featured"),
+      label: t("cards.featured.label"),
       value: galleryStats.featured,
-      helper: t("featuredHelper"),
+      helper: t("cards.featured.helper"),
       icon: Sparkles,
       accent: "bg-amber-500",
       iconTone: "bg-amber-500/10 text-amber-600 dark:text-amber-400",
     },
     {
       key: "gallery-hidden",
-      label: t("hidden"),
+      label: t("cards.hidden.label"),
       value: galleryStats.hidden,
-      helper: t("hiddenHelper"),
+      helper: t("cards.hidden.helper"),
       icon: EyeOff,
       accent: "bg-rose-500",
       iconTone: "bg-rose-500/10 text-rose-600 dark:text-rose-400",
@@ -90,9 +90,9 @@ export default async function DashboardOverviewCards({
       ? [
           {
             key: "accounts",
-            label: t("totalAccounts"),
+            label: t("cards.totalAccounts.label"),
             value: totalUsers,
-            helper: t("totalAccountsHelper"),
+            helper: t("cards.totalAccounts.helper"),
             icon: Users,
             accent: "bg-emerald-500",
             iconTone:

--- a/src/components/dashboard/UsersManager.tsx
+++ b/src/components/dashboard/UsersManager.tsx
@@ -145,7 +145,7 @@ export default function DashboardUsersManager({
         };
         if (cancelled) return;
         if (!res.ok || !payload.ok) {
-          toast.error(payload.error ?? t("loadFailed"));
+          toast.error(payload.error ?? t("messages.loadFailed"));
           return;
         }
         if (payload.stats && payload.recentEvents) {
@@ -156,7 +156,7 @@ export default function DashboardUsersManager({
         }
       })
       .catch(() => {
-        if (!cancelled) toast.error(t("loadFailed"));
+        if (!cancelled) toast.error(t("messages.loadFailed"));
       })
       .finally(() => {
         if (!cancelled) setInspectLoading(false);
@@ -170,9 +170,9 @@ export default function DashboardUsersManager({
   const copyToClipboard = async (value: string, label: string) => {
     try {
       await navigator.clipboard.writeText(value);
-      toast.success(t("copySuccess", { label }));
+      toast.success(t("messages.copySuccess", { label }));
     } catch {
-      toast.error(t("copyFailed", { label }));
+      toast.error(t("messages.copyFailed", { label }));
     }
   };
 
@@ -197,7 +197,7 @@ export default function DashboardUsersManager({
       };
 
       if (!response.ok || !payload.ok || !payload.user) {
-        throw new Error(payload.error ?? t("updateFailed"));
+        throw new Error(payload.error ?? t("messages.updateFailed"));
       }
 
       const updated = payload.user;
@@ -207,13 +207,15 @@ export default function DashboardUsersManager({
       );
       setDraftRoles((prev) => ({ ...prev, [updated.id]: updated.role }));
       toast.success(
-        t("updateSuccess", {
-          name: getUserLabel(updated, t("unnamedUser")),
+        t("messages.updateSuccess", {
+          name: getUserLabel(updated, t("fallback.unnamedUser")),
           role: getAccountRoleLabel(updated.role),
         })
       );
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : t("updateFailed"));
+      toast.error(
+        err instanceof Error ? err.message : t("messages.updateFailed")
+      );
     } finally {
       setPendingUserId(null);
     }
@@ -222,7 +224,7 @@ export default function DashboardUsersManager({
   const columns: ColumnDef<AdminUser>[] = [
     {
       id: "user",
-      accessorFn: (row) => getUserLabel(row, t("unnamedUser")),
+      accessorFn: (row) => getUserLabel(row, t("fallback.unnamedUser")),
       meta: { className: "w-[40%] min-w-56" },
       header: ({ column }) => (
         <Button
@@ -241,10 +243,10 @@ export default function DashboardUsersManager({
         return (
           <div className="min-w-0">
             <p className="truncate text-sm font-medium">
-              {getUserLabel(user, t("unnamedUser"))}
+              {getUserLabel(user, t("fallback.unnamedUser"))}
               {isSelf && (
                 <span className="text-muted-foreground ml-1.5 text-xs font-normal">
-                  {t("you")}
+                  {t("selfBadge")}
                 </span>
               )}
             </p>
@@ -369,10 +371,10 @@ export default function DashboardUsersManager({
       <DataTableToolbar
         searchValue={globalFilter}
         onSearchChange={setGlobalFilter}
-        searchPlaceholder={t("searchPlaceholder")}
+        searchPlaceholder={t("filters.searchPlaceholder")}
       >
         <DataTableFacetFilter
-          title={t("role")}
+          title={t("filters.role")}
           selected={selectedRoles}
           options={roleFilterOptions}
           onChange={setSelectedRoles}
@@ -383,12 +385,15 @@ export default function DashboardUsersManager({
         table={table}
         rows={filteredRows}
         columnsLength={columns.length}
-        emptyMessage={t("emptyMessage")}
+        emptyMessage={t("empty.default")}
         onRowClick={(row) => setInspectCandidate(row.original)}
       />
 
       <p className="text-muted-foreground text-xs">
-        {t("showing", { filtered: filteredRows.length, total: users.length })}
+        {t("status.showing", {
+          filtered: filteredRows.length,
+          total: users.length,
+        })}
       </p>
 
       <Sheet
@@ -409,7 +414,10 @@ export default function DashboardUsersManager({
                   </Avatar>
                   <div className="min-w-0">
                     <SheetTitle className="truncate text-base leading-tight">
-                      {getUserLabel(inspectCandidate, t("unnamedUser"))}
+                      {getUserLabel(
+                        inspectCandidate,
+                        t("fallback.unnamedUser")
+                      )}
                     </SheetTitle>
                     <SheetDescription className="truncate text-xs">
                       {inspectCandidate.email ?? inspectCandidate.id}
@@ -422,7 +430,7 @@ export default function DashboardUsersManager({
                 {inspectLoading ? (
                   <div className="text-muted-foreground flex items-center justify-center gap-2 py-12 text-sm">
                     <Loader2 className="size-4 animate-spin" />
-                    {t("panel.loading")}
+                    {t("panel.status.loading")}
                   </div>
                 ) : inspectData ? (
                   <div className="divide-y">
@@ -461,12 +469,12 @@ export default function DashboardUsersManager({
 
                     <div className="space-y-3 px-6 py-5">
                       <p className="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
-                        {t("panel.accountSection")}
+                        {t("panel.sections.account")}
                       </p>
                       <dl className="space-y-2.5">
                         <div className="flex items-center justify-between gap-4">
                           <dt className="text-muted-foreground text-xs">
-                            {t("panel.memberSince")}
+                            {t("panel.fields.memberSince")}
                           </dt>
                           <dd className="text-xs font-medium">
                             {formatDate(inspectCandidate.createdAt)}
@@ -474,7 +482,7 @@ export default function DashboardUsersManager({
                         </div>
                         <div className="flex items-center justify-between gap-4">
                           <dt className="text-muted-foreground text-xs">
-                            {t("panel.lastLogin")}
+                            {t("panel.fields.lastLogin")}
                           </dt>
                           <dd className="text-xs font-medium">
                             {inspectCandidate.lastLoginAt
@@ -484,7 +492,7 @@ export default function DashboardUsersManager({
                         </div>
                         <div className="flex items-center justify-between gap-4">
                           <dt className="text-muted-foreground text-xs">
-                            {t("panel.role")}
+                            {t("panel.fields.role")}
                           </dt>
                           <dd>
                             <Badge
@@ -499,7 +507,7 @@ export default function DashboardUsersManager({
                         </div>
                         <div className="flex items-start justify-between gap-4">
                           <dt className="text-muted-foreground shrink-0 text-xs">
-                            {t("panel.userId")}
+                            {t("panel.fields.userId")}
                           </dt>
                           <dd className="flex min-w-0 items-center gap-1">
                             <span className="text-muted-foreground truncate font-mono text-[11px]">
@@ -510,11 +518,11 @@ export default function DashboardUsersManager({
                               variant="ghost"
                               size="icon"
                               className="text-muted-foreground hover:text-foreground size-5 shrink-0"
-                              aria-label={t("panel.copyUserId")}
+                              aria-label={t("panel.actions.copyUserId")}
                               onClick={() =>
                                 void copyToClipboard(
                                   inspectCandidate.id,
-                                  t("panel.userId")
+                                  t("panel.fields.userId")
                                 )
                               }
                             >
@@ -527,11 +535,11 @@ export default function DashboardUsersManager({
 
                     <div className="flex items-center justify-between gap-4 px-6 py-2.5">
                       <dt className="text-muted-foreground shrink-0 text-xs">
-                        {t("panel.changeRole")}
+                        {t("panel.actions.changeRole")}
                       </dt>
                       {inspectCandidate.id === currentUserId ? (
                         <dd className="text-muted-foreground text-xs">
-                          {t("panel.cannotChangeOwnRole")}
+                          {t("panel.messages.cannotChangeOwnRole")}
                         </dd>
                       ) : (
                         <dd className="flex items-center gap-1.5">
@@ -596,7 +604,7 @@ export default function DashboardUsersManager({
                             {pendingUserId === inspectCandidate.id ? (
                               <Loader2 className="size-3 animate-spin" />
                             ) : (
-                              t("panel.save")
+                              t("panel.actions.save")
                             )}
                           </Button>
                         </dd>
@@ -605,7 +613,7 @@ export default function DashboardUsersManager({
 
                     <div className="space-y-3 px-6 py-5">
                       <p className="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
-                        {t("panel.recentActivitySection")}
+                        {t("panel.sections.recentActivity")}
                       </p>
                       {inspectData.recentEvents.length > 0 ? (
                         <ul className="space-y-1">
@@ -624,8 +632,8 @@ export default function DashboardUsersManager({
                                   </p>
                                   <p className="text-muted-foreground mt-0.5 text-xs">
                                     {isActor
-                                      ? t("panel.actor")
-                                      : t("panel.target")}{" "}
+                                      ? t("panel.relation.actor")
+                                      : t("panel.relation.target")}{" "}
                                     · {formatDate(event.createdAt)}
                                   </p>
                                 </div>
@@ -635,7 +643,7 @@ export default function DashboardUsersManager({
                         </ul>
                       ) : (
                         <p className="text-muted-foreground text-sm">
-                          {t("panel.noAuditEvents")}
+                          {t("panel.messages.noAuditEvents")}
                         </p>
                       )}
                     </div>
@@ -647,7 +655,7 @@ export default function DashboardUsersManager({
                 <Button asChild variant="outline" className="w-full" size="sm">
                   <Link href="/dashboard/audit">
                     <ExternalLink className="size-3.5" />
-                    {t("panel.viewFullAuditTrail")}
+                    {t("panel.actions.viewFullAuditTrail")}
                   </Link>
                 </Button>
               </div>

--- a/src/components/dashboard/tables/AuditEventsTable.tsx
+++ b/src/components/dashboard/tables/AuditEventsTable.tsx
@@ -188,7 +188,7 @@ function getEventDetailLabel(
   }
 
   if (event.metadata?.shareToken) {
-    return t("share", {
+    return t("filters.share", {
       token: formatMetadataValue(event.metadata.shareToken),
     });
   }
@@ -237,7 +237,7 @@ function getEntityDisplay(event: DashboardAuditEvent, t: Translate) {
   return {
     label: getEntityTypeLabel(event.entityType, t),
     detail: event.entityId
-      ? t("entityId", { id: shortenId(event.entityId) })
+      ? t("entity.id", { id: shortenId(event.entityId) })
       : null,
   };
 }
@@ -318,7 +318,7 @@ export default function DashboardAuditEventsTable({
   initialCategories = [],
 }: AuditEventsTableProps) {
   const t: Translate = useTranslations("dashboard.audit");
-  const unknownUserLabel = t("unknownUser");
+  const unknownUserLabel = t("fallback.unknownUser");
   const [globalFilter, setGlobalFilter] = useState("");
   const [selectedCategories, setSelectedCategories] =
     useState<AuditEventCategory[]>(initialCategories);
@@ -354,7 +354,7 @@ export default function DashboardAuditEventsTable({
       size="sm"
       className={cn(dataTableSortButtonClassName, className)}
       onClick={() => toggleSort(key)}
-      aria-label={t("sortAriaLabel", { label: label.toLowerCase() })}
+      aria-label={t("aria.sort", { label: label.toLowerCase() })}
     >
       {label}
       <ArrowUpDown
@@ -492,22 +492,22 @@ export default function DashboardAuditEventsTable({
       <DataTableToolbar
         searchValue={globalFilter}
         onSearchChange={setGlobalFilter}
-        searchPlaceholder={t("searchPlaceholder")}
+        searchPlaceholder={t("filters.searchPlaceholder")}
       >
         <DataTableFacetFilter
-          title={t("category")}
+          title={t("filters.category")}
           selected={selectedCategories}
           options={categoryFilterOptions}
           onChange={setSelectedCategories}
         />
         <DataTableFacetFilter
-          title={t("event")}
+          title={t("filters.event")}
           selected={selectedEventTypes}
           options={eventTypeFilters}
           onChange={setSelectedEventTypes}
         />
         <DataTableFacetFilter
-          title={t("actor")}
+          title={t("filters.actor")}
           selected={selectedActors}
           options={actorFilterOptions}
           onChange={setSelectedActors}


### PR DESCRIPTION
## Summary

- normalize the remaining dashboard i18n groups for KPI cards, filters, empty states, status text, panel copy, row actions, gallery lifecycle, and admin messages
- normalize landing workflow bullets and FAQ entries into arrays for easier review and extension
- review common i18n groups and keep the existing reusable actions, labels, status, theme toggle, and version tag structure stable

## Issue

Close #517.

## Validation

- `npm run i18n:check`
- `npm run i18n:scan-hardcoded`
- `npm run type`
- `npm run lint`