### PR TITLE
feat: Add German locale

### DIFF
--- a/lang/de/common.json
+++ b/lang/de/common.json
@@ -1,0 +1,78 @@
+{
+  "actions": {
+    "cancel": "Abbrechen",
+    "close": "Schließen",
+    "copy": "Kopieren",
+    "delete": "Löschen",
+    "duplicate": "Duplizieren",
+    "hide": "Ausblenden",
+    "lock": "Sperren",
+    "remove": "Entfernen",
+    "rename": "Umbenennen",
+    "reset": "Zurücksetzen",
+    "save": "Speichern",
+    "saveChanges": "Änderungen speichern",
+    "select": "Auswählen",
+    "undo": "Rückgängig",
+    "unlock": "Entsperren"
+  },
+  "labels": {
+    "account": "Konto",
+    "actions": "Aktionen",
+    "dashboard": "Dashboard",
+    "description": "Beschreibung",
+    "expires": "Läuft ab",
+    "language": "Sprache",
+    "name": "Name",
+    "owner": "Besitzer",
+    "profile": "Profil",
+    "project": "Projekt",
+    "role": "Rolle",
+    "status": "Status",
+    "theme": "Design",
+    "title": "Titel",
+    "type": "Typ",
+    "view": "Ansicht"
+  },
+  "dataTable": {
+    "filterPlaceholder": "{title} filtern...",
+    "noResults": "Keine Ergebnisse gefunden.",
+    "selectedCount": "{count} ausgewählt",
+    "clearFilters": "Filter löschen"
+  },
+  "measurementUnit": {
+    "metric": "Metrisch",
+    "imperial": "Imperial",
+    "presetAriaLabel": "Maßeinheiten-Voreinstellung: {current}. Zu {next} wechseln.",
+    "presetLabel": "Maßeinheiten-Voreinstellung: {current}",
+    "description": "Angezeigte Entfernungen und kompatible Eingaben umschalten."
+  },
+  "themeToggle": {
+    "labels": {
+      "light": "Hell",
+      "dark": "Dunkel",
+      "system": "System"
+    },
+    "ariaLabel": "Design: {theme}",
+    "tooltip": "Aktuell: {current}. Klicken für {next}."
+  },
+  "versionTag": {
+    "tooltip": {
+      "openReleaseNotes": "Release Notes auf GitHub öffnen",
+      "openReleaseNotesForCommit": "Commit {sha} · Release Notes auf GitHub öffnen"
+    }
+  },
+  "status": {
+    "active": "Aktiv",
+    "expired": "Abgelaufen",
+    "featured": "Hervorgehoben",
+    "hidden": "Ausgeblendet",
+    "listed": "Gelistet",
+    "loading": "Lädt",
+    "off": "Aus",
+    "on": "Ein",
+    "pending": "Ausstehend",
+    "published": "Veröffentlicht",
+    "revoked": "Widerrufen"
+  }
+}

--- a/lang/de/dialogs.json
+++ b/lang/de/dialogs.json
@@ -726,7 +726,7 @@
   },
   "completeProfile": {
     "title": "Namen hinzufügen",
-    "subtitle": "Gib deinem Konto einen klaren Anzeigenamen für Cloud-Projekte und Teilen.",
+    "subtitle": "Gib deinem Konto einen klaren Anzeigenamen für Cloud-Projekte und geteilte Layouts.",
     "displayNameLabel": "Anzeigename",
     "namePlaceholder": "Dein Name",
     "description": "Das ist der Name, den TrackDraw für Cloud-Projekte und geteilte Layouts anzeigt.",

--- a/lang/de/dialogs.json
+++ b/lang/de/dialogs.json
@@ -1,0 +1,798 @@
+{
+  "account": {
+    "dialog": {
+      "eyebrow": "Studio",
+      "mobileSubtitle": "Verwalte dein TrackDraw-Konto."
+    },
+    "nav": {
+      "security": "Sicherheit",
+      "apiKeys": "API-Keys",
+      "danger": "Gefahrenzone"
+    },
+    "panels": {
+      "profile": {
+        "title": "Dein Profil",
+        "description": "Verwalte den Namen, der in deinem TrackDraw-Konto angezeigt wird."
+      },
+      "security": {
+        "title": "Sicherheit",
+        "description": "Verwalte Anmeldemethoden, Konto-E-Mail und Passkeys für dein TrackDraw-Konto."
+      },
+      "apiKeys": {
+        "title": "API-Keys",
+        "description": "Erstelle und widerrufe ablaufende Keys für externe TrackDraw-Integrationen."
+      },
+      "danger": {
+        "title": "Gefahrenzone",
+        "description": "Destruktive und irreversible Kontoaktionen."
+      }
+    },
+    "profile": {
+      "displayName": {
+        "label": "Anzeigename",
+        "placeholder": "Dein Name"
+      },
+      "language": {
+        "description": "Änderungen werden sofort übernommen"
+      },
+      "status": {
+        "saving": "Speichert..."
+      },
+      "fallback": {
+        "noAccountEmail": "TrackDraw-Konto"
+      }
+    },
+    "security": {
+      "email": {
+        "address": "E-Mail-Adresse",
+        "newEmail": "Neue E-Mail",
+        "placeholder": "name@example.com",
+        "changeDescription": "Nach dem Speichern senden wir zuerst eine Bestätigung an deine aktuelle E-Mail-Adresse. Nach der Bestätigung verifizierst du die neue Adresse.",
+        "change": "E-Mail ändern",
+        "saving": "Speichert..."
+      },
+      "passkeys": {
+        "title": "Passkeys",
+        "description": "Füge einen Passkey für schnelleres Anmelden auf unterstützten Geräten hinzu.",
+        "add": "Passkey hinzufügen",
+        "adding": "Wird hinzugefügt...",
+        "devAuthUnavailable": "Passkeys sind in `npm run dev` nicht verfügbar. Nutze `npm run preview`, um den echten Auth-Flow lokal zu testen.",
+        "unsupportedBrowser": "Dieser Browser stellt hier derzeit kein WebAuthn bereit, daher ist Passkey-Einrichtung auf diesem Gerät nicht verfügbar.",
+        "loading": "Passkeys werden geladen...",
+        "addedDate": "Hinzugefügt {date}",
+        "status": {
+          "synced": "synchronisiert"
+        },
+        "reauth": {
+          "title": "Melde dich erneut an, um fortzufahren",
+          "description": "Passkey-Einrichtung erfordert eine aktuelle Anmeldung. Für normale Arbeit kannst du angemeldet bleiben, aber diese Sicherheitsaktion braucht Bestätigung.",
+          "action": "Erneut anmelden"
+        },
+        "empty": {
+          "title": "Noch keine Passkeys",
+          "description": "Füge einen hinzu, um dich auf deinen vertrauenswürdigen Geräten schneller anzumelden."
+        },
+        "aria": {
+          "rename": "Passkey umbenennen",
+          "removing": "Passkey wird entfernt",
+          "remove": "Passkey entfernen"
+        },
+        "actions": {
+          "removing": "Wird entfernt...",
+          "removeTooltip": "Aus Konto entfernen",
+          "saveName": "Namen speichern"
+        },
+        "fields": {
+          "namePlaceholder": "Passkey-Name"
+        },
+        "fallback": {
+          "unnamed": "Unbenannter Passkey"
+        },
+        "rename": {
+          "description": "Dies ändert nur, wie der Passkey in deinem TrackDraw-Konto bezeichnet wird."
+        }
+      }
+    },
+    "apiKeys": {
+      "form": {
+        "keyNameLabel": "Key-Name",
+        "expiryDays": "{days} Tage",
+        "expiryYear": "1 Jahr",
+        "namePlaceholder": "Overlay-Integration",
+        "create": "Erstellen"
+      },
+      "created": {
+        "title": "API-Key erstellt",
+        "description": "Dieses Secret wird nur einmal angezeigt. Speichere es, bevor du diesen Dialog schließt."
+      },
+      "active": {
+        "title": "Aktive API-Keys",
+        "descriptionPrefix": "Schreibgeschützte Keys für vertrauenswürdige Integrationen.",
+        "docsLink": "API-Doku",
+        "refreshAriaLabel": "API-Keys aktualisieren",
+        "loading": "API-Keys werden geladen..."
+      },
+      "empty": {
+        "title": "Noch keine API-Keys",
+        "description": "Erstelle einen, wenn eine vertrauenswürdige Integration schreibgeschützten Zugriff auf deine Kontoprojekte braucht."
+      },
+      "fallback": {
+        "unnamed": "Unbenannter API-Key"
+      },
+      "meta": {
+        "expiresOn": "Läuft ab {date}",
+        "lastUsed": "Zuletzt verwendet {date}"
+      },
+      "revoke": {
+        "confirmTitle": "API-Key widerrufen?",
+        "tooltip": "Widerrufen",
+        "ariaLabel": "{name} widerrufen",
+        "warningExpiring": "Dieser Key funktioniert nicht mehr.",
+        "warningNonExpiring": "Integrationen, die diesen Key verwenden, verlieren schreibgeschützten Zugriff.",
+        "revoking": "Wird widerrufen...",
+        "action": "Widerrufen"
+      }
+    },
+    "danger": {
+      "description": "Das Löschen deines Kontos entfernt Kontoprojekte, veröffentlichte Links, API-Keys und andere kontobasierte Daten. Exportiere alles Kontobasierte, das du behalten möchtest, bevor du fortfährst.",
+      "confirm": {
+        "label": "Zum Bestätigen DELETE eingeben",
+        "placeholder": "DELETE"
+      },
+      "actions": {
+        "deleting": "Wird gelöscht...",
+        "deleteAccount": "Konto löschen"
+      }
+    },
+    "shared": {
+      "loading": "Konto wird geladen...",
+      "signInTitle": "Anmelden, um dein Konto zu verwalten",
+      "signInBody": "Nutze deine E-Mail, um auf cloudbasierte Kontoeinstellungen und Profildetails zuzugreifen."
+    },
+    "errors": {
+      "loadPasskeysFailed": "Passkeys konnten nicht geladen werden.",
+      "loadApiKeysFailed": "API-Keys konnten nicht geladen werden.",
+      "profileNameRequired": "Bitte gib den Namen ein, den TrackDraw anzeigen soll.",
+      "profileUpdateFailed": "Profil konnte nicht aktualisiert werden.",
+      "deleteConfirmRequired": "Gib DELETE ein, um die Kontolöschung zu bestätigen.",
+      "deleteFailed": "Konto konnte nicht gelöscht werden.",
+      "emailRequired": "Bitte gib die E-Mail ein, die du für TrackDraw verwenden möchtest.",
+      "emailSame": "Gib eine andere E-Mail-Adresse ein, um sie zu ändern.",
+      "emailChangeFailed": "E-Mail konnte nicht geändert werden.",
+      "passkeyAddFailed": "Passkey konnte nicht hinzugefügt werden.",
+      "passkeyNameRequired": "Bitte gib vor dem Speichern einen Passkey-Namen ein.",
+      "passkeyRenameFailed": "Passkey konnte nicht umbenannt werden.",
+      "passkeyRemoveFailed": "Passkey konnte nicht entfernt werden.",
+      "apiKeyNameRequired": "Gib einen Namen für diesen API-Key ein.",
+      "apiKeyCreateFailed": "API-Key konnte nicht erstellt werden.",
+      "apiKeyRevokeFailed": "API-Key konnte nicht widerrufen werden."
+    },
+    "success": {
+      "profileUpdated": "Profil aktualisiert",
+      "passkeyAdded": "Passkey hinzugefügt. Du kannst ihn unten umbenennen oder entfernen.",
+      "passkeyRenamed": "Passkey umbenannt",
+      "apiKeyCreated": "API-Key erstellt",
+      "apiKeyCopied": "API-Key kopiert",
+      "apiKeyRevoked": "API-Key widerrufen"
+    }
+  },
+  "export": {
+    "dialog": {
+      "title": "Export",
+      "subtitle": "Exportiere den aktuellen Track als visuelle Assets, Projekt-Übergabedateien oder simulatorbereite Ausgaben."
+    },
+    "fields": {
+      "filename": {
+        "label": "Dateiname"
+      }
+    },
+    "theme": {
+      "label": "Design",
+      "dark": "Dunkel",
+      "light": "Hell"
+    },
+    "routeNumbers": {
+      "label": "Routennummern",
+      "hint": "In 2D-Exporten",
+      "enable": "Routennummern im Export aktivieren",
+      "disable": "Routennummern im Export deaktivieren",
+      "enableMobile": "Routennummern aktivieren",
+      "disableMobile": "Routennummern deaktivieren"
+    },
+    "actions": {
+      "switchTo3dView": "Zur 3D-Ansicht wechseln",
+      "openRequiredView": "Erforderliche Ansicht öffnen"
+    },
+    "aria": {
+      "exportFormat": "{label} exportieren"
+    },
+    "messages": {
+      "view3dUnavailable": "3D-Ansicht nicht verfügbar — öffne zuerst den 3D-Tab",
+      "canvasNotReady": "Canvas ist nicht bereit",
+      "exported": "Exportiert"
+    },
+    "webm": {
+      "renderingBackground": "Cinematic FPV rendert im Hintergrund…",
+      "renderingProgress": "Cinematic FPV wird gerendert… {status}",
+      "ready": "Cinematic-FPV-Export bereit",
+      "progressLabel": "Fly-through wird gerendert… Video {duration}"
+    },
+    "sections": {
+      "visualExports": {
+        "title": "Visuelle Exporte",
+        "description": "Schreibgeschützte Captures für Review, Druck oder Teilen."
+      },
+      "projectHandoff": {
+        "title": "Projekt & Übergabe",
+        "description": "Bearbeitbares Backup oder schreibgeschützte Aufbau-Übergabe."
+      },
+      "simulatorMotion": {
+        "title": "Simulator & Motion",
+        "description": "Review-Video und experimentelle Simulatorausgabe."
+      }
+    },
+    "formats": {
+      "image": {
+        "label": "Bild",
+        "descriptionFull": "Hochauflösende 2D-Karte für Druck, Slides, Chat oder schnelle Review.",
+        "descriptionShort": "Hochauflösende 2D-Karte für Druck, Chat oder Review."
+      },
+      "vector": {
+        "label": "Vektor",
+        "descriptionFull": "Skalierbare Grafik für Bearbeitung in Illustrator, Figma oder Inkscape.",
+        "descriptionShort": "Skalierbare Grafik für Illustrator, Figma oder Inkscape."
+      },
+      "render3d": {
+        "label": "3D-Render",
+        "descriptionFull": "Screenshot der aktuellen 3D-Kameraansicht für visuelle Review.",
+        "descriptionShort": "Aktueller 3D-Kamera-Screenshot für visuelle Review."
+      },
+      "projectFile": {
+        "label": "Projektdatei",
+        "descriptionFull": "Bearbeitbares Backup zum Wiederöffnen, Teilen oder Archivieren in TrackDraw.",
+        "descriptionShort": "Bearbeitbares Backup zum Wiederöffnen oder Archivieren in TrackDraw."
+      },
+      "racePack": {
+        "label": "Race Pack",
+        "descriptionFull": "Aufbau-Übergabe für den Renntag mit Karte, Material, Ablauf und QR.",
+        "descriptionShort": "Aufbau-PDF mit Karte, Material, Ablauf und QR."
+      },
+      "cinematicFpv": {
+        "label": "Cinematic FPV",
+        "descriptionFull": "Ein-Runden-Routenvideo zum Prüfen des Flows oder Teilen der Runde.",
+        "descriptionShort": "Ein-Runden-Routenvideo zum Prüfen des Flows."
+      },
+      "velocidrone": {
+        "label": "Velocidrone",
+        "descriptionFull": "Experimentelle Velocidrone-Trackdatei zum Testen im Simulator; prüfe das Layout nach dem Import.",
+        "descriptionShort": "Experimentelle Datei zum Testen; nach Import prüfen."
+      }
+    },
+    "errors": {
+      "exportFailed": "Export fehlgeschlagen: {message}"
+    }
+  },
+  "import": {
+    "dialogTitle": "Projekt öffnen",
+    "dialogSubtitle": "Importiere ein TrackDraw-Projekt aus einer JSON-Datei.",
+    "dropFile": "Datei hier ablegen",
+    "browseFile": "oder klicken zum Durchsuchen",
+    "errorInvalidJson": "Ungültige JSON-Datei.",
+    "errorInvalidProject": "Das sieht nicht wie ein TrackDraw-Projekt aus.",
+    "errorUnsupportedFile": "Nur TrackDraw-JSON-Projektdateien werden unterstützt.",
+    "errorReadFailed": "TrackDraw konnte diese Datei nicht lesen.",
+    "toastImportFailed": "Import fehlgeschlagen",
+    "toastUnsupportedFile": "Wähle eine aus TrackDraw exportierte .json-Datei.",
+    "toastInvalidJson": "TrackDraw konnte diese JSON-Datei nicht lesen. Prüfe die Datei und versuche es erneut.",
+    "toastInvalidProject": "Wähle eine aus TrackDraw exportierte JSON-Projektdatei.",
+    "toastReadFailed": "TrackDraw konnte die ausgewählte Datei nicht lesen. Versuche es erneut oder wähle ein anderes Backup.",
+    "untitledProject": "Unbenanntes Projekt",
+    "objectCount": "{count, plural, one {# Objekt} other {# Objekte}}",
+    "replaceWarning": "Das aktuelle Projekt wird ersetzt. Exportiere zuerst ein JSON-Backup, wenn du außerhalb des lokalen Autosaves einen manuellen Wiederherstellungspunkt möchtest.",
+    "replaceProject": "Projekt ersetzen",
+    "backupFirst": "Aktuelles Projekt zuerst sichern"
+  },
+  "share": {
+    "dialog": {
+      "eyebrow": "Studio",
+      "existingEyebrow": "Geteilter Track",
+      "title": "Teilen",
+      "mobileSubtitle": "Teile einen schreibgeschützten Review-Link für diesen Track"
+    },
+    "nav": {
+      "shareLink": "Share-Link",
+      "share": "Teilen",
+      "embed": "Embed",
+      "gallery": "Galerie"
+    },
+    "currentLink": {
+      "title": "Aktueller geteilter Link",
+      "readOnlyReviewOn": "Schreibgeschützte {view}-Review auf {hostname}"
+    },
+    "content": {
+      "share": {
+        "title": "Share-Link",
+        "description": {
+          "existing": "Kopiere oder sende diesen veröffentlichten schreibgeschützten Link erneut, oder öffne Studio, um eine eigene bearbeitbare Kopie zu erstellen.",
+          "account": "Erstelle oder aktualisiere den dauerhaften schreibgeschützten Link für dieses Kontoprojekt.",
+          "separate": "Erstelle einen separaten dauerhaften schreibgeschützten Link für diese bearbeitbare Kopie oder den lokalen Track.",
+          "anonymous": "Erstelle einen temporären schreibgeschützten Snapshot-Link und steuere, wie lange er aktiv bleibt."
+        }
+      },
+      "gallery": {
+        "title": "Galerie-Sichtbarkeit",
+        "description": "Verwalte, wie dieser veröffentlichte Link in der öffentlichen Galerie erscheint."
+      },
+      "embed": {
+        "title": "Embed",
+        "description": "Kopiere iframe-Code für einen über ein Konto veröffentlichten Track, der bis zum Widerruf aktiv bleibt."
+      },
+      "actions": {
+        "descriptionExisting": "Nutze den aktuellen veröffentlichten Link in anderen Apps oder öffne ihn in einem neuen Tab erneut.",
+        "description": "Öffne, sende, widerrufe oder exportiere diese Freigabe, ohne den Track selbst zu ändern."
+      }
+    },
+    "link": {
+      "expiry": {
+        "days": "{days} Tage",
+        "label": "Link läuft ab nach",
+        "description": "Temporäre Snapshots bleiben verfügbar, bis sie ablaufen."
+      },
+      "titles": {
+        "savedProject": "Link zum gespeicherten Projekt",
+        "newShare": "Neuer Share-Link",
+        "separatePublished": "Separater veröffentlichter Link",
+        "temporary": "Temporärer Link",
+        "noSavedProject": "Noch kein gespeicherter Projektlink",
+        "noSeparate": "Noch kein separater Link",
+        "noTemporary": "Noch kein temporärer Link"
+      },
+      "descriptions": {
+        "savedProject": "Dieses gespeicherte Kontoprojekt nutzt einen dauerhaften schreibgeschützten Link. Aktualisieren behält dieselbe URL mit dem neuesten Design.",
+        "newShare": "Diese bearbeitbare Kopie erhält ihren eigenen dauerhaften schreibgeschützten Link. Sie aktualisiert keinen veröffentlichten Link eines anderen Projekts.",
+        "createSavedProject": "Erstelle eine dauerhafte URL für dieses Kontoprojekt. Zukünftige Updates können denselben Link behalten.",
+        "createSeparate": "Erstelle eine dauerhafte URL für diese Kopie, ohne frühere Freigaben zu ändern.",
+        "createTemporary": "Wähle, wann er abläuft, und erstelle einen schreibgeschützten Snapshot."
+      },
+      "lifetime": {
+        "published": "Veröffentlichter Link auf {hostname}, aktiv bis zum Widerruf",
+        "temporary": "Schreibgeschützter Snapshot auf {hostname}, läuft in {days} Tagen ab"
+      },
+      "warnings": {
+        "outdatedDesign": "Dieser Link spiegelt nicht mehr das neueste Design wider.",
+        "outdatedExpiry": "Dieser Link spiegelt nicht mehr die neueste Ablauf-Auswahl wider."
+      }
+    },
+    "embed": {
+      "iframeTitle": "TrackDraw Track Embed",
+      "code": {
+        "title": "Embed-Code",
+        "description": "Über Konten veröffentlichte Tracks können auf Club- oder Event-Websites eingebettet werden.",
+        "label": "Iframe-Code",
+        "selectedViewDescription": "Enthält die ausgewählte Startansicht.",
+        "copy": "Code kopieren"
+      },
+      "state": {
+        "loading": "Embed-Status wird geladen…"
+      },
+      "publish": {
+        "title": "Vor dem Einbetten veröffentlichen",
+        "description": "Embeds nutzen den dauerhaften über das Konto veröffentlichten Link. Erstelle daher den veröffentlichten Link, bevor du iframe-Code kopierst.",
+        "action": "Veröffentlichten Link erstellen"
+      },
+      "temporary": {
+        "title": "Temporäre Links können nicht eingebettet werden",
+        "description": "Melde dich an und veröffentliche diesen Track über dein Konto, um ein dauerhaftes Embed zu erstellen."
+      },
+      "refresh": {
+        "message": "Aktualisiere zuerst den veröffentlichten Link, damit das Embed das neueste Design nutzt.",
+        "action": "Link aktualisieren"
+      },
+      "initialView": {
+        "label": "Startansicht",
+        "options": {
+          "layout2d": {
+            "label": "2D-Layout",
+            "description": "Als flachen Feldplan öffnen"
+          },
+          "preview3d": {
+            "label": "3D-Vorschau",
+            "description": "In der Orbit-Review öffnen"
+          }
+        }
+      }
+    },
+    "gallery": {
+      "status": {
+        "loading": "Aktueller Status wird geladen",
+        "featured": "In Galerie hervorgehoben",
+        "listed": "In Galerie gelistet",
+        "hiddenByModeration": "Durch Moderation ausgeblendet",
+        "linkOnly": "Nur Link",
+        "noPublishedLink": "Kein veröffentlichter Link",
+        "checking": "Prüfen",
+        "noLink": "Kein Link",
+        "expiresInDays": "Läuft in {days} Tagen ab",
+        "noExpiry": "Kein Ablauf"
+      },
+      "descriptions": {
+        "checking": "Aktueller Galerie-Status wird geprüft.",
+        "featured": "In der öffentlichen Galerie sichtbar und oben angepinnt.",
+        "listed": "In der öffentlichen Galerie sichtbar.",
+        "hidden": "Durch Moderation ausgeblendet. Der direkte Link funktioniert weiterhin, bis er widerrufen wird.",
+        "linkOnly": "Nur Share-Link. Nicht in der öffentlichen Galerie sichtbar.",
+        "noLink": "Erstelle zuerst einen Share-Link."
+      },
+      "labels": {
+        "visibility": "Sichtbarkeit",
+        "shareLink": "Share-Link",
+        "author": "Autor"
+      },
+      "publishFirst": {
+        "title": "Vor dem Listen veröffentlichen",
+        "description": "Die Galerie nutzt den aktuellen veröffentlichten Snapshot. Daher ist ein Share-Link erforderlich, bevor dieser Track gelistet werden kann.",
+        "action": "Zuerst Share-Link erstellen"
+      },
+      "moderation": {
+        "title": "Moderationssperre",
+        "description": "Dieser Track ist durch Moderation aus der Galerie ausgeblendet. Der direkte Share-Link kann weiter funktionieren, bis er widerrufen wird."
+      },
+      "details": {
+        "title": "Galeriedetails",
+        "description": "Aktualisiere Titel und Beschreibung, die auf der öffentlichen Galerie-Karte angezeigt werden.",
+        "edit": "Details bearbeiten"
+      },
+      "list": {
+        "title": "In Galerie listen",
+        "description": "Füge Titel, Beschreibung und generierte Vorschau für öffentliches Browsen hinzu.",
+        "add": "Zur Galerie hinzufügen",
+        "readyTitle": "Bereit zum Listen",
+        "readyDescription": "Füge diesen veröffentlichten Snapshot mit eigenem Titel, Beschreibung und Vorschau zur öffentlichen Galerie hinzu."
+      },
+      "fields": {
+        "titlePlaceholder": "Track-Titel",
+        "descriptionPlaceholder": "Kurze Beschreibung für die Galerie-Karte"
+      },
+      "validation": {
+        "titleRequired": "Füge vor dem Speichern einen Titel hinzu.",
+        "descriptionLength": "Verwende {min}-{max} Zeichen für die Beschreibung.",
+        "displayNameRequired": "Lege zuerst einen Anzeigenamen für dein Konto fest.",
+        "noMetadataChanges": "Aktualisiere Titel oder Beschreibung, um Änderungen zu speichern.",
+        "refreshShareFirst": "Aktualisiere zuerst den Share-Link, damit die Galerie den neuesten Snapshot nutzt."
+      },
+      "preview": {
+        "generating": "Vorschau wird generiert...",
+        "ready": "Vorschau bereit"
+      },
+      "card": {
+        "title": "Galerie-Karte",
+        "description": "Prüfe oder aktualisiere öffentlichen Titel und Beschreibung für diesen Track.",
+        "untitled": "Unbenannt",
+        "noDescription": "Keine Galerie-Beschreibung gesetzt.",
+        "viewGallery": "Galerie ansehen"
+      },
+      "remove": {
+        "confirm": "Aus der öffentlichen Galerie entfernen? Der Share-Link selbst funktioniert weiter, bis er widerrufen wird.",
+        "action": "Aus Galerie entfernen"
+      },
+      "fallback": {
+        "noDisplayName": "kein Anzeigename gesetzt"
+      }
+    },
+    "actions": {
+      "primary": {
+        "updateLink": "Link aktualisieren",
+        "copyLink": "Link kopieren",
+        "createLink": "Link erstellen",
+        "createNewLink": "Neuen Link erstellen"
+      },
+      "copyLink": "Link kopieren",
+      "revoke": "Widerrufen",
+      "share": {
+        "existingDescription": "Diese Seite ist bereits der veröffentlichte schreibgeschützte Review-Link. Teile sie unverändert oder öffne Studio, wenn du eine bearbeitbare Kopie möchtest.",
+        "withPathDescription": "Geteilte Links öffnen als schreibgeschützte Review-Seiten. Dieser Link öffnet direkt in der {view}-Review und die Route ist für Fly-through bereit.",
+        "withoutPathDescription": "Geteilte Links öffnen als schreibgeschützte Review-Seiten. Füge zuerst einen Pfad hinzu, wenn Reviewer Fly-through und Höhenprüfung nutzen sollen."
+      },
+      "nativeShare": {
+        "title": "Teilen über...",
+        "description": "An Apps oder Kontakte senden"
+      },
+      "openInTab": {
+        "label": "In Tab öffnen",
+        "reopenCurrent": "Aktuellen geteilten Link in neuem Tab erneut öffnen",
+        "previewLink": "Share-Link in neuem Fenster ansehen"
+      },
+      "exportJson": {
+        "label": "Stattdessen JSON exportieren",
+        "description": "Bearbeitbares Backup zum Wiederöffnen in TrackDraw"
+      }
+    },
+    "errors": {
+      "createFailed": "Share-Link konnte nicht erstellt werden",
+      "copyFailed": "Link konnte nicht kopiert werden",
+      "revokeFailed": "Link konnte nicht widerrufen werden",
+      "embedCopyFailed": "Embed-Code konnte nicht kopiert werden",
+      "galleryListFailed": "Konnte nicht in Galerie gelistet werden",
+      "galleryUpdateFailed": "Galeriedetails konnten nicht aktualisiert werden",
+      "unableToReadLink": "Aktueller Share-Link konnte nicht gelesen werden"
+    },
+    "success": {
+      "linkUpdated": "Link aktualisiert",
+      "linkCreated": "Link erstellt",
+      "linkCopied": "Link kopiert",
+      "embedCopied": "Embed-Code kopiert",
+      "galleryListed": "Track in Galerie gelistet",
+      "galleryUpdated": "Galeriedetails aktualisiert",
+      "linkRevoked": "Link widerrufen"
+    }
+  },
+  "projectManager": {
+    "dialog": {
+      "eyebrow": "Studio",
+      "title": "Projekte",
+      "mobileSubtitle": "Öffnen, umbenennen, synchronisieren oder wiederherstellen."
+    },
+    "nav": {
+      "thisDevice": "Dieses Gerät",
+      "shares": "Freigaben",
+      "snapshots": "Snapshots"
+    },
+    "panels": {
+      "device": {
+        "label": "Auf diesem Gerät",
+        "description": "Lokale Kopien, die auf diesem Gerät gespeichert sind. Synchronisierte Projekte können auch unter Konto erscheinen."
+      },
+      "account": {
+        "label": "Kontoprojekte",
+        "description": "Kontokopien, die auf deinen angemeldeten Geräten verfügbar sind. Öffne eines hier, um diesen Browser zu aktualisieren."
+      },
+      "snapshots": {
+        "label": "Snapshots",
+        "description": "Frühere gespeicherte Zustände des aktuellen Projekts. Stelle einen beliebigen Punkt wieder her, um Änderungen zurückzusetzen."
+      },
+      "shares": {
+        "label": "Veröffentlichte Freigaben",
+        "description": "Aktive Share-Links, die über dein Konto veröffentlicht wurden. Kopiere, öffne oder widerrufe sie hier."
+      }
+    },
+    "device": {
+      "sync": {
+        "resolveConflict": "Synchronisierungskonflikt lösen",
+        "retry": "Synchronisierung erneut versuchen",
+        "updateAccountCopy": "Kontokopie aktualisieren",
+        "syncToAccount": "Mit Konto synchronisieren",
+        "conflictDescription": "Dieses Projekt wurde auf einem anderen Gerät geändert. Prüfe die Version, bevor du fortfährst.",
+        "failedDescription": "Die letzte Synchronisierung ist fehlgeschlagen. Versuche, die neueste lokale Version erneut zu senden.",
+        "pendingDescription": "Übertrage die neuesten lokalen Änderungen in dein Konto.",
+        "updateDescription": "Ersetze die synchronisierte Kontokopie durch diese Geräteversion.",
+        "description": "Mache dieses Projekt auf deinen angemeldeten Geräten verfügbar.",
+        "localChangesWaiting": "Lokale Änderungen warten auf Synchronisierung",
+        "latestLocalCopySaved": "Neueste lokale Kopie gespeichert {relativeTime}",
+        "changedOnAnotherDevice": "Dieses Projekt wurde auf einem anderen Gerät geändert",
+        "couldNotSyncProject": "Dieses Projekt konnte nicht synchronisiert werden",
+        "resolveVersionConflict": "Versionskonflikt lösen"
+      },
+      "status": {
+        "syncing": "Synchronisiert",
+        "reviewNeeded": "Prüfung nötig",
+        "failed": "Synchronisierung fehlgeschlagen",
+        "synced": "Synchronisiert",
+        "localOnly": "Nur lokal"
+      },
+      "meta": {
+        "localCopyWaitingToSync": "{itemLabel} · lokale Kopie wartet auf Synchronisierung",
+        "localCopySynced": "{itemLabel} · lokale Kopie synchronisiert {relativeTime}",
+        "localCopy": "{itemLabel} · lokale Kopie",
+        "onlyOnThisDevice": "{itemLabel} · nur auf diesem Gerät · {relativeTime}",
+        "onThisDeviceSubtitle": "{itemLabel} auf diesem Gerät"
+      },
+      "aria": {
+        "resolveVersionConflictFor": "Versionskonflikt für {title} lösen",
+        "retrySyncFor": "Synchronisierung für {title} erneut versuchen",
+        "updateAccountCopyFor": "Kontokopie für {title} aktualisieren",
+        "syncProjectToAccount": "{title} mit Konto synchronisieren",
+        "exportProjectAsJson": "{title} als JSON exportieren",
+        "manageProject": "{title} verwalten",
+        "renameProject": "{title} umbenennen",
+        "deleteProject": "{title} löschen"
+      },
+      "actions": {
+        "confirmRenameTitle": "Umbenennen bestätigen",
+        "more": "Weitere Aktionen",
+        "newProject": "Neues Projekt",
+        "newProjectDescription": "Starte einen frischen Track oder nutze ein Starter-Layout.",
+        "cleanUpLocal": "Lokal aufräumen",
+        "cleanUpLocalDescription": "Ältere Kopien nur von diesem Gerät entfernen.",
+        "renameDescription": "Gib diesem Projekt einen klareren Namen.",
+        "openBadge": "offen"
+      },
+      "export": {
+        "json": "JSON exportieren",
+        "jsonDescription": "Dieses Projekt als wiederverwendbare TrackDraw-Datei herunterladen."
+      },
+      "delete": {
+        "localProject": "Lokales Projekt löschen?",
+        "localProjectDescription": "Entfernt diese lokale Kopie.",
+        "permanently": "Dauerhaft löschen?",
+        "permanentlyDescription": "Dies entfernt nur das lokale Projekt aus diesem Browser.",
+        "localProjectActionDescription": "Dieses lokale Projekt vom Gerät entfernen.",
+        "removeLocalProjectsTitle": "{count, plural, one {# lokales Projekt entfernen} other {# lokale Projekte entfernen}}?",
+        "accountSyncedCopiesStayAvailable": "Kontosynchronisierte Kopien bleiben in deinem Konto verfügbar."
+      },
+      "groups": {
+        "localCopiesLinkedToAccount": "Lokale Kopien mit Konto verknüpft",
+        "onlyOnThisDevice": "Nur auf diesem Gerät"
+      },
+      "empty": {
+        "noProjects": "Keine gespeicherten Projekte",
+        "noProjectsDescription": "Projekte, die du speicherst, erscheinen hier."
+      },
+      "fallback": {
+        "project": "Projekt",
+        "untitled": "Unbenannt"
+      }
+    },
+    "account": {
+      "status": {
+        "loadingProjects": "Kontoprojekte werden geladen...",
+        "syncing": "Synchronisiert",
+        "reviewNeeded": "Prüfung nötig",
+        "failed": "Synchronisierung fehlgeschlagen",
+        "synced": "Synchronisiert"
+      },
+      "empty": {
+        "noProjects": "Keine Kontoprojekte",
+        "description": "Synchronisiere ein Projekt, um es geräteübergreifend verfügbar zu machen."
+      },
+      "messages": {
+        "loadFailed": "Kontoprojekte konnten nicht geladen werden",
+        "conflictWarning": "Dieses Projekt wurde auf einem anderen Gerät geändert, während du abgemeldet warst",
+        "syncError": "Neueste Änderungen konnten nicht synchronisiert werden",
+        "resolveConflictFirst": "Löse zuerst den Versionskonflikt"
+      },
+      "actions": {
+        "retrySync": "Synchronisierung erneut versuchen",
+        "syncPendingChanges": "Ausstehende Änderungen synchronisieren"
+      },
+      "fallback": {
+        "untitled": "Unbenannt"
+      }
+    },
+    "restore": {
+      "empty": {
+        "noSnapshots": "Noch keine Snapshots",
+        "description": "Snapshots werden automatisch erstellt, wenn du ein Projekt öffnest oder ersetzt.",
+        "desktopDescription": "Drücke <kbdMeta>⌘S</kbdMeta> / <kbdCtrl>Ctrl S</kbdCtrl> oder nutze den Speicherbutton im Header."
+      },
+      "actions": {
+        "restoreTitle": "Diesen Snapshot wiederherstellen",
+        "deleteTitle": "Snapshot löschen",
+        "restore": "Wiederherstellen"
+      },
+      "aria": {
+        "restoreSnapshot": "{title} wiederherstellen",
+        "deleteSnapshot": "{title} löschen"
+      },
+      "confirm": {
+        "restoreSnapshot": "Diesen Snapshot wiederherstellen?"
+      },
+      "status": {
+        "active": "aktiv"
+      },
+      "fallback": {
+        "snapshot": "Snapshot",
+        "untitled": "Unbenannt"
+      }
+    },
+    "shares": {
+      "status": {
+        "loadingPublishedShares": "Veröffentlichte Freigaben werden geladen...",
+        "published": "veröffentlicht",
+        "expired": "abgelaufen",
+        "expiresInDays": "{days, plural, one {1 Tag übrig} other {# Tage übrig}}"
+      },
+      "messages": {
+        "readOnlyReviewLinks": "Freigaben sind schreibgeschützte Review-Links. Exportiere JSON, wenn jemand ein bearbeitbares TrackDraw-Backup braucht."
+      },
+      "empty": {
+        "noShares": "Keine aktiven Freigaben",
+        "description": "Über Konten veröffentlichte Links bleiben aktiv, bis sie widerrufen werden. Temporäre anonyme Links laufen automatisch ab und werden hier nicht verwaltet."
+      },
+      "lifetime": {
+        "published": "schreibgeschützter veröffentlichter Link, aktiv bis zum Widerruf",
+        "temporary": "schreibgeschützter temporärer Link, {expiresIn}"
+      },
+      "actions": {
+        "copyLink": "Link kopieren",
+        "openTab": "In neuem Tab öffnen",
+        "revokeLink": "Link widerrufen"
+      },
+      "aria": {
+        "copyLink": "Share-Link kopieren",
+        "openTab": "Share-Link öffnen",
+        "revokeLink": "Share-Link widerrufen"
+      },
+      "confirm": {
+        "revokeLink": "Diesen Link widerrufen?"
+      }
+    },
+    "projectIdCopy": {
+      "success": "Projekt-ID kopiert",
+      "failed": "Projekt-ID konnte aus diesem Browser nicht kopiert werden.",
+      "label": "API-Projekt-ID",
+      "ariaLabel": "API-Projekt-ID kopieren",
+      "action": "Kopieren"
+    }
+  },
+  "completeProfile": {
+    "title": "Namen hinzufügen",
+    "subtitle": "Gib deinem Konto einen klaren Anzeigenamen für Cloud-Projekte und Teilen.",
+    "displayNameLabel": "Anzeigename",
+    "namePlaceholder": "Dein Name",
+    "description": "Das ist der Name, den TrackDraw für Cloud-Projekte und geteilte Layouts anzeigt.",
+    "descriptionWithEmail": "Das ist der Name, den TrackDraw für Cloud-Projekte und geteilte Layouts auf {email} anzeigt.",
+    "skip": "Überspringen",
+    "save": "Namen speichern",
+    "saving": "Speichert…",
+    "nameRequired": "Bitte gib den Namen ein, den TrackDraw anzeigen soll.",
+    "updateFailed": "Kontoname konnte nicht aktualisiert werden.",
+    "success": "Profil aktualisiert"
+  },
+  "newProject": {
+    "title": "Neues Projekt",
+    "closeAriaLabel": "Schließen",
+    "subtitle": "Starte mit einem leeren Canvas oder wähle ein Starter-Layout.",
+    "desktopSubtitle": "Starte mit einem leeren Canvas oder wähle ein Starter-Layout.",
+    "studioLabel": "Studio",
+    "blankCanvasLabel": "Leeres Canvas",
+    "starterLayoutsLabel": "Starter-Layouts",
+    "saveWarningTitle": "Speichere zuerst deinen aktuellen Track",
+    "saveWarningBody": "Ein neues Projekt ersetzt den Inhalt des Canvas. Exportiere oder sichere zuerst, wenn du ihn behalten möchtest.",
+    "startFreshTitle": "Mit leerem Canvas starten",
+    "startFreshBody": "Feld leeren und den Track von Grund auf bauen.",
+    "exportFirstTitle": "Aktuelles Projekt sichern",
+    "exportFirstBody": "Speichere eine Kopie des aktuellen Tracks, bevor du einen neuen startest."
+  },
+  "keyboardShortcuts": {
+    "dialogTitle": "Tastenkürzel",
+    "dialogSubtitle": "Verfügbare Tastatur- und Canvas-Kürzel im Studio.",
+    "sectionTools": "Werkzeuge",
+    "sectionSelection": "Auswahl",
+    "sectionPathEditing": "Pfadbearbeitung",
+    "sectionCanvas": "Canvas",
+    "shortcuts": {
+      "duplicateItems": "Ausgewählte Elemente duplizieren",
+      "copyItems": "Ausgewählte Elemente kopieren",
+      "pasteItems": "Kopierte Elemente einfügen",
+      "rotateLeft": "Ausgewählte Elemente nach links drehen",
+      "rotateRight": "Ausgewählte Elemente nach rechts drehen",
+      "mouseRotateSnap": "Mausrotation mit Snap",
+      "mouseRotateFine": "Feine Mausrotation",
+      "keyRotateFine": "Feine Tastenrotation",
+      "deleteItems": "Ausgewählte Elemente löschen",
+      "nudgeItems": "Ausgewählte Elemente verschieben",
+      "fineNudge": "Fein verschieben",
+      "finishPath": "Pfad abschließen",
+      "removeLastPoint": "Letzten Entwurfspunkt entfernen",
+      "deletePathPoint": "Ausgewählten Pfadpunkt löschen",
+      "cancelDraft": "Aktuellen Entwurf abbrechen",
+      "fitView": "Ansicht ans Feld anpassen",
+      "clearSelection": "Auswahl aufheben",
+      "panView": "Ansicht verschieben",
+      "bypassSnap": "Snap vorübergehend umgehen",
+      "zoom": "Zoomen",
+      "saveSnapshot": "Snapshot speichern"
+    }
+  },
+  "versionConflict": {
+    "title": "Projektversion auswählen",
+    "subtitle": "Wähle die Version, die du auf diesem Gerät weiterverwenden möchtest.",
+    "thisProject": "Dieses Projekt",
+    "body": "wurde auf einem anderen Gerät geändert, während du abgemeldet warst. Wähle, welche Version du auf diesem Gerät weiterverwenden möchtest.",
+    "localVersion": "Version dieses Geräts",
+    "cloudVersion": "Kontoversion",
+    "lastChanged": "Zuletzt geändert {date}",
+    "keepLocal": "Version dieses Geräts behalten",
+    "useCloud": "Kontoversion verwenden"
+  }
+}

--- a/lang/de/editor.json
+++ b/lang/de/editor.json
@@ -1,0 +1,446 @@
+{
+  "toolbar": {
+    "homepageLabel": "Zur Startseite",
+    "projects": "Projekte",
+    "projectsTooltip": "Projekte verwalten",
+    "import": "Importieren",
+    "importTooltip": "JSON importieren",
+    "export": "Exportieren",
+    "exportTooltip": "Track exportieren"
+  },
+  "contextMenu": {
+    "quickActions": "Schnellaktionen",
+    "selectedCount": "{count, plural, one {1 ausgewählt} other {{count} ausgewählt}}",
+    "segmentSelected": "Segment ausgewählt",
+    "waypointSelected": "Wegpunkt ausgewählt",
+    "addWaypoint": "Wegpunkt hinzufügen",
+    "deleteWaypoint": "Wegpunkt löschen",
+    "arrange": "Anordnen",
+    "bringForward": "Nach vorne bringen",
+    "sendBackward": "Nach hinten senden",
+    "rotate": "Drehen",
+    "rotateLeft": "Nach links drehen",
+    "rotateRight": "Nach rechts drehen"
+  },
+  "canvasOverlay": {
+    "pathEditing": "Pfadbearbeitung",
+    "addPoints": "Punkte hinzufügen",
+    "finish": "abschließen",
+    "cancel": "abbrechen",
+    "connectEnds": "Klicken, um Enden zu verbinden",
+    "grid": "Raster {grid}",
+    "snapOn": "Snap aktiv: Raster, Objekte, Routen",
+    "snapOff": "Snap aus: freie Platzierung",
+    "midClick": "Mittelklick",
+    "rightClick": "Rechtsklick",
+    "pan": "verschieben",
+    "menu": "Menü",
+    "bypass": "umgehen",
+    "fitToWindow": "An Fenster anpassen",
+    "viewerPanZoom": "Ziehen zum Verschieben, Mausrad zum Zoomen"
+  },
+  "preview3dOverlay": {
+    "pause": "Pause",
+    "play": "Abspielen",
+    "speed": "Geschwindigkeit",
+    "toggleFpv": "FPV-Kameraverhalten umschalten",
+    "on": "Ein",
+    "off": "Aus",
+    "exit": "Beenden",
+    "flyThrough": "Fly-Through",
+    "dragWaypointMobile": "Ziehe einen Wegpunkt-Griff nach oben oder unten, um die Höhe anzupassen",
+    "dragWaypointDesktop": "Ziehe Wegpunkt-Griffe nach oben oder unten, um die Höhe anzupassen",
+    "dragDiveGateMobile": "Ring ziehen zum Drehen · orangefarbener Puck zum Neigen",
+    "dragDiveGateDesktop": "Ring ziehen zum Drehen · orangefarbenen Puck ziehen zum Neigen",
+    "dragRing": "Ring ziehen zum Drehen",
+    "orbitHint": "Orbit zum Prüfen · Scrollen zum Zoomen · Mitteltaste ziehen zum Verschieben",
+    "drawRoute": "Zeichne die Route in 2D, um den Fly-through zu aktivieren"
+  },
+  "statusBar": {
+    "snapActive": "Snap",
+    "snapOn": "Snap Ein",
+    "snapOff": "Snap Aus",
+    "snapIsOn": "Snap ist aktiv",
+    "snapIsOff": "Snap ist aus",
+    "snapOnDescription": "Punkte und Ziehvorgänge rasten an nahegelegenen Rasterpositionen, Objekten und Routenpunkten ein. Halte Alt beim Platzieren oder Ziehen, um es einmalig zu umgehen.",
+    "snapOffDescription": "Platzierung und Ziehen bleiben frei, bis du Snap wieder aktivierst.",
+    "selected": "{count} ausgewählt",
+    "grouped": "Gruppiert",
+    "groupNamed": "Gruppe: {name}",
+    "groups": "{count} Gruppen",
+    "devOn": "Dev Ein",
+    "dev": "Dev"
+  },
+  "accountMenu": {
+    "checkingAuth": "Authentifizierung prüfen…",
+    "signIn": "Anmelden",
+    "signedIn": "Angemeldet",
+    "noDisplayName": "Kein Anzeigename gesetzt",
+    "trackdrawAccount": "TrackDraw-Konto",
+    "profile": "Profil",
+    "dashboard": "Dashboard",
+    "signOut": "Abmelden",
+    "signingOut": "Abmeldung läuft…"
+  },
+  "common": {
+    "canvas2d": "2D-Canvas",
+    "preview3d": "3D-Vorschau"
+  },
+  "elementPlacementControl": {
+    "official": "Offiziell",
+    "typeLabel": "{tool}-Typ"
+  },
+  "header": {
+    "untitledTitle": "Unbenannt",
+    "statusFailed": "Fehlgeschlagen",
+    "statusPending": "Ausstehend",
+    "statusSyncing": "Synchronisiert",
+    "statusSynced": "Synchronisiert",
+    "expandSidebar": "Seitenleiste erweitern",
+    "collapseSidebar": "Seitenleiste einklappen",
+    "sharedReviewBadge": "Geteilte Review",
+    "makeEditableCopy": "Bearbeitbare Kopie erstellen",
+    "undo": "Rückgängig",
+    "redo": "Wiederholen",
+    "saveSnapshot": "Snapshot speichern",
+    "keyboardShortcuts": "Tastenkürzel",
+    "retrySync": "Kontosynchronisierung erneut versuchen ({status})",
+    "share": "Teilen",
+    "export": "Exportieren",
+    "openAppMenu": "App-Menü öffnen",
+    "hideObstacleNumbers": "Hindernisnummern ausblenden",
+    "showObstacleNumbers": "Hindernisnummern anzeigen"
+  },
+  "sharedHeader": {
+    "embedLabel": "Embed",
+    "sharedPreviewLabel": "Geteilte Vorschau"
+  },
+  "mobileAppMenu": {
+    "openAppMenu": "App-Menü öffnen",
+    "title": "TrackDraw",
+    "subtitle": "Projekte, Teilen, Konto und App-Einstellungen",
+    "signIn": "Anmelden",
+    "yourAccount": "Dein TrackDraw-Konto",
+    "trackdrawAccount": "TrackDraw-Konto",
+    "projectsSection": "Projekte",
+    "projectsLabel": "Projekte",
+    "projectsDescription": "Gespeicherte Projekte öffnen und verwalten",
+    "accountSection": "Konto",
+    "profileLabel": "Profil",
+    "profileDescription": "Profil, Sicherheit und API-Keys verwalten",
+    "dashboardLabel": "Dashboard",
+    "dashboardDescription": "Moderations- und Admin-Tools öffnen",
+    "shareSection": "Teilen und übertragen",
+    "shareLabel": "Teilen",
+    "shareDescription": "Schreibgeschützten Link für diesen Track veröffentlichen",
+    "importLabel": "Importieren",
+    "importDescription": "Eine JSON-Projektdatei einlesen",
+    "exportLabel": "Exportieren",
+    "exportDescription": "PNG, PDF, SVG oder JSON herunterladen",
+    "themeLabel": "Design",
+    "themeDescription": "Hell, dunkel oder System wechseln",
+    "signOut": "Abmelden",
+    "signingOut": "Abmeldung läuft…"
+  },
+  "layoutPresetPicker": {
+    "itemsCount": "{count} Elemente",
+    "renamePresetTooltip": "Preset umbenennen",
+    "deletePresetTooltip": "Preset löschen",
+    "signInTitle": "Anmelden, um Presets zu nutzen",
+    "signInDescription": "Presets werden in deinem Konto gespeichert, damit sie auf allen Geräten verfügbar sind.",
+    "noPresetsTitle": "Noch keine Presets",
+    "noPresetsDescription": "Wähle mehrere Formen auf dem Canvas aus und nutze <strong>Preset speichern</strong> im Inspector, um dein erstes Preset hier hinzuzufügen.",
+    "comingSoonTitle": "Demnächst",
+    "comingSoonDescription": "Von der Community geteilte Presets erscheinen hier. Speichere eigene Presets und teile sie mit der TrackDraw-Community.",
+    "myPresetsNav": "Meine Presets",
+    "storeNav": "Store",
+    "soonBadge": "Bald",
+    "mobileTitle": "Presets",
+    "mobileSubtitle": "Wähle ein Preset und tippe dann einmal auf das Canvas, um es zu platzieren.",
+    "placeFlowTitle": "Platzierungsflow",
+    "placeFlowDescription": "Wähle hier ein Preset und tippe dann auf das Canvas. Das Ergebnis wird sofort zu normalen bearbeitbaren Formen erweitert.",
+    "desktopTitle": "Layout-Presets",
+    "desktopSubtitle": "Wähle ein Preset, platziere es auf dem Canvas und bearbeite die eingefügten Formen anschließend normal.",
+    "tipText": "Wähle Formen auf dem Canvas aus und nutze dann <strong>Preset speichern</strong> im Inspector, um eigene Presets hinzuzufügen."
+  },
+  "starterOverlay": {
+    "dialog": {
+      "title": "Willkommen bei TrackDraw",
+      "mobileSubtitle": "Platziere ein paar Gates, zeichne die Route, prüfe 3D und teile, wenn der Track bereit ist.",
+      "studioEyebrow": "Studio",
+      "desktopDescription": "Entwirf das Layout in 2D, prüfe Höhen in 3D und teile einen schreibgeschützten Link, wenn der Track bereit ist.",
+      "dismissAria": "Startdialog schließen"
+    },
+    "hints": {
+      "gate": {
+        "badge": "Geführt",
+        "title": "Platziere dein erstes Gate",
+        "description": "Tippe oder klicke auf das Canvas, um das erste Gate zu setzen. Füge ein paar Gates hinzu, bevor du zu Pfad wechselst.",
+        "action": "Verstanden",
+        "dismiss": "Hinweis zur Gate-Platzierung schließen"
+      },
+      "path": {
+        "badge": "Geführt",
+        "title": "Als Nächstes: Route zeichnen",
+        "description": "Platziere zuerst ein paar Gates, wechsle dann zu Pfad und zeichne die Runde durch sie hindurch. Schließe die Route ab, bevor du 3D prüfst.",
+        "action": "Pfad starten",
+        "dismiss": "Pfad-Onboarding-Hinweis schließen"
+      },
+      "preview3d": {
+        "badge": "Vorschau",
+        "title": "3D funktioniert am besten nach der Route",
+        "description": "Die Hindernisplatzierung wird hier bereits angezeigt, aber die Route macht Höhen- und Fly-through-Review wirklich nützlich.",
+        "action": "Pfad in 2D zeichnen",
+        "dismiss": "3D-Vorschau-Onboarding schließen"
+      },
+      "review3d": {
+        "badge": "Geführt",
+        "title": "Jetzt in 3D prüfen",
+        "description": "Umlaufe die Route, prüfe Höhe und Abstände und teile oder exportiere, sobald sich das Layout richtig anfühlt.",
+        "action": "Als Nächstes teilen oder exportieren",
+        "dismiss": "3D-Review-Hinweis schließen"
+      },
+      "postPath": {
+        "badge": "Nächster Schritt",
+        "title": "Route bereit — in 3D prüfen",
+        "description": "Wechsle jetzt zum 3D-Tab, um die Route zu prüfen, bevor du weitere Hindernisplatzierungen verfeinerst.",
+        "action": "Zu 3D wechseln",
+        "dismiss": "Post-Pfad-3D-Hinweis schließen"
+      }
+    }
+  },
+  "starterFlow": {
+    "intro": {
+      "goodFirstSteps": "Gute erste Schritte"
+    },
+    "steps": {
+      "step1": {
+        "title": "Ein paar Gates und Hindernisse platzieren",
+        "description": "Starte klein, damit die Kursstruktur schnell sichtbar wird."
+      },
+      "step2": {
+        "title": "Rennpfad hindurch zeichnen",
+        "description": "Der Pfad macht das Layout meist schneller verständlich als reines Hindernis-Feintuning."
+      },
+      "step3": {
+        "title": "3D prüfen, dann exportieren oder teilen",
+        "description": "Prüfe die Route früh und sende einen schreibgeschützten Link, wenn sie bereit ist."
+      }
+    },
+    "starterLayouts": {
+      "label": "Starter-Layouts"
+    },
+    "guided": {
+      "label": "Geführter Start",
+      "title": "Mit Anleitung starten",
+      "descriptionDesktop": "Öffne ein leeres Feld mit ausgewähltem `Gate`, damit du zuerst den Kurs grob blocken kannst. Zeichne den Pfad, sobald die ersten Hindernisse stehen.",
+      "descriptionMobile": "Öffne ein leeres Feld mit ausgewähltem Gate. Zeichne den Pfad, sobald die ersten Hindernisse stehen."
+    },
+    "empty": {
+      "label": "Leerer Start",
+      "continue": "Mit leerem Canvas fortfahren",
+      "description": "Überspringe den geführten Start und öffne stattdessen das leere Studio."
+    },
+    "shortcuts": {
+      "gate": "platziert Gates",
+      "path": "startet die Route",
+      "finish": "schließt den Pfad ab"
+    }
+  },
+  "saveAsPresetDialog": {
+    "title": "Als Preset speichern",
+    "subtitle": "Gib deiner Auswahl einen Namen, damit du sie später erneut aus dem Preset-Picker platzieren kannst.",
+    "shapeCount": "{count, plural, one {# Form} other {# Formen}}",
+    "pathsExcluded": "{count, plural, one {1 Pfad wird ausgeschlossen} other {# Pfade werden ausgeschlossen}} — Presets erfassen nur Nicht-Pfad-Formen.",
+    "presetNameLabel": "Preset-Name",
+    "presetNamePlaceholder": "z. B. Timing-Gate-Setup",
+    "savePreset": "Preset speichern"
+  },
+  "mobilePanels": {
+    "viewControls": {
+      "mode": {
+        "current": "Aktueller Modus",
+        "viewModeLabel": "Ansichtsmodus"
+      },
+      "controls": {
+        "fitToField": {
+          "label": "Ans Feld anpassen",
+          "description": "Aktuelles Design in der Ansicht zentrieren"
+        },
+        "snap": {
+          "label": "Snap",
+          "description": "An nahegelegenen Rasterpositionen und Objekten einrasten"
+        },
+        "rulers": {
+          "label": "Lineale",
+          "description": "Obere und linke Hilfslinien auf Mobilgeräten anzeigen"
+        },
+        "obstacleNumbers": {
+          "label": "Hindernisnummern",
+          "description": "Pfadnummern auf Routenhindernissen anzeigen"
+        },
+        "flyThrough": {
+          "label": "Fly-through",
+          "descriptions": {
+            "available": "Race-Line-Vorschaukamera starten",
+            "readOnly": "Keine Route in diesem geteilten Track",
+            "draw": "Zeichne zuerst einen Pfad in 2D, um dies zu aktivieren"
+          }
+        },
+        "gizmo": {
+          "label": "Gizmo",
+          "description": "Achsenhilfe in der 3D-Vorschau anzeigen"
+        }
+      },
+      "readOnly": {
+        "review3dWithPath": "Schreibgeschützte 3D-Review mit verfügbarem Fly-through für diesen geteilten Track.",
+        "review3dNoPath": "Schreibgeschützte 3D-Review für diesen geteilten Track. Keine Route für Fly-through verfügbar.",
+        "review2dWithPath": "Schreibgeschützte 2D-Review für diesen geteilten Track. Wechsle zu 3D, um Fly-through zu nutzen.",
+        "review2dNoPath": "Schreibgeschützte 2D-Review für diesen geteilten Track."
+      },
+      "share": {
+        "sectionLabel": "Teilen",
+        "editableCopy": "Bearbeitbare Kopie",
+        "shareButton": "Teilen"
+      }
+    },
+    "multiSelect": {
+      "header": {
+        "title": "Mehrfachauswahl",
+        "lockedHint": "Gesperrte Auswahl. Vor dem Verschieben oder Skalieren entsperren.",
+        "tapHint": "Tippe Elemente an, um sie hinzuzufügen oder zu entfernen."
+      },
+      "fields": {
+        "groupNamePlaceholder": "Gruppenname"
+      },
+      "actions": {
+        "ungroup": "Gruppierung aufheben",
+        "group": "Gruppieren"
+      }
+    },
+    "pathBuilder": {
+      "header": {
+        "title": "Pfad-Builder"
+      },
+      "status": {
+        "loopConnected": "Loop verbunden · {count} Punkte · {length}",
+        "pointsCount": "{count} Punkte · {length}",
+        "tapToStart": "Tippe auf das Canvas, um den ersten Punkt zu setzen"
+      },
+      "actions": {
+        "undo": "Rückgängig",
+        "connectEnds": "Enden verbinden",
+        "finish": "Fertigstellen",
+        "cancel": "Abbrechen"
+      }
+    },
+    "editorPanels": {
+      "quickActions": {
+        "title": "Schnellaktionen",
+        "adjustTitle": "Anpassen",
+        "hints": {
+          "addPoint": "Punkt auf ausgewähltem Segment hinzufügen",
+          "deleteWaypoint": "Ausgewählten Wegpunkt löschen",
+          "resume": "Diesen Pfad fortsetzen oder anpassen",
+          "selectionStep": "{label} · {step} Schritt",
+          "selectionFallback": "Auswahl"
+        },
+        "actions": {
+          "addPoint": "Punkt hinzufügen",
+          "editPath": "Pfad bearbeiten",
+          "deletePoint": "Punkt löschen",
+          "adjust": "Anpassen",
+          "back": "Zurück"
+        },
+        "adjust": {
+          "step": "Schritt",
+          "left": "Links",
+          "up": "Hoch",
+          "down": "Runter",
+          "right": "Rechts"
+        }
+      },
+      "nav": {
+        "exit": "Beenden",
+        "select": "Auswählen",
+        "tools": "Werkzeuge",
+        "inspect": "Prüfen",
+        "view": "Ansicht",
+        "review": "Review",
+        "share": "Teilen",
+        "editCopy": "Kopie bearbeiten",
+        "preview": "Vorschau"
+      },
+      "inspector": {
+        "designSettingsHint": "Design-Einstellungen",
+        "title": "Inspector",
+        "subtitles": {
+          "empty": "Design-Einstellungen und platzierte Elemente",
+          "selected": "Auswahleigenschaften und Bearbeitung"
+        }
+      },
+      "tools": {
+        "title": "Werkzeuge",
+        "subtitles": {
+          "preview3d": "Projektaktionen für die aktuelle 3D-Sitzung",
+          "canvas2d": "Zeichen- und Bearbeitungswerkzeuge"
+        }
+      },
+      "view": {
+        "title": "Ansicht",
+        "subtitle": "Canvas-Modus, Hilfslinien und Viewport-Steuerung"
+      }
+    }
+  },
+  "viewModeSwitch": {
+    "ariaLabel": "Ansichtsmodus",
+    "canvas2dShort": "2D",
+    "preview3dShort": "3D",
+    "canvas2dDrawer": "2D-Canvas",
+    "preview3dDrawer": "3D-Vorschau"
+  },
+  "desktopInspectorPanel": {
+    "ariaLabel": "Inspector",
+    "expandTooltip": "Inspector erweitern",
+    "collapseTooltip": "Inspector einklappen",
+    "verticalLabel": "Inspector"
+  },
+  "shell": {
+    "untitledTrack": "Unbenannter Track",
+    "untitledFallback": "Unbenannt",
+    "exportFailed": "Export fehlgeschlagen",
+    "exportFailedNoProjectDescription": "TrackDraw konnte dieses lokale Projekt nicht laden. Öffne es zuerst oder wähle ein anderes gespeichertes Projekt.",
+    "exportSuccess": "Projekt-JSON exportiert",
+    "embeddedTrack": "Eingebetteter Track",
+    "sharedPreview": "Geteilte Vorschau",
+    "loading3d": "3D wird geladen…"
+  },
+  "languagePicker": {
+    "ariaLabel": "Sprache"
+  },
+  "performanceHud": {
+    "title": "Developer HUD",
+    "summary": "Werkzeug {tool} · {count} ausgewählt",
+    "reset": "Zurücksetzen",
+    "close": "Schließen",
+    "metrics": {
+      "canvas2d": "2D-Canvas",
+      "preview3d": "3D-Ansicht",
+      "inspector": "Inspector",
+      "autosave": "Autosave"
+    },
+    "levels": {
+      "noData": "Keine Daten",
+      "heavy": "Schwer",
+      "busy": "Ausgelastet",
+      "ok": "OK"
+    }
+  },
+  "textureDebug": {
+    "title": "Texture Debug",
+    "copyConfig": "Konfiguration kopieren",
+    "copied": "Kopiert",
+    "noPanels": "Noch keine Panels registriert",
+    "flip": "flip"
+  }
+}

--- a/lang/de/exportPdf.json
+++ b/lang/de/exportPdf.json
@@ -1,0 +1,66 @@
+{
+  "renderFailed": "PDF-Rendering fehlgeschlagen",
+  "untitledTrack": "Unbenannter Track",
+  "footer": {
+    "brand": "TrackDraw · {pageLabel}",
+    "pageOf": "Seite {pageNumber} von {totalPages}",
+    "pageOverview": "Übersicht",
+    "pageTrackMap": "Track-Karte",
+    "pageBuildSheet": "Aufbaublatt"
+  },
+  "sharedView": {
+    "title": "GETEILTE ANSICHT",
+    "scanToOpen": "Scannen, um den Track zu öffnen",
+    "scanDescription": "Öffnet den kanonischen TrackDraw-Share-Link für mobile Durchsicht und Briefing.",
+    "noShare": "Keine veröffentlichte Freigabe verknüpft",
+    "noShareDescription": "Veröffentliche dieses Projekt zuerst, wenn der Race Pack einen Scan-Code enthalten soll."
+  },
+  "cover": {
+    "title": "Race Pack",
+    "numberingIncluded": "Nummerierung enthalten",
+    "numberingHidden": "Nummerierung ausgeblendet",
+    "statusLabel": "Status",
+    "statusBuildable": "Baubar",
+    "statusShort": "Fehlt",
+    "missingLabel": "Fehlend",
+    "obstaclesLabel": "Hindernisse",
+    "intro": "Dieser Race Pack ist dafür gedacht, die Aufbaucrew am Renntag zu begleiten. Nutze die Karte als Platzierungsreferenz, die Materialliste als Bestandscheck und die Aufbaufolge als praktische Reihenfolge, um den Kurs aufs Feld zu bringen. Die Aufbauzeit basiert auf einer typischen Crew aus 2-3 Personen und einem Club-Workflow: entladen, bereitstellen, vormontieren, dann platzieren und sichern.",
+    "contentsTitle": "Inhalt",
+    "contentsItem1": "1. Track-Karte und Feldübersicht",
+    "contentsItem2": "2. Materialliste, Bestandscheck und Timingpunkte",
+    "contentsItem3": "3. Aufbaufolge und Hinweise für den Renntag",
+    "summaryTitle": "Zusammenfassung",
+    "summaryShortage": "{count, plural, one {Dieses Layout überschreitet aktuell den verfügbaren Bestand bei 1 Hindernistyp.} other {Dieses Layout überschreitet aktuell den verfügbaren Bestand bei {count} Hindernistypen.}} Behebe Engpässe, bevor du diesen Pack als finale Aufbau-Referenz nutzt.",
+    "summaryBuildable": "Dieses Layout ist mit dem gespeicherten Inventarprofil aktuell baubar. Nutze die folgenden Seiten als Aufbau- und Übergabereferenz für den Renntag."
+  },
+  "mapPage": {
+    "title": "Track-Karte",
+    "stockShort": "Bestand fehlt um {count}",
+    "stockBuildable": "Bestandscheck: baubar",
+    "numberingShown": "Nummerierung sichtbar",
+    "numberingHidden": "Nummerierung ausgeblendet"
+  },
+  "buildSheet": {
+    "title": "Aufbaublatt",
+    "materialListTitle": "Materialliste",
+    "obstacleColumn": "Hindernis",
+    "requiredColumn": "Benötigt",
+    "availableColumn": "Verfügbar",
+    "missingColumn": "Fehlend",
+    "timingPointsTitle": "Timingpunkte",
+    "noTimingPoints": "Es sind noch keine Timingpunkte zugewiesen. Markiere vor der Übergabe am Renntag im Inspector ein Gate als Start/Ziel oder Split.",
+    "setupSequenceTitle": "Aufbaufolge",
+    "setupIntro": "Geschätzter Aufbauaufwand: etwa {min}-{max} Minuten. Gesamtkomplexität: {complexity}. {summary}",
+    "crewStepLabel": "Crew-Schritt",
+    "groupedTaskLabel": "Gruppierte Track-Aufgabe",
+    "obstacleNumberSuffix": "{kind} · Hindernis #{number}",
+    "minutesSuffix": "{minutes} Min.",
+    "noSetupSequenceNumbering": "Noch keine Aufbaufolge verfügbar. Füge eine Route hinzu und platziere einige Hindernisse, um einen nützlicheren Pack zu erzeugen.",
+    "noSetupSequenceHidden": "Die Nummerierung ist in diesem Export ausgeblendet. Aktiviere Hindernisnummern, wenn die Aufbaufolge den Routenreferenzen folgen soll.",
+    "notesTitle": "Hinweise für den Renntag",
+    "note1": "Nutze die Kartenseite während Aufbau und Pilotenbriefing als Platzierungsreferenz.",
+    "note2": "Behandle den Bestandscheck als Quelle der Wahrheit, bevor du das Layout für den Aufbau freigibst.",
+    "note3": "Verankere zuerst den Kurs und sichere dann aufwendigere Strukturen wie Dive Gates und Ladders vor dem Standard-Gate-Durchgang.",
+    "note4": "Wenn sich Route oder Hinderniszahl ändern, erstelle den Race Pack neu, damit Karte, Bestandsliste und Aufbaufolge abgestimmt bleiben."
+  }
+}

--- a/lang/de/exportPdf.json
+++ b/lang/de/exportPdf.json
@@ -24,7 +24,7 @@
     "statusShort": "Fehlt",
     "missingLabel": "Fehlend",
     "obstaclesLabel": "Hindernisse",
-    "intro": "Dieser Race Pack ist dafür gedacht, die Aufbaucrew am Renntag zu begleiten. Nutze die Karte als Platzierungsreferenz, die Materialliste als Bestandscheck und die Aufbaufolge als praktische Reihenfolge, um den Kurs aufs Feld zu bringen. Die Aufbauzeit basiert auf einer typischen Crew aus 2-3 Personen und einem Club-Workflow: entladen, bereitstellen, vormontieren, dann platzieren und sichern.",
+    "intro": "Dieses Race Pack ist dafür gedacht, die Aufbaucrew am Renntag zu begleiten. Nutze die Karte als Platzierungsreferenz, die Materialliste als Bestandscheck und die Aufbaufolge als praktische Reihenfolge, um den Kurs aufs Feld zu bringen. Die Aufbauzeit basiert auf einer typischen Crew aus 2-3 Personen und einem Club-Workflow: entladen, bereitstellen, vormontieren, dann platzieren und sichern.",
     "contentsTitle": "Inhalt",
     "contentsItem1": "1. Track-Karte und Feldübersicht",
     "contentsItem2": "2. Materialliste, Bestandscheck und Timingpunkte",

--- a/lang/de/index.ts
+++ b/lang/de/index.ts
@@ -1,0 +1,10 @@
+export { default as editor } from "./editor.json";
+export { default as common } from "./common.json";
+export { default as inspector } from "./inspector.json";
+export { default as dialogs } from "./dialogs.json";
+export { default as landing } from "./landing.json";
+export { default as login } from "./login.json";
+export { default as share } from "./share.json";
+export { default as shapes } from "./shapes.json";
+export { default as setupEstimate } from "./setupEstimate.json";
+export { default as exportPdf } from "./exportPdf.json";

--- a/lang/de/inspector.json
+++ b/lang/de/inspector.json
@@ -1,0 +1,316 @@
+{
+  "tabs": {
+    "ariaLabel": "Inspector-Panels",
+    "layout": "Layout",
+    "selection": "Auswahl"
+  },
+  "emptyState": {
+    "title": "Keine Auswahl",
+    "body": "Wähle ein oder mehrere Elemente auf dem Canvas aus, um hier Objekteigenschaften zu bearbeiten."
+  },
+  "actions": {
+    "group": "Gruppieren",
+    "continueEditing": "Fortfahren",
+    "connectEnds": "Verbinden",
+    "ungroup": "Gruppierung aufheben",
+    "groupSelection": "Auswahl gruppieren",
+    "ungroupSelection": "Auswahlgruppierung aufheben",
+    "savePreset": "Als Preset speichern",
+    "joinPaths": "Pfade verbinden",
+    "remove": "Entfernen",
+    "removeItem": "Element entfernen"
+  },
+  "hints": {
+    "locked": "Auf dem Canvas gesperrt. Vor dem Verschieben, Skalieren oder Fortsetzen von Pfadbearbeitungen entsperren."
+  },
+  "group": {
+    "sectionTitle": "Gruppe",
+    "nameLabel": "Gruppenname",
+    "namePlaceholder": "Optionaler Gruppenname"
+  },
+  "raceTiming": {
+    "sectionTitle": "Race Timing",
+    "ariaLabel": "Timing-Rolle",
+    "splitIdLabel": "Split-ID",
+    "splitIdPlaceholder": "split-1",
+    "roleStart": "Start",
+    "roleSplit": "Split",
+    "metaTimingStart": "timing: start",
+    "metaTimingSplit": "timing: {id}",
+    "metaGrouped": "gruppiert",
+    "metaLocked": "gesperrt",
+    "metaEditable": "bearbeitbar"
+  },
+  "transform": {
+    "sectionTitle": "Transformieren",
+    "positionLabel": "Position",
+    "rotationLabel": "Rotation (Grad)",
+    "colorLabel": "Farbe",
+    "pickColorAriaLabel": "Farbe wählen",
+    "editingSubtitle": "{kind}-Eigenschaften und Platzierung bearbeiten."
+  },
+  "ladder": {
+    "sectionTitle": "Ladder"
+  },
+  "tower": {
+    "sectionTitle": "Tower"
+  },
+  "catalog": {
+    "sectionTitle": "Katalog",
+    "sourceLabel": "Quelle",
+    "sizeLabel": "Größe",
+    "officialBadge": "Offiziell"
+  },
+  "dimensions": {
+    "widthLabel": "Breite ({unit})",
+    "heightLabel": "Höhe ({unit})",
+    "gridLabel": "Raster ({unit})",
+    "thicknessLabel": "Dicke ({unit})",
+    "radiusLabel": "Radius ({unit})",
+    "poleHeightLabel": "Masthöhe ({unit})",
+    "tiltLabel": "Neigung (Grad)",
+    "gatesLabel": "Gates",
+    "elevationLabel": "Höhe ({unit})",
+    "levelsLabel": "Ebenen",
+    "sizeLabel": "Größe ({unit})",
+    "openingHeightLabel": "Öffnungshöhe ({unit})"
+  },
+  "label": {
+    "sectionTitle": "Label",
+    "textLabel": "Text",
+    "fontSizeLabel": "Schriftgröße (px)",
+    "threeDModeLabel": "3D-Modus",
+    "floatOption": "Schweben (Billboard)",
+    "groundOption": "Auf Boden projizieren"
+  },
+  "multiSelection": {
+    "sectionTitle": "Auswahl",
+    "mixedTypesPlaceholder": "Gemischte Typen",
+    "titleSelected": "{count, plural, one {1 Element ausgewählt} other {{count} Elemente ausgewählt}}",
+    "subtitle": "Massenaktionen sind hier verfügbar. Öffne ein einzelnes Element vom Canvas, wenn du detaillierte Bearbeitung brauchst.",
+    "groupCountMeta": "{count, plural, one {1 Gruppe} other {{count} Gruppen}}",
+    "joinAvailableMeta": "Verbinden verfügbar",
+    "saveSectionLabel": "Abschnitt speichern",
+    "lockedItemsNote": "Gesperrte Elemente bleiben unverändert."
+  },
+  "polyline": {
+    "sectionTitle": "Rennlinie",
+    "flowLabel": "Flow",
+    "directionLabel": "Richtung",
+    "waypointsTitle": "Wegpunkte",
+    "waypointsSubtitle": "Passe jeden Punkt und seine Höhe an.",
+    "elevationColumn": "Höhe",
+    "editColumn": "Bearb.",
+    "insertPointAfter": "Punkt danach einfügen",
+    "removePoint": "Punkt entfernen",
+    "addPoint": "Punkt hinzufügen"
+  },
+  "listPanel": {
+    "panelTitle": "Track-Elemente",
+    "placedItemsTitle": "Platzierte Elemente",
+    "placedItemsSubtitle": "Wähle ein Element aus der Liste.",
+    "filterPlaceholder": "Elemente filtern",
+    "filterAll": "Alle",
+    "filterObstacles": "Hindernisse",
+    "itemColumn": "Element",
+    "pathColumn": "Pfad",
+    "noItemsMatchFilter": "Keine Elemente passen zu diesem Filter.",
+    "routeStatus": {
+      "off": "aus"
+    }
+  },
+  "layout": {
+    "mapReference": {
+      "title": "Kartenreferenz",
+      "fields": {
+        "opacity": "Deckkraft",
+        "rotation": "Rotation"
+      },
+      "actions": {
+        "removeTitle": "Kartenreferenz entfernen",
+        "editTitle": "Kartenreferenz bearbeiten",
+        "addTitle": "Kartenreferenz hinzufügen",
+        "edit": "Bearbeiten",
+        "add": "Karte hinzufügen",
+        "showTitle": "Kartenreferenz anzeigen",
+        "hideTitle": "Kartenreferenz ausblenden",
+        "show": "Anzeigen"
+      }
+    },
+    "sections": {
+      "routeNumbering": "Routennummerierung",
+      "inventory": "Inventar",
+      "field": "Feld"
+    },
+    "field": {
+      "unitsLabel": "Einheiten",
+      "renderScaleLabel": "Render-Skalierung",
+      "renderScaleTooltip": "Interne Canvas-Dichte in Pixel pro Meter",
+      "pxPerMeterAriaLabel": "Pixel pro Meter, interne Canvas-Skalierung"
+    },
+    "project": {
+      "titlePlaceholder": "Unbenannter Track",
+      "subtitle": "Passe Projekttitel, Feldeinstellungen und verfügbaren Hindernisbestand an."
+    },
+    "overview": {
+      "title": "Aktuelles Layout",
+      "subtitle": "Prüfe platzierte Elemente, Routennummerierung und Baubarkeit für das aktuelle Layout.",
+      "emptyTitle": "Noch keine Elemente platziert",
+      "emptyDescription": "Füge ein paar Objekte auf dem Canvas hinzu, um das Layout zu prüfen und mit deinem Inventar zu vergleichen."
+    },
+    "inventory": {
+      "status": {
+        "buildable": "Baubar",
+        "short": "Fehlt"
+      },
+      "labels": {
+        "missing": "Fehlend",
+        "types": "Typen"
+      },
+      "description": "TrackDraw vergleicht das aktuelle Layout mit dem in diesem Projekt gespeicherten Hindernisbestand.",
+      "needCountSuffix": "braucht {count}",
+      "stockOk": "ok"
+    },
+    "meta": {
+      "itemsCount": "{count} Elemente",
+      "buildable": "baubar",
+      "shortItems": "{count, plural, one {1 Element fehlt} other {{count} Elemente fehlen}}",
+      "stockCovered": "Bestand gedeckt",
+      "typesShort": "{count, plural, one {1 Typ fehlt} other {{count} Typen fehlen}}",
+      "numbered": "{count} nummeriert",
+      "numberingIdle": "Nummerierung inaktiv",
+      "numberingNeedsReview": "Nummerierung prüfen"
+    }
+  },
+  "routeNumbering": {
+    "status": {
+      "ready": "Bereit",
+      "partial": "Prüfung nötig",
+      "noRouteMatches": "Keine Treffer",
+      "missingRoute": "Route fehlt",
+      "noNumberedObstacles": "Keine Routenhindernisse",
+      "empty": "Leer"
+    },
+    "messages": {
+      "ready": "{count, plural, one {1 Routenhindernis nummeriert.} other {{count} Routenhindernisse nummeriert.}}",
+      "partial": "{mapped} von {total} Routenhindernissen sind nummeriert.",
+      "noRouteMatches": "{count, plural, one {1 Routenhindernis gefunden, aber keines liegt nah genug an der Rennlinie.} other {{count} Routenhindernisse gefunden, aber keines liegt nah genug an der Rennlinie.}}",
+      "missingRoute": "{count, plural, one {1 Routenhindernis benötigt eine Rennlinie, bevor die Nummerierung abgeleitet werden kann.} other {{count} Routenhindernisse benötigen eine Rennlinie, bevor die Nummerierung abgeleitet werden kann.}}",
+      "noNumberedObstacles": "Gates, Ladders und Dive Gates erscheinen in der Routennummerierung.",
+      "empty": "Füge Routenhindernisse und eine Rennlinie hinzu, um Nummerierung abzuleiten."
+    },
+    "issues": {
+      "offRoutePrefix": "Abseits der Route: {names}",
+      "moreSuffix": " +{count} weitere"
+    },
+    "meta": {
+      "numbered": "Nummeriert",
+      "issues": "Probleme"
+    }
+  },
+  "elevationChart": {
+    "noRouteSelected": "Keine Rennlinie ausgewählt",
+    "title": "Höhenprofil",
+    "subtitle": "Routenhöhe, farbige Warnabschnitte und Hinweise zur Routenprüfung.",
+    "openDetailsAria": "Höhendetails öffnen",
+    "detailsTooltip": "Höhendetails",
+    "chartAriaLabel": "Diagramm des Höhenprofils",
+    "routeDistance": "{distance} Route",
+    "elevationRange": "{min}-{max} Höhe",
+    "moreCount": "+{count} weitere",
+    "maneuversHeading": "Manöver",
+    "maneuverDetected": "{maneuver} bei {range} erkannt",
+    "apexSuffix": ", Scheitel {index}",
+    "waypointSingle": "Wegpunkt {index}",
+    "waypointRange": "Wegpunkte {start}-{end}",
+    "routeReviewHeading": "Routenprüfung",
+    "noWarnings": "Keine Routenwarnungen für diesen Pfad.",
+    "normal": "Normal",
+    "maneuvers": {
+      "powerloop": "Powerloop",
+      "split-s": "Split-S"
+    },
+    "warnings": {
+      "stub": {
+        "summary": "Pfad braucht mindestens 2 Wegpunkte, um eine Route zu bilden",
+        "shortLabel": "Unvollständige Route",
+        "title": "Route ist unvollständig",
+        "problem": "Der Pfad braucht mindestens zwei Wegpunkte, bevor TrackDraw ihn als Route prüfen kann.",
+        "fix": "Füge einen weiteren Wegpunkt hinzu oder schließe das Zeichnen der Rennlinie ab."
+      },
+      "flat": {
+        "summary": "Keine Höhe gesetzt - 3D-Vorschau bleibt flach",
+        "shortLabel": "Flache Höhe",
+        "title": "Es wurde keine Höhe gesetzt",
+        "problem": "Alle Wegpunkte stehen noch auf 0 m, daher bleiben 3D-Vorschau und Höhendiagramm flach.",
+        "fix": "Setze Wegpunkthöhen im Inspector oder in der 3D-Ansicht, wenn die Route steigen oder fallen soll."
+      },
+      "steep": {
+        "summary": "{count, plural, one {Steile Steigung bei Wegpunkt {first}} other {Steile Steigung an {count} Segmenten}}",
+        "shortLabel": "Steile Steigung",
+        "title": "Steigung ändert sich zu schnell",
+        "problem": "Ein Abschnitt steigt oder fällt stark über eine kurze Distanz, wodurch die 3D-Linie abrupt wirken kann.",
+        "fix": "Verteile die Höhenänderung über mehr Distanz oder füge einen Zwischenwegpunkt hinzu."
+      },
+      "hairpin": {
+        "summary": "{count, plural, one {Enge Kurve bei Wegpunkt {first}} other {{count} enge Kurven}}",
+        "shortLabel": "Enge Kurve",
+        "title": "Kurve ist sehr eng",
+        "problem": "Ein Wegpunkt erzeugt eine scharfe Richtungsumkehr, die bei Geschwindigkeit schwer sauber zu fliegen sein kann.",
+        "fix": "Verschiebe den Wegpunkt nach außen oder schaffe vor und nach der Kurve mehr Raum."
+      },
+      "close-points": {
+        "summary": "{count, plural, one {Nahe Wegpunkte bei {first}} other {{count} eng beieinanderliegende Wegpunkte}}",
+        "shortLabel": "Nahe Punkte",
+        "title": "Wegpunkte liegen zu nah beieinander",
+        "problem": "Zwei Wegpunkte liegen so nah beieinander, dass sie ein winziges Routensegment erzeugen.",
+        "fix": "Lösche einen der Punkte oder verschiebe ihn weiter vom Nachbarn weg."
+      },
+      "spacing-shift": {
+        "summary": "{count, plural, one {Abrupter Abstandswechsel bei Wegpunkt {first}} other {{count} abrupte Abstandswechsel}}",
+        "shortLabel": "Abstandswechsel",
+        "title": "Gate-Rhythmus ändert sich abrupt",
+        "problem": "Der Abstand vor und nach einem Wegpunkt ändert sich plötzlich, wodurch die Route ungleichmäßig wirken kann.",
+        "fix": "Positioniere nahe Wegpunkte neu, damit sich die Abstände schrittweiser ändern."
+      },
+      "rhythm-break": {
+        "summary": "{count, plural, one {Kurzes Korrektursegment bei Wegpunkt {first}} other {{count} kurze Korrektursegmente}}",
+        "shortLabel": "Kurze Korrektur",
+        "title": "Kurze Korrektur bricht den Flow",
+        "problem": "Ein kurzes mittleres Segment unterbricht längere umliegende Abschnitte und kann ein unangenehmes Wackeln erzeugen.",
+        "fix": "Glätte die Korrektur, indem du den Punkt verschiebst, ihn löschst oder einen sanfteren Übergang hinzufügst."
+      }
+    }
+  },
+  "mapReference": {
+    "title": "Kartenreferenz",
+    "subtitle": "Wähle das Feldzentrum und richte den Feldumriss aus.",
+    "searchPlaceholder": "Ort suchen oder Koordinaten einfügen",
+    "searching": "Sucht",
+    "enterHint": "Enter",
+    "zoomLabel": "Zoom {zoom}",
+    "zoomIn": "Hineinzoomen",
+    "zoomOut": "Herauszoomen",
+    "resetRotation": "Rotation zurücksetzen",
+    "rotateLeft15": "15 Grad nach links drehen",
+    "rotateLeft1": "1 Grad nach links drehen",
+    "rotateRight1": "1 Grad nach rechts drehen",
+    "rotateRight15": "15 Grad nach rechts drehen",
+    "latitude": "Breitengrad",
+    "longitude": "Längengrad",
+    "rotation": "Rotation",
+    "rotationValue": "{deg} Grad",
+    "view": "Ansicht",
+    "out": "Raus",
+    "in": "Rein",
+    "previewZoom": "Vorschau-Zoom {zoom}",
+    "center": "Zentrum",
+    "useLocation": "Standort verwenden",
+    "locating": "Standort wird ermittelt",
+    "saveMap": "Karte speichern",
+    "locationUnavailable": "Standort ist in diesem Browser nicht verfügbar.",
+    "locationPermissionDenied": "Standortberechtigung wurde verweigert.",
+    "locationTimeout": "Standortsuche hat zu lange gedauert.",
+    "locationError": "Dein Standort konnte nicht bestimmt werden."
+  }
+}

--- a/lang/de/landing.json
+++ b/lang/de/landing.json
@@ -31,7 +31,7 @@
   },
   "hero": {
     "eyebrow": "Gebaut für FPV-Renndirektoren",
-    "headingLine1": "Der Renntag beginnt",
+    "headingLine1": "Renntag startet",
     "headingLine2": "mit einem Plan.",
     "description": "TrackDraw ist ein browserbasierter Drone-Race-Track-Builder für FPV-Renndirektoren. Zeichne maßstabsgetreu in 2D, prüfe den Flow in 3D, teile ein schreibgeschütztes Layout mit Piloten und Crew und halte den Plan auf Desktop und Mobilgerät nutzbar.",
     "ctaStudio": "Studio öffnen",
@@ -45,8 +45,8 @@
   },
   "features": {
     "sectionTitle": "Funktionen",
-    "sectionHeading": "Planen, prüfen und übergeben.",
-    "sectionDescription": "TrackDraw gibt FPV-Renndirektoren eine praktische Möglichkeit, Tracks sauber zu entwerfen: reale Feldmaße, das richtige Hindernisset und ein Workflow, der denselben Plan vom Layout über die Prüfung bis zur Übergabe ans Team trägt.",
+    "sectionHeading": "Entwerfen, prüfen und teilen.",
+    "sectionDescription": "TrackDraw gibt FPV-Renndirektoren eine praktische Möglichkeit, Tracks sauber zu entwerfen: reale Feldmaße, die passenden Hindernisse und ein Workflow, der denselben Plan vom Layout über die Prüfung bis zur Übergabe ans Team trägt.",
     "trueToScale": {
       "title": "Maßstabsgetreues Canvas",
       "description": "Lege die Feldgröße fest, platziere Elemente maßstabsgetreu und arbeite auf einem Raster, das zur realen Location passt."

--- a/lang/de/landing.json
+++ b/lang/de/landing.json
@@ -1,0 +1,267 @@
+{
+  "metadata": {
+    "homeTitle": "TrackDraw · Drone Race Track Builder",
+    "homeSocialTitle": "TrackDraw | Drone Race Track Builder",
+    "homeDescription": "TrackDraw ist ein Drone-Race-Track-Builder für FPV-Renndirektoren. Entwirf Tracks maßstabsgetreu, prüfe den Trackflow in 3D und teile schreibgeschützte Layouts für den Renntag.",
+    "homeSocialDescription": "Nutze TrackDraw als Drone-Race-Track-Builder, um FPV-Layouts maßstabsgetreu zu planen, den Trackflow in 3D zu prüfen und schreibgeschützte Pläne für den Renntag zu teilen.",
+    "studioTitle": "Drone Race Track Builder",
+    "studioSocialTitle": "TrackDraw | Drone Race Track Builder",
+    "studioDescription": "Öffne den TrackDraw Drone Race Track Builder, um FPV-Layouts maßstabsgetreu zu entwerfen, Gates und Hindernisse hinzuzufügen und den Trackflow in 3D zu prüfen.",
+    "studioSocialDescription": "Entwirf FPV-Drone-Race-Tracks maßstabsgetreu, füge Gates und Hindernisse hinzu und prüfe den Trackflow in 3D."
+  },
+  "header": {
+    "homeAriaLabel": "Startseite",
+    "homeTooltip": "Zur Haupt-Landingpage zurück",
+    "featuresNav": "Funktionen",
+    "featuresTooltip": "Zur Produktübersicht springen",
+    "galleryNav": "Galerie",
+    "galleryTooltip": "Öffentliche Community-Layouts ansehen",
+    "pricingNav": "Preise",
+    "pricingTooltip": "Pläne und Preise ansehen",
+    "faqNav": "FAQ",
+    "faqTooltip": "Häufige Fragen und Antworten lesen",
+    "logoAriaLabel": "TrackDraw",
+    "siteNavAriaLabel": "Startseite, Galerie und öffentliche Website-Bereiche",
+    "mobileNavAriaLabel": "Navigieren",
+    "themeAriaLabel": "Design",
+    "themeTooltip": "Design der öffentlichen Website wechseln.",
+    "languageAriaLabel": "Sprache",
+    "languageTooltip": "Sprache der Website wechseln.",
+    "openStudio": "Studio öffnen"
+  },
+  "hero": {
+    "eyebrow": "Gebaut für FPV-Renndirektoren",
+    "headingLine1": "Der Renntag beginnt",
+    "headingLine2": "mit einem Plan.",
+    "description": "TrackDraw ist ein browserbasierter Drone-Race-Track-Builder für FPV-Renndirektoren. Zeichne maßstabsgetreu in 2D, prüfe den Flow in 3D, teile ein schreibgeschütztes Layout mit Piloten und Crew und halte den Plan auf Desktop und Mobilgerät nutzbar.",
+    "ctaStudio": "Studio öffnen",
+    "ctaFeatures": "Funktionen ansehen",
+    "feature1": "Offizieller Hinderniskatalog",
+    "feature2": "Track-Abschnitte",
+    "feature3": "3D-Vorschau und Flythrough",
+    "feature4": "Race Pack PDF und SVG",
+    "videoAlt": "TrackDraw Drone Race Track Builder Demo",
+    "videoDescription": "Eine kurze Produktdemo, die zeigt, wie TrackDraw FPV-Renndirektoren hilft, ein Drone-Race-Track-Layout zu bauen, es in 3D zu prüfen und mit Piloten und Crew zu teilen."
+  },
+  "features": {
+    "sectionTitle": "Funktionen",
+    "sectionHeading": "Planen, prüfen und übergeben.",
+    "sectionDescription": "TrackDraw gibt FPV-Renndirektoren eine praktische Möglichkeit, Tracks sauber zu entwerfen: reale Feldmaße, das richtige Hindernisset und ein Workflow, der denselben Plan vom Layout über die Prüfung bis zur Übergabe ans Team trägt.",
+    "trueToScale": {
+      "title": "Maßstabsgetreues Canvas",
+      "description": "Lege die Feldgröße fest, platziere Elemente maßstabsgetreu und arbeite auf einem Raster, das zur realen Location passt."
+    },
+    "obstacleCatalog": {
+      "title": "Offizieller Hinderniskatalog",
+      "description": "Platziere offizielle MultiGP-Hindernisse (Gates, Flaggen, Ladders, Hurdles und Barrieren) mit realen Maßen und präzisem 3D-Rendering."
+    },
+    "preview3d": {
+      "title": "Realistische 3D-Vorschau",
+      "description": "Umlaufe den Track in 3D, füge der Rennlinie Höhe hinzu, prüfe Manöverkurven und fliege die Route ab, um Flow-Probleme vor dem Aufbautag zu erkennen."
+    },
+    "shareLinks": {
+      "title": "Geteilte Review-Links",
+      "description": "Teile ein schreibgeschütztes Layout mit Piloten und Crew. Gastlinks sind temporär; über Konten veröffentlichte Links bleiben aktiv, bis sie widerrufen werden."
+    },
+    "sections": {
+      "title": "Track-Abschnitte",
+      "description": "Speichere jede Canvas-Auswahl als benannten Abschnitt und platziere sie mit einem Klick erneut. Abschnitte synchronisieren sich geräteübergreifend mit deinem Konto."
+    },
+    "export": {
+      "title": "Race Pack und Export",
+      "description": "Erzeuge ein Pilotenbriefing-PDF mit Hindernis-Layout, Routenkarte und Aufbauhinweisen. Exportiere außerdem SVG, PNG und JSON aus demselben Design."
+    }
+  },
+  "workflow": {
+    "sectionEyebrow": "Im Detail",
+    "sectionHeading": "Vom ersten Layout bis zur Team-Übergabe.",
+    "sectionDescription": "Das Tool funktioniert am besten als Abfolge: Drone-Race-Track in 2D abbilden, in 3D prüfen, praktische Änderungen vornehmen, wenn die Realität sich ändert, und denselben Plan anschließend an Piloten und Crew übergeben.",
+    "layout": {
+      "title": "2D-Layout",
+      "subtitle": "Baue den Track auf einem Feld, das der Realität entspricht.",
+      "description": "Starte mit den Feldmaßen und platziere dann die Elemente, die Crews bereits kennen. So ist die erste Version des Plans sofort nützlich, statt nur eine grobe Skizze zu sein.",
+      "screenshotAlt": "TrackDraw 2D-Layout-Editor mit Hindernisbibliothek und Trackplan",
+      "bullets": [
+        "Maßstabsgetreue Feldmaße",
+        "Gates, Flaggen, Kegel, Startpads und größere Features",
+        "Rennlinie und Labels für klare Briefings"
+      ]
+    },
+    "fineTune": {
+      "title": "Feinabstimmung",
+      "subtitle": "Weiter bearbeiten, wenn die Location Änderungen erzwingt.",
+      "description": "Ein guter Plan lässt sich sauber ändern. Inspector-Steuerungen und mobilfreundliches Bearbeiten ermöglichen es, Objekteigenschaften anzupassen, Elemente zu verschieben und das Design nutzbar zu halten, selbst wenn die reale Location nicht statisch bleibt.",
+      "screenshotAlt": "TrackDraw Mobile-Editor mit geöffnetem Einstellungsbereich",
+      "bullets": [
+        "Inspector-Steuerungen für Maße, Rotation und Farbe",
+        "Touchfreundliches Bearbeiten auf Smartphones und Tablets",
+        "Schnelle Anpassungen ohne den Hauptplan zu verlassen"
+      ]
+    },
+    "preview": {
+      "title": "3D-Vorschau",
+      "subtitle": "Gehe den Track ab, bevor du ihn aufbaust.",
+      "description": "Ein Klick wechselt vom flachen 2D-Plan in eine Live-3D-Szene. Weise jedem Wegpunkt auf der Rennlinie eine Höhe zu, um das vollständige vertikale Profil zu modellieren. Erkenne gefährliche Anflüge, bevor ein einziger Hering im Boden steckt.",
+      "screenshotAlt": "TrackDraw 3D-Vorschau mit Trackflow und Höhenprofil",
+      "bullets": [
+        "Live-3D direkt aus deinem 2D-Design gerendert",
+        "Höhe pro Wegpunkt auf der Rennlinie",
+        "Höhendiagramm im Inspector-Panel"
+      ]
+    },
+    "handOff": {
+      "title": "Übergabe",
+      "subtitle": "Gib Piloten und Crew dieselbe aktuelle Version.",
+      "description": "Ein Plan zählt nur, wenn andere ihn öffnen können. Geteilte schreibgeschützte Links und Exporte machen aus dem Layout etwas, das Piloten prüfen, Crews drucken und Veranstalter später wiederverwenden können.",
+      "screenshotAlt": "Schreibgeschützte geteilte TrackDraw-Ansicht auf einem Mobilgerät",
+      "gallery": "Galerie zur Inspiration ansehen",
+      "bullets": [
+        "Schreibgeschützte Links, die auf jedem Gerät öffnen",
+        "PDF, PNG und SVG für Briefing- und Druck-Workflows",
+        "JSON-Export zum Archivieren und späteren Wiederverwenden von Layouts"
+      ]
+    }
+  },
+  "faq": {
+    "sectionTitle": "FAQ",
+    "sectionHeading": "Gut zu wissen.",
+    "items": [
+      {
+        "question": "Ist TrackDraw ein Drone Race Track Builder?",
+        "answer": "Ja. TrackDraw ist ein browserbasierter Drone Race Track Builder für FPV-Renndirektoren, die maßstabsgetreue Layouts, 3D-Review, Teilen und Export in einem Workflow brauchen."
+      },
+      {
+        "question": "Wie plant man einen FPV-Racetrack am besten?",
+        "answer": "Beginne mit den Feldmaßen, platziere die Hindernisse, die du wirklich hast, und prüfe die Route anschließend in 3D, bevor du den Plan teilst oder exportierst. TrackDraw ist genau um diese Abfolge herum gebaut."
+      },
+      {
+        "question": "Können Piloten das Layout ohne Konto ansehen?",
+        "answer": "Ja. Share-Links öffnen auf jedem Gerät im schreibgeschützten Modus, ohne Konto oder App. Sende den Link an Piloten, Judges oder Crew und alle sehen dieselbe veröffentlichte Version."
+      },
+      {
+        "question": "Funktioniert es auf einem Tablet an der Location?",
+        "answer": "Ja. Der Editor ist touchfreundlich, sodass schnelle Anpassungen auf Smartphone oder Tablet praktisch sind, wenn die reale Location eine Änderung erzwingt."
+      },
+      {
+        "question": "Welche Exportformate sind verfügbar?",
+        "answer": "PDF, PNG, SVG, JSON und ein cineastischer FPV-Videoexport. Das deckt gedruckte Race-Briefings, teilbare Visuals, wiederverwendbare Projektdateien und bewegungsbasierte Routenprüfung ab."
+      },
+      {
+        "question": "Brauche ich ein Konto, um loszulegen?",
+        "answer": "Nein. Öffne das Studio und beginne sofort mit dem Design. Ein Konto ergänzt Cloud-Speicher, dauerhafte veröffentlichte Links, Galerie-Veröffentlichung und Embeds."
+      },
+      {
+        "question": "Kann ich ein Layout für ein zukünftiges Event wiederverwenden?",
+        "answer": "Ja. Speichere Teile eines Layouts als benannte Presets und platziere sie mit einem Klick erneut. Um ein ganzes Projekt wiederzuverwenden, exportiere es als JSON und importiere es zu Beginn eines neuen Events."
+      },
+      {
+        "question": "Kann TrackDraw helfen, Routenprobleme vor dem Renntag zu erkennen?",
+        "answer": "Ja. Die 3D-Vorschau und Routenprüfungswarnungen helfen, ungleichmäßige Abstände, Rhythmusbrüche und Ausrichtungsprobleme sichtbar zu machen, bevor du das Layout teilst oder mit dem Aufbau beginnst."
+      }
+    ]
+  },
+  "pricing": {
+    "sectionEyebrow": "Pläne",
+    "sectionHeading": "Starte jetzt, registriere dich, wenn du mehr brauchst.",
+    "sectionDescription": "Beide aktuellen Optionen sind kostenlos. Der Gastmodus hält den Kerneditor ohne Einrichtung offen; Konten ergänzen dauerhafte Veröffentlichung, Embeds, Galerie-Listings und Projektkontinuität über Geräte hinweg.",
+    "guest": {
+      "badge": "Keine Registrierung",
+      "name": "Gast",
+      "price": "Kostenlos",
+      "description": "Am besten für schnelle Entwürfe, einmalige temporäre Review-Links und lokalen Export ohne Konto.",
+      "cta": "Studio öffnen"
+    },
+    "account": {
+      "badge": "Mit Konto",
+      "name": "Konto",
+      "price": "Kostenlos",
+      "description": "Am besten für dauerhafte veröffentlichte Links, Embeds, Galerie, Track-Abschnitte, REST-API-Zugriff und geräteübergreifende Projektkontinuität.",
+      "cta": "Konto erstellen"
+    },
+    "features": {
+      "fullDesigner": "Vollständiger Track-Designer",
+      "preview2d3d": "2D- und 3D-Vorschau",
+      "export": "PDF-, SVG-, PNG- und JSON-Export",
+      "shareLinks": "Share-Links",
+      "temporaryLinks": "Temporäre Links",
+      "publishedLinks": "Veröffentlicht bis zum Widerruf",
+      "shareLinksNote": "Gast-Share-Links sind temporär. Über Konten veröffentlichte Links bleiben bis zum Widerruf aktiv und können auch eingebettet werden.",
+      "embeds": "Website-Embeds",
+      "embedsDetail": "Per iframe auf jeder Website einbetten",
+      "gallery": "Galerie-Veröffentlichung",
+      "cloudProjects": "Cloud-synchronisierte Projekte",
+      "cloudProjectsDetail": "Projekte synchronisieren sich mit deinem Konto, damit du auf jedem Gerät weitermachen kannst — vom Desktop zuhause bis zum Mobilgerät an der Location.",
+      "sections": "Track-Abschnitte",
+      "sectionsDetail": "Speichere jede Canvas-Auswahl als benanntes Preset und platziere sie erneut aus dem Preset-Picker. Synchronisiert sich geräteübergreifend mit deinem Konto.",
+      "api": "REST-API-Zugriff",
+      "apiDetail": "Bearer-authentifiziert, API-Key-Verwaltung"
+    },
+    "categories": {
+      "design": "Design",
+      "sharing": "Teilen",
+      "projects": "Projekte",
+      "integration": "Integration"
+    }
+  },
+  "footer": {
+    "tagline": "Browserbasierter Track-Designer für FPV-Renndirektoren. Maßstabsgetreu zeichnen, in 3D prüfen, einen schreibgeschützten Link teilen und schnelle mobile Änderungen möglich halten.",
+    "productTitle": "Produkt",
+    "openStudio": "Studio öffnen",
+    "releaseNotes": "Release Notes",
+    "legalTitle": "Rechtliches",
+    "privacy": "Datenschutzerklärung",
+    "terms": "Nutzungsbedingungen",
+    "communityTitle": "Community",
+    "github": "GitHub",
+    "dutchDroneSquad": "Dutch Drone Squad",
+    "reportIssue": "Problem melden",
+    "supportTitle": "Support",
+    "githubSponsors": "GitHub Sponsors",
+    "kofi": "Ko-fi",
+    "copyright": "© {year} Dutch Drone Squad. Open-Source-Projekt.",
+    "madeWithPre": "Gemacht mit",
+    "madeWithPost": "für die FPV-Community"
+  },
+  "gallery": {
+    "pageTitle": "FPV Drone Race Track Galerie",
+    "metaTitle": "TrackDraw | FPV Drone Race Track Galerie",
+    "metaDescription": "Durchstöbere FPV-Drone-Race-Track-Designs, die von der TrackDraw-Community geteilt wurden.",
+    "sectionLabel": "Galerie",
+    "headingLine1": "Entdecke Layouts, die",
+    "headingLine2": "dein nächstes Trackdesign prägen.",
+    "description": "Durchstöbere öffentliche TrackDraw-Layouts aus der Community zur Inspiration. Hervorgehobene Tracks zeigen die stärksten Beispiele zuerst, aktuelle Community-Uploads folgen direkt darunter.",
+    "grid": {
+      "recentlyAdded": "Neu hinzugefügt",
+      "fieldSizeNotSet": "Feldgröße nicht gesetzt",
+      "unknownPilot": "TrackDraw-Pilot",
+      "featuredBadge": "Hervorgehoben",
+      "byOwner": "von {owner}",
+      "obstacleCount": "{count} Hindernisse",
+      "published": "Veröffentlicht {date}",
+      "open": "Öffnen",
+      "emptyTitle": "Noch keine Tracks.",
+      "emptyDescription": "Galerie-Einträge erscheinen hier, sobald TrackDraw-Piloten sie öffentlich teilen.",
+      "featuredHeading": "Hervorgehoben",
+      "featuredSubtitle": "Handverlesene Layouts oben in der Galerie.",
+      "recentHeading": "Aktuell",
+      "recentSubtitle": "Neu gelistete Layouts aus der Community.",
+      "loadMore": "Mehr laden"
+    }
+  },
+  "notFound": {
+    "logoAriaLabel": "TrackDraw",
+    "badge": "Fehler 404",
+    "heading": "Diese Seite ist vom Kurs abgekommen",
+    "description": "Die angeforderte Seite existiert nicht, wurde möglicherweise verschoben oder hat am Gate falsch abgebogen. Der neueste Track oder die Route sollte in der Nähe sein.",
+    "whatToTry": "Was du versuchen kannst",
+    "step1": "Springe zurück ins Studio und öffne den neuesten Track.",
+    "step2": "Kehre zur Startseite zurück, wenn du über ein altes Lesezeichen gekommen bist.",
+    "step3": "Versuche die neueste Route erneut, falls die Seite kürzlich verschoben wurde.",
+    "goHome": "Zur Startseite",
+    "openStudio": "Studio öffnen"
+  },
+  "screenshotPlaceholder": {
+    "label": "Screenshot-Platzhalter",
+    "plannedAsset": "Geplantes Asset"
+  }
+}

--- a/lang/de/login.json
+++ b/lang/de/login.json
@@ -1,0 +1,43 @@
+{
+  "metadata": {
+    "title": "Anmelden",
+    "description": "Melde dich mit einem einmaligen Magic Link bei TrackDraw an."
+  },
+  "goHome": "Zur Startseite",
+  "backToStudio": "Zurück zum Studio",
+  "pageTitle": "TrackDraw-Konto",
+  "heading": "Arbeite überall an deinen TrackDraw-Projekten weiter.",
+  "description": "Greife geräteübergreifend auf deine Layouts zu, verknüpfe geteilte Tracks mit deinem Konto und steige mit einem einfachen E-Mail-Link wieder ein.",
+  "featureDevices": {
+    "title": "Geräteübergreifend",
+    "description": "Setze die Arbeit auf einem anderen Gerät fort, ohne den Editor-Workflow zu ändern."
+  },
+  "featureOwnership": {
+    "title": "Besitz",
+    "description": "Gib geteilten Layouts und zukünftigen Kontofunktionen einen klaren Ort."
+  },
+  "featureMagicLink": {
+    "title": "Magic-Link-Fallback",
+    "description": "Nutze einen Passkey, wenn verfügbar, oder weiche auf einen Anmeldelink aus, der an deine E-Mail gesendet wird."
+  },
+  "signIn": {
+    "title": "Anmelden",
+    "description": "Melde dich auf diesem Gerät mit einem Passkey an oder nutze deine E-Mail, um einen Magic Link ohne Passwort zu erhalten.",
+    "checkInboxTitle": "Posteingang prüfen",
+    "checkInboxBody": "Dein einmaliger Anmeldelink wurde an {email} gesendet. Öffne ihn auf diesem oder einem anderen Gerät, um fortzufahren. Wenn er nicht bald erscheint, prüfe deinen Spam-Ordner.",
+    "howItWorksTitle": "So funktioniert die Anmeldung per Magic Link",
+    "howItWorksBody": "Jede E-Mail enthält einen einmaligen Anmeldelink. Kein Passwort-Setup: Link öffnen und TrackDraw meldet dich an.",
+    "useDifferentEmail": "Andere E-Mail verwenden",
+    "openingPasskey": "Passkey wird geöffnet…",
+    "signInPasskey": "Mit Passkey anmelden",
+    "or": "oder",
+    "emailLabel": "E-Mail",
+    "emailPlaceholder": "du@example.com",
+    "sendingLink": "Link wird gesendet…",
+    "sendLink": "Anmeldelink per E-Mail senden",
+    "noPasskeySupport": "Dieser Browser unterstützt hier derzeit keine Passkeys. Verwende daher den Magic-Link-Fallback.",
+    "passkeyNotFound": "Dieser Passkey konnte keinem TrackDraw-Konto zugeordnet werden. Versuche einen anderen Passkey oder nutze den Anmeldelink per E-Mail.",
+    "passkeyFailed": "Anmeldung mit Passkey fehlgeschlagen.",
+    "checkEmail": "Prüfe deine E-Mail auf einen Anmeldelink."
+  }
+}

--- a/lang/de/setupEstimate.json
+++ b/lang/de/setupEstimate.json
@@ -1,0 +1,48 @@
+{
+  "complexity": {
+    "light": "Leicht",
+    "standard": "Standard",
+    "heavy": "Aufwendig"
+  },
+  "kinds": {
+    "trackGroup": "Track-Gruppe",
+    "crew": "Crew"
+  },
+  "flagsFinalPass": {
+    "label": "Letzter Durchgang für Flaggen",
+    "note": "Schließe das Feld mit Flaggenmarkierungen und finalen Sichtbarkeitschecks ab, sobald die nummerierte Haupt-Hindernislinie steht."
+  },
+  "conesTrackWalk": {
+    "label": "Kegelplatzierung beim Track Walk (optional)",
+    "note": "Kegel können während des Track Walks der Piloten platziert werden, um einen separaten Durchgang zu vermeiden. Wenn du sie lieber früher setzt, plane vor Ort etwas zusätzliche Zeit ein."
+  },
+  "crewUnloadStage": {
+    "label": "Ausrüstung entladen und bereitstellen",
+    "note": "Fahrzeug entladen, Anker und Hardware sortieren und das Material auslegen, damit die Rahmenvorbereitung die spätere Feldplatzierung nicht blockiert."
+  },
+  "crewPreassemble": {
+    "label": "Rahmen und Softgoods vormontieren",
+    "noteWithSoftGoods": "Bereite PVC-Gate-Rahmen und Beachflags vor, bevor die Elemente aufs Feld getragen werden, damit der Platzierungsdurchgang auf Abstände fokussiert bleibt.",
+    "noteWithoutSoftGoods": "Bereite PVC-Gate-Rahmen vor, bevor die Elemente aufs Feld getragen werden, damit der Platzierungsdurchgang auf Abstände fokussiert bleibt."
+  },
+  "crewRiggingCheck": {
+    "label": "Rigging- und Ankercheck",
+    "note": "Prüfe Ankerpunkte, Überkopf-Leinen und den Freiraumplan, bevor schwerere Strukturen angehoben oder aufgehängt werden."
+  },
+  "obstacleNoteWithNumber": "{note} Nutze Hindernis #{number} auf der Karte als Platzierungsreferenz.",
+  "summaryHeavy": "{count, plural, one {1 aufwendigere Struktur sollte vor dem Standard-Gate-Durchgang platziert und gesichert werden.} other {{count} aufwendigere Strukturen sollten vor dem Standard-Gate-Durchgang platziert und gesichert werden.}} Die Zeitplanung geht von einer typischen Crew aus 2-3 Personen aus und kann bei Überkopf-Rigging oder langen Tragewegen steigen.",
+  "summaryLight": "Der größte Teil der Aufbauzeit entsteht durch Entladen, Vormontage der Rahmen und anschließend sauberes Platzieren der nummerierten Hindernislinie mit einer Crew aus 2-3 Personen.",
+  "crewAssumption": "Die Zeitplanung basiert auf einer typischen Crew aus 2-3 Personen und geht von einer Standard-Clubvorbereitung aus: entladen, bereitstellen, vormontieren, dann platzieren und sichern.",
+  "obstacleNotes": {
+    "gate": "Platziere und richte dieses Gate aus, sobald die Ankerstrukturen stehen.",
+    "tower": "Platziere und sichere dies zusammen mit den anderen aufwendigeren Strukturen. Towers brauchen stabile Füße, saubere vertikale Ausrichtung und genug Freiraum für gestapelte Öffnungen.",
+    "flag": "Nutze Flaggen nach dem Setzen der Haupthindernisse für finale Sichtbarkeit und Randdefinition.",
+    "cone": "Nutze Kegel im finalen Aufräumdurchgang für Begrenzungsmarkierung und Abstandschecks.",
+    "label": "Für dieses Element ist noch keine Aufbauanleitung verfügbar.",
+    "polyline": "Für dieses Element ist noch keine Aufbauanleitung verfügbar.",
+    "startfinish": "Setze dies zuerst, damit die Start- und Zielreferenz feststeht, bevor der restliche Kurs aufgebaut wird.",
+    "ladder": "Behandle dies als aufwendigeres Element. Plane zusätzliche Zeit ein, wenn Überkopf-Rigging oder ein sorgfältiger Aufhängepunkt nötig ist.",
+    "divegate": "Platziere und sichere dies früh. Dive Gates benötigen meist mehr Ausrichtung und Verankerung als ein Standard-Gate.",
+    "barrier": "Baue Barrieren auf, nachdem die Haupt-Gates und Hindernisse positioniert sind."
+  }
+}

--- a/lang/de/shapes.json
+++ b/lang/de/shapes.json
@@ -1,0 +1,48 @@
+{
+  "kindLabels": {
+    "gate": "Gate",
+    "tower": "Tower",
+    "flag": "Flagge",
+    "cone": "Kegel",
+    "label": "Label",
+    "polyline": "Rennlinie",
+    "startfinish": "Start / Ziel",
+    "ladder": "Ladder",
+    "divegate": "Dive Gate",
+    "barrier": "Barriere"
+  },
+  "toolLabels": {
+    "select": "Auswählen",
+    "grab": "Verschieben",
+    "preset": "Presets",
+    "gate": "Gate",
+    "tower": "Tower",
+    "flag": "Flagge",
+    "cone": "Kegel",
+    "label": "Label",
+    "polyline": "Pfad",
+    "startfinish": "Startpads",
+    "ladder": "Ladder",
+    "divegate": "Dive Gate",
+    "barrier": "Barriere"
+  },
+  "toolGroups": {
+    "track": "Track",
+    "extra": "Extra"
+  },
+  "toolMobileLabels": {
+    "startfinish": "Start",
+    "divegate": "Dive",
+    "barrier": "Barriere"
+  },
+  "mobileStatus": {
+    "multiSelect": "Multi",
+    "tool": "Werkzeug",
+    "itemsCount": "{count} Elemente"
+  },
+  "canvas": {
+    "selectionCount": "{count} Elemente",
+    "selectionFallback": "Auswahl",
+    "frontLabel": "Vorne"
+  }
+}

--- a/lang/de/share.json
+++ b/lang/de/share.json
@@ -1,0 +1,58 @@
+{
+  "badge": "Geteilte Ansicht",
+  "backToHome": "Zurück zur Startseite",
+  "whatToTry": "Was du versuchen kannst",
+  "openStudio": "Studio öffnen",
+  "error": {
+    "heading": "Dieser geteilte Track-Link wird nicht mehr unterstützt",
+    "description": "TrackDraw verwendet jetzt veröffentlichte Share-Links statt des älteren URL-eingebetteten Share-Formats. Dieser ältere Link kann nicht mehr direkt geöffnet werden.",
+    "whatToDo": "Was zu tun ist",
+    "step1": "Bitte den Absender, im <strong>Studio</strong> einen neuen Share-Link zu veröffentlichen.",
+    "step2": "Wenn du weiterhin eine Offline-Übergabe brauchst, bitte um einen <strong>JSON-Export</strong> und öffne ihn im Studio über Import.",
+    "step3": "Neue veröffentlichte Links verwenden die kanonische Route `/share/[token]` und bleiben der unterstützte Weg, schreibgeschützte Layouts zu teilen.",
+    "openStudioToImport": "Studio zum Importieren öffnen"
+  },
+  "expired": {
+    "heading": "Dieser Share-Link ist abgelaufen",
+    "description": "Temporäre TrackDraw-Share-Links laufen nach der beim Erstellen gewählten Dauer ab. Über ein Konto veröffentlichte Projektlinks bleiben aktiv, bis der Besitzer sie widerruft. Bitte den Absender, einen neuen Link zu veröffentlichen, wenn du dieses Layout noch brauchst.",
+    "step1": "Bitte den Absender, den Track erneut zu veröffentlichen oder einen über ein Konto veröffentlichten Link für längerfristigen schreibgeschützten Zugriff zu senden.",
+    "step2": "Bitte um einen JSON-Export, wenn das Layout längerfristig übergeben werden muss."
+  },
+  "notFound": {
+    "heading": "Dieser geteilte Track konnte nicht geöffnet werden",
+    "description": "Der Share-Link wurde möglicherweise vom Besitzer widerrufen oder ist veraltet, unvollständig oder falsch kopiert. Bitte den Absender, zu bestätigen, dass der Link noch aktiv ist, oder einen neuen Link zu veröffentlichen. Wenn der Track sehr groß ist, ist ein JSON-Export zuverlässiger als ein Share-Link.",
+    "step1": "Bitte den Absender, zu bestätigen, dass die Freigabe noch aktiv ist, und den neuesten Share-Link erneut zu kopieren.",
+    "step2": "Öffne den Link direkt aus der Nachricht, in der er gesendet wurde.",
+    "step3": "Bitte um einen JSON-Export, wenn der Track sehr groß ist — JSON-Dateien unterliegen keinen URL-Größenlimits."
+  },
+  "viewer": {
+    "dismissIntro": "Einführung zur geteilten Strecke schließen",
+    "sharedByReadOnly": "Geteilt von {author}. Schreibgeschützt, Änderungen werden nicht gespeichert. Wechsle zu {view} oder erstelle im Studio deine eigene bearbeitbare Kopie.",
+    "readOnlyNoAuthor": "Schreibgeschützt, Änderungen werden nicht gespeichert. Wechsle zu {view} oder erstelle im Studio deine eigene bearbeitbare Kopie.",
+    "openView": "{view} öffnen",
+    "makeEditableCopy": "Bearbeitbare Kopie erstellen"
+  },
+  "metadata": {
+    "title": "Track ansehen",
+    "description": "Sieh dir diesen mit TrackDraw entworfenen FPV-Racetrack an.",
+    "expiredTitle": "Abgelaufene Track-Freigabe",
+    "expiredDescription": "Dieser TrackDraw-Share-Link ist abgelaufen. Bitte den Absender, einen neuen Link zu veröffentlichen.",
+    "retiredTitle": "Nicht unterstützte Track-Freigabe",
+    "retiredDescription": "Dieses ältere TrackDraw-Share-Format wird nicht mehr unterstützt. Bitte den Absender, einen neuen Link zu veröffentlichen.",
+    "embedTitle": "Track-Embed",
+    "embedDescription": "Eingebettete schreibgeschützte TrackDraw-Trackansicht."
+  },
+  "embedUnavailable": {
+    "temporaryTitle": "Embed nicht verfügbar",
+    "temporaryDescription": "Embeds sind für veröffentlichte Konto-Freigaben verfügbar. Öffne den Share-Link oder melde dich an, um ein dauerhaftes Embed zu veröffentlichen.",
+    "expiredTitle": "Dieses Embed ist abgelaufen",
+    "expiredDescription": "Diese temporäre TrackDraw-Freigabe ist nicht mehr aktiv. Bitte den Besitzer, eine dauerhafte Konto-Freigabe zu veröffentlichen.",
+    "revokedTitle": "Dieses Embed wurde widerrufen",
+    "revokedDescription": "Der Besitzer hat diese TrackDraw-Freigabe widerrufen, daher ist der eingebettete Track nicht mehr verfügbar.",
+    "missingTitle": "Track nicht gefunden",
+    "missingDescription": "Dieses TrackDraw-Embed passt zu keiner aktiven veröffentlichten Konto-Freigabe.",
+    "openShareLink": "Share-Link öffnen",
+    "signIn": "Anmelden",
+    "brand": "TrackDraw"
+  }
+}

--- a/lang/en/landing.json
+++ b/lang/en/landing.json
@@ -45,7 +45,7 @@
   },
   "features": {
     "sectionTitle": "Features",
-    "sectionHeading": "Plan, review, and hand off.",
+    "sectionHeading": "Design, review, and share.",
     "sectionDescription": "TrackDraw gives FPV race directors a practical way to design tracks properly: real field dimensions, the right obstacle set, and one workflow that carries the same plan from layout to review to team hand-off.",
     "trueToScale": {
       "title": "True-to-scale canvas",

--- a/lang/nl/exportPdf.json
+++ b/lang/nl/exportPdf.json
@@ -60,7 +60,7 @@
     "notesTitle": "Race day-notities",
     "note1": "Gebruik de kaartpagina als plaatsingsreferentie tijdens opbouw en pilotenbriefing.",
     "note2": "Behandel de voorraadcheck als de bron van waarheid voordat je de indeling definitief maakt voor de bouw.",
-    "note3": "Verankker het parcours eerst en zet daarna obstakels met hogere inspanning zoals Dive Gates en Ladders vast voor de standaard gate-ronde.",
+    "note3": "Veranker het parcours eerst en zet daarna obstakels met hogere inspanning zoals Dive Gates en Ladders vast voor de standaard gate-ronde.",
     "note4": "Als de route of het obstakelaantal verandert, genereer het Race Pack opnieuw zodat kaart, voorraadlijst en opbouwvolgorde op elkaar aansluiten."
   }
 }

--- a/lang/nl/landing.json
+++ b/lang/nl/landing.json
@@ -45,7 +45,7 @@
   },
   "features": {
     "sectionTitle": "Functies",
-    "sectionHeading": "Plan, beoordeel en lever op.",
+    "sectionHeading": "Ontwerp, controleer en deel.",
     "sectionDescription": "TrackDraw geeft FPV-raceorganisatoren een praktische manier om tracks goed te ontwerpen: echte veldafmetingen, de juiste obstakelset en één workflow die hetzelfde plan van lay-out naar review naar teamoverdracht draagt.",
     "trueToScale": {
       "title": "Canvas op ware schaal",

--- a/lang/nl/login.json
+++ b/lang/nl/login.json
@@ -10,7 +10,7 @@
   "description": "Toegang tot je lay-outs op alle apparaten, houd gedeelde banen gekoppeld aan je account en ga verder met een eenvoudige e-maillink.",
   "featureDevices": {
     "title": "Op alle apparaten",
-    "description": "Pak werk op op een ander apparaat zonder de editorflow te veranderen."
+    "description": "Pak werk weer op een ander apparaat op zonder de editorflow te veranderen."
   },
   "featureOwnership": {
     "title": "Eigenaarschap",

--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -25,6 +25,7 @@ const localeConfig: Record<
 > = {
   en: { label: "English", abbr: "EN", flag: "🇬🇧" },
   nl: { label: "Nederlands", abbr: "NL", flag: "🇳🇱" },
+  de: { label: "Deutsch", abbr: "DE", flag: "🇩🇪" },
 };
 
 interface LanguagePickerProps {

--- a/src/i18n/catalogs.ts
+++ b/src/i18n/catalogs.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import * as de from "@lang/de";
 import * as en from "@lang/en";
 import i18nPolicy from "@lang/i18n-policy.json";
 import * as nl from "@lang/nl";
@@ -14,7 +15,7 @@ const englishOnlyNamespaceSet = new Set<MessageNamespace>(
 const catalogs: Record<
   SupportedLocale,
   Partial<Record<MessageNamespace, unknown>>
-> = { en, nl };
+> = { en, nl, de };
 
 const catalogNamespaces = Object.keys(en) as MessageNamespace[];
 const catalogCache = new Map<

--- a/src/lib/i18n/locales.ts
+++ b/src/lib/i18n/locales.ts
@@ -1,4 +1,4 @@
-export const supportedLocales = ["en", "nl"] as const;
+export const supportedLocales = ["en", "nl", "de"] as const;
 export type SupportedLocale = (typeof supportedLocales)[number];
 
 export const defaultLocale: SupportedLocale = "en";


### PR DESCRIPTION
## Summary

Adds German as a supported TrackDraw locale and registers it in the language picker and catalog loader.

## Notes

- Translates the public/editor-facing namespaces into German.
- Keeps dashboard and legal content English-only through the existing i18n policy.

## Validation

- `npm run i18n:check`
