### PR TITLE
docs: Research presets and generated flightpaths

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -39,6 +39,7 @@ Current research documents:
 - `ar-mode-evaluation.md` — AR mode technical feasibility
 - `ar-mode-product-shape.md` — AR product model and go/no-go criteria
 - `live-race-overlay-evaluation.md` — race overlay product model and technical analysis
+- `rotorhazard-event-viewer-integration.md` — long-term RotorHazard-hosted offline-capable TrackDraw event viewer direction
 - `map-field-overlay-evaluation.md` — field overlay product model and UX analysis
 - `accounts-project-sync.md` — shipped product direction for accounts and project sync
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -40,6 +40,8 @@ Current research documents:
 - `ar-mode-product-shape.md` — AR product model and go/no-go criteria
 - `live-race-overlay-evaluation.md` — race overlay product model and technical analysis
 - `rotorhazard-event-viewer-integration.md` — long-term RotorHazard-hosted offline-capable TrackDraw event viewer direction
+- `presets-store.md` — community preset store publication, browse, and save-to-private-copy direction
+- `generated-flightpath-assistance.md` — obstacle-order-based generated Race Line assistance direction
 - `map-field-overlay-evaluation.md` — field overlay product model and UX analysis
 - `accounts-project-sync.md` — shipped product direction for accounts and project sync
 

--- a/docs/pva/i18n-multilingual-pva.md
+++ b/docs/pva/i18n-multilingual-pva.md
@@ -270,27 +270,23 @@ Concrete copy fixes applied:
 - dynamic translation usage outside the simple `const t = useTranslations("namespace")` pattern;
 - semantic mistakes where both locales have a key but the NL copy is wrong.
 
-Resolution: added `scripts/i18n_hardcoded_scan.mjs` (`npm run i18n:scan-hardcoded`) as a separate, conservative TypeScript/TSX parser-based scan for hardcoded JSX text, common user-facing props, and metadata fields. It uses `scripts/i18n_hardcoded_allowlist.json` as the current debt baseline, so new hardcoded UI copy fails while existing known debt can be translated down over time.
+Resolution: added `scripts/i18n_hardcoded_scan.mjs` (`npm run i18n:scan-hardcoded`) as a separate, conservative TypeScript/TSX parser-based scan for hardcoded JSX text, common user-facing props, and metadata fields. It uses `scripts/i18n_hardcoded_allowlist.json` as the baseline, so new hardcoded UI copy fails unless it is explicitly categorized.
 
-The hardcoded allowlist is categorized by `group`, `priority`, and `note` so long-lived exceptions can be separated from product UI that should be translated soon. Current categories include:
+The hardcoded allowlist is categorized by `group`, `priority`, and `note` so long-lived exceptions are separated from product UI. After the final allowlist cleanup, the remaining baseline is exception-only. Current categories include:
 
-- `product-ui-translate`
-- `metadata-translate`
 - `intentional-brand-alt`
 - `keyboard-or-unit`
 - `technical-token`
-- `dev-or-technical-ui`
 - `design-system-exception`
 
 CI status: `.github/workflows/linting.yaml` runs both `npm run i18n:check` and `npm run i18n:scan-hardcoded`.
 
-Baseline follow-up order:
+Baseline maintenance rule:
 
-1. Reduce `high:product-ui-translate` first, especially dialog, project manager, export, and data-table copy.
-2. Reduce `high:metadata-translate` after product UI, because it affects public/social surfaces but is less interactive.
-3. Review `medium:product-ui-translate` opportunistically when touching the owning surface.
-4. Leave `exception:*` entries unless the UI context changes or a screen-reader/user-facing label clearly needs localization.
-5. Keep baseline updates separate from feature work: when an entry is translated, remove or regenerate only the matching baseline entries.
+1. New product UI copy should be translated instead of allowlisted.
+2. New allowlist entries should be limited to intentional exceptions such as brand-only alt text, keyboard shortcuts, units, file extensions, coordinate labels, separators, or design-system primitive defaults without app-level i18n context.
+3. Leave existing `exception:*` entries unless the UI context changes or a screen-reader/user-facing label clearly needs localization.
+4. Keep baseline updates separate from feature work: when an entry is translated, remove or regenerate only the matching baseline entries.
 
 Remaining gap: semantic NL copy mistakes still require review or a future glossary/lint pass.
 
@@ -304,6 +300,7 @@ Remaining gap: semantic NL copy mistakes still require review or a future glossa
 6. Updated this PVA to match the implemented `lang/` structure and cookie/storage naming.
 7. Added `common` for reusable actions, labels, and states, and moved low-risk repeated usages there.
 8. Added categorized hardcoded-copy tooling and CI coverage.
+9. Reduced the hardcoded-copy allowlist to exception-only baseline entries.
 
 ### Language Picker Placement
 

--- a/docs/research/generated-flightpath-assistance.md
+++ b/docs/research/generated-flightpath-assistance.md
@@ -1,0 +1,150 @@
+# Generated Flightpath Assistance Research
+
+## Short Version
+
+Generated flightpath should create an editable first-pass Race Line from the user's intended obstacle order. It should not try to infer the perfect racing line, simulate a drone, or replace manual route authoring.
+
+Recommended first slice:
+
+1. Make obstacle order easy to edit with drag-to-reorder in the track items list.
+2. Add explicit generated-route metadata to the track item registry.
+3. Generate a normal polyline draft from ordered pass-through obstacles.
+4. Show a preview with warnings, then let the user accept or cancel.
+5. Validate on real layouts before adding curvature optimization or simulation-heavy behavior.
+
+## Context
+
+TrackDraw already has manual Race Line authoring, elevation-aware 3D preview, obstacle numbering, route overlay preparation, flythrough/export consumers, and Catmull-Rom smoothing. Generated flightpath should build on that foundation by creating a suggested route that becomes a normal editable polyline.
+
+The core product question is:
+
+> Given my intended obstacle order, can TrackDraw create a reasonable editable first-pass Race Line?
+
+Out of scope for the first version:
+
+- fastest possible racing line
+- automatic sequence inference from arbitrary geometry
+- drone physics or turn-radius simulation
+- replacing explicit Race Line editing
+
+## Existing Foundation
+
+Useful existing pieces:
+
+- `TrackDesign.shapeOrder` stores the current item order.
+- `useEditor.reorderShapes(fromId, beforeId)` already exists and is tested.
+- `useEditor.addShape` / `updateShape` are the right commit paths for accepted generated routes.
+- `obstacleNumbering.ts` can validate whether obstacles sit on a route.
+- `polyline-derived.ts` and `geometry.ts` already provide the Catmull-Rom smoothing used by normal routes.
+
+Important technical note: route projection math is currently duplicated in `obstacleNumbering.ts` and `overlay-prep.ts`. Before adding a third caller, extract shared projection helpers into something like `src/lib/track/route-projection.ts`.
+
+## First Algorithm
+
+Use obstacle order first, geometry second.
+
+Input:
+
+- ordered pass-through obstacles from `shapeOrder`
+- optional start/finish or timing markers later
+- optional existing route when regenerating
+
+Output:
+
+- a draft `PolylineShape`
+- warnings/confidence report
+
+Basic pipeline:
+
+1. Collect supported route obstacles in `shapeOrder`.
+2. Resolve each obstacle's anchor, heading, traversal type, and approach distance from registry metadata.
+3. Add approach, center/pass-through, and exit waypoints for gate-like obstacles.
+4. Create a normal open Race Line polyline with smoothing enabled.
+5. Run obstacle numbering against the generated draft and show warnings.
+
+This intentionally avoids nearest-neighbor, TSP-style ordering, Dubins paths, or simulation. The user already owns the sequence through item order.
+
+## Registry Metadata Needed
+
+Do not overload existing fields like `numberedObstacle` or raw `rotation`. They are related, but not specific enough for generation.
+
+Add explicit route-generation capability metadata to `trackItemAdapters`:
+
+- `routeAnchor(shape)`: defaults to `{ x: shape.x, y: shape.y }`
+- `routeHeading(shape)`: pass-through direction for gate-like shapes
+- `routeApproachDistance(shape)`: distance before/after an obstacle
+- `routeTraversal`: `through`, `around`, `marker`, or `none`
+- `supportsGeneratedRoute`: true for shapes the generator can use
+
+Start with obstacles where traversal is clear: gates, ladders, towers, dive gates, and launch gates. Keep cones, barriers, labels, map references, and decorative items out of phase 1.
+
+## UI Shape
+
+Prerequisite:
+
+- Drag-to-reorder in the track items list should ship first or alongside generation.
+
+Suggested flow:
+
+- Add `Generate Race Line` in the project layout / route-numbering inspector area.
+- Show a preview route before committing.
+- Actions: `Accept`, `Replace existing Race Line`, `Create as new Race Line`, `Cancel`.
+- Keep warnings short and actionable:
+  - "3 obstacles are not supported for route generation."
+  - "2 gates are very close together; review the generated turn."
+  - "No start/finish found; route starts at the first ordered obstacle."
+
+Mobile should use the same inspector action and a compact accept/cancel sheet. It should not introduce a new canvas mode.
+
+## Implementation Shape
+
+Add a pure module first:
+
+- `src/lib/track/generated-route.ts`
+
+Suggested API:
+
+```ts
+generateRaceLineDraft(design, options): {
+  draft: ShapeDraft<PolylineShape> | null;
+  report: GeneratedRouteReport;
+}
+```
+
+Keep generation logic out of React and out of the Zustand store. The store should only commit an accepted draft through existing shape mutation paths.
+
+Tests to add:
+
+- generated waypoint order and warnings
+- no supported obstacles
+- one/two obstacle edge cases
+- overlapping obstacles and degenerate segments
+- generated route maps source obstacles without off-route issues
+- accepted route is undoable and behaves like a normal polyline
+- replacing an existing route requires explicit user intent
+
+## Why Not Dubins Or Simulation First
+
+Dubins paths are useful for shortest bounded-curvature paths with known headings. That may become relevant later, but it is too heavy for the first product slice.
+
+TrackDraw's first version should stay explainable: ordered obstacles produce editable waypoints, and existing Catmull-Rom smoothing makes the route look natural enough for review and manual adjustment.
+
+## Recommendation
+
+Do the practical version first:
+
+1. Drag-to-reorder obstacles.
+2. Registry metadata for route generation.
+3. Pure obstacle-order generator.
+4. Preview/accept UI.
+5. Real-layout validation.
+
+Only after that should TrackDraw consider ambiguity detection, curvature constraints, or simulation-style route optimization.
+
+## References
+
+- `docs/research/path-curve-ux.md`
+- `docs/research/maneuver-curve-optimization.md`
+- Centripetal Catmull-Rom splines: `https://en.wikipedia.org/wiki/Centripetal_Catmull%E2%80%93Rom_spline`
+- Dubins paths: `https://en.wikipedia.org/wiki/Dubins_path`
+- Ayala, Kirszenblat, Rubinstein, "A geometric approach to shortest bounded curvature paths": `https://arxiv.org/abs/1403.4899`

--- a/docs/research/presets-store.md
+++ b/docs/research/presets-store.md
@@ -1,0 +1,122 @@
+# Presets Store Research
+
+## Short Version
+
+TrackDraw already has private, account-backed user presets. The presets store should be the next layer: a community/published store where users can publish reusable presets and other users can browse, inspect, and save a copy into `My presets`.
+
+Recommended first slice:
+
+1. Add publishable preset snapshots.
+2. Keep private `layout_presets` and public store records separate.
+3. Add an admin-visible/publication list before building a full browse UI.
+4. Replace the existing `Store` placeholder tab once publish/save semantics are proven.
+
+## Context
+
+Existing foundation:
+
+- `LayoutPreset` stores `{ id, name, description, shapes }`.
+- `shapesToPreset` saves selected non-path shapes relative to a centroid anchor.
+- `placeLayoutPreset` places those saved offsets at a drop point.
+- Private presets are synced through `useAccountPresetSync`.
+- Private preset API routes live under `/api/layout-presets`.
+- `migrations/0010_layout_presets.sql` stores private presets in `layout_presets`.
+- `LayoutPresetPicker` already has `My presets` and a placeholder `Store` tab.
+
+The store item is not the same thing as a private preset. A store item needs publication metadata, moderation state, preview media, and snapshot semantics.
+
+## Product Shape
+
+Use the existing product language:
+
+- `My presets`: the user's private account-backed presets.
+- `Store` or `Community presets`: published presets users can browse and save.
+- `LayoutPreset`: acceptable internal type name for now.
+
+Primary user jobs:
+
+- Find a reusable setup quickly, such as a start box, slalom, ladder, dive-gate sequence, or timing-area layout.
+- Inspect size, element counts, catalog-backed parts, and setup notes before saving.
+- Save a community preset into `My presets`.
+- Publish one of my presets when it is clean and reusable.
+
+The first store should feel like curation and reuse, not like a marketplace.
+
+## Recommended Phases
+
+### Phase 1: Publishable Preset Snapshots
+
+Add the ability to publish a snapshot of a private preset.
+
+Prefer a separate `preset_publications` table over adding public fields directly to `layout_presets`.
+
+Why:
+
+- private preset edits should not silently change a published store item
+- owners should be able to unpublish without deleting the private preset
+- public browse/moderation fields do not belong in the private sync model
+- TrackDraw already uses a similar separate-publication pattern for gallery entries
+
+Minimum publication fields:
+
+- `id`
+- `owner_user_id`
+- `source_preset_id`
+- `title`
+- `description`
+- `status`: align with gallery-style states such as `unlisted`, `listed`, `featured`, `hidden`
+- `preset_json`: snapshot payload needed for placement
+- `summary_json`: shape count, kind counts, bounds, catalog ids, official element flags
+- `preview_media_key`
+- `created_at`, `updated_at`, `published_at`
+
+### Phase 2: Store Browse And Save
+
+Replace the placeholder `Store` tab in `LayoutPresetPicker`.
+
+Start small:
+
+- featured presets
+- search by title
+- filter by obstacle family or official/catalog-backed elements
+- compact cards with preview, counts, and bounds
+- detail sheet with notes and element summary
+- `Save to My presets`
+
+Do not support direct placement from the store in the first browse version. Saving a copy first keeps ownership and editing expectations clear.
+
+### Phase 3: Moderation And Collections
+
+Add curation only after public browse is useful.
+
+Candidates:
+
+- admin status controls
+- featured collections
+- abuse/report flow
+- duplicate/fork metadata
+- source attribution
+
+## Technical Notes
+
+Keep responsibilities separate:
+
+- private presets: `/api/layout-presets`, `useAccountPresetSync`, `layout_presets`
+- public store: new server module and API routes, likely `/api/preset-store/*`
+
+Useful helper:
+
+- `src/lib/planning/preset-summary.ts` for counts, bounds, catalog ids, and display metadata
+
+Do not put public store browsing inside `useAccountPresetSync`. That hook should stay focused on the signed-in user's own presets.
+
+## Risks
+
+- Public presets can imply quality or officialness, so store UI needs clear source and official-size labels.
+- Snapshot semantics need clear copy, otherwise owners may expect private edits to update the public item.
+- Preview media may add R2/Cloudflare and moderation work; a placeholder preview is acceptable for phase 1.
+- Saving from the store should create a private copy, not a live dependency on someone else's preset.
+
+## Recommendation
+
+Start with publishable preset snapshots and a small management/admin surface. Build the public `Store` tab only after the data model and save-to-private-copy behavior are proven.

--- a/docs/research/presets-store.md
+++ b/docs/research/presets-store.md
@@ -104,9 +104,13 @@ Keep responsibilities separate:
 - private presets: `/api/layout-presets`, `useAccountPresetSync`, `layout_presets`
 - public store: new server module and API routes, likely `/api/preset-store/*`
 
-Useful helper:
+Existing private-preset helpers:
 
-- `src/lib/planning/preset-summary.ts` for counts, bounds, catalog ids, and display metadata
+- `src/lib/planning/layout-presets.ts` already owns basic preset counts and bounds.
+
+Future helper candidate:
+
+- Extract `src/lib/planning/preset-summary.ts` only if public-store summaries need a shared module for counts, bounds, catalog ids, official element flags, and display metadata.
 
 Do not put public store browsing inside `useAccountPresetSync`. That hook should stay focused on the signed-in user's own presets.
 

--- a/docs/research/rotorhazard-event-viewer-integration.md
+++ b/docs/research/rotorhazard-event-viewer-integration.md
@@ -18,6 +18,7 @@ TrackDraw editor
 ```
 
 **Ownership split:**
+
 - TrackDraw owns: package schema, package generation, Track Viewer build, rendering, asset packaging.
 - RotorHazard owns: event attachment, static file serving, admin import/sync UI, public page placement, optional live race context.
 
@@ -48,6 +49,7 @@ trackdraw-event-viewer/
 ```
 
 **Two modes (future):**
+
 - Phase 1 — self-contained: viewer JS + data + assets all in one zip. Easier to test offline.
 - Phase 2 — split: RH installs Track Viewer separately, packages contain only data + assets. Smaller per-event files, safer for upload security.
 
@@ -114,7 +116,10 @@ Normalized viewer-safe shape — not raw editor JSON.
       "rotation": { "yaw": 90 },
       "dimensions": { "width": 1.52, "height": 1.52, "depth": 0.4 },
       "route_number": 1,
-      "visual": { "renderer": "catalog-gate", "asset_set": "multigp-obstacles-v1" }
+      "visual": {
+        "renderer": "catalog-gate",
+        "asset_set": "multigp-obstacles-v1"
+      }
     }
   ],
   "route": {
@@ -147,6 +152,7 @@ Read-only app. Not the full editor.
 **Out of scope:** editing, project manager, account sign-in, share publishing, export dialogs.
 
 **Camera presets:**
+
 - Overview — angled above field, all obstacles visible
 - Pilot approach — low near start/finish for route review
 - Top-down — for setup / briefing
@@ -166,6 +172,7 @@ trackdraw.track-viewer.setLiveRaceState   // deferred to Phase 7
 ```
 
 **Form factors:**
+
 - Embedded panel on `/event/{eventId}` public page
 - Standalone viewer at `/event/{eventId}/track` (for phones, tablets, briefing screens)
 
@@ -267,14 +274,14 @@ Highlight current heat, active pilot progress on route, link route anchors to RH
 
 ## Technical Risks
 
-| Risk | Mitigation |
-|------|------------|
-| **Bundle size** — Three.js/R3F pulls in a lot | Lazy-load 3D; 2D fallback cheap; optimize textures; warn on large packages |
+| Risk                                                                        | Mitigation                                                                         |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| **Bundle size** — Three.js/R3F pulls in a lot                               | Lazy-load 3D; 2D fallback cheap; optimize textures; warn on large packages         |
 | **Viewer extraction** — viewer is coupled to Next.js + Zustand editor store | Start with spike; extract read-only state boundary; reuse renderer components only |
-| **Asset licensing** — MultiGP artwork may have constraints | Attribution where needed; generic fallback rendering available |
-| **Package security** — self-contained zip includes JS | Use self-contained for prototype; move to RH-bundled viewer for production |
-| **Schema drift** — renderer evolves faster than RH can release | Explicit schema versions; compatibility export target; conservative v1 |
-| **Offline browser constraints** — WebGL, cross-origin, file:// | RH must serve over local HTTP, not file://; use relative asset paths |
+| **Asset licensing** — MultiGP artwork may have constraints                  | Attribution where needed; generic fallback rendering available                     |
+| **Package security** — self-contained zip includes JS                       | Use self-contained for prototype; move to RH-bundled viewer for production         |
+| **Schema drift** — renderer evolves faster than RH can release              | Explicit schema versions; compatibility export target; conservative v1             |
+| **Offline browser constraints** — WebGL, cross-origin, file://              | RH must serve over local HTTP, not file://; use relative asset paths               |
 
 ---
 
@@ -295,12 +302,14 @@ Highlight current heat, active pilot progress on route, link route anchors to RH
 ## Go / No-Go
 
 **Move to PVA if:**
+
 - RH maintainers want a hosted/cached Track Viewer package on the event page.
 - RH can provide an event attachment point and serve static files.
 - TrackDraw can produce a standalone viewer without dragging in the full editor.
 - Both teams accept a versioned package contract.
 
 **Keep parked if:**
+
 - RH cannot host static viewer assets per event.
 - Viewer extraction would require destabilizing the editor.
 - Offline/LAN reliability is not a priority for the expected user base.

--- a/docs/research/rotorhazard-event-viewer-integration.md
+++ b/docs/research/rotorhazard-event-viewer-integration.md
@@ -1,0 +1,306 @@
+# RotorHazard Event Viewer Integration
+
+**Date:** June 15, 2026
+**Status:** Long-term product direction — not yet in PVA
+
+---
+
+## Concept
+
+TrackDraw exports a self-contained **Track Viewer package** (`.tdviewer.zip`). RotorHazard imports it, stores it with the event, and serves it on the public event page. The viewer works on a race-day LAN without internet after import.
+
+```
+TrackDraw editor
+  → export / publish Track Viewer package
+  → RotorHazard imports or syncs package
+  → RH serves viewer + data from local event server
+  → public event page shows interactive 2D/3D course
+```
+
+**Ownership split:**
+- TrackDraw owns: package schema, package generation, Track Viewer build, rendering, asset packaging.
+- RotorHazard owns: event attachment, static file serving, admin import/sync UI, public page placement, optional live race context.
+
+---
+
+## Package Format
+
+**File extension:** `.tdviewer.zip`
+
+```
+trackdraw-event-viewer/
+  manifest.json
+  track.json
+  track-viewer/
+    index.html
+    assets/
+      viewer.[hash].js
+      viewer.[hash].css
+  assets/
+    textures/
+      multigp-gate-panel.webp
+    models/
+      optional-model.glb
+  preview/
+    thumbnail.png
+    poster-3d.png
+  checksums.json
+```
+
+**Two modes (future):**
+- Phase 1 — self-contained: viewer JS + data + assets all in one zip. Easier to test offline.
+- Phase 2 — split: RH installs Track Viewer separately, packages contain only data + assets. Smaller per-event files, safer for upload security.
+
+### manifest.json
+
+```json
+{
+  "type": "trackdraw_viewer_package",
+  "schema": "trackdraw.viewer-package.v1",
+  "generated_at": "2026-06-15T12:00:00.000Z",
+  "trackdraw_version": "1.8.0",
+  "required_track_viewer": {
+    "name": "trackdraw-track-viewer",
+    "api": "trackdraw.track-viewer.v1",
+    "min_version": "1.8.0"
+  },
+  "source": {
+    "type": "project",
+    "project_id": "project_123",
+    "share_token": "share_abc",
+    "published_version_id": "share_version_456"
+  },
+  "display": {
+    "title": "DDS Sportpaleis Race Layout",
+    "description": "Public event layout for pilot briefing and spectator review.",
+    "default_view": "3d",
+    "allow_view_switching": true
+  },
+  "files": {
+    "track": "track.json",
+    "track_viewer": "track-viewer/index.html",
+    "thumbnail": "preview/thumbnail.png",
+    "poster_3d": "preview/poster-3d.png"
+  },
+  "capabilities": {
+    "views": ["2d", "3d"],
+    "route": true,
+    "timing_markers": true,
+    "catalog_assets": true,
+    "map_reference": false,
+    "live_race_overlay": false
+  }
+}
+```
+
+### track.json
+
+Normalized viewer-safe shape — not raw editor JSON.
+
+```json
+{
+  "type": "trackdraw_event_track",
+  "schema": "trackdraw.event-track.v1",
+  "title": "DDS Sportpaleis Race Layout",
+  "field": { "width": 60, "height": 40, "origin": "tl", "unit": "m" },
+  "units": { "display": "metric", "geometry": "m" },
+  "objects": [
+    {
+      "id": "gate_1",
+      "kind": "gate",
+      "name": "Gate 1",
+      "catalog_id": "multigp-standard-gate-5x5",
+      "position": { "x": 12, "y": 18, "z": 0 },
+      "rotation": { "yaw": 90 },
+      "dimensions": { "width": 1.52, "height": 1.52, "depth": 0.4 },
+      "route_number": 1,
+      "visual": { "renderer": "catalog-gate", "asset_set": "multigp-obstacles-v1" }
+    }
+  ],
+  "route": {
+    "id": "route_1",
+    "closed": false,
+    "length_m": 126.4,
+    "waypoints": [{ "x": 8, "y": 20, "z": 0 }],
+    "sampled_points": [{ "x": 8, "y": 20, "z": 0 }]
+  },
+  "timing_markers": [
+    {
+      "object_id": "gate_1",
+      "role": "start_finish",
+      "route_distance_m": 14.2
+    }
+  ]
+}
+```
+
+**Excluded from package:** account email, API keys, private project history, autosave snapshots, editor selection state, private map source metadata.
+
+---
+
+## Track Viewer
+
+Read-only app. Not the full editor.
+
+**In scope:** 2D layout view, 3D orbit view, route + direction, object labels/numbers, start/finish + split markers, camera presets (overview, pilot approach, top-down, orbit), mobile controls, fullscreen, integration API.
+
+**Out of scope:** editing, project manager, account sign-in, share publishing, export dialogs.
+
+**Camera presets:**
+- Overview — angled above field, all obstacles visible
+- Pilot approach — low near start/finish for route review
+- Top-down — for setup / briefing
+- Orbit — free exploration
+
+**Integration API (postMessage):**
+
+```
+trackdraw.track-viewer.ready
+trackdraw.track-viewer.error
+trackdraw.track-viewer.setView       // "2d" | "3d"
+trackdraw.track-viewer.fit
+trackdraw.track-viewer.setTheme
+trackdraw.track-viewer.highlightObject
+trackdraw.track-viewer.highlightTimingMarker
+trackdraw.track-viewer.setLiveRaceState   // deferred to Phase 7
+```
+
+**Form factors:**
+- Embedded panel on `/event/{eventId}` public page
+- Standalone viewer at `/event/{eventId}/track` (for phones, tablets, briefing screens)
+
+---
+
+## Workflows
+
+### Offline import (no account required)
+
+1. Design track in TrackDraw Studio.
+2. Export "Track Viewer package" → downloads `.tdviewer.zip`.
+3. Open RotorHazard event → upload `.tdviewer.zip`.
+4. RH validates, stores, serves locally.
+5. Public event page shows viewer on LAN.
+
+### API sync (account-backed)
+
+1. Design track, publish project in TrackDraw.
+2. Open RH event → paste share URL or project ID + API key.
+3. RH fetches `GET /api/v1/projects/{id}/event-viewer-package` → stores local snapshot.
+4. Admin clicks "Refresh from TrackDraw" before race day if needed.
+5. During event: RH uses cached snapshot, no live dependency on TrackDraw.
+
+**Auth:** bearer API key with `tracks:read` scope. Future: OAuth if adoption justifies it.
+
+### Snapshot states in RH
+
+```
+No layout attached
+Imported package
+Synced package
+Sync available
+Sync failed
+Package incompatible
+Package missing assets
+```
+
+---
+
+## Versioning
+
+Schema names: `trackdraw.viewer-package.v1`, `trackdraw.event-track.v1`, `trackdraw.track-viewer.v1`
+
+- Additive fields allowed within `v1`.
+- Removing or renaming fields requires `v2`.
+- Viewer ignores unknown fields, fails clearly on unsupported required capabilities.
+- RH validates compatibility before attaching a package to an event.
+- RH shows "exported with newer TrackDraw version" if `min_version` exceeds installed viewer.
+
+---
+
+## Implementation Phases
+
+### Phase 0 — Align with RotorHazard
+
+Open questions for RH maintainers (see below). No code yet.
+
+### Phase 1 — Standalone viewer spike (TrackDraw side)
+
+Extract read-only viewer from current share/embed renderer. Load `track.json` from a local relative path. Render 2D + 3D offline without server calls. Strip editor/account UI entirely.
+
+**Success:** open `index.html` locally, load sample package, render 2D + 3D.
+
+### Phase 2 — Package schema
+
+Define `trackdraw.viewer-package.v1` and `trackdraw.event-track.v1` as TypeScript/JSON schemas. Add validator tests. Add sample packages in test fixtures.
+
+**Success:** generate a valid package from a real TrackDraw design; invalid packages produce actionable errors.
+
+### Phase 3 — Browser export
+
+Add "Export Track Viewer package" action in TrackDraw. Generates manifest, track data, previews, assets, viewer. Shows route readiness warnings on export.
+
+**Success:** export without account, open offline, no private data included.
+
+### Phase 4 — RotorHazard import prototype
+
+RH side: admin upload control, package validation, event attachment storage, static file serving, public page viewer placement, compatibility error states.
+
+**Success:** upload to RH, public event page renders on local network without internet.
+
+### Phase 5 — Account-backed API sync
+
+Add server-side package generation endpoint. RH admin: enter API key + project/share ID, fetch, store snapshot, manual refresh, show last sync timestamp.
+
+**Success:** RH fetches before race day, stores local copy, no live dependency during event.
+
+### Phase 6 — Trusted viewer + asset deduplication
+
+RH bundles a known TrackDraw Track Viewer build. Packages contain only data + assets. RH does not execute uploaded viewer JS.
+
+**Success:** smaller packages, safer upload handling, compatibility errors still clear.
+
+### Phase 7 — Optional live event hooks
+
+Highlight current heat, active pilot progress on route, link route anchors to RH timing events. Static viewer must be stable first. Live state remains optional.
+
+---
+
+## Technical Risks
+
+| Risk | Mitigation |
+|------|------------|
+| **Bundle size** — Three.js/R3F pulls in a lot | Lazy-load 3D; 2D fallback cheap; optimize textures; warn on large packages |
+| **Viewer extraction** — viewer is coupled to Next.js + Zustand editor store | Start with spike; extract read-only state boundary; reuse renderer components only |
+| **Asset licensing** — MultiGP artwork may have constraints | Attribution where needed; generic fallback rendering available |
+| **Package security** — self-contained zip includes JS | Use self-contained for prototype; move to RH-bundled viewer for production |
+| **Schema drift** — renderer evolves faster than RH can release | Explicit schema versions; compatibility export target; conservative v1 |
+| **Offline browser constraints** — WebGL, cross-origin, file:// | RH must serve over local HTTP, not file://; use relative asset paths |
+
+---
+
+## Open Questions for RotorHazard
+
+1. Core integration or plugin/extension?
+2. Upload-only to start, or API sync from day one?
+3. Can RH store and serve static asset packages per event?
+4. Inline viewer panel, modal, or dedicated route — preference?
+5. How does RH store per-event plugin data today?
+6. Acceptable package size for typical race computers?
+7. Should RH bundle the Track Viewer separately, or accept self-contained packages?
+8. Should the package be downloadable from the public event page?
+9. Which RotorHazard versions would be targetable?
+
+---
+
+## Go / No-Go
+
+**Move to PVA if:**
+- RH maintainers want a hosted/cached Track Viewer package on the event page.
+- RH can provide an event attachment point and serve static files.
+- TrackDraw can produce a standalone viewer without dragging in the full editor.
+- Both teams accept a versioned package contract.
+
+**Keep parked if:**
+- RH cannot host static viewer assets per event.
+- Viewer extraction would require destabilizing the editor.
+- Offline/LAN reliability is not a priority for the expected user base.

--- a/docs/research/rotorhazard-event-viewer-integration.md
+++ b/docs/research/rotorhazard-event-viewer-integration.md
@@ -1,42 +1,154 @@
-# RotorHazard Event Viewer Integration
+# RotorHazard Track Viewer Integration Research
 
 **Date:** June 15, 2026
-**Status:** Long-term product direction — not yet in PVA
+**Status:** Long-term product direction - not yet in PVA
 
 ---
 
-## Concept
+## Short Version
 
-TrackDraw exports a self-contained **Track Viewer package** (`.tdviewer.zip`). RotorHazard imports it, stores it with the event, and serves it on the public event page. The viewer works on a race-day LAN without internet after import.
+TrackDraw could eventually provide a read-only track viewer that RotorHazard can show inside an event page. The main user-facing outcome is simple: open a RotorHazard event and see the TrackDraw project as a 2D/3D course preview for pilots, race directors, and spectators.
+
+The integration should be offline-first. Race-day RotorHazard deployments often run on a local network where internet access is unavailable, unreliable, or intentionally avoided. RotorHazard should be able to serve the viewer and track data from its own local event server after import or sync.
+
+Recommended first slice:
+
+1. Build a standalone TrackDraw viewer runtime that can load a normalized read-only track file without the editor shell.
+2. Distribute that viewer as an npm package and a static browser build.
+3. Add a Track Viewer package export for offline event use.
+4. Prototype a RotorHazard event-page embed that serves local viewer assets and local track data.
+5. Keep online TrackDraw embeds as a convenience path, not as the race-day dependency.
+
+## Product Goal
+
+The goal is not to make RotorHazard an editor and not to require RotorHazard users to have a TrackDraw account. The goal is to let a RotorHazard event page include a faithful TrackDraw track preview:
+
+- event overview page with an embedded 3D track preview
+- dedicated `/event/{eventId}/track` style page for phones, tablets, briefing screens, or livestream overlays
+- 2D fallback for low-powered race laptops or browsers without reliable WebGL
+- optional event context later, such as current heat, start/finish marker, or active race state
+
+The viewer should support the same basic track-reading job as the current shared/embed viewer, but with a different deployment model:
+
+| Mode | Primary use | Dependency during event |
+| --- | --- | --- |
+| TrackDraw share/embed | Website embed, quick sharing, always-current published link | TrackDraw hosted app |
+| npm viewer package | Third-party apps that want to render TrackDraw data themselves | Installed app bundle |
+| `.tdviewer.zip` package | Offline RotorHazard event attachment | RotorHazard local server only |
+
+This makes the npm viewer package the reusable foundation. The offline event package can include that viewer build at first, and later RotorHazard can bundle a trusted viewer version itself.
+
+## Integration Shape
 
 ```
-TrackDraw editor
-  → export / publish Track Viewer package
-  → RotorHazard imports or syncs package
-  → RH serves viewer + data from local event server
-  → public event page shows interactive 2D/3D course
+TrackDraw project
+  -> publish, export, or generate viewer-safe snapshot
+  -> RotorHazard imports or syncs snapshot before race day
+  -> RotorHazard stores viewer assets and track data with the event
+  -> public event page renders a local TrackDraw viewer
+  -> race-day clients use only the local RotorHazard server
 ```
 
 **Ownership split:**
 
-- TrackDraw owns: package schema, package generation, Track Viewer build, rendering, asset packaging.
-- RotorHazard owns: event attachment, static file serving, admin import/sync UI, public page placement, optional live race context.
+- TrackDraw owns: viewer runtime, viewer data schema, package generation, rendering, asset packaging, compatibility metadata.
+- RotorHazard owns: event attachment, admin import/sync UI, static file serving, public page placement, plugin/core integration, optional live race context.
 
----
+**Design principle:** RotorHazard should never need the full TrackDraw editor to display a track. It should load a stable, read-only viewer contract.
 
-## Package Format
+## Viewer Runtime
 
-**File extension:** `.tdviewer.zip`
+The viewer should be a small read-only application/runtime extracted from the existing share/embed experience. It should reuse proven renderer logic where safe, but it should not depend on editor state, account flows, autosave, project management, or export dialogs.
+
+Potential package:
+
+- npm name: `@trackdraw/viewer`
+- browser global: `TrackDrawViewer`
+- custom element: `<trackdraw-viewer>`
+- optional React wrapper later if it helps TrackDraw's own app
+- static build output for apps that do not use npm bundling
+
+Suggested package outputs:
+
+```
+@trackdraw/viewer
+  dist/
+    index.js              # ESM API
+    trackdraw-viewer.js   # browser/custom-element build
+    trackdraw-viewer.css
+    assets/
+      ...
+  schemas/
+    event-track.schema.json
+    viewer-package.schema.json
+```
+
+Minimal API:
+
+```ts
+import { createTrackDrawViewer } from "@trackdraw/viewer";
+
+const viewer = createTrackDrawViewer(container, {
+  track,
+  assetsBaseUrl: "/event/123/trackdraw/assets/",
+  defaultView: "3d",
+  allowViewSwitching: true,
+});
+
+viewer.fit();
+viewer.setView("2d");
+viewer.highlightObject("gate_1");
+viewer.destroy();
+```
+
+Custom element shape:
+
+```html
+<trackdraw-viewer
+  src="/event/123/trackdraw/track.json"
+  assets-base-url="/event/123/trackdraw/assets/"
+  default-view="3d"
+></trackdraw-viewer>
+```
+
+**In scope:**
+
+- 2D layout view
+- 3D orbit view
+- route and direction display
+- object labels and numbers
+- start/finish and split markers
+- camera presets: overview, pilot approach, top-down, orbit
+- mobile controls
+- fullscreen
+- offline asset loading from relative URLs
+- small integration API for host apps
+
+**Out of scope:**
+
+- editing
+- account sign-in
+- autosave and project restore points
+- share publishing
+- export dialogs
+- RotorHazard race control logic
+- live race overlays in the first version
+
+## Offline Event Package
+
+File extension: `.tdviewer.zip`
+
+The package is an event snapshot, not an editor project backup. It should contain only the viewer-safe data and assets needed to display the course.
 
 ```
 trackdraw-event-viewer/
   manifest.json
   track.json
-  track-viewer/
+  viewer/
     index.html
     assets/
-      viewer.[hash].js
-      viewer.[hash].css
+      trackdraw-viewer.[hash].js
+      trackdraw-viewer.[hash].css
   assets/
     textures/
       multigp-gate-panel.webp
@@ -48,10 +160,12 @@ trackdraw-event-viewer/
   checksums.json
 ```
 
-**Two modes (future):**
+Two package modes are useful:
 
-- Phase 1 — self-contained: viewer JS + data + assets all in one zip. Easier to test offline.
-- Phase 2 — split: RH installs Track Viewer separately, packages contain only data + assets. Smaller per-event files, safer for upload security.
+- Phase 1 self-contained package: viewer JS, CSS, data, and assets in one zip. This is easiest to test and proves the offline workflow.
+- Phase 2 data-only package: RotorHazard installs or bundles `@trackdraw/viewer`; uploaded packages contain only `manifest.json`, `track.json`, preview media, and assets. This is smaller and avoids executing uploaded JS.
+
+RotorHazard should serve unpacked package files over local HTTP. The package should not depend on `file://`, CDN URLs, external fonts, external images, or TrackDraw API calls during the event.
 
 ### manifest.json
 
@@ -61,9 +175,9 @@ trackdraw-event-viewer/
   "schema": "trackdraw.viewer-package.v1",
   "generated_at": "2026-06-15T12:00:00.000Z",
   "trackdraw_version": "1.8.0",
-  "required_track_viewer": {
-    "name": "trackdraw-track-viewer",
-    "api": "trackdraw.track-viewer.v1",
+  "required_viewer": {
+    "package": "@trackdraw/viewer",
+    "api": "trackdraw.viewer.v1",
     "min_version": "1.8.0"
   },
   "source": {
@@ -80,7 +194,7 @@ trackdraw-event-viewer/
   },
   "files": {
     "track": "track.json",
-    "track_viewer": "track-viewer/index.html",
+    "viewer_entry": "viewer/index.html",
     "thumbnail": "preview/thumbnail.png",
     "poster_3d": "preview/poster-3d.png"
   },
@@ -97,7 +211,7 @@ trackdraw-event-viewer/
 
 ### track.json
 
-Normalized viewer-safe shape — not raw editor JSON.
+`track.json` should be a normalized viewer-safe shape, not raw editor JSON.
 
 ```json
 {
@@ -139,177 +253,201 @@ Normalized viewer-safe shape — not raw editor JSON.
 }
 ```
 
-**Excluded from package:** account email, API keys, private project history, autosave snapshots, editor selection state, private map source metadata.
+Excluded from package:
 
----
+- account email
+- API keys
+- private project history
+- autosave snapshots
+- editor selection state
+- unpublished comments or notes
+- private map source metadata
 
-## Track Viewer
+## RotorHazard Workflows
 
-Read-only app. Not the full editor.
-
-**In scope:** 2D layout view, 3D orbit view, route + direction, object labels/numbers, start/finish + split markers, camera presets (overview, pilot approach, top-down, orbit), mobile controls, fullscreen, integration API.
-
-**Out of scope:** editing, project manager, account sign-in, share publishing, export dialogs.
-
-**Camera presets:**
-
-- Overview — angled above field, all obstacles visible
-- Pilot approach — low near start/finish for route review
-- Top-down — for setup / briefing
-- Orbit — free exploration
-
-**Integration API (postMessage):**
-
-```
-trackdraw.track-viewer.ready
-trackdraw.track-viewer.error
-trackdraw.track-viewer.setView       // "2d" | "3d"
-trackdraw.track-viewer.fit
-trackdraw.track-viewer.setTheme
-trackdraw.track-viewer.highlightObject
-trackdraw.track-viewer.highlightTimingMarker
-trackdraw.track-viewer.setLiveRaceState   // deferred to Phase 7
-```
-
-**Form factors:**
-
-- Embedded panel on `/event/{eventId}` public page
-- Standalone viewer at `/event/{eventId}/track` (for phones, tablets, briefing screens)
-
----
-
-## Workflows
-
-### Offline import (no account required)
+### Offline import, no TrackDraw account required
 
 1. Design track in TrackDraw Studio.
-2. Export "Track Viewer package" → downloads `.tdviewer.zip`.
-3. Open RotorHazard event → upload `.tdviewer.zip`.
-4. RH validates, stores, serves locally.
-5. Public event page shows viewer on LAN.
+2. Export `Track Viewer package`.
+3. Open RotorHazard event admin.
+4. Upload `.tdviewer.zip`.
+5. RotorHazard validates schema, compatibility, size, checksums, and required assets.
+6. RotorHazard stores the package with the event.
+7. Public event page shows the local TrackDraw viewer on the race-day LAN.
 
-### API sync (account-backed)
+This should be the baseline workflow because it works without account setup and without internet.
 
-1. Design track, publish project in TrackDraw.
-2. Open RH event → paste share URL or project ID + API key.
-3. RH fetches `GET /api/v1/projects/{id}/event-viewer-package` → stores local snapshot.
-4. Admin clicks "Refresh from TrackDraw" before race day if needed.
-5. During event: RH uses cached snapshot, no live dependency on TrackDraw.
+### Pre-race API sync, account-backed
 
-**Auth:** bearer API key with `tracks:read` scope. Future: OAuth if adoption justifies it.
+1. Design track and publish a TrackDraw project/share.
+2. Open RotorHazard event admin.
+3. Paste share URL or project ID and an API key.
+4. RotorHazard fetches `GET /api/v1/projects/{id}/event-viewer-package`.
+5. RotorHazard stores the returned package as a local event snapshot.
+6. Admin can refresh before race day.
+7. During the event, RotorHazard serves the cached snapshot only.
 
-### Snapshot states in RH
+Auth: bearer API key with a narrow `tracks:read` or `viewer-packages:read` scope. OAuth can wait until adoption justifies it.
+
+### Existing online embed, convenience only
+
+RotorHazard could optionally allow a normal TrackDraw embed URL for events that have reliable internet. This should not be the primary integration because it creates a live dependency on TrackDraw availability, the public internet, and the published share route during race day.
+
+Useful copy distinction:
+
+- "Embed TrackDraw share" = fastest online setup
+- "Import Track Viewer package" = recommended offline race-day setup
+- "Sync from TrackDraw" = pre-race convenience that still stores a local snapshot
+
+### RotorHazard attachment states
 
 ```
-No layout attached
+No track attached
 Imported package
 Synced package
-Sync available
-Sync failed
+Online embed configured
+Refresh available
+Refresh failed
 Package incompatible
 Package missing assets
+Viewer version unsupported
 ```
 
----
+## Host Integration API
+
+For iframe or custom-element integration, keep the API small and event-page oriented.
+
+Suggested `postMessage` events:
+
+```
+trackdraw.viewer.ready
+trackdraw.viewer.error
+trackdraw.viewer.setView
+trackdraw.viewer.fit
+trackdraw.viewer.setTheme
+trackdraw.viewer.highlightObject
+trackdraw.viewer.highlightTimingMarker
+trackdraw.viewer.setLiveRaceState
+```
+
+Suggested direct runtime methods:
+
+```ts
+viewer.setView("2d" | "3d");
+viewer.fit();
+viewer.setTheme("light" | "dark" | "system");
+viewer.highlightObject(objectId);
+viewer.highlightTimingMarker(markerId);
+viewer.setLiveRaceState(state);
+```
+
+`setLiveRaceState` should stay optional until the static viewer is stable.
 
 ## Versioning
 
-Schema names: `trackdraw.viewer-package.v1`, `trackdraw.event-track.v1`, `trackdraw.track-viewer.v1`
+Schema names:
 
-- Additive fields allowed within `v1`.
+- `trackdraw.viewer-package.v1`
+- `trackdraw.event-track.v1`
+- `trackdraw.viewer.v1`
+
+Rules:
+
+- Additive fields are allowed within `v1`.
 - Removing or renaming fields requires `v2`.
-- Viewer ignores unknown fields, fails clearly on unsupported required capabilities.
-- RH validates compatibility before attaching a package to an event.
-- RH shows "exported with newer TrackDraw version" if `min_version` exceeds installed viewer.
-
----
+- Viewer ignores unknown optional fields.
+- Viewer fails clearly on unsupported required capabilities.
+- RotorHazard validates compatibility before attaching a package to an event.
+- RotorHazard shows "exported with newer TrackDraw version" if `min_version` exceeds its installed viewer.
+- TrackDraw export should allow targeting an older supported viewer version once RotorHazard integration exists.
 
 ## Implementation Phases
 
-### Phase 0 — Align with RotorHazard
+### Phase 0: Align with RotorHazard
 
-Open questions for RH maintainers (see below). No code yet.
+Confirm whether this belongs in RotorHazard core or a plugin, and whether the event page can host local static viewer assets per event.
 
-### Phase 1 — Standalone viewer spike (TrackDraw side)
+Success: both projects agree on integration surface, storage expectations, and offline-first goals.
 
-Extract read-only viewer from current share/embed renderer. Load `track.json` from a local relative path. Render 2D + 3D offline without server calls. Strip editor/account UI entirely.
+### Phase 1: Standalone viewer spike
 
-**Success:** open `index.html` locally, load sample package, render 2D + 3D.
+Extract a read-only viewer from the current share/embed renderer. Load a local `track.json`, render 2D and 3D without server calls, and remove editor/account UI.
 
-### Phase 2 — Package schema
+Success: open a sample viewer over local HTTP and render a real TrackDraw design without the editor app.
 
-Define `trackdraw.viewer-package.v1` and `trackdraw.event-track.v1` as TypeScript/JSON schemas. Add validator tests. Add sample packages in test fixtures.
+### Phase 2: npm package and static build
 
-**Success:** generate a valid package from a real TrackDraw design; invalid packages produce actionable errors.
+Create `@trackdraw/viewer` with an ESM API, custom element build, CSS, and schemas. Keep the viewer runtime independent from Next.js routes.
 
-### Phase 3 — Browser export
+Success: a plain HTML page and a small bundled app can both render the same sample track using the package.
 
-Add "Export Track Viewer package" action in TrackDraw. Generates manifest, track data, previews, assets, viewer. Shows route readiness warnings on export.
+### Phase 3: Viewer-safe schema and package export
 
-**Success:** export without account, open offline, no private data included.
+Define `trackdraw.viewer-package.v1` and `trackdraw.event-track.v1` as TypeScript/JSON schemas. Add browser export for `.tdviewer.zip` with manifest, track data, previews, assets, and self-contained viewer files.
 
-### Phase 4 — RotorHazard import prototype
+Success: export without an account, serve locally, no private data included.
 
-RH side: admin upload control, package validation, event attachment storage, static file serving, public page viewer placement, compatibility error states.
+### Phase 4: RotorHazard import prototype
 
-**Success:** upload to RH, public event page renders on local network without internet.
+RotorHazard side: admin upload control, package validation, event attachment storage, static file serving, public event-page viewer placement, and compatibility error states.
 
-### Phase 5 — Account-backed API sync
+Success: upload to RotorHazard and view the track from another device on the local network without internet.
 
-Add server-side package generation endpoint. RH admin: enter API key + project/share ID, fetch, store snapshot, manual refresh, show last sync timestamp.
+### Phase 5: Trusted viewer and data-only packages
 
-**Success:** RH fetches before race day, stores local copy, no live dependency during event.
+RotorHazard installs or bundles a known `@trackdraw/viewer` version. TrackDraw can export data-only packages for that viewer version.
 
-### Phase 6 — Trusted viewer + asset deduplication
+Success: smaller packages, no uploaded JS execution, compatibility errors remain clear.
 
-RH bundles a known TrackDraw Track Viewer build. Packages contain only data + assets. RH does not execute uploaded viewer JS.
+### Phase 6: Account-backed pre-race sync
 
-**Success:** smaller packages, safer upload handling, compatibility errors still clear.
+Add server-side package generation endpoint. RotorHazard admin enters API key and project/share ID, fetches a local snapshot, manually refreshes before race day, and sees the last sync timestamp.
 
-### Phase 7 — Optional live event hooks
+Success: sync improves setup convenience but event display still works fully offline after sync.
 
-Highlight current heat, active pilot progress on route, link route anchors to RH timing events. Static viewer must be stable first. Live state remains optional.
+### Phase 7: Optional live event hooks
 
----
+Highlight current heat, start/finish, active pilot state, or route-relevant timing markers from RotorHazard. Static display remains the stable baseline.
+
+Success: live context enriches the event page without coupling TrackDraw viewer rendering to race control.
 
 ## Technical Risks
 
-| Risk                                                                        | Mitigation                                                                         |
-| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| **Bundle size** — Three.js/R3F pulls in a lot                               | Lazy-load 3D; 2D fallback cheap; optimize textures; warn on large packages         |
-| **Viewer extraction** — viewer is coupled to Next.js + Zustand editor store | Start with spike; extract read-only state boundary; reuse renderer components only |
-| **Asset licensing** — MultiGP artwork may have constraints                  | Attribution where needed; generic fallback rendering available                     |
-| **Package security** — self-contained zip includes JS                       | Use self-contained for prototype; move to RH-bundled viewer for production         |
-| **Schema drift** — renderer evolves faster than RH can release              | Explicit schema versions; compatibility export target; conservative v1             |
-| **Offline browser constraints** — WebGL, cross-origin, file://              | RH must serve over local HTTP, not file://; use relative asset paths               |
-
----
+| Risk | Mitigation |
+| --- | --- |
+| Viewer extraction is coupled to Next.js, Zustand, or editor state | Start with a spike; define a read-only data boundary; reuse renderers only where they do not pull editor behavior |
+| Bundle size is high because of Three.js/R3F | Lazy-load 3D; keep 2D fallback cheap; optimize textures; set package size warnings |
+| Uploaded package includes executable JS | Allow only for prototype; move production toward RotorHazard-bundled `@trackdraw/viewer` and data-only packages |
+| Offline assets fail because of CDN or absolute URLs | Require relative asset URLs; include fonts/textures/models in package or viewer bundle |
+| Schema drift breaks older RotorHazard installs | Version schemas; support export target versions; make compatibility errors actionable |
+| WebGL is unreliable on race laptops | Ship 2D fallback and poster preview; do not require 3D for event page usefulness |
+| Asset licensing is unclear | Provide generic fallback rendering; include attribution metadata where needed |
 
 ## Open Questions for RotorHazard
 
-1. Core integration or plugin/extension?
-2. Upload-only to start, or API sync from day one?
-3. Can RH store and serve static asset packages per event?
-4. Inline viewer panel, modal, or dedicated route — preference?
-5. How does RH store per-event plugin data today?
-6. Acceptable package size for typical race computers?
-7. Should RH bundle the Track Viewer separately, or accept self-contained packages?
-8. Should the package be downloadable from the public event page?
-9. Which RotorHazard versions would be targetable?
-
----
+1. Should this be RotorHazard core, a plugin, or both?
+2. Can RotorHazard store and serve static files per event?
+3. What is the preferred public placement: inline event panel, modal, dedicated track page, or all three?
+4. What package size is acceptable for typical race computers and SD card deployments?
+5. Should RotorHazard bundle `@trackdraw/viewer`, accept self-contained packages, or support both?
+6. Can plugin data include checksums, package metadata, and extracted asset folders?
+7. Which RotorHazard versions would be realistic targets?
+8. Should the public event page allow downloading the attached TrackDraw viewer package?
+9. What live race state, if any, is worth exposing to the viewer after the static display works?
 
 ## Go / No-Go
 
-**Move to PVA if:**
+Move to PVA if:
 
-- RH maintainers want a hosted/cached Track Viewer package on the event page.
-- RH can provide an event attachment point and serve static files.
-- TrackDraw can produce a standalone viewer without dragging in the full editor.
-- Both teams accept a versioned package contract.
+- RotorHazard maintainers want local track preview support on event pages.
+- RotorHazard can host static viewer assets and event-specific track data.
+- TrackDraw can produce a standalone viewer without destabilizing the editor.
+- Both projects accept a versioned viewer/data contract.
+- Offline/LAN reliability is treated as a first-class requirement.
 
-**Keep parked if:**
+Keep parked if:
 
-- RH cannot host static viewer assets per event.
-- Viewer extraction would require destabilizing the editor.
-- Offline/LAN reliability is not a priority for the expected user base.
+- RotorHazard cannot host local static viewer assets per event.
+- Viewer extraction would require large editor rewrites.
+- Online embed is considered sufficient for the expected RotorHazard use case.
+- The integration cannot avoid race-day dependency on TrackDraw hosted services.

--- a/docs/research/rotorhazard-event-viewer-integration.md
+++ b/docs/research/rotorhazard-event-viewer-integration.md
@@ -30,11 +30,11 @@ The goal is not to make RotorHazard an editor and not to require RotorHazard use
 
 The viewer should support the same basic track-reading job as the current shared/embed viewer, but with a different deployment model:
 
-| Mode | Primary use | Dependency during event |
-| --- | --- | --- |
-| TrackDraw share/embed | Website embed, quick sharing, always-current published link | TrackDraw hosted app |
-| npm viewer package | Third-party apps that want to render TrackDraw data themselves | Installed app bundle |
-| `.tdviewer.zip` package | Offline RotorHazard event attachment | RotorHazard local server only |
+| Mode                    | Primary use                                                    | Dependency during event       |
+| ----------------------- | -------------------------------------------------------------- | ----------------------------- |
+| TrackDraw share/embed   | Website embed, quick sharing, always-current published link    | TrackDraw hosted app          |
+| npm viewer package      | Third-party apps that want to render TrackDraw data themselves | Installed app bundle          |
+| `.tdviewer.zip` package | Offline RotorHazard event attachment                           | RotorHazard local server only |
 
 This makes the npm viewer package the reusable foundation. The offline event package can include that viewer build at first, and later RotorHazard can bundle a trusted viewer version itself.
 
@@ -413,15 +413,15 @@ Success: live context enriches the event page without coupling TrackDraw viewer 
 
 ## Technical Risks
 
-| Risk | Mitigation |
-| --- | --- |
+| Risk                                                              | Mitigation                                                                                                        |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | Viewer extraction is coupled to Next.js, Zustand, or editor state | Start with a spike; define a read-only data boundary; reuse renderers only where they do not pull editor behavior |
-| Bundle size is high because of Three.js/R3F | Lazy-load 3D; keep 2D fallback cheap; optimize textures; set package size warnings |
-| Uploaded package includes executable JS | Allow only for prototype; move production toward RotorHazard-bundled `@trackdraw/viewer` and data-only packages |
-| Offline assets fail because of CDN or absolute URLs | Require relative asset URLs; include fonts/textures/models in package or viewer bundle |
-| Schema drift breaks older RotorHazard installs | Version schemas; support export target versions; make compatibility errors actionable |
-| WebGL is unreliable on race laptops | Ship 2D fallback and poster preview; do not require 3D for event page usefulness |
-| Asset licensing is unclear | Provide generic fallback rendering; include attribution metadata where needed |
+| Bundle size is high because of Three.js/R3F                       | Lazy-load 3D; keep 2D fallback cheap; optimize textures; set package size warnings                                |
+| Uploaded package includes executable JS                           | Allow only for prototype; move production toward RotorHazard-bundled `@trackdraw/viewer` and data-only packages   |
+| Offline assets fail because of CDN or absolute URLs               | Require relative asset URLs; include fonts/textures/models in package or viewer bundle                            |
+| Schema drift breaks older RotorHazard installs                    | Version schemas; support export target versions; make compatibility errors actionable                             |
+| WebGL is unreliable on race laptops                               | Ship 2D fallback and poster preview; do not require 3D for event page usefulness                                  |
+| Asset licensing is unclear                                        | Provide generic fallback rendering; include attribution metadata where needed                                     |
 
 ## Open Questions for RotorHazard
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -16,7 +16,7 @@ TrackDraw is now strong in these areas:
 - Portable outputs through PNG, SVG, PDF, 3D render capture, and JSON project files
 - Account-backed REST API with API key management and a live race overlay data endpoint
 - Catalog-backed official MultiGP obstacles including gates, ladders, flags, dive gate, launch gate, and a barrier category for hurdles, banners, fencing, and nets
-- Account-backed track section library where users save and reuse named canvas selections across devices
+- Account-backed user presets where users save and reuse named canvas selections across devices
 - EN/NL multilingual product experience with explicit language choice, route-scoped message loading, and CI checks for catalog parity and new hardcoded UI copy
 
 The most useful next product move is deepening the race-day workflow, keeping the editor dependable, refining the account-backed project model, and completing the remaining 3D item control and path geometry work:
@@ -308,24 +308,24 @@ Current shipped foundation:
 
 These items are now follow-up work rather than intentionally blocked. The first ownership model is clear enough that they can move forward when priority allows.
 
-#### User-Defined Track Sections (`Account-backed`)
+#### User-Defined Presets (`Account-backed`)
 
-User-defined track sections are now shipped. The four hard-coded presets in `layout-presets.ts` are removed and replaced with an account-backed section library where users save, name, and reuse their own canvas selections.
+User-defined presets are now shipped. The four hard-coded presets in `layout-presets.ts` are removed and replaced with an account-backed preset library where users save, name, and reuse their own canvas selections.
 
 Current shipped foundation:
 
-- The hard-coded section list is removed; the picker shows only user-created sections with an empty state that guides new users toward saving their first section from a canvas selection
-- Users select one or more non-path shapes on the canvas and save them as a named section; positions are normalized to a centroid-relative coordinate system so placement is anchor-based and consistent with how the existing `placeLayoutPreset` helper works
-- Sections are account-backed only; the sidebar sections button is hidden when not signed in, and `addUserPreset` shows a toast error if called without a valid session
-- Account sections are fetched on sign-in and cleared on sign-out or account switch; a module-level `lastSyncedUserId` guard prevents double-fetching
-- Rename and delete actions are available per section in the picker UI
-- A "Save section" action is available both from the multi-selection inspector and from the canvas context menu when multiple shapes are selected
-- Route lines and paths are never captured in a section; the `PlaceablePresetShape = Exclude<Shape, PolylineShape>` type enforces this at the type level
+- The hard-coded preset list is removed; the picker shows only user-created presets with an empty state that guides new users toward saving their first preset from a canvas selection
+- Users select one or more non-path shapes on the canvas and save them as a named preset; positions are normalized to a centroid-relative coordinate system so placement is anchor-based and consistent with how the existing `placeLayoutPreset` helper works
+- Presets are account-backed only; the sidebar presets button is hidden when not signed in, and `addUserPreset` shows a toast error if called without a valid session
+- Account presets are fetched on sign-in and cleared on sign-out or account switch; a module-level `lastSyncedUserId` guard prevents double-fetching
+- Rename and delete actions are available per preset in the picker UI
+- A "Save preset" action is available both from the multi-selection inspector and from the canvas context menu when multiple shapes are selected
+- Route lines and paths are never captured in a preset; the `PlaceablePresetShape = Exclude<Shape, PolylineShape>` type enforces this at the type level
 
 Deliberate scope decisions:
 
-- Local-first section storage for logged-out users was deferred; the first version is account-backed only, keeping the implementation simple and the data model unambiguous
-- Local-to-account migration was skipped for the same reason — there is no local section state to migrate
+- Local-first preset storage for logged-out users was deferred; the first version is account-backed only, keeping the implementation simple and the data model unambiguous
+- Local-to-account migration was skipped for the same reason — there is no local preset state to migrate
 - A community presets store where users publish and browse each other's presets remains a deliberate future follow-up. Research document: `docs/research/presets-store.md`
 
 Supporting design doc:
@@ -710,9 +710,9 @@ Included:
 - `useMeasurementUnitSystem` migrated from a manual `useSyncExternalStore` + custom event pattern to a Zustand `persist` store; legacy raw-string storage format is migrated transparently on first read with no change to the hook interface
 - `useEditorHints` migrated from five separate localStorage keys with manual get/set/remove calls to a single Zustand `persist` store under `trackdraw.editorHints`; all dismissed-hint states are stored as one JSON object, making `resetGuidedHints` a single store reset with no change to the hook interface
 
-### User-Defined Track Sections (`Account-backed`)
+### User-Defined Presets (`Account-backed`)
 
-The four hard-coded layout presets are replaced with an account-backed track section library. Users select any combination of non-path shapes on the canvas, name the selection, and save it as a reusable section. Sections sync with the account on sign-in and are cleared on sign-out or account switch. The section picker is hidden when not signed in. Rename, delete, and empty-state guidance are included. A "Save section" action is available from both the canvas context menu and the multi-selection inspector. Local-first storage and local-to-account migration were intentionally deferred.
+The four hard-coded layout presets are replaced with an account-backed preset library. Users select any combination of non-path shapes on the canvas, name the selection, and save it as a reusable preset. Presets sync with the account on sign-in and are cleared on sign-out or account switch. The preset picker is hidden when not signed in. Rename, delete, and empty-state guidance are included. A "Save preset" action is available from both the canvas context menu and the multi-selection inspector. Local-first storage and local-to-account migration were intentionally deferred.
 
 ### 3D Route Maneuver Review (`No account required`)
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -17,6 +17,7 @@ TrackDraw is now strong in these areas:
 - Account-backed REST API with API key management and a live race overlay data endpoint
 - Catalog-backed official MultiGP obstacles including gates, ladders, flags, dive gate, launch gate, and a barrier category for hurdles, banners, fencing, and nets
 - Account-backed track section library where users save and reuse named canvas selections across devices
+- EN/NL multilingual product experience with explicit language choice, route-scoped message loading, and CI checks for catalog parity and new hardcoded UI copy
 
 The most useful next product move is deepening the race-day workflow, keeping the editor dependable, refining the account-backed project model, and completing the remaining 3D item control and path geometry work:
 
@@ -26,7 +27,6 @@ The most useful next product move is deepening the race-day workflow, keeping th
 - Focused 3D item controls where direct manipulation is safer and faster than inspector-only editing
 - Account-backed custom banner texture support for official-size gates, ladders, and flags, so clubs can preview their own printed banners on MultiGP-sized hardware
 - Generated flightpath research as a separate route-authoring assist
-- Multilingual product experience built on the same locale-aware foundation, starting with explicit language choice and controlled translation scope
 
 Lower-priority follow-up such as share version history, gallery collections, Velocidrone export stabilization, AR, and build mode should stay parked until there is clearer need.
 
@@ -260,7 +260,7 @@ Next catalog slices:
 
 #### Generated Flightpath Assistance
 
-TrackDraw should research generated flightpaths as route-authoring assistance, separate from the element catalog and separate from 3D preview rendering.
+TrackDraw should research generated flightpaths as route-authoring assistance, separate from the element catalog and separate from 3D preview rendering. Research document: `docs/research/generated-flightpath-assistance.md`.
 
 Why:
 
@@ -326,7 +326,7 @@ Deliberate scope decisions:
 
 - Local-first section storage for logged-out users was deferred; the first version is account-backed only, keeping the implementation simple and the data model unambiguous
 - Local-to-account migration was skipped for the same reason — there is no local section state to migrate
-- A community section store where users publish and browse each other's sections remains a deliberate future follow-up
+- A community presets store where users publish and browse each other's presets remains a deliberate future follow-up. Research document: `docs/research/presets-store.md`
 
 Supporting design doc:
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -181,8 +181,8 @@ The completed release-sized work is archived below. The next TrackDraw priority 
 - [x] Barriers (`No account required`)
       Dedicated barrier category for obstacles that block sightlines, mark field boundaries, or serve as physical separators. Includes the MultiGP Hurdle with official dimensions and artwork, plus TrackDraw banner, fence panel, and net entries. Catalog-backed placement, 2D/3D rendering, inspector type switching, inventory counts, and Race Pack material output.
 
-- [x] User-defined track sections (`Account-backed`)
-      The hard-coded section list is replaced with an account-backed section library. Users select non-path shapes on the canvas, name the selection, and save it as a reusable section. Sections sync with the account on sign-in and are cleared on sign-out or account switch. The section picker is hidden when not signed in. Rename, delete, and empty-state guidance are included. "Save section" is available from both the canvas context menu and the multi-selection inspector. Local-first storage and migration were intentionally deferred.
+- [x] User-defined presets (`Account-backed`)
+      The hard-coded preset list is replaced with an account-backed preset library. Users select non-path shapes on the canvas, name the selection, and save it as a reusable preset. Presets sync with the account on sign-in and are cleared on sign-out or account switch. The preset picker is hidden when not signed in. Rename, delete, and empty-state guidance are included. "Save preset" is available from both the canvas context menu and the multi-selection inspector. Local-first storage and migration were intentionally deferred.
 
 - [x] 3D route maneuver review (`No account required`)
       The 3D route review surface now surfaces maneuver quality for powerloops, split-S, and similar moves through geometry-driven signals. Route curves are rendered more accurately and consistently across elevation changes, with first-pass powerloop and split-S detection visible in the elevation review.

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -22,7 +22,7 @@ Labels used below:
 
 ## Current Priority
 
-The completed release-sized work is archived below. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, remaining focused 3D item controls, generated flightpath assistance, multilingual-readiness for international users, account-backed project lifecycle depth beyond the shipped conflict/retry baseline, and powerloop 3D curve replacement in the route path.
+The completed release-sized work is archived below. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, remaining focused 3D item controls, generated flightpath assistance, account-backed project lifecycle depth beyond the shipped conflict/retry baseline, and powerloop 3D curve replacement in the route path.
 
 ## Follow-up
 
@@ -49,26 +49,26 @@ The completed release-sized work is archived below. The next TrackDraw priority 
         Replace detected maneuver sections with physically plausible vertical loop or half-loop curve geometry and blend cleanly into surrounding route segments. Keep this open until the 3D preview renders the corrected maneuver shape rather than only detecting and reviewing it.
 
 - [ ] Generated flightpath assistance (`Research`, `No account required`)
-      Research generated flightpaths from placed obstacles as an optional drafting aid. The intended race sequence is defined by the obstacle order in the track items list (backed by `shapeOrder`), which users can set via drag-to-reorder once this feature ships. The generator connects obstacles in that order and produces an editable race line — it assists authoring rather than replacing it.
+      Research generated flightpaths from placed obstacles as an optional drafting aid. The intended race sequence is defined by the obstacle order in the track items list (backed by `shapeOrder`), which users can set via drag-to-reorder once this feature ships. The generator connects obstacles in that order and produces an editable race line — it assists authoring rather than replacing it. Research document: `docs/research/generated-flightpath-assistance.md`.
   - [ ] Generated flightpath research
         Prototype flightpath generation from the ordered obstacle list as an assistive review/drafting feature. The output should be an editable race line, not a locked result. Validate that the sequence-based model (list order → path) is intuitive before committing to the full UI.
   - [ ] Drag-to-reorder obstacles (prerequisite)
         Wire up the drag handles in the track items list so users can explicitly set the intended race sequence before generating a path. The store action is ready; this is a UI-only change gated on the path generator being useful enough to justify the interaction.
 
-- [ ] Multilingual product experience (`No account required`)
-      Use the regional measurement work as a first locale-aware foundation, then evaluate a full i18n layer for the public site, editor, share pages, and exported handoff copy. Architecture PVA: [I18n Multilingual PVA](../pva/i18n-multilingual-pva.md).
-  - [ ] I18n architecture + editor pilot
-        Install next-intl (without routing), add a Zustand locale store, wire the NextIntlClientProvider into the root layout, and convert the editor Toolbar and StatusBar as the pilot namespace. Language picker stub in account menu. See PVA phase 1.
-  - [ ] Inspector + dialogs namespace
-        Migrate inspector panels and the share, account, project, and import/export dialogs to the message catalog (~200 strings).
-  - [ ] Landing page namespace
-        Migrate all hard-coded marketing copy to the message catalog (~500+ strings).
-  - [ ] Dashboard + remaining surfaces
-        Migrate admin dashboard and any remaining hard-coded copy.
-  - [ ] First language rollout
-        Choose the first supported languages from actual user demand and translation-maintenance capacity, with English as the stable fallback for incomplete translations.
-  - [ ] Translation QA boundary
-        Define how translated UI, mobile layouts, export PDFs/Race Packs, share pages, and legal pages are reviewed so longer translated strings do not break core workflows.
+- [x] Multilingual product experience (`No account required`)
+      Shipped the EN/NL i18n layer for the public site, editor, share/embed/gallery surfaces, dashboard, dialogs, inspector, exported handoff copy, and validation tooling. Architecture and review notes: [I18n Multilingual PVA](../pva/i18n-multilingual-pva.md).
+  - [x] I18n architecture + editor pilot
+        Installed next-intl without locale routing, added persisted language preference handling, wired route-scoped message providers, and migrated the editor pilot surfaces behind message catalogs.
+  - [x] Inspector + dialogs namespace
+        Migrated inspector panels and the share, account, project, import/export, keyboard shortcut, and profile dialogs to the message catalog.
+  - [x] Landing page namespace
+        Migrated landing, login, legal/static public copy, and placeholder content to the message catalog.
+  - [x] Dashboard + remaining surfaces
+        Migrated dashboard/admin, gallery, share/embed, metadata, API docs, mobile editor, export/PDF/Race Pack, developer HUD, and remaining hardcoded UI surfaces.
+  - [x] First language rollout
+        Shipped English and Dutch with English as the stable baseline and Dutch copy reviewed for FPV terminology such as `track`, `path`, `waypoint`, `gate`, and `race line`.
+  - [x] Translation QA boundary
+        Added locale parity/unresolved-key validation and a hardcoded-copy scan in CI. The remaining hardcoded allowlist baseline is exception-only: brand alt text, shortcuts/units, technical tokens, and design-system primitive defaults.
 
 ## Later Product Follow-up
 
@@ -84,8 +84,8 @@ The completed release-sized work is archived below. The next TrackDraw priority 
 - [ ] Gallery featured collections (`Lower priority`, `Account-backed`)
       Let admins curate small gallery collections such as indoor practice, beginner friendly, technical layouts, and race-day examples when gallery growth warrants it.
 
-- [ ] Section store (`Lower priority`, `Account-backed`)
-      Let users publish a track section to a community store where others can browse and save it. Keep out of scope until account-backed section storage is proven in practice.
+- [ ] Presets store (`Lower priority`, `Account-backed`)
+      Let users publish a preset to a community store where others can browse and save it. Keep out of scope until account-backed preset storage is proven in practice. Research document: `docs/research/presets-store.md`.
 
 - [ ] Race-day communication and briefing (`No account required`)
       The first Race Pack release and immediate QR/timing-marker slice are shipped. The remaining work here is larger race-day operations follow-up.


### PR DESCRIPTION
## Summary

- Adds research notes for a presets store and generated flightpath assistance.
- Documents RotorHazard Event Viewer integration considerations.
- Updates roadmap terminology from track sections toward presets.

## Impact

This is planning and research documentation only. It does not change runtime editor, sharing, export, or gallery behavior.