### PR TITLE
chore: Reduce final i18n hardcoded allowlist

### DIFF
--- a/lang/en/editor.json
+++ b/lang/en/editor.json
@@ -429,5 +429,30 @@
   },
   "languagePicker": {
     "ariaLabel": "Language"
+  },
+  "performanceHud": {
+    "title": "Developer HUD",
+    "summary": "Tool {tool} · {count} selected",
+    "reset": "Reset",
+    "close": "Close",
+    "metrics": {
+      "canvas2d": "2D Canvas",
+      "preview3d": "3D View",
+      "inspector": "Inspector",
+      "autosave": "Autosave"
+    },
+    "levels": {
+      "noData": "No data",
+      "heavy": "Heavy",
+      "busy": "Busy",
+      "ok": "OK"
+    }
+  },
+  "textureDebug": {
+    "title": "Texture Debug",
+    "copyConfig": "Copy config",
+    "copied": "Copied",
+    "noPanels": "No panels registered yet",
+    "flip": "flip"
   }
 }

--- a/lang/en/inspector.json
+++ b/lang/en/inspector.json
@@ -118,7 +118,10 @@
     "filterObstacles": "Obstacles",
     "itemColumn": "Item",
     "pathColumn": "Path",
-    "noItemsMatchFilter": "No items match this filter."
+    "noItemsMatchFilter": "No items match this filter.",
+    "routeStatus": {
+      "off": "off"
+    }
   },
   "layout": {
     "mapReference": {

--- a/lang/en/landing.json
+++ b/lang/en/landing.json
@@ -259,5 +259,9 @@
     "step3": "Try the latest route again if the page moved recently.",
     "goHome": "Go Home",
     "openStudio": "Open Studio"
+  },
+  "screenshotPlaceholder": {
+    "label": "Screenshot Placeholder",
+    "plannedAsset": "Planned Asset"
   }
 }

--- a/lang/nl/editor.json
+++ b/lang/nl/editor.json
@@ -429,5 +429,30 @@
   },
   "languagePicker": {
     "ariaLabel": "Taal"
+  },
+  "performanceHud": {
+    "title": "Developer-HUD",
+    "summary": "Tool {tool} · {count} geselecteerd",
+    "reset": "Resetten",
+    "close": "Sluiten",
+    "metrics": {
+      "canvas2d": "2D-canvas",
+      "preview3d": "3D-weergave",
+      "inspector": "Inspector",
+      "autosave": "Autosave"
+    },
+    "levels": {
+      "noData": "Geen data",
+      "heavy": "Zwaar",
+      "busy": "Druk",
+      "ok": "OK"
+    }
+  },
+  "textureDebug": {
+    "title": "Texture-debug",
+    "copyConfig": "Config kopiëren",
+    "copied": "Gekopieerd",
+    "noPanels": "Nog geen panels geregistreerd",
+    "flip": "flip"
   }
 }

--- a/lang/nl/inspector.json
+++ b/lang/nl/inspector.json
@@ -118,7 +118,10 @@
     "filterObstacles": "Obstakels",
     "itemColumn": "Item",
     "pathColumn": "Path",
-    "noItemsMatchFilter": "Geen items komen overeen met dit filter."
+    "noItemsMatchFilter": "Geen items komen overeen met dit filter.",
+    "routeStatus": {
+      "off": "naast route"
+    }
   },
   "layout": {
     "mapReference": {

--- a/lang/nl/landing.json
+++ b/lang/nl/landing.json
@@ -259,5 +259,9 @@
     "step3": "Probeer de route opnieuw als de pagina recent is verplaatst.",
     "goHome": "Naar home",
     "openStudio": "Open Studio"
+  },
+  "screenshotPlaceholder": {
+    "label": "Screenshot-placeholder",
+    "plannedAsset": "Geplande asset"
   }
 }

--- a/scripts/i18n_hardcoded_allowlist.json
+++ b/scripts/i18n_hardcoded_allowlist.json
@@ -54,33 +54,6 @@
     "note": "Keyboard shortcut token; not natural-language copy."
   },
   {
-    "file": "src/components/canvas/editor/TrackPreview3D.tsx",
-    "kind": "JSX text",
-    "text": "flip",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
-    "file": "src/components/canvas/editor/TrackPreview3D.tsx",
-    "kind": "JSX text",
-    "text": "No panels registered yet",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
-    "file": "src/components/canvas/editor/TrackPreview3D.tsx",
-    "kind": "JSX text",
-    "text": "Texture Debug",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
     "file": "src/components/dialogs/ImportDialog.tsx",
     "kind": "JSX text",
     "text": ".json",
@@ -135,51 +108,6 @@
     "note": "Keyboard shortcut token; not natural-language copy."
   },
   {
-    "file": "src/components/editor/PerformanceHud.tsx",
-    "kind": "JSX text",
-    "text": "Close",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
-    "file": "src/components/editor/PerformanceHud.tsx",
-    "kind": "JSX text",
-    "text": "Developer HUD",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
-    "file": "src/components/editor/PerformanceHud.tsx",
-    "kind": "JSX text",
-    "text": "Reset",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
-    "file": "src/components/editor/PerformanceHud.tsx",
-    "kind": "JSX text",
-    "text": "selected",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
-    "file": "src/components/editor/PerformanceHud.tsx",
-    "kind": "JSX text",
-    "text": "Tool",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
     "file": "src/components/editor/Toolbar.tsx",
     "kind": "JSX prop alt",
     "text": "TrackDraw",
@@ -214,15 +142,6 @@
     "group": "technical-token",
     "priority": "exception",
     "note": "Unit, file extension, coordinate label, or visual separator."
-  },
-  {
-    "file": "src/components/inspector/views/list-panel.tsx",
-    "kind": "JSX text",
-    "text": "off",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
   },
   {
     "file": "src/components/inspector/views/polyline/PolylineWaypointList.tsx",
@@ -277,24 +196,6 @@
     "group": "intentional-brand-alt",
     "priority": "exception",
     "note": "Brand-only alt text is intentionally stable unless the image needs descriptive alt copy."
-  },
-  {
-    "file": "src/components/landing/Screenshot.tsx",
-    "kind": "JSX text",
-    "text": "Planned Asset",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
-  },
-  {
-    "file": "src/components/landing/Screenshot.tsx",
-    "kind": "JSX text",
-    "text": "Screenshot Placeholder",
-    "count": 1,
-    "group": "dev-or-technical-ui",
-    "priority": "low",
-    "note": "Developer/debug/technical UI; translate later if exposed to normal users."
   },
   {
     "file": "src/components/ui/breadcrumb.tsx",

--- a/src/components/canvas/editor/TrackPreview3D.tsx
+++ b/src/components/canvas/editor/TrackPreview3D.tsx
@@ -87,6 +87,7 @@ import { resolveDiveGateElevation } from "@/lib/track/render3d-layout";
 import { useDeveloperMode } from "@/hooks/account/useDeveloperMode";
 import { useTrackPreview3DInteractions } from "@/components/canvas/editor/useTrackPreview3DInteractions";
 import { motion, useReducedMotion } from "framer-motion";
+import { useTranslations } from "next-intl";
 import dynamic from "next/dynamic";
 
 const DroneCamera = dynamic(
@@ -100,6 +101,7 @@ const DroneCamera = dynamic(
 const POPUP_TRANSITION = { duration: 0.16, ease: [0.22, 1, 0.36, 1] as const };
 
 function TextureDebugPopup({ catalogId }: { catalogId: string }) {
+  const t = useTranslations("editor.textureDebug");
   useOverrideVersion();
   const theme = useTheme();
   const prefersReducedMotion = useReducedMotion();
@@ -153,7 +155,7 @@ function TextureDebugPopup({ catalogId }: { catalogId: string }) {
             <p
               className={`text-[9px] font-semibold tracking-[0.2em] uppercase ${titleClass}`}
             >
-              Texture Debug
+              {t("title")}
             </p>
             <p className={`mt-1 truncate text-[11px] ${bodyClass}`}>
               {catalogId}
@@ -168,7 +170,7 @@ function TextureDebugPopup({ catalogId }: { catalogId: string }) {
                 : buttonClass
             }`}
           >
-            {copied ? "✓ Copied" : "Copy config"}
+            {copied ? `✓ ${t("copied")}` : t("copyConfig")}
           </button>
         </div>
       </div>
@@ -177,7 +179,7 @@ function TextureDebugPopup({ catalogId }: { catalogId: string }) {
       <div className="space-y-1.5 p-3">
         {panels.length === 0 ? (
           <p className={`py-1 text-center text-[11px] ${bodyClass}`}>
-            No panels registered yet
+            {t("noPanels")}
           </p>
         ) : (
           panels.map((panel) => {
@@ -198,7 +200,7 @@ function TextureDebugPopup({ catalogId }: { catalogId: string }) {
                   <span className="text-[11px]">{panel.panelName}</span>
                   <div className="flex items-center gap-1">
                     <span className={`mr-0.5 text-[9px] ${bodyClass}`}>
-                      flip
+                      {t("flip")}
                     </span>
                     {(["x", "y"] as const).map((axis) => {
                       const active = axis === "x" ? flips.flipX : flips.flipY;

--- a/src/components/editor/PerformanceHud.tsx
+++ b/src/components/editor/PerformanceHud.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion, useReducedMotion } from "framer-motion";
+import { useTranslations } from "next-intl";
 import { useMemo, useSyncExternalStore } from "react";
 import { useDeveloperMode } from "@/hooks/account/useDeveloperMode";
 import { useTheme } from "@/hooks/useTheme";
@@ -19,14 +20,25 @@ const HUD_TRANSITION = {
   ease: [0.22, 1, 0.36, 1] as const,
 };
 
-function getMetricLevel(metric: PerfMetric | undefined) {
-  if (!metric) return { label: "No data", tone: "text-slate-500" };
-  if (metric.lastMs >= 80) return { label: "Heavy", tone: "text-amber-500" };
-  if (metric.lastMs >= 32) return { label: "Busy", tone: "text-amber-400" };
-  return { label: "OK", tone: "text-emerald-500" };
+function getMetricLevel(
+  metric: PerfMetric | undefined,
+  labels: {
+    noData: string;
+    heavy: string;
+    busy: string;
+    ok: string;
+  }
+) {
+  if (!metric) return { label: labels.noData, tone: "text-slate-500" };
+  if (metric.lastMs >= 80)
+    return { label: labels.heavy, tone: "text-amber-500" };
+  if (metric.lastMs >= 32)
+    return { label: labels.busy, tone: "text-amber-400" };
+  return { label: labels.ok, tone: "text-emerald-500" };
 }
 
 export default function PerformanceHud() {
+  const t = useTranslations("editor.performanceHud");
   const { enabled, setEnabled } = useDeveloperMode();
   const prefersReducedMotion = useReducedMotion();
   const theme = useTheme();
@@ -39,19 +51,25 @@ export default function PerformanceHud() {
   );
 
   const rows = useMemo(() => {
+    const levelLabels = {
+      noData: t("levels.noData"),
+      heavy: t("levels.heavy"),
+      busy: t("levels.busy"),
+      ok: t("levels.ok"),
+    };
     const summaryRows = [
-      ["2D Canvas", metrics["render:TrackCanvas"]],
-      ["3D View", metrics["render:TrackPreview3D"]],
-      ["Inspector", metrics["render:Inspector"]],
-      ["Autosave", metrics["autosave:localStorage"]],
+      [t("metrics.canvas2d"), metrics["render:TrackCanvas"]],
+      [t("metrics.preview3d"), metrics["render:TrackPreview3D"]],
+      [t("metrics.inspector"), metrics["render:Inspector"]],
+      [t("metrics.autosave"), metrics["autosave:localStorage"]],
     ] as const;
 
     return summaryRows.map(([label, metric]) => ({
       label,
       metric,
-      level: getMetricLevel(metric),
+      level: getMetricLevel(metric, levelLabels),
     }));
-  }, [metrics]);
+  }, [metrics, t]);
 
   if (process.env.NODE_ENV === "production" || !enabled) {
     return null;
@@ -84,10 +102,10 @@ export default function PerformanceHud() {
             <p
               className={`text-[9px] font-semibold tracking-[0.2em] uppercase ${titleClass}`}
             >
-              Developer HUD
+              {t("title")}
             </p>
             <p className={`mt-1 text-[11px] ${bodyClass}`}>
-              Tool {activeTool} · {selectionCount} selected
+              {t("summary", { tool: activeTool, count: selectionCount })}
             </p>
           </div>
           <div className="flex items-center gap-1">
@@ -96,14 +114,14 @@ export default function PerformanceHud() {
               onClick={() => resetPerfMetrics()}
               className={`rounded-md border px-2 py-1 text-[9px] font-medium tracking-[0.04em] transition-colors ${buttonClass}`}
             >
-              Reset
+              {t("reset")}
             </button>
             <button
               type="button"
               onClick={() => setEnabled(false)}
               className={`rounded-md border px-2 py-1 text-[9px] font-medium tracking-[0.04em] transition-colors ${buttonClass}`}
             >
-              Close
+              {t("close")}
             </button>
           </div>
         </div>

--- a/src/components/inspector/views/list-panel.tsx
+++ b/src/components/inspector/views/list-panel.tsx
@@ -289,7 +289,7 @@ export function ItemOverviewList({
                         </span>
                       ) : unmappedObstacleIds.has(shape.id) ? (
                         <span className="flex h-5 w-12 shrink-0 items-center justify-center rounded-md border border-amber-500/25 bg-amber-500/10 font-mono text-[10px] font-medium text-amber-500">
-                          off
+                          {t("listPanel.routeStatus.off")}
                         </span>
                       ) : (
                         <span className="text-muted-foreground/30 flex h-5 w-12 shrink-0 items-center justify-center font-mono text-[10px]">

--- a/src/components/inspector/views/list-panel.tsx
+++ b/src/components/inspector/views/list-panel.tsx
@@ -251,6 +251,7 @@ export function ItemOverviewList({
                   const pathNumber = numberingReport.obstacleNumberMap.get(
                     shape.id
                   );
+                  const routeStatusOff = t("listPanel.routeStatus.off");
                   return (
                     <div
                       key={shape.id}
@@ -288,8 +289,11 @@ export function ItemOverviewList({
                           #{pathNumber}
                         </span>
                       ) : unmappedObstacleIds.has(shape.id) ? (
-                        <span className="flex h-5 w-12 shrink-0 items-center justify-center rounded-md border border-amber-500/25 bg-amber-500/10 font-mono text-[10px] font-medium text-amber-500">
-                          {t("listPanel.routeStatus.off")}
+                        <span
+                          title={routeStatusOff}
+                          className="flex h-5 w-12 shrink-0 items-center justify-center truncate rounded-md border border-amber-500/25 bg-amber-500/10 px-1 font-mono text-[10px] font-medium text-amber-500"
+                        >
+                          {routeStatusOff}
                         </span>
                       ) : (
                         <span className="text-muted-foreground/30 flex h-5 w-12 shrink-0 items-center justify-center font-mono text-[10px]">

--- a/src/components/landing/Screenshot.tsx
+++ b/src/components/landing/Screenshot.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion, useInView } from "framer-motion";
+import { useTranslations } from "next-intl";
 import { useRef } from "react";
 
 // ── Section screenshot — scroll-triggered reveal, hover lift ──
@@ -90,6 +91,7 @@ export function ScreenshotPlaceholder({
   frameClassName?: string;
   className?: string;
 }) {
+  const t = useTranslations("landing.screenshotPlaceholder");
   const ref = useRef<HTMLDivElement>(null);
   const inView = useInView(ref, { once: true, margin: "-80px" });
   const isPortrait = aspect === "portrait";
@@ -125,7 +127,7 @@ export function ScreenshotPlaceholder({
 
           <div className="mt-4 flex items-center gap-2">
             <p className="text-muted-foreground text-[10px] font-semibold tracking-[0.18em] uppercase">
-              Screenshot Placeholder
+              {t("label")}
             </p>
             {badge ? (
               <span className="border-border/60 bg-muted/65 text-muted-foreground rounded-full border px-2 py-0.5 text-[9px] font-semibold tracking-[0.12em] uppercase">
@@ -141,7 +143,7 @@ export function ScreenshotPlaceholder({
 
           <div className="border-border/60 bg-background/72 mt-4 rounded-2xl border px-3 py-2.5 backdrop-blur-xs">
             <p className="text-muted-foreground text-[10px] tracking-[0.16em] uppercase">
-              Planned Asset
+              {t("plannedAsset")}
             </p>
             <p className="text-foreground mt-1 font-mono text-sm">{filename}</p>
           </div>


### PR DESCRIPTION
## Summary
- translate the remaining low-priority hardcoded UI copy in the developer HUD, texture debug popup, inspector list route status, and landing screenshot placeholders
- remove those entries from the hardcoded i18n allowlist
- leave the remaining allowlist baseline as documented exceptions for brand alt text, shortcuts/units, technical tokens, and design-system primitives

## Validation
- npm run i18n:check
- npm run i18n:scan-hardcoded
- npm run type
- npm run lint
- git diff --check