### PR TITLE
refactor: Extract dashboard table columns

### DIFF
--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -25,10 +25,14 @@
   "pages": {
     "overview": "Overview",
     "users": "Users",
+    "usersIntro": "Every registered account. Review roles, activity, and account-backed content per user.",
     "apiKeys": "API Keys",
+    "apiKeysIntro": "API keys issued across all accounts. Monitor usage, expiry, and rate-limit status.",
     "audit": "Audit",
+    "auditIntro": "A timeline of moderation and account actions across the dashboard.",
     "metrics": "Metrics",
     "gallery": "Gallery",
+    "galleryIntro": "Published tracks visible to everyone on the public gallery. Feature, list, hide, or remove entries from public discovery.",
     "emailPreview": "Email Preview"
   },
   "overview": {

--- a/src/app/dashboard/api-keys/columns.tsx
+++ b/src/app/dashboard/api-keys/columns.tsx
@@ -8,7 +8,10 @@ import { dataTableSortButtonClassName } from "@/components/data-table/DataTableL
 import type { AdminApiKey } from "@/lib/server/api-keys";
 
 export type ApiKeyStatus = "active" | "expired" | "disabled";
-export type Translate = (key: string, values?: Record<string, unknown>) => string;
+export type Translate = (
+  key: string,
+  values?: Record<string, unknown>
+) => string;
 
 export function getApiKeyStatus(key: AdminApiKey): ApiKeyStatus {
   if (!key.enabled) return "disabled";

--- a/src/app/dashboard/api-keys/columns.tsx
+++ b/src/app/dashboard/api-keys/columns.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { ArrowUpDown } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { dataTableSortButtonClassName } from "@/components/data-table/DataTableLayout";
+import type { AdminApiKey } from "@/lib/server/api-keys";
+
+export type ApiKeyStatus = "active" | "expired" | "disabled";
+export type Translate = (key: string, values?: Record<string, unknown>) => string;
+
+export function getApiKeyStatus(key: AdminApiKey): ApiKeyStatus {
+  if (!key.enabled) return "disabled";
+  if (key.expiresAt && new Date(key.expiresAt).getTime() <= Date.now()) {
+    return "expired";
+  }
+  return "active";
+}
+
+export function getStatusVariant(
+  status: ApiKeyStatus
+): "default" | "muted" | "outline" {
+  if (status === "active") return "outline";
+  return "muted";
+}
+
+export function getStatusLabel(status: ApiKeyStatus, t: Translate) {
+  return t(`statusValues.${status}`);
+}
+
+export function getOwnerLabel(key: AdminApiKey) {
+  return key.ownerName?.trim() || key.ownerEmail?.trim() || key.ownerUserId;
+}
+
+export function getKeyLabel(key: AdminApiKey) {
+  return key.name ?? key.start ?? key.id;
+}
+
+export function formatDate(value: string | null) {
+  if (!value) return "—";
+  try {
+    return new Intl.DateTimeFormat("en-GB", { dateStyle: "medium" }).format(
+      new Date(value)
+    );
+  } catch {
+    return value;
+  }
+}
+
+export function formatDateTime(value: string | null) {
+  if (!value) return "—";
+  try {
+    return new Intl.DateTimeFormat("en-GB", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+type GetApiKeysColumnsParams = {
+  t: Translate;
+};
+
+export function getApiKeysColumns({
+  t,
+}: GetApiKeysColumnsParams): ColumnDef<AdminApiKey>[] {
+  return [
+    {
+      id: "key",
+      accessorFn: (row) => getKeyLabel(row),
+      meta: { className: "w-[28%] min-w-48" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.key")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      cell: ({ row }) => (
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">
+            {getKeyLabel(row.original)}
+          </p>
+          <p className="text-muted-foreground truncate font-mono text-xs">
+            {row.original.prefix ?? ""}
+            {row.original.start ?? ""}…
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "owner",
+      accessorFn: (row) => getOwnerLabel(row),
+      header: t("table.owner"),
+      meta: { className: "w-[25%] min-w-44" },
+      cell: ({ row }) => (
+        <div className="min-w-0">
+          <p className="truncate text-sm">{getOwnerLabel(row.original)}</p>
+          <p className="text-muted-foreground truncate text-xs">
+            {row.original.ownerEmail ?? row.original.ownerUserId}
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "status",
+      accessorFn: (row) => getApiKeyStatus(row),
+      header: t("table.status"),
+      meta: { className: "w-28" },
+      cell: ({ row }) => {
+        const status = getApiKeyStatus(row.original);
+        return (
+          <Badge variant={getStatusVariant(status)}>
+            {getStatusLabel(status, t)}
+          </Badge>
+        );
+      },
+    },
+    {
+      id: "requests",
+      accessorKey: "requestCount",
+      meta: { className: "w-28" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.requests")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      cell: ({ row }) => (
+        <span className="text-sm tabular-nums">
+          {row.original.requestCount.toLocaleString()}
+        </span>
+      ),
+    },
+    {
+      id: "lastUsed",
+      accessorKey: "lastRequest",
+      meta: { className: "w-36" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.lastUsed")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-xs">
+          {formatDateTime(row.original.lastRequest)}
+        </span>
+      ),
+    },
+    {
+      id: "expires",
+      accessorKey: "expiresAt",
+      meta: { className: "w-32 hidden lg:table-cell" },
+      header: t("table.expires"),
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-xs">
+          {formatDate(row.original.expiresAt)}
+        </span>
+      ),
+    },
+  ];
+}

--- a/src/app/dashboard/api-keys/page.tsx
+++ b/src/app/dashboard/api-keys/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
+import { KeyRound } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import DashboardPageIntro from "@/components/dashboard/PageIntro";
 import DashboardSiteHeader from "@/components/dashboard/SiteHeader";
 import DashboardApiKeysManager from "@/components/dashboard/ApiKeysManager";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
@@ -39,7 +41,13 @@ export default async function DashboardApiKeysPage() {
         parent={{ label: tCommon("labels.dashboard"), href: "/dashboard" }}
         title={t("pages.apiKeys")}
       />
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
+        <DashboardPageIntro
+          icon={KeyRound}
+          title={t("pages.apiKeys")}
+          description={t("pages.apiKeysIntro")}
+          accent="bg-violet-500/10 text-violet-600 dark:text-violet-400"
+        />
         <DashboardApiKeysManager initialKeys={apiKeys} />
       </div>
     </>

--- a/src/app/dashboard/audit/columns.tsx
+++ b/src/app/dashboard/audit/columns.tsx
@@ -291,7 +291,9 @@ export function getAuditColumns({
 
         return (
           <div className="min-w-0">
-            <p className="text-sm font-medium">{getEventTitle(event.eventType, t)}</p>
+            <p className="text-sm font-medium">
+              {getEventTitle(event.eventType, t)}
+            </p>
             <div className="mt-1 flex items-center gap-2">
               <Badge variant="outline">
                 {getEventCategoryLabel(event.eventType, t)}
@@ -422,7 +424,9 @@ export function getAuditColumns({
         const entityDisplay = getEntityDisplay(row.original, t);
         return (
           <div className="min-w-0">
-            <p className="truncate text-sm font-medium">{entityDisplay.label}</p>
+            <p className="truncate text-sm font-medium">
+              {entityDisplay.label}
+            </p>
             {entityDisplay.detail ? (
               <p className="text-muted-foreground truncate text-xs">
                 {entityDisplay.detail}
@@ -440,7 +444,7 @@ export function getAuditColumns({
         <Button
           variant="ghost"
           size="sm"
-          className={`${dataTableSortButtonClassName} ml-auto -mr-2`}
+          className={`${dataTableSortButtonClassName} -mr-2 ml-auto`}
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
         >
           {t("table.when")}

--- a/src/app/dashboard/audit/columns.tsx
+++ b/src/app/dashboard/audit/columns.tsx
@@ -262,6 +262,9 @@ export function getAuditColumns({
   t,
   unknownUserLabel,
 }: GetAuditColumnsParams): ColumnDef<DashboardAuditEvent>[] {
+  const getSortAriaLabel = (label: string) =>
+    t("aria.sort", { label: label.toLowerCase() });
+
   return [
     {
       id: "event",
@@ -273,6 +276,7 @@ export function getAuditColumns({
           size="sm"
           className={dataTableSortButtonClassName}
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          aria-label={getSortAriaLabel(t("table.event"))}
         >
           {t("table.event")}
           <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
@@ -338,6 +342,7 @@ export function getAuditColumns({
           size="sm"
           className={dataTableSortButtonClassName}
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          aria-label={getSortAriaLabel(t("table.actor"))}
         >
           {t("table.actor")}
           <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
@@ -373,6 +378,7 @@ export function getAuditColumns({
           size="sm"
           className={dataTableSortButtonClassName}
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          aria-label={getSortAriaLabel(t("table.target"))}
         >
           {t("table.target")}
           <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
@@ -408,6 +414,7 @@ export function getAuditColumns({
           size="sm"
           className={dataTableSortButtonClassName}
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          aria-label={getSortAriaLabel(t("table.entity"))}
         >
           {t("table.entity")}
           <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
@@ -446,6 +453,7 @@ export function getAuditColumns({
           size="sm"
           className={`${dataTableSortButtonClassName} -mr-2 ml-auto`}
           onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          aria-label={getSortAriaLabel(t("table.when"))}
         >
           {t("table.when")}
           <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />

--- a/src/app/dashboard/audit/columns.tsx
+++ b/src/app/dashboard/audit/columns.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { ArrowUpDown } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { dataTableSortButtonClassName } from "@/components/data-table/DataTableLayout";
+import { getAccountRoleLabel, parseAccountRole } from "@/lib/account/roles";
+
+export type AuditEventActor = {
+  id: string;
+  name: string | null;
+  email: string | null;
+} | null;
+
+export type DashboardAuditEvent = {
+  id: string;
+  actorUserId: string | null;
+  targetUserId: string | null;
+  eventType: string;
+  entityType: string;
+  entityId: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+  actor: AuditEventActor;
+  target: AuditEventActor;
+};
+
+export type AuditEventCategory = "Account" | "Gallery" | "System";
+
+export const categoryFilterValues: AuditEventCategory[] = [
+  "Account",
+  "Gallery",
+  "System",
+];
+export const unknownActorValue = "__unknown_actor__";
+
+export type Translate = (
+  key: string,
+  values?: Record<string, string | number | Date>
+) => string;
+
+export function formatDateTime(value: string) {
+  try {
+    return new Intl.DateTimeFormat("en-GB", {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export function getUserLabel(user: AuditEventActor, unknownUserLabel: string) {
+  if (!user) {
+    return unknownUserLabel;
+  }
+
+  return user.name?.trim() || user.email?.trim() || unknownUserLabel;
+}
+
+export function getSecondaryLabel(user: AuditEventActor) {
+  if (!user) {
+    return null;
+  }
+
+  if (user.name?.trim() && user.email?.trim()) {
+    return user.email;
+  }
+
+  return user.email?.trim() || user.id;
+}
+
+export function getActorFilterValue(event: DashboardAuditEvent) {
+  return event.actorUserId ?? unknownActorValue;
+}
+
+export function getActorFilterLabel(
+  event: DashboardAuditEvent,
+  unknownUserLabel: string
+) {
+  const label = getUserLabel(event.actor, unknownUserLabel);
+  const secondary = getSecondaryLabel(event.actor);
+
+  return secondary && secondary !== label ? `${label} (${secondary})` : label;
+}
+
+export function getRoleChangeSummary(metadata: Record<string, unknown> | null) {
+  const previousRole = parseAccountRole(metadata?.previousRole);
+  const nextRole = parseAccountRole(metadata?.nextRole);
+
+  return {
+    previousRole,
+    nextRole,
+    label: `${getAccountRoleLabel(previousRole)} -> ${getAccountRoleLabel(nextRole)}`,
+  };
+}
+
+export function formatEventType(value: string) {
+  return value
+    .split(".")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+const EVENT_TITLE_KEYS: Record<string, string> = {
+  "account.role.changed": "accountRoleChanged",
+  "gallery.entry.featured": "galleryEntryFeatured",
+  "gallery.entry.unfeatured": "galleryEntryUnfeatured",
+  "gallery.entry.hidden": "galleryEntryHidden",
+  "gallery.entry.restored": "galleryEntryRestored",
+  "gallery.entry.deleted": "galleryEntryDeleted",
+};
+
+export function getEventTitle(eventType: string, t: Translate) {
+  const key = EVENT_TITLE_KEYS[eventType];
+  if (key) return t(`eventTitles.${key}`);
+  return formatEventType(eventType);
+}
+
+export function getEventCategory(eventType: string): AuditEventCategory {
+  if (eventType.startsWith("account.")) return "Account";
+  if (eventType.startsWith("gallery.")) return "Gallery";
+  return "System";
+}
+
+export function getEventCategoryLabel(eventType: string, t: Translate) {
+  return t(`categoryValues.${getEventCategory(eventType)}`);
+}
+
+export function formatMetadataValue(value: unknown) {
+  if (value === null || value === undefined) return "-";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(value);
+}
+
+export function formatMetadataLabel(value: string) {
+  return value
+    .replace(/([A-Z])/g, " $1")
+    .replace(/[_-]+/g, " ")
+    .replace(/^./, (char) => char.toUpperCase());
+}
+
+export function getEventDetailLabel(
+  event: {
+    eventType: string;
+    entityType: string;
+    entityId: string | null;
+    metadata: Record<string, unknown> | null;
+  },
+  t: Translate
+) {
+  if (event.eventType === "account.role.changed") {
+    return getRoleChangeSummary(event.metadata).label;
+  }
+
+  const previousState = formatMetadataValue(event.metadata?.previousState);
+  const nextState = formatMetadataValue(event.metadata?.nextState);
+  if (previousState !== "-" && nextState !== "-") {
+    return `${previousState} -> ${nextState}`;
+  }
+
+  if (event.metadata?.shareToken) {
+    return t("filters.share", {
+      token: formatMetadataValue(event.metadata.shareToken),
+    });
+  }
+
+  return event.entityId
+    ? `${event.entityType} ${event.entityId}`
+    : event.entityType;
+}
+
+export function getEntityTypeLabel(entityType: string, t: Translate) {
+  switch (entityType) {
+    case "user":
+      return t("entityLabels.account");
+    case "gallery_entry":
+      return t("entityLabels.galleryEntry");
+    default:
+      return formatMetadataLabel(entityType);
+  }
+}
+
+export function shortenId(value: string) {
+  if (value.length <= 14) return value;
+  return `${value.slice(0, 8)}...${value.slice(-4)}`;
+}
+
+export function getEntityDisplay(event: DashboardAuditEvent, t: Translate) {
+  if (event.entityType === "user") {
+    return {
+      label: t("entityLabels.accountRole"),
+      detail: getRoleChangeSummary(event.metadata).label,
+    };
+  }
+
+  if (event.entityType === "gallery_entry") {
+    const shareToken =
+      typeof event.metadata?.shareToken === "string"
+        ? event.metadata.shareToken
+        : null;
+
+    return {
+      label: t("entityLabels.galleryEntry"),
+      detail: shareToken ?? (event.entityId ? shortenId(event.entityId) : null),
+    };
+  }
+
+  return {
+    label: getEntityTypeLabel(event.entityType, t),
+    detail: event.entityId
+      ? t("entity.id", { id: shortenId(event.entityId) })
+      : null,
+  };
+}
+
+export function eventMatchesSearch(
+  event: DashboardAuditEvent,
+  query: string,
+  t: Translate,
+  unknownUserLabel: string
+) {
+  if (!query) return true;
+  const entityDisplay = getEntityDisplay(event, t);
+
+  const searchable = [
+    getEventTitle(event.eventType, t),
+    getEventCategoryLabel(event.eventType, t),
+    getEventDetailLabel(event, t),
+    getUserLabel(event.actor, unknownUserLabel),
+    getSecondaryLabel(event.actor),
+    getUserLabel(event.target, unknownUserLabel),
+    getSecondaryLabel(event.target),
+    event.entityType,
+    event.entityId,
+    entityDisplay.label,
+    entityDisplay.detail,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return searchable.includes(query);
+}
+
+function compareText(a: string, b: string, aDate: string, bDate: string) {
+  const primary = a.localeCompare(b, undefined, { sensitivity: "base" });
+  if (primary !== 0) return primary;
+  return new Date(aDate).getTime() - new Date(bDate).getTime();
+}
+
+type GetAuditColumnsParams = {
+  t: Translate;
+  unknownUserLabel: string;
+};
+
+export function getAuditColumns({
+  t,
+  unknownUserLabel,
+}: GetAuditColumnsParams): ColumnDef<DashboardAuditEvent>[] {
+  return [
+    {
+      id: "event",
+      accessorFn: (row) => getEventTitle(row.eventType, t),
+      meta: { className: "w-[34%]" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.event")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      sortingFn: (rowA, rowB) =>
+        compareText(
+          getEventTitle(rowA.original.eventType, t),
+          getEventTitle(rowB.original.eventType, t),
+          rowA.original.createdAt,
+          rowB.original.createdAt
+        ),
+      cell: ({ row }) => {
+        const event = row.original;
+        const metadataEntries = Object.entries(event.metadata ?? {});
+
+        return (
+          <div className="min-w-0">
+            <p className="text-sm font-medium">{getEventTitle(event.eventType, t)}</p>
+            <div className="mt-1 flex items-center gap-2">
+              <Badge variant="outline">
+                {getEventCategoryLabel(event.eventType, t)}
+              </Badge>
+              <span className="text-muted-foreground text-xs">
+                {getEventDetailLabel(event, t)}
+              </span>
+            </div>
+            {metadataEntries.length > 0 ? (
+              <details className="mt-2">
+                <summary className="text-muted-foreground hover:text-foreground cursor-pointer text-xs">
+                  {t("table.details")}
+                </summary>
+                <dl className="mt-2 grid gap-1 text-xs">
+                  {metadataEntries.map(([key, value]) => (
+                    <div
+                      key={key}
+                      className="grid grid-cols-[112px_minmax(0,1fr)] gap-2"
+                    >
+                      <dt className="text-muted-foreground">
+                        {formatMetadataLabel(key)}
+                      </dt>
+                      <dd className="text-foreground min-w-0 truncate font-mono">
+                        {formatMetadataValue(value)}
+                      </dd>
+                    </div>
+                  ))}
+                </dl>
+              </details>
+            ) : null}
+          </div>
+        );
+      },
+    },
+    {
+      id: "actor",
+      accessorFn: (row) => getUserLabel(row.actor, unknownUserLabel),
+      meta: { className: "w-[20%]" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.actor")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      sortingFn: (rowA, rowB) =>
+        compareText(
+          getUserLabel(rowA.original.actor, unknownUserLabel),
+          getUserLabel(rowB.original.actor, unknownUserLabel),
+          rowA.original.createdAt,
+          rowB.original.createdAt
+        ),
+      cell: ({ row }) => (
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">
+            {getUserLabel(row.original.actor, unknownUserLabel)}
+          </p>
+          {getSecondaryLabel(row.original.actor) ? (
+            <p className="text-muted-foreground truncate text-xs">
+              {getSecondaryLabel(row.original.actor)}
+            </p>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      id: "target",
+      accessorFn: (row) => getUserLabel(row.target, unknownUserLabel),
+      meta: { className: "w-[20%]" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.target")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      sortingFn: (rowA, rowB) =>
+        compareText(
+          getUserLabel(rowA.original.target, unknownUserLabel),
+          getUserLabel(rowB.original.target, unknownUserLabel),
+          rowA.original.createdAt,
+          rowB.original.createdAt
+        ),
+      cell: ({ row }) => (
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">
+            {getUserLabel(row.original.target, unknownUserLabel)}
+          </p>
+          {getSecondaryLabel(row.original.target) ? (
+            <p className="text-muted-foreground truncate text-xs">
+              {getSecondaryLabel(row.original.target)}
+            </p>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      id: "entity",
+      accessorFn: (row) => getEntityDisplay(row, t).label,
+      meta: { className: "w-[16%]" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.entity")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      sortingFn: (rowA, rowB) =>
+        compareText(
+          getEntityDisplay(rowA.original, t).label,
+          getEntityDisplay(rowB.original, t).label,
+          rowA.original.createdAt,
+          rowB.original.createdAt
+        ),
+      cell: ({ row }) => {
+        const entityDisplay = getEntityDisplay(row.original, t);
+        return (
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium">{entityDisplay.label}</p>
+            {entityDisplay.detail ? (
+              <p className="text-muted-foreground truncate text-xs">
+                {entityDisplay.detail}
+              </p>
+            ) : null}
+          </div>
+        );
+      },
+    },
+    {
+      id: "createdAt",
+      accessorFn: (row) => row.createdAt,
+      meta: { className: "w-40 text-right" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={`${dataTableSortButtonClassName} ml-auto -mr-2`}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.when")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      sortingFn: (rowA, rowB) =>
+        new Date(rowA.original.createdAt).getTime() -
+        new Date(rowB.original.createdAt).getTime(),
+      cell: ({ row }) => (
+        <span className="text-right text-xs whitespace-nowrap">
+          {formatDateTime(row.original.createdAt)}
+        </span>
+      ),
+    },
+  ];
+}

--- a/src/app/dashboard/audit/page.tsx
+++ b/src/app/dashboard/audit/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
+import { Bell } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import DashboardAuditEventsTable, {
   type AuditEventCategory,
 } from "@/components/dashboard/tables/AuditEventsTable";
+import DashboardPageIntro from "@/components/dashboard/PageIntro";
 import DashboardSiteHeader from "@/components/dashboard/SiteHeader";
 import { listAuditEvents } from "@/lib/server/audit";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
@@ -59,11 +61,19 @@ export default async function DashboardAuditPage({
         parent={{ label: tCommon("labels.dashboard"), href: "/dashboard" }}
         title={t("pages.audit")}
       />
-      <DashboardAuditEventsTable
-        key={activeFilterValue}
-        events={events}
-        initialCategories={initialCategories}
-      />
+      <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
+        <DashboardPageIntro
+          icon={Bell}
+          title={t("pages.audit")}
+          description={t("pages.auditIntro")}
+          accent="bg-rose-500/10 text-rose-600 dark:text-rose-400"
+        />
+        <DashboardAuditEventsTable
+          key={activeFilterValue}
+          events={events}
+          initialCategories={initialCategories}
+        />
+      </div>
     </>
   );
 }

--- a/src/app/dashboard/gallery/columns.tsx
+++ b/src/app/dashboard/gallery/columns.tsx
@@ -32,7 +32,10 @@ import { formatFieldSize as formatMeasurementFieldSize } from "@/lib/track/units
 
 export type GalleryUpdateAction = "feature" | "unfeature" | "hide" | "restore";
 export type ShareLifecycleState = "active" | "expired" | "revoked";
-export type Translate = (key: string, values?: Record<string, unknown>) => string;
+export type Translate = (
+  key: string,
+  values?: Record<string, unknown>
+) => string;
 
 export function getOwnerLabel(entry: DashboardGalleryEntry) {
   return (
@@ -400,7 +403,9 @@ export function getGalleryColumns({
                   className="hover:bg-muted hover:text-foreground size-7"
                   disabled={isPending || !canManageGallery}
                   aria-label={`${featureAction.label} ${entry.galleryTitle}`}
-                  onClick={() => onUpdateEntry(entry.shareToken, featureAction.action)}
+                  onClick={() =>
+                    onUpdateEntry(entry.shareToken, featureAction.action)
+                  }
                 >
                   {isPending ? (
                     <Loader2 className="size-4 animate-spin" />
@@ -456,7 +461,9 @@ export function getGalleryColumns({
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-44">
                 <DropdownMenuItem
-                  onClick={() => onUpdateEntry(entry.shareToken, featureAction.action)}
+                  onClick={() =>
+                    onUpdateEntry(entry.shareToken, featureAction.action)
+                  }
                 >
                   <FeatureIcon className="size-4" />
                   {featureAction.label}

--- a/src/app/dashboard/gallery/columns.tsx
+++ b/src/app/dashboard/gallery/columns.tsx
@@ -1,0 +1,487 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+  ArrowUpDown,
+  Eye,
+  EyeOff,
+  Loader2,
+  MoreHorizontal,
+  Sparkles,
+  StarOff,
+  Trash2,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/AppTooltip";
+import { dataTableSortButtonClassName } from "@/components/data-table/DataTableLayout";
+import { getSiteMediaUrl } from "@/lib/seo";
+import type { DashboardGalleryEntry, GalleryState } from "@/lib/server/gallery";
+import { formatFieldSize as formatMeasurementFieldSize } from "@/lib/track/units";
+
+export type GalleryUpdateAction = "feature" | "unfeature" | "hide" | "restore";
+export type ShareLifecycleState = "active" | "expired" | "revoked";
+export type Translate = (key: string, values?: Record<string, unknown>) => string;
+
+export function getOwnerLabel(entry: DashboardGalleryEntry) {
+  return (
+    entry.ownerName?.trim() || entry.ownerEmail?.trim() || entry.ownerUserId
+  );
+}
+
+export function getTrackSecondaryLabel(entry: DashboardGalleryEntry) {
+  const shareTitle = entry.shareTitle?.trim();
+  if (
+    shareTitle &&
+    shareTitle.toLowerCase() !== entry.galleryTitle.trim().toLowerCase()
+  ) {
+    return shareTitle;
+  }
+
+  return entry.shareToken;
+}
+
+export function getStateVariant(
+  state: GalleryState
+): "default" | "muted" | "outline" {
+  if (state === "featured") return "default";
+  if (state === "hidden") return "muted";
+  return "outline";
+}
+
+export function getStateLabel(
+  state: GalleryState,
+  t: Translate,
+  tCommon: Translate
+) {
+  switch (state) {
+    case "listed":
+      return tCommon("status.listed");
+    case "featured":
+      return tCommon("status.featured");
+    case "hidden":
+      return tCommon("status.hidden");
+    default:
+      return t("stateValues.unlistedBadge");
+  }
+}
+
+export function getShareLifecycleState(
+  entry: DashboardGalleryEntry
+): ShareLifecycleState {
+  if (entry.shareRevokedAt) return "revoked";
+  if (
+    entry.shareExpiresAt &&
+    new Date(entry.shareExpiresAt).getTime() <= Date.now()
+  ) {
+    return "expired";
+  }
+
+  return "active";
+}
+
+export function getShareLifecycleLabel(
+  state: ShareLifecycleState,
+  t: Translate
+) {
+  return t(`shareValues.${state}`);
+}
+
+export function getShareLifecycleVariant(
+  state: ShareLifecycleState
+): "default" | "muted" | "outline" {
+  if (state === "active") return "outline";
+  return "muted";
+}
+
+export function formatDate(value: string | null) {
+  if (!value) return "—";
+
+  try {
+    return new Intl.DateTimeFormat("en-GB", {
+      dateStyle: "medium",
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export function getShareLifecycleDetail(
+  entry: DashboardGalleryEntry,
+  t: Translate
+) {
+  const state = getShareLifecycleState(entry);
+  if (state === "revoked")
+    return t("lifecycle.revokedOn", { date: formatDate(entry.shareRevokedAt) });
+  if (state === "expired")
+    return t("lifecycle.expiredOn", { date: formatDate(entry.shareExpiresAt) });
+  if (entry.shareExpiresAt)
+    return t("lifecycle.expiresOn", { date: formatDate(entry.shareExpiresAt) });
+  return t("lifecycle.noExpiry");
+}
+
+export function formatFieldSize(entry: DashboardGalleryEntry, t: Translate) {
+  if (entry.fieldWidth == null || entry.fieldHeight == null) {
+    return t("fallback.notSet");
+  }
+
+  return formatMeasurementFieldSize(
+    entry.fieldWidth,
+    entry.fieldHeight,
+    "metric"
+  );
+}
+
+export function formatElementCount(entry: DashboardGalleryEntry, t: Translate) {
+  if (entry.shapeCount == null) return t("fallback.notAvailable");
+  return t("meta.elementCount", { count: entry.shapeCount });
+}
+
+export function getPreviewImageUrl(entry: DashboardGalleryEntry) {
+  if (!entry.galleryPreviewImage) return null;
+  if (entry.galleryPreviewImage.startsWith("http")) {
+    return entry.galleryPreviewImage;
+  }
+
+  return getSiteMediaUrl(entry.galleryPreviewImage);
+}
+
+export function getEmbedAvailable(entry: DashboardGalleryEntry) {
+  return (
+    entry.shareType === "published" &&
+    getShareLifecycleState(entry) === "active"
+  );
+}
+
+export function getEmbedUnavailableReason(
+  entry: DashboardGalleryEntry,
+  t: Translate
+) {
+  if (entry.shareType !== "published") return t("embed.unavailableTemporary");
+  const state = getShareLifecycleState(entry);
+  if (state === "revoked") return t("embed.unavailableRevoked");
+  if (state === "expired") return t("embed.unavailableExpired");
+  return null;
+}
+
+export function getInspectSummary(entry: DashboardGalleryEntry, t: Translate) {
+  const shareState = getShareLifecycleState(entry);
+
+  if (shareState === "revoked") {
+    return {
+      tone: "warning" as const,
+      title: t("reviewState.revokedTitle"),
+      detail: t("reviewState.revokedDetail"),
+    };
+  }
+
+  if (shareState === "expired") {
+    return {
+      tone: "warning" as const,
+      title: t("reviewState.expiredTitle"),
+      detail: t("reviewState.expiredDetail"),
+    };
+  }
+
+  if (entry.galleryState === "hidden") {
+    return {
+      tone: "info" as const,
+      title: t("reviewState.hiddenTitle"),
+      detail: t("reviewState.hiddenDetail"),
+    };
+  }
+
+  if (!entry.galleryPreviewImage) {
+    return {
+      tone: "warning" as const,
+      title: t("reviewState.missingPreviewTitle"),
+      detail: t("reviewState.missingPreviewDetail"),
+    };
+  }
+
+  return {
+    tone: "ok" as const,
+    title: t("reviewState.readyTitle"),
+    detail: t("reviewState.readyDetail"),
+  };
+}
+
+function ActionTooltip({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactElement;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+function getFeatureAction(entry: DashboardGalleryEntry, t: Translate) {
+  return entry.galleryState !== "featured"
+    ? {
+        action: "feature" as const,
+        label: t("actions.feature"),
+        icon: Sparkles,
+      }
+    : {
+        action: "unfeature" as const,
+        label: t("actions.unfeature"),
+        icon: StarOff,
+      };
+}
+
+function getVisibilityAction(entry: DashboardGalleryEntry, t: Translate) {
+  return entry.galleryState !== "hidden"
+    ? {
+        action: "hide" as const,
+        label: t("actions.hide"),
+        icon: EyeOff,
+      }
+    : {
+        action: "restore" as const,
+        label: t("actions.restore"),
+        icon: Eye,
+      };
+}
+
+type GetGalleryColumnsParams = {
+  t: Translate;
+  tCommon: Translate;
+  pendingShareToken: string | null;
+  canManageGallery: boolean;
+  onUpdateEntry: (shareToken: string, action: GalleryUpdateAction) => void;
+  onDeleteCandidate: (entry: DashboardGalleryEntry) => void;
+};
+
+export function getGalleryColumns({
+  t,
+  tCommon,
+  pendingShareToken,
+  canManageGallery,
+  onUpdateEntry,
+  onDeleteCandidate,
+}: GetGalleryColumnsParams): ColumnDef<DashboardGalleryEntry>[] {
+  return [
+    {
+      id: "track",
+      accessorFn: (row) => row.galleryTitle,
+      meta: { className: "w-[30%] min-w-56" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.track")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      cell: ({ row }) => (
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">
+            {row.original.galleryTitle}
+          </p>
+          <p className="text-muted-foreground truncate text-xs">
+            {getTrackSecondaryLabel(row.original)}
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "owner",
+      accessorFn: (row) => getOwnerLabel(row),
+      header: tCommon("labels.owner"),
+      meta: { className: "w-[22%] min-w-48" },
+      cell: ({ row }) => (
+        <div className="min-w-0">
+          <p className="truncate text-sm">{getOwnerLabel(row.original)}</p>
+          <p className="text-muted-foreground truncate text-xs">
+            {row.original.ownerEmail ?? row.original.ownerUserId}
+          </p>
+        </div>
+      ),
+    },
+    {
+      accessorKey: "galleryState",
+      header: t("table.state"),
+      meta: { className: "w-28" },
+      cell: ({ row }) => (
+        <Badge variant={getStateVariant(row.original.galleryState)}>
+          {getStateLabel(row.original.galleryState, t, tCommon)}
+        </Badge>
+      ),
+    },
+    {
+      id: "shareLifecycle",
+      header: t("table.share"),
+      accessorFn: (row) => getShareLifecycleState(row),
+      meta: { className: "w-56" },
+      cell: ({ row }) => {
+        const lifecycleState = getShareLifecycleState(row.original);
+
+        return (
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+            <Badge
+              variant={getShareLifecycleVariant(lifecycleState)}
+              className="shrink-0"
+            >
+              {getShareLifecycleLabel(lifecycleState, t)}
+            </Badge>
+            <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs">
+              {getShareLifecycleDetail(row.original, t)}
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      id: "published",
+      meta: { className: "w-36" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.published")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      accessorFn: (row) => row.galleryPublishedAt ?? row.updatedAt,
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-xs">
+          {formatDate(row.original.galleryPublishedAt)}
+        </span>
+      ),
+    },
+    {
+      id: "actions",
+      header: "",
+      meta: { className: "w-32 text-right" },
+      cell: ({ row }) => {
+        const entry = row.original;
+        const isPending = pendingShareToken === entry.shareToken;
+        const featureAction = getFeatureAction(entry, t);
+        const FeatureIcon = featureAction.icon;
+        const visibilityAction = getVisibilityAction(entry, t);
+        const VisibilityIcon = visibilityAction.icon;
+
+        return (
+          <div
+            className="flex justify-end"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="hidden items-center justify-end gap-1 md:flex">
+              <ActionTooltip label={featureAction.label}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="hover:bg-muted hover:text-foreground size-7"
+                  disabled={isPending || !canManageGallery}
+                  aria-label={`${featureAction.label} ${entry.galleryTitle}`}
+                  onClick={() => onUpdateEntry(entry.shareToken, featureAction.action)}
+                >
+                  {isPending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <FeatureIcon className="size-4" />
+                  )}
+                </Button>
+              </ActionTooltip>
+              <ActionTooltip label={visibilityAction.label}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="hover:bg-muted hover:text-foreground size-7"
+                  disabled={isPending || !canManageGallery}
+                  aria-label={`${visibilityAction.label} ${entry.galleryTitle}`}
+                  onClick={() =>
+                    onUpdateEntry(entry.shareToken, visibilityAction.action)
+                  }
+                >
+                  <VisibilityIcon className="size-4" />
+                </Button>
+              </ActionTooltip>
+              <ActionTooltip label={t("actions.delete")}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="text-destructive hover:bg-muted hover:text-destructive size-7"
+                  disabled={isPending || !canManageGallery}
+                  aria-label={`${t("actions.delete")} ${entry.galleryTitle}`}
+                  onClick={() => onDeleteCandidate(entry)}
+                >
+                  <Trash2 className="size-4" />
+                </Button>
+              </ActionTooltip>
+            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:text-foreground ml-auto size-8 p-0 md:hidden"
+                  disabled={isPending || !canManageGallery}
+                  aria-label={t("actions.open")}
+                >
+                  {isPending ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <MoreHorizontal className="size-4" />
+                  )}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-44">
+                <DropdownMenuItem
+                  onClick={() => onUpdateEntry(entry.shareToken, featureAction.action)}
+                >
+                  <FeatureIcon className="size-4" />
+                  {featureAction.label}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() =>
+                    onUpdateEntry(entry.shareToken, visibilityAction.action)
+                  }
+                >
+                  <VisibilityIcon className="size-4" />
+                  {visibilityAction.label}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => onDeleteCandidate(entry)}
+                  className="text-destructive focus:text-destructive"
+                >
+                  <Trash2 className="size-4" />
+                  {t("actions.delete")}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        );
+      },
+    },
+  ];
+}

--- a/src/app/dashboard/gallery/page.tsx
+++ b/src/app/dashboard/gallery/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
+import { Image as ImageIcon } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import DashboardGalleryManager from "@/components/dashboard/GalleryManager";
+import DashboardPageIntro from "@/components/dashboard/PageIntro";
 import DashboardSiteHeader from "@/components/dashboard/SiteHeader";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 import { hasCapability } from "@/lib/server/authorization";
@@ -42,7 +44,13 @@ export default async function DashboardGalleryPage() {
         parent={{ label: tCommon("labels.dashboard"), href: "/dashboard" }}
         title={t("pages.gallery")}
       />
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
+        <DashboardPageIntro
+          icon={ImageIcon}
+          title={t("pages.gallery")}
+          description={t("pages.galleryIntro")}
+          accent="bg-sky-500/10 text-sky-600 dark:text-sky-400"
+        />
         <DashboardGalleryManager
           currentUserRole={currentUser.role}
           initialEntries={entries}

--- a/src/app/dashboard/users/columns.tsx
+++ b/src/app/dashboard/users/columns.tsx
@@ -8,7 +8,10 @@ import { dataTableSortButtonClassName } from "@/components/data-table/DataTableL
 import type { AdminUser } from "@/lib/account/admin-users";
 import { getAccountRoleLabel, type AccountRole } from "@/lib/account/roles";
 
-export type Translate = (key: string, values?: Record<string, unknown>) => string;
+export type Translate = (
+  key: string,
+  values?: Record<string, unknown>
+) => string;
 
 export function getUserLabel(user: AdminUser, unnamedUserLabel: string) {
   return user.name?.trim() || user.email?.trim() || unnamedUserLabel;

--- a/src/app/dashboard/users/columns.tsx
+++ b/src/app/dashboard/users/columns.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import type { ColumnDef } from "@tanstack/react-table";
+import { ArrowUpDown } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { dataTableSortButtonClassName } from "@/components/data-table/DataTableLayout";
+import type { AdminUser } from "@/lib/account/admin-users";
+import { getAccountRoleLabel, type AccountRole } from "@/lib/account/roles";
+
+export type Translate = (key: string, values?: Record<string, unknown>) => string;
+
+export function getUserLabel(user: AdminUser, unnamedUserLabel: string) {
+  return user.name?.trim() || user.email?.trim() || unnamedUserLabel;
+}
+
+export function getSecondaryLabel(user: AdminUser) {
+  if (user.name?.trim() && user.email?.trim()) return user.email;
+  return user.email?.trim() || user.id;
+}
+
+export function formatDate(value: string) {
+  try {
+    return new Intl.DateTimeFormat("en-GB", {
+      dateStyle: "medium",
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+export function roleBadgeClassName(role: AccountRole) {
+  if (role === "admin") {
+    return "border-rose-500/25 bg-rose-500/10 text-rose-700 dark:text-rose-300";
+  }
+  if (role === "moderator") {
+    return "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300";
+  }
+  return "border-border bg-muted/50 text-muted-foreground";
+}
+
+type GetUsersColumnsParams = {
+  t: Translate;
+  currentUserId: string;
+};
+
+export function getUsersColumns({
+  t,
+  currentUserId,
+}: GetUsersColumnsParams): ColumnDef<AdminUser>[] {
+  return [
+    {
+      id: "user",
+      accessorFn: (row) => getUserLabel(row, t("fallback.unnamedUser")),
+      meta: { className: "w-[40%] min-w-56" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.user")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      cell: ({ row }) => {
+        const user = row.original;
+        const isSelf = user.id === currentUserId;
+        return (
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium">
+              {getUserLabel(user, t("fallback.unnamedUser"))}
+              {isSelf && (
+                <span className="text-muted-foreground ml-1.5 text-xs font-normal">
+                  {t("selfBadge")}
+                </span>
+              )}
+            </p>
+            <p className="text-muted-foreground truncate text-xs">
+              {getSecondaryLabel(user)}
+            </p>
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "projectCount",
+      meta: { className: "hidden w-28 sm:table-cell" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.projects")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-xs tabular-nums">
+          {row.original.projectCount}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "role",
+      header: t("table.role"),
+      meta: { className: "w-32" },
+      cell: ({ row }) => (
+        <Badge
+          variant="outline"
+          className={roleBadgeClassName(row.original.role)}
+        >
+          {getAccountRoleLabel(row.original.role)}
+        </Badge>
+      ),
+    },
+    {
+      accessorKey: "createdAt",
+      meta: { className: "hidden w-36 lg:table-cell" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.joined")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-xs">
+          {formatDate(row.original.createdAt)}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "lastLoginAt",
+      meta: { className: "hidden w-36 sm:table-cell" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.lastLogin")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-xs">
+          {row.original.lastLoginAt
+            ? formatDate(row.original.lastLoginAt)
+            : "—"}
+        </span>
+      ),
+    },
+  ];
+}

--- a/src/app/dashboard/users/page.tsx
+++ b/src/app/dashboard/users/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
+import { Users as UsersIcon } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import DashboardPageIntro from "@/components/dashboard/PageIntro";
 import DashboardSiteHeader from "@/components/dashboard/SiteHeader";
 import DashboardUsersManager from "@/components/dashboard/UsersManager";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
@@ -39,7 +41,13 @@ export default async function DashboardUsersPage() {
         parent={{ label: tCommon("labels.dashboard"), href: "/dashboard" }}
         title={t("pages.users")}
       />
-      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+      <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
+        <DashboardPageIntro
+          icon={UsersIcon}
+          title={t("pages.users")}
+          description={t("pages.usersIntro")}
+          accent="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+        />
         <DashboardUsersManager
           currentUserId={currentUser.id}
           initialUsers={users}

--- a/src/components/dashboard/ApiKeysManager.tsx
+++ b/src/components/dashboard/ApiKeysManager.tsx
@@ -3,17 +3,27 @@
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import {
-  type ColumnDef,
   getCoreRowModel,
   getFilteredRowModel,
   getSortedRowModel,
   type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import { ArrowUpDown, KeyRound } from "lucide-react";
+import { KeyRound } from "lucide-react";
+import {
+  formatDate,
+  formatDateTime,
+  getApiKeyStatus,
+  getApiKeysColumns,
+  getKeyLabel,
+  getOwnerLabel,
+  getStatusLabel,
+  getStatusVariant,
+  type ApiKeyStatus,
+  type Translate,
+} from "@/app/dashboard/api-keys/columns";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import {
   Sheet,
   SheetContent,
@@ -23,36 +33,10 @@ import {
 } from "@/components/ui/sheet";
 import DataTable from "@/components/data-table/DataTable";
 import DataTableFacetFilter from "@/components/data-table/DataTableFacetFilter";
-import { dataTableSortButtonClassName } from "@/components/data-table/DataTableLayout";
 import DataTableToolbar from "@/components/data-table/DataTableToolbar";
 import type { AdminApiKey } from "@/lib/server/api-keys";
 
-type ApiKeyStatus = "active" | "expired" | "disabled";
-
 const statusFilterValues: ApiKeyStatus[] = ["active", "expired", "disabled"];
-
-function getApiKeyStatus(key: AdminApiKey): ApiKeyStatus {
-  if (!key.enabled) return "disabled";
-  if (key.expiresAt && new Date(key.expiresAt).getTime() <= Date.now()) {
-    return "expired";
-  }
-  return "active";
-}
-
-function getStatusVariant(
-  status: ApiKeyStatus
-): "default" | "muted" | "outline" {
-  if (status === "active") return "outline";
-  return "muted";
-}
-
-function getStatusLabel(status: ApiKeyStatus, t: (key: string) => string) {
-  return t(`statusValues.${status}`);
-}
-
-function getOwnerLabel(key: AdminApiKey) {
-  return key.ownerName?.trim() || key.ownerEmail?.trim() || key.ownerUserId;
-}
 
 function getOwnerInitials(key: AdminApiKey) {
   const name = key.ownerName?.trim();
@@ -63,33 +47,6 @@ function getOwnerInitials(key: AdminApiKey) {
     .join("")
     .slice(0, 2)
     .toUpperCase();
-}
-
-function getKeyLabel(key: AdminApiKey) {
-  return key.name ?? key.start ?? key.id;
-}
-
-function formatDate(value: string | null) {
-  if (!value) return "—";
-  try {
-    return new Intl.DateTimeFormat("en-GB", { dateStyle: "medium" }).format(
-      new Date(value)
-    );
-  } catch {
-    return value;
-  }
-}
-
-function formatDateTime(value: string | null) {
-  if (!value) return "—";
-  try {
-    return new Intl.DateTimeFormat("en-GB", {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  } catch {
-    return value;
-  }
 }
 
 function formatRateLimitWindow(
@@ -122,116 +79,7 @@ export default function DashboardApiKeysManager({
   const [selectedStatuses, setSelectedStatuses] = useState<ApiKeyStatus[]>([]);
   const [inspectKey, setInspectKey] = useState<AdminApiKey | null>(null);
 
-  const columns: ColumnDef<AdminApiKey>[] = [
-    {
-      id: "key",
-      accessorFn: (row) => getKeyLabel(row),
-      meta: { className: "w-[28%] min-w-48" },
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          className={dataTableSortButtonClassName}
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          {t("table.key")}
-          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => (
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium">
-            {getKeyLabel(row.original)}
-          </p>
-          <p className="text-muted-foreground truncate font-mono text-xs">
-            {row.original.prefix ?? ""}
-            {row.original.start ?? ""}…
-          </p>
-        </div>
-      ),
-    },
-    {
-      id: "owner",
-      accessorFn: (row) => getOwnerLabel(row),
-      header: t("table.owner"),
-      meta: { className: "w-[25%] min-w-44" },
-      cell: ({ row }) => (
-        <div className="min-w-0">
-          <p className="truncate text-sm">{getOwnerLabel(row.original)}</p>
-          <p className="text-muted-foreground truncate text-xs">
-            {row.original.ownerEmail ?? row.original.ownerUserId}
-          </p>
-        </div>
-      ),
-    },
-    {
-      id: "status",
-      accessorFn: (row) => getApiKeyStatus(row),
-      header: t("table.status"),
-      meta: { className: "w-28" },
-      cell: ({ row }) => {
-        const status = getApiKeyStatus(row.original);
-        return (
-          <Badge variant={getStatusVariant(status)}>
-            {getStatusLabel(status, t)}
-          </Badge>
-        );
-      },
-    },
-    {
-      id: "requests",
-      accessorKey: "requestCount",
-      meta: { className: "w-28" },
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          className={dataTableSortButtonClassName}
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          {t("table.requests")}
-          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => (
-        <span className="text-sm tabular-nums">
-          {row.original.requestCount.toLocaleString()}
-        </span>
-      ),
-    },
-    {
-      id: "lastUsed",
-      accessorKey: "lastRequest",
-      meta: { className: "w-36" },
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          className={dataTableSortButtonClassName}
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          {t("table.lastUsed")}
-          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => (
-        <span className="text-muted-foreground text-xs">
-          {formatDateTime(row.original.lastRequest)}
-        </span>
-      ),
-    },
-    {
-      id: "expires",
-      accessorKey: "expiresAt",
-      meta: { className: "w-32 hidden lg:table-cell" },
-      header: t("table.expires"),
-      cell: ({ row }) => (
-        <span className="text-muted-foreground text-xs">
-          {formatDate(row.original.expiresAt)}
-        </span>
-      ),
-    },
-  ];
+  const columns = getApiKeysColumns({ t: t as unknown as Translate });
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
@@ -373,7 +221,10 @@ export default function DashboardApiKeysManager({
                       label: t("panel.fields.status"),
                       value: (
                         <Badge variant={getStatusVariant(inspectStatus)}>
-                          {getStatusLabel(inspectStatus, t)}
+                          {getStatusLabel(
+                            inspectStatus,
+                            t as unknown as Translate
+                          )}
                         </Badge>
                       ),
                     },

--- a/src/components/dashboard/GalleryManager.tsx
+++ b/src/components/dashboard/GalleryManager.tsx
@@ -367,6 +367,12 @@ export default function DashboardGalleryManager({
       (row) => getShareLifecycleState(row.original) === value
     ).length,
   }));
+  const expiredShareCount = entries.filter(
+    (entry) => getShareLifecycleState(entry) === "expired"
+  ).length;
+  const revokedShareCount = entries.filter(
+    (entry) => getShareLifecycleState(entry) === "revoked"
+  ).length;
   const emptyMessage =
     entries.length === 0 ? t("empty.default") : t("empty.filtered");
   const inspectShareLifecycle = inspectCandidate
@@ -399,6 +405,13 @@ export default function DashboardGalleryManager({
           onChange={setSelectedShareLifecycles}
         />
       </DataTableToolbar>
+
+      <p className="text-muted-foreground text-xs">
+        {t("status.cleanupNotice", {
+          expired: expiredShareCount,
+          revoked: revokedShareCount,
+        })}
+      </p>
 
       <DataTable
         table={table}

--- a/src/components/dashboard/GalleryManager.tsx
+++ b/src/components/dashboard/GalleryManager.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import {
-  type ColumnDef,
   getCoreRowModel,
   getFilteredRowModel,
   getSortedRowModel,
@@ -13,23 +12,34 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import {
-  ArrowUpDown,
   AlertCircle,
   CheckCircle2,
   Copy,
-  Eye,
-  EyeOff,
   ExternalLink,
   ImageOff,
   Info,
   Link2,
   Loader2,
-  MoreHorizontal,
-  Sparkles,
-  StarOff,
-  Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
+import {
+  formatDate,
+  formatElementCount,
+  formatFieldSize,
+  getEmbedAvailable,
+  getEmbedUnavailableReason,
+  getGalleryColumns,
+  getInspectSummary,
+  getOwnerLabel,
+  getPreviewImageUrl,
+  getShareLifecycleLabel,
+  getShareLifecycleState,
+  getShareLifecycleVariant,
+  getStateLabel,
+  getStateVariant,
+  type GalleryUpdateAction,
+  type Translate,
+} from "@/app/dashboard/gallery/columns";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -41,37 +51,21 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/AppTooltip";
 import DataTable from "@/components/data-table/DataTable";
 import DataTableFacetFilter from "@/components/data-table/DataTableFacetFilter";
-import { dataTableSortButtonClassName } from "@/components/data-table/DataTableLayout";
 import DataTableToolbar from "@/components/data-table/DataTableToolbar";
 import type { AccountRole } from "@/lib/account/roles";
-import { getSiteMediaUrl } from "@/lib/seo";
 import type {
   DashboardGalleryEntry,
   GalleryState,
   StoredGalleryEntry,
 } from "@/lib/server/gallery";
-import { formatFieldSize as formatMeasurementFieldSize } from "@/lib/track/units";
 
 type DashboardGalleryManagerProps = {
   currentUserRole: AccountRole;
   initialEntries: DashboardGalleryEntry[];
 };
 
-type GalleryUpdateAction = "feature" | "unfeature" | "hide" | "restore";
 type ShareLifecycleState = "active" | "expired" | "revoked";
 
 const galleryManagerRoles: AccountRole[] = ["moderator", "admin"];
@@ -86,193 +80,6 @@ const shareFilterValues: ShareLifecycleState[] = [
   "expired",
   "revoked",
 ];
-
-type Translate = (key: string, values?: Record<string, unknown>) => string;
-
-function getOwnerLabel(entry: DashboardGalleryEntry) {
-  return (
-    entry.ownerName?.trim() || entry.ownerEmail?.trim() || entry.ownerUserId
-  );
-}
-
-function getTrackSecondaryLabel(entry: DashboardGalleryEntry) {
-  const shareTitle = entry.shareTitle?.trim();
-  if (
-    shareTitle &&
-    shareTitle.toLowerCase() !== entry.galleryTitle.trim().toLowerCase()
-  ) {
-    return shareTitle;
-  }
-
-  return entry.shareToken;
-}
-
-function getStateVariant(state: GalleryState): "default" | "muted" | "outline" {
-  if (state === "featured") return "default";
-  if (state === "hidden") return "muted";
-  return "outline";
-}
-
-function getStateLabel(state: GalleryState, t: Translate, tCommon: Translate) {
-  switch (state) {
-    case "listed":
-      return tCommon("status.listed");
-    case "featured":
-      return tCommon("status.featured");
-    case "hidden":
-      return tCommon("status.hidden");
-    default:
-      return t("stateValues.unlistedBadge");
-  }
-}
-
-function getShareLifecycleState(
-  entry: DashboardGalleryEntry
-): ShareLifecycleState {
-  if (entry.shareRevokedAt) return "revoked";
-  if (
-    entry.shareExpiresAt &&
-    new Date(entry.shareExpiresAt).getTime() <= Date.now()
-  ) {
-    return "expired";
-  }
-
-  return "active";
-}
-
-function getShareLifecycleLabel(state: ShareLifecycleState, t: Translate) {
-  return t(`shareValues.${state}`);
-}
-
-function getShareLifecycleVariant(
-  state: ShareLifecycleState
-): "default" | "muted" | "outline" {
-  if (state === "active") return "outline";
-  return "muted";
-}
-
-function formatDate(value: string | null) {
-  if (!value) return "—";
-
-  try {
-    return new Intl.DateTimeFormat("en-GB", {
-      dateStyle: "medium",
-    }).format(new Date(value));
-  } catch {
-    return value;
-  }
-}
-
-function getShareLifecycleDetail(entry: DashboardGalleryEntry, t: Translate) {
-  const state = getShareLifecycleState(entry);
-  if (state === "revoked")
-    return t("lifecycle.revokedOn", { date: formatDate(entry.shareRevokedAt) });
-  if (state === "expired")
-    return t("lifecycle.expiredOn", { date: formatDate(entry.shareExpiresAt) });
-  if (entry.shareExpiresAt)
-    return t("lifecycle.expiresOn", { date: formatDate(entry.shareExpiresAt) });
-  return t("lifecycle.noExpiry");
-}
-
-function formatFieldSize(entry: DashboardGalleryEntry, t: Translate) {
-  if (entry.fieldWidth == null || entry.fieldHeight == null) {
-    return t("fallback.notSet");
-  }
-
-  return formatMeasurementFieldSize(
-    entry.fieldWidth,
-    entry.fieldHeight,
-    "metric"
-  );
-}
-
-function formatElementCount(entry: DashboardGalleryEntry, t: Translate) {
-  if (entry.shapeCount == null) return t("fallback.notAvailable");
-  return t("meta.elementCount", { count: entry.shapeCount });
-}
-
-function getPreviewImageUrl(entry: DashboardGalleryEntry) {
-  if (!entry.galleryPreviewImage) return null;
-  if (entry.galleryPreviewImage.startsWith("http")) {
-    return entry.galleryPreviewImage;
-  }
-
-  return getSiteMediaUrl(entry.galleryPreviewImage);
-}
-
-function getEmbedAvailable(entry: DashboardGalleryEntry) {
-  return (
-    entry.shareType === "published" &&
-    getShareLifecycleState(entry) === "active"
-  );
-}
-
-function getEmbedUnavailableReason(entry: DashboardGalleryEntry, t: Translate) {
-  if (entry.shareType !== "published") return t("embed.unavailableTemporary");
-  const state = getShareLifecycleState(entry);
-  if (state === "revoked") return t("embed.unavailableRevoked");
-  if (state === "expired") return t("embed.unavailableExpired");
-  return null;
-}
-
-function getInspectSummary(entry: DashboardGalleryEntry, t: Translate) {
-  const shareState = getShareLifecycleState(entry);
-
-  if (shareState === "revoked") {
-    return {
-      tone: "warning" as const,
-      title: t("reviewState.revokedTitle"),
-      detail: t("reviewState.revokedDetail"),
-    };
-  }
-
-  if (shareState === "expired") {
-    return {
-      tone: "warning" as const,
-      title: t("reviewState.expiredTitle"),
-      detail: t("reviewState.expiredDetail"),
-    };
-  }
-
-  if (entry.galleryState === "hidden") {
-    return {
-      tone: "info" as const,
-      title: t("reviewState.hiddenTitle"),
-      detail: t("reviewState.hiddenDetail"),
-    };
-  }
-
-  if (!entry.galleryPreviewImage) {
-    return {
-      tone: "warning" as const,
-      title: t("reviewState.missingPreviewTitle"),
-      detail: t("reviewState.missingPreviewDetail"),
-    };
-  }
-
-  return {
-    tone: "ok" as const,
-    title: t("reviewState.readyTitle"),
-    detail: t("reviewState.readyDetail"),
-  };
-}
-
-function ActionTooltip({
-  label,
-  children,
-}: {
-  label: string;
-  children: React.ReactElement;
-}) {
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipContent side="top" sideOffset={6}>
-        {label}
-      </TooltipContent>
-    </Tooltip>
-  );
-}
 
 function InspectDetail({
   label,
@@ -496,247 +303,14 @@ export default function DashboardGalleryManager({
     }
   };
 
-  function getFeatureAction(entry: DashboardGalleryEntry) {
-    return entry.galleryState !== "featured"
-      ? {
-          action: "feature" as const,
-          label: t("actions.feature"),
-          icon: Sparkles,
-        }
-      : {
-          action: "unfeature" as const,
-          label: t("actions.unfeature"),
-          icon: StarOff,
-        };
-  }
-
-  function getVisibilityAction(entry: DashboardGalleryEntry) {
-    return entry.galleryState !== "hidden"
-      ? {
-          action: "hide" as const,
-          label: t("actions.hide"),
-          icon: EyeOff,
-        }
-      : {
-          action: "restore" as const,
-          label: t("actions.restore"),
-          icon: Eye,
-        };
-  }
-
-  const columns: ColumnDef<DashboardGalleryEntry>[] = [
-    {
-      id: "track",
-      accessorFn: (row) => row.galleryTitle,
-      meta: { className: "w-[30%] min-w-56" },
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          className={dataTableSortButtonClassName}
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          {t("table.track")}
-          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => (
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium">
-            {row.original.galleryTitle}
-          </p>
-          <p className="text-muted-foreground truncate text-xs">
-            {getTrackSecondaryLabel(row.original)}
-          </p>
-        </div>
-      ),
-    },
-    {
-      id: "owner",
-      accessorFn: (row) => getOwnerLabel(row),
-      header: tCommon("labels.owner"),
-      meta: { className: "w-[22%] min-w-48" },
-      cell: ({ row }) => (
-        <div className="min-w-0">
-          <p className="truncate text-sm">{getOwnerLabel(row.original)}</p>
-          <p className="text-muted-foreground truncate text-xs">
-            {row.original.ownerEmail ?? row.original.ownerUserId}
-          </p>
-        </div>
-      ),
-    },
-    {
-      accessorKey: "galleryState",
-      header: t("table.state"),
-      meta: { className: "w-28" },
-      cell: ({ row }) => (
-        <Badge variant={getStateVariant(row.original.galleryState)}>
-          {getStateLabel(
-            row.original.galleryState,
-            t as unknown as Translate,
-            tCommon as unknown as Translate
-          )}
-        </Badge>
-      ),
-    },
-    {
-      id: "shareLifecycle",
-      header: t("table.share"),
-      accessorFn: (row) => getShareLifecycleState(row),
-      meta: { className: "w-44" },
-      cell: ({ row }) => {
-        const lifecycleState = getShareLifecycleState(row.original);
-
-        return (
-          <div className="min-w-0">
-            <Badge variant={getShareLifecycleVariant(lifecycleState)}>
-              {getShareLifecycleLabel(
-                lifecycleState,
-                t as unknown as Translate
-              )}
-            </Badge>
-            <p className="text-muted-foreground mt-1 truncate text-xs">
-              {getShareLifecycleDetail(row.original, t as unknown as Translate)}
-            </p>
-          </div>
-        );
-      },
-    },
-    {
-      id: "published",
-      meta: { className: "w-36" },
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          className={dataTableSortButtonClassName}
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          {t("table.published")}
-          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
-        </Button>
-      ),
-      accessorFn: (row) => row.galleryPublishedAt ?? row.updatedAt,
-      cell: ({ row }) => (
-        <span className="text-muted-foreground text-xs">
-          {formatDate(row.original.galleryPublishedAt)}
-        </span>
-      ),
-    },
-    {
-      id: "actions",
-      header: "",
-      meta: { className: "w-32 text-right" },
-      cell: ({ row }) => {
-        const entry = row.original;
-        const isPending = pendingShareToken === entry.shareToken;
-        const featureAction = getFeatureAction(entry);
-        const FeatureIcon = featureAction.icon;
-        const visibilityAction = getVisibilityAction(entry);
-        const VisibilityIcon = visibilityAction.icon;
-
-        return (
-          <div
-            className="flex justify-end"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="hidden items-center justify-end gap-1 md:flex">
-              <ActionTooltip label={featureAction.label}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="hover:bg-muted hover:text-foreground size-7"
-                  disabled={isPending || !canManageGallery}
-                  aria-label={`${featureAction.label} ${entry.galleryTitle}`}
-                  onClick={() =>
-                    void updateEntry(entry.shareToken, featureAction.action)
-                  }
-                >
-                  {isPending ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <FeatureIcon className="size-4" />
-                  )}
-                </Button>
-              </ActionTooltip>
-              <ActionTooltip label={visibilityAction.label}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="hover:bg-muted hover:text-foreground size-7"
-                  disabled={isPending || !canManageGallery}
-                  aria-label={`${visibilityAction.label} ${entry.galleryTitle}`}
-                  onClick={() =>
-                    void updateEntry(entry.shareToken, visibilityAction.action)
-                  }
-                >
-                  <VisibilityIcon className="size-4" />
-                </Button>
-              </ActionTooltip>
-              <ActionTooltip label={t("actions.delete")}>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="text-destructive hover:bg-muted hover:text-destructive size-7"
-                  disabled={isPending || !canManageGallery}
-                  aria-label={`${t("actions.delete")} ${entry.galleryTitle}`}
-                  onClick={() => setDeleteCandidate(entry)}
-                >
-                  <Trash2 className="size-4" />
-                </Button>
-              </ActionTooltip>
-            </div>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-muted-foreground hover:text-foreground ml-auto size-8 p-0 md:hidden"
-                  disabled={isPending || !canManageGallery}
-                  aria-label={t("actions.open")}
-                >
-                  {isPending ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <MoreHorizontal className="size-4" />
-                  )}
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-44">
-                <DropdownMenuItem
-                  onClick={() =>
-                    void updateEntry(entry.shareToken, featureAction.action)
-                  }
-                >
-                  <FeatureIcon className="size-4" />
-                  {featureAction.label}
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  onClick={() =>
-                    void updateEntry(entry.shareToken, visibilityAction.action)
-                  }
-                >
-                  <VisibilityIcon className="size-4" />
-                  {visibilityAction.label}
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={() => setDeleteCandidate(entry)}
-                  className="text-destructive focus:text-destructive"
-                >
-                  <Trash2 className="size-4" />
-                  {t("actions.delete")}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        );
-      },
-    },
-  ];
+  const columns = getGalleryColumns({
+    t: t as unknown as Translate,
+    tCommon: tCommon as unknown as Translate,
+    pendingShareToken,
+    canManageGallery,
+    onUpdateEntry: (shareToken, action) => void updateEntry(shareToken, action),
+    onDeleteCandidate: setDeleteCandidate,
+  });
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
@@ -793,12 +367,6 @@ export default function DashboardGalleryManager({
       (row) => getShareLifecycleState(row.original) === value
     ).length,
   }));
-  const expiredShareCount = entries.filter(
-    (entry) => getShareLifecycleState(entry) === "expired"
-  ).length;
-  const revokedShareCount = entries.filter(
-    (entry) => getShareLifecycleState(entry) === "revoked"
-  ).length;
   const emptyMessage =
     entries.length === 0 ? t("empty.default") : t("empty.filtered");
   const inspectShareLifecycle = inspectCandidate
@@ -831,13 +399,6 @@ export default function DashboardGalleryManager({
           onChange={setSelectedShareLifecycles}
         />
       </DataTableToolbar>
-
-      <p className="text-muted-foreground text-xs">
-        {t("status.cleanupNotice", {
-          expired: expiredShareCount,
-          revoked: revokedShareCount,
-        })}
-      </p>
 
       <DataTable
         table={table}

--- a/src/components/dashboard/PageIntro.tsx
+++ b/src/components/dashboard/PageIntro.tsx
@@ -18,7 +18,7 @@ export default function DashboardPageIntro({
       <span
         className={`mt-0.5 inline-flex size-9 shrink-0 items-center justify-center rounded-lg ${accent}`}
       >
-        <Icon className="size-4.5" />
+        <Icon aria-hidden="true" className="size-4.5" />
       </span>
       <div>
         <h1 className="text-lg leading-tight font-semibold">{title}</h1>

--- a/src/components/dashboard/PageIntro.tsx
+++ b/src/components/dashboard/PageIntro.tsx
@@ -1,0 +1,29 @@
+import type { LucideIcon } from "lucide-react";
+
+type DashboardPageIntroProps = {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  accent: string;
+};
+
+export default function DashboardPageIntro({
+  icon: Icon,
+  title,
+  description,
+  accent,
+}: DashboardPageIntroProps) {
+  return (
+    <div className="flex items-start gap-3">
+      <span
+        className={`mt-0.5 inline-flex size-9 shrink-0 items-center justify-center rounded-lg ${accent}`}
+      >
+        <Icon className="size-4.5" />
+      </span>
+      <div>
+        <h1 className="text-lg leading-tight font-semibold">{title}</h1>
+        <p className="text-muted-foreground text-sm">{description}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/UsersManager.tsx
+++ b/src/components/dashboard/UsersManager.tsx
@@ -191,7 +191,10 @@ export default function DashboardUsersManager({
     }
   };
 
-  const columns = getUsersColumns({ t: t as unknown as Translate, currentUserId });
+  const columns = getUsersColumns({
+    t: t as unknown as Translate,
+    currentUserId,
+  });
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({

--- a/src/components/dashboard/UsersManager.tsx
+++ b/src/components/dashboard/UsersManager.tsx
@@ -4,21 +4,21 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
-  type ColumnDef,
   getCoreRowModel,
   getFilteredRowModel,
   getSortedRowModel,
   type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import {
-  ArrowUpDown,
-  ChevronDown,
-  Copy,
-  ExternalLink,
-  Loader2,
-} from "lucide-react";
+import { ChevronDown, Copy, ExternalLink, Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import {
+  formatDate,
+  getUserLabel,
+  getUsersColumns,
+  roleBadgeClassName,
+  type Translate,
+} from "@/app/dashboard/users/columns";
 import {
   accountRoles,
   getAccountRoleLabel,
@@ -29,7 +29,6 @@ import type { AuditEvent } from "@/lib/server/audit";
 import type { UserContextStats } from "@/lib/server/users";
 import DataTable from "@/components/data-table/DataTable";
 import DataTableFacetFilter from "@/components/data-table/DataTableFacetFilter";
-import { dataTableSortButtonClassName } from "@/components/data-table/DataTableLayout";
 import DataTableToolbar from "@/components/data-table/DataTableToolbar";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -54,35 +53,6 @@ type DashboardUsersManagerProps = {
   currentUserId: string;
   initialUsers: AdminUser[];
 };
-
-function getUserLabel(user: AdminUser, unnamedUserLabel: string) {
-  return user.name?.trim() || user.email?.trim() || unnamedUserLabel;
-}
-
-function getSecondaryLabel(user: AdminUser) {
-  if (user.name?.trim() && user.email?.trim()) return user.email;
-  return user.email?.trim() || user.id;
-}
-
-function formatDate(value: string) {
-  try {
-    return new Intl.DateTimeFormat("en-GB", {
-      dateStyle: "medium",
-    }).format(new Date(value));
-  } catch {
-    return value;
-  }
-}
-
-function roleBadgeClassName(role: AccountRole) {
-  if (role === "admin") {
-    return "border-rose-500/25 bg-rose-500/10 text-rose-700 dark:text-rose-300";
-  }
-  if (role === "moderator") {
-    return "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300";
-  }
-  return "border-border bg-muted/50 text-muted-foreground";
-}
 
 function getUserInitials(user: AdminUser) {
   const name = user.name?.trim();
@@ -221,118 +191,7 @@ export default function DashboardUsersManager({
     }
   };
 
-  const columns: ColumnDef<AdminUser>[] = [
-    {
-      id: "user",
-      accessorFn: (row) => getUserLabel(row, t("fallback.unnamedUser")),
-      meta: { className: "w-[40%] min-w-56" },
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          className={dataTableSortButtonClassName}
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          {t("table.user")}
-          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => {
-        const user = row.original;
-        const isSelf = user.id === currentUserId;
-        return (
-          <div className="min-w-0">
-            <p className="truncate text-sm font-medium">
-              {getUserLabel(user, t("fallback.unnamedUser"))}
-              {isSelf && (
-                <span className="text-muted-foreground ml-1.5 text-xs font-normal">
-                  {t("selfBadge")}
-                </span>
-              )}
-            </p>
-            <p className="text-muted-foreground truncate text-xs">
-              {getSecondaryLabel(user)}
-            </p>
-          </div>
-        );
-      },
-    },
-    {
-      accessorKey: "projectCount",
-      meta: { className: "hidden w-28 sm:table-cell" },
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          className={dataTableSortButtonClassName}
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          {t("table.projects")}
-          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => (
-        <span className="text-muted-foreground text-xs tabular-nums">
-          {row.original.projectCount}
-        </span>
-      ),
-    },
-    {
-      accessorKey: "role",
-      header: t("table.role"),
-      meta: { className: "w-32" },
-      cell: ({ row }) => (
-        <Badge
-          variant="outline"
-          className={roleBadgeClassName(row.original.role)}
-        >
-          {getAccountRoleLabel(row.original.role)}
-        </Badge>
-      ),
-    },
-    {
-      accessorKey: "createdAt",
-      meta: { className: "hidden w-36 lg:table-cell" },
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          className={dataTableSortButtonClassName}
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          {t("table.joined")}
-          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => (
-        <span className="text-muted-foreground text-xs">
-          {formatDate(row.original.createdAt)}
-        </span>
-      ),
-    },
-    {
-      accessorKey: "lastLoginAt",
-      meta: { className: "hidden w-36 sm:table-cell" },
-      header: ({ column }) => (
-        <Button
-          variant="ghost"
-          size="sm"
-          className={dataTableSortButtonClassName}
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          {t("table.lastLogin")}
-          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
-        </Button>
-      ),
-      cell: ({ row }) => (
-        <span className="text-muted-foreground text-xs">
-          {row.original.lastLoginAt
-            ? formatDate(row.original.lastLoginAt)
-            : "—"}
-        </span>
-      ),
-    },
-  ];
+  const columns = getUsersColumns({ t: t as unknown as Translate, currentUserId });
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({

--- a/src/components/dashboard/tables/AuditEventsTable.tsx
+++ b/src/components/dashboard/tables/AuditEventsTable.tsx
@@ -1,317 +1,36 @@
 "use client";
 
 import { useState } from "react";
-import { ArrowUpDown } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
-  DataTableBodyCell,
-  DataTableEmptyState,
-  DataTableFrame,
-  DataTableHeaderCell,
-} from "@/components/data-table/DataTable";
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import {
+  categoryFilterValues,
+  eventMatchesSearch,
+  getActorFilterLabel,
+  getActorFilterValue,
+  getAuditColumns,
+  getEventCategory,
+  getEventTitle,
+  type AuditEventCategory,
+  type DashboardAuditEvent,
+  type Translate,
+} from "@/app/dashboard/audit/columns";
+import DataTable from "@/components/data-table/DataTable";
 import DataTableFacetFilter from "@/components/data-table/DataTableFacetFilter";
-import { dataTableSortButtonClassName } from "@/components/data-table/DataTableLayout";
 import DataTableToolbar from "@/components/data-table/DataTableToolbar";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { TableBody, TableHeader, TableRow } from "@/components/ui/table";
-import { getAccountRoleLabel, parseAccountRole } from "@/lib/account/roles";
-import { cn } from "@/lib/utils";
 
-type AuditEventActor = {
-  id: string;
-  name: string | null;
-  email: string | null;
-} | null;
-
-type DashboardAuditEvent = {
-  id: string;
-  actorUserId: string | null;
-  targetUserId: string | null;
-  eventType: string;
-  entityType: string;
-  entityId: string | null;
-  metadata: Record<string, unknown> | null;
-  createdAt: string;
-  actor: AuditEventActor;
-  target: AuditEventActor;
-};
-
-export type AuditEventCategory = "Account" | "Gallery" | "System";
+export type { AuditEventCategory };
 
 type AuditEventsTableProps = {
   events: DashboardAuditEvent[];
   initialCategories?: AuditEventCategory[];
 };
-
-const categoryFilterValues: AuditEventCategory[] = [
-  "Account",
-  "Gallery",
-  "System",
-];
-const unknownActorValue = "__unknown_actor__";
-
-type Translate = (
-  key: string,
-  values?: Record<string, string | number | Date>
-) => string;
-
-type AuditSortKey = "event" | "actor" | "target" | "entity" | "createdAt";
-type AuditSortDirection = "asc" | "desc";
-
-type AuditSortState = {
-  key: AuditSortKey;
-  direction: AuditSortDirection;
-};
-
-function formatDateTime(value: string) {
-  try {
-    return new Intl.DateTimeFormat("en-GB", {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  } catch {
-    return value;
-  }
-}
-
-function getUserLabel(user: AuditEventActor, unknownUserLabel: string) {
-  if (!user) {
-    return unknownUserLabel;
-  }
-
-  return user.name?.trim() || user.email?.trim() || unknownUserLabel;
-}
-
-function getSecondaryLabel(user: AuditEventActor) {
-  if (!user) {
-    return null;
-  }
-
-  if (user.name?.trim() && user.email?.trim()) {
-    return user.email;
-  }
-
-  return user.email?.trim() || user.id;
-}
-
-function getActorFilterValue(event: DashboardAuditEvent) {
-  return event.actorUserId ?? unknownActorValue;
-}
-
-function getActorFilterLabel(
-  event: DashboardAuditEvent,
-  unknownUserLabel: string
-) {
-  const label = getUserLabel(event.actor, unknownUserLabel);
-  const secondary = getSecondaryLabel(event.actor);
-
-  return secondary && secondary !== label ? `${label} (${secondary})` : label;
-}
-
-function getRoleChangeSummary(metadata: Record<string, unknown> | null) {
-  const previousRole = parseAccountRole(metadata?.previousRole);
-  const nextRole = parseAccountRole(metadata?.nextRole);
-
-  return {
-    previousRole,
-    nextRole,
-    label: `${getAccountRoleLabel(previousRole)} -> ${getAccountRoleLabel(nextRole)}`,
-  };
-}
-
-function formatEventType(value: string) {
-  return value
-    .split(".")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
-}
-
-const EVENT_TITLE_KEYS: Record<string, string> = {
-  "account.role.changed": "accountRoleChanged",
-  "gallery.entry.featured": "galleryEntryFeatured",
-  "gallery.entry.unfeatured": "galleryEntryUnfeatured",
-  "gallery.entry.hidden": "galleryEntryHidden",
-  "gallery.entry.restored": "galleryEntryRestored",
-  "gallery.entry.deleted": "galleryEntryDeleted",
-};
-
-function getEventTitle(eventType: string, t: Translate) {
-  const key = EVENT_TITLE_KEYS[eventType];
-  if (key) return t(`eventTitles.${key}`);
-  return formatEventType(eventType);
-}
-
-function getEventCategory(eventType: string): AuditEventCategory {
-  if (eventType.startsWith("account.")) return "Account";
-  if (eventType.startsWith("gallery.")) return "Gallery";
-  return "System";
-}
-
-function getEventCategoryLabel(eventType: string, t: Translate) {
-  return t(`categoryValues.${getEventCategory(eventType)}`);
-}
-
-function formatMetadataValue(value: unknown) {
-  if (value === null || value === undefined) return "-";
-  if (typeof value === "string") return value;
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return JSON.stringify(value);
-}
-
-function formatMetadataLabel(value: string) {
-  return value
-    .replace(/([A-Z])/g, " $1")
-    .replace(/[_-]+/g, " ")
-    .replace(/^./, (char) => char.toUpperCase());
-}
-
-function getEventDetailLabel(
-  event: {
-    eventType: string;
-    entityType: string;
-    entityId: string | null;
-    metadata: Record<string, unknown> | null;
-  },
-  t: Translate
-) {
-  if (event.eventType === "account.role.changed") {
-    return getRoleChangeSummary(event.metadata).label;
-  }
-
-  const previousState = formatMetadataValue(event.metadata?.previousState);
-  const nextState = formatMetadataValue(event.metadata?.nextState);
-  if (previousState !== "-" && nextState !== "-") {
-    return `${previousState} -> ${nextState}`;
-  }
-
-  if (event.metadata?.shareToken) {
-    return t("filters.share", {
-      token: formatMetadataValue(event.metadata.shareToken),
-    });
-  }
-
-  return event.entityId
-    ? `${event.entityType} ${event.entityId}`
-    : event.entityType;
-}
-
-function getEntityTypeLabel(entityType: string, t: Translate) {
-  switch (entityType) {
-    case "user":
-      return t("entityLabels.account");
-    case "gallery_entry":
-      return t("entityLabels.galleryEntry");
-    default:
-      return formatMetadataLabel(entityType);
-  }
-}
-
-function shortenId(value: string) {
-  if (value.length <= 14) return value;
-  return `${value.slice(0, 8)}...${value.slice(-4)}`;
-}
-
-function getEntityDisplay(event: DashboardAuditEvent, t: Translate) {
-  if (event.entityType === "user") {
-    return {
-      label: t("entityLabels.accountRole"),
-      detail: getRoleChangeSummary(event.metadata).label,
-    };
-  }
-
-  if (event.entityType === "gallery_entry") {
-    const shareToken =
-      typeof event.metadata?.shareToken === "string"
-        ? event.metadata.shareToken
-        : null;
-
-    return {
-      label: t("entityLabels.galleryEntry"),
-      detail: shareToken ?? (event.entityId ? shortenId(event.entityId) : null),
-    };
-  }
-
-  return {
-    label: getEntityTypeLabel(event.entityType, t),
-    detail: event.entityId
-      ? t("entity.id", { id: shortenId(event.entityId) })
-      : null,
-  };
-}
-
-function getSortValue(
-  event: DashboardAuditEvent,
-  key: AuditSortKey,
-  t: Translate,
-  unknownUserLabel: string
-) {
-  if (key === "event") return getEventTitle(event.eventType, t);
-  if (key === "actor") return getUserLabel(event.actor, unknownUserLabel);
-  if (key === "target") return getUserLabel(event.target, unknownUserLabel);
-  if (key === "entity") return getEntityDisplay(event, t).label;
-  return event.createdAt;
-}
-
-function compareAuditEvents(
-  a: DashboardAuditEvent,
-  b: DashboardAuditEvent,
-  sorting: AuditSortState,
-  t: Translate,
-  unknownUserLabel: string
-) {
-  const direction = sorting.direction === "asc" ? 1 : -1;
-
-  if (sorting.key === "createdAt") {
-    return (
-      (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) *
-      direction
-    );
-  }
-
-  const primary = String(
-    getSortValue(a, sorting.key, t, unknownUserLabel)
-  ).localeCompare(
-    String(getSortValue(b, sorting.key, t, unknownUserLabel)),
-    undefined,
-    { sensitivity: "base" }
-  );
-
-  if (primary !== 0) return primary * direction;
-
-  return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-}
-
-function eventMatchesSearch(
-  event: DashboardAuditEvent,
-  query: string,
-  t: Translate,
-  unknownUserLabel: string
-) {
-  if (!query) return true;
-  const entityDisplay = getEntityDisplay(event, t);
-
-  const searchable = [
-    getEventTitle(event.eventType, t),
-    getEventCategoryLabel(event.eventType, t),
-    getEventDetailLabel(event, t),
-    getUserLabel(event.actor, unknownUserLabel),
-    getSecondaryLabel(event.actor),
-    getUserLabel(event.target, unknownUserLabel),
-    getSecondaryLabel(event.target),
-    event.entityType,
-    event.entityId,
-    entityDisplay.label,
-    entityDisplay.detail,
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-
-  return searchable.includes(query);
-}
 
 export default function DashboardAuditEventsTable({
   events,
@@ -324,125 +43,81 @@ export default function DashboardAuditEventsTable({
     useState<AuditEventCategory[]>(initialCategories);
   const [selectedEventTypes, setSelectedEventTypes] = useState<string[]>([]);
   const [selectedActors, setSelectedActors] = useState<string[]>([]);
-  const [sorting, setSorting] = useState<AuditSortState>({
-    key: "createdAt",
-    direction: "desc",
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "createdAt", desc: true },
+  ]);
+
+  const columns = getAuditColumns({ t, unknownUserLabel });
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data: events,
+    columns,
+    state: { globalFilter, sorting },
+    onGlobalFilterChange: setGlobalFilter,
+    onSortingChange: setSorting,
+    globalFilterFn: (row, _columnId, filterValue: string) =>
+      eventMatchesSearch(
+        row.original,
+        filterValue.trim().toLowerCase(),
+        t,
+        unknownUserLabel
+      ),
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
   });
 
-  const toggleSort = (key: AuditSortKey) => {
-    setSorting((current) =>
-      current.key === key
-        ? {
-            key,
-            direction: current.direction === "asc" ? "desc" : "asc",
-          }
-        : {
-            key,
-            direction: key === "createdAt" ? "desc" : "asc",
-          }
-    );
-  };
+  const rowsForCurrentSearch = table.getRowModel().rows;
+  const byCategory = (event: DashboardAuditEvent) =>
+    selectedCategories.length === 0 ||
+    selectedCategories.includes(getEventCategory(event.eventType));
+  const byEventType = (event: DashboardAuditEvent) =>
+    selectedEventTypes.length === 0 ||
+    selectedEventTypes.includes(event.eventType);
+  const byActor = (event: DashboardAuditEvent) =>
+    selectedActors.length === 0 ||
+    selectedActors.includes(getActorFilterValue(event));
 
-  const renderSortHeader = (
-    key: AuditSortKey,
-    label: string,
-    className?: string
-  ) => (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      className={cn(dataTableSortButtonClassName, className)}
-      onClick={() => toggleSort(key)}
-      aria-label={t("aria.sort", { label: label.toLowerCase() })}
-    >
-      {label}
-      <ArrowUpDown
-        className={cn(
-          "text-muted-foreground ml-1 size-3.5",
-          sorting.key === key && "text-foreground"
-        )}
-      />
-    </Button>
-  );
-
-  const normalizedQuery = globalFilter.trim().toLowerCase();
-  const searchedEvents = events.filter((event) =>
-    eventMatchesSearch(event, normalizedQuery, t, unknownUserLabel)
-  );
-  const categoryFacetEvents = searchedEvents
-    .filter((event) =>
-      selectedEventTypes.length === 0
-        ? true
-        : selectedEventTypes.includes(event.eventType)
-    )
-    .filter((event) =>
-      selectedActors.length === 0
-        ? true
-        : selectedActors.includes(getActorFilterValue(event))
-    );
-  const eventTypeFacetEvents = searchedEvents
-    .filter((event) =>
-      selectedCategories.length === 0
-        ? true
-        : selectedCategories.includes(getEventCategory(event.eventType))
-    )
-    .filter((event) =>
-      selectedActors.length === 0
-        ? true
-        : selectedActors.includes(getActorFilterValue(event))
-    );
-  const actorFacetEvents = searchedEvents
-    .filter((event) =>
-      selectedCategories.length === 0
-        ? true
-        : selectedCategories.includes(getEventCategory(event.eventType))
-    )
-    .filter((event) =>
-      selectedEventTypes.length === 0
-        ? true
-        : selectedEventTypes.includes(event.eventType)
-    );
-  const filteredEvents = eventTypeFacetEvents
-    .filter((event) =>
-      selectedEventTypes.length === 0
-        ? true
-        : selectedEventTypes.includes(event.eventType)
-    )
-    .filter((event) =>
-      selectedActors.length === 0
-        ? true
-        : selectedActors.includes(getActorFilterValue(event))
-    );
-  const sortedEvents = [...filteredEvents].sort((a, b) =>
-    compareAuditEvents(a, b, sorting, t, unknownUserLabel)
-  );
+  const categoryFacetRows = rowsForCurrentSearch.filter((row) =>
+    byEventType(row.original)
+  ).filter((row) => byActor(row.original));
+  const eventTypeFacetRows = rowsForCurrentSearch
+    .filter((row) => byCategory(row.original))
+    .filter((row) => byActor(row.original));
+  const actorFacetRows = rowsForCurrentSearch
+    .filter((row) => byCategory(row.original))
+    .filter((row) => byEventType(row.original));
+  const filteredRows = rowsForCurrentSearch
+    .filter((row) => byCategory(row.original))
+    .filter((row) => byEventType(row.original))
+    .filter((row) => byActor(row.original));
 
   const eventTypeFilters = Array.from(
     new Set(events.map((event) => event.eventType))
   )
-    .sort((a, b) => getEventTitle(a, t).localeCompare(getEventTitle(b, t)))
     .map((eventType) => ({
       label: getEventTitle(eventType, t),
       value: eventType,
-      count: eventTypeFacetEvents.filter(
-        (event) => event.eventType === eventType
+      count: eventTypeFacetRows.filter(
+        (row) => row.original.eventType === eventType
       ).length,
-    }));
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
   const categoryFilterOptions = categoryFilterValues.map((value) => ({
     value,
     label: t(`categoryValues.${value}`),
-    count: categoryFacetEvents.filter(
-      (event) => getEventCategory(event.eventType) === value
+    count: categoryFacetRows.filter(
+      (row) => getEventCategory(row.original.eventType) === value
     ).length,
   }));
   const actorFilterOptions = Array.from(
     new Map(
-      searchedEvents.map((event) => [
-        getActorFilterValue(event),
+      rowsForCurrentSearch.map((row) => [
+        getActorFilterValue(row.original),
         {
-          label: getActorFilterLabel(event, unknownUserLabel),
-          value: getActorFilterValue(event),
+          label: getActorFilterLabel(row.original, unknownUserLabel),
+          value: getActorFilterValue(row.original),
         },
       ])
     ).values()
@@ -450,25 +125,26 @@ export default function DashboardAuditEventsTable({
     .sort((a, b) => a.label.localeCompare(b.label))
     .map((filter) => ({
       ...filter,
-      count: actorFacetEvents.filter(
-        (event) => getActorFilterValue(event) === filter.value
+      count: actorFacetRows.filter(
+        (row) => getActorFilterValue(row.original) === filter.value
       ).length,
     }));
+
   const uniqueActorCount = new Set(
-    filteredEvents.map((event) => event.actorUserId).filter(Boolean)
+    filteredRows.map((row) => row.original.actorUserId).filter(Boolean)
   ).size;
   const uniqueTargetCount = new Set(
-    filteredEvents.map((event) => event.targetUserId).filter(Boolean)
+    filteredRows.map((row) => row.original.targetUserId).filter(Boolean)
   ).size;
 
   return (
-    <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+    <div className="space-y-4">
       <div className="grid auto-rows-min gap-4 md:grid-cols-3">
         <div className="bg-muted/50 rounded-xl p-5">
           <p className="text-muted-foreground text-sm">
             {t("stats.visibleEvents")}
           </p>
-          <p className="mt-2 text-2xl font-semibold">{filteredEvents.length}</p>
+          <p className="mt-2 text-2xl font-semibold">{filteredRows.length}</p>
           <p className="text-muted-foreground mt-1 text-xs">
             {t("stats.visibleEventsHelper")}
           </p>
@@ -514,118 +190,13 @@ export default function DashboardAuditEventsTable({
         />
       </DataTableToolbar>
 
-      <DataTableFrame minWidthClassName="min-w-[980px]">
-        <TableHeader>
-          <TableRow>
-            <DataTableHeaderCell className="w-[34%]">
-              {renderSortHeader("event", t("table.event"))}
-            </DataTableHeaderCell>
-            <DataTableHeaderCell className="w-[20%]">
-              {renderSortHeader("actor", t("table.actor"))}
-            </DataTableHeaderCell>
-            <DataTableHeaderCell className="w-[20%]">
-              {renderSortHeader("target", t("table.target"))}
-            </DataTableHeaderCell>
-            <DataTableHeaderCell className="w-[16%]">
-              {renderSortHeader("entity", t("table.entity"))}
-            </DataTableHeaderCell>
-            <DataTableHeaderCell className="w-40 text-right">
-              {renderSortHeader("createdAt", t("table.when"), "ml-auto -mr-2")}
-            </DataTableHeaderCell>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {sortedEvents.length > 0 ? (
-            sortedEvents.map((event) => {
-              const metadataEntries = Object.entries(event.metadata ?? {});
-              const entityDisplay = getEntityDisplay(event, t);
-
-              return (
-                <TableRow key={event.id}>
-                  <DataTableBodyCell>
-                    <div className="min-w-0">
-                      <p className="text-sm font-medium">
-                        {getEventTitle(event.eventType, t)}
-                      </p>
-                      <div className="mt-1 flex items-center gap-2">
-                        <Badge variant="outline">
-                          {getEventCategoryLabel(event.eventType, t)}
-                        </Badge>
-                        <span className="text-muted-foreground text-xs">
-                          {getEventDetailLabel(event, t)}
-                        </span>
-                      </div>
-                      {metadataEntries.length > 0 ? (
-                        <details className="mt-2">
-                          <summary className="text-muted-foreground hover:text-foreground cursor-pointer text-xs">
-                            {t("table.details")}
-                          </summary>
-                          <dl className="mt-2 grid gap-1 text-xs">
-                            {metadataEntries.map(([key, value]) => (
-                              <div
-                                key={key}
-                                className="grid grid-cols-[112px_minmax(0,1fr)] gap-2"
-                              >
-                                <dt className="text-muted-foreground">
-                                  {formatMetadataLabel(key)}
-                                </dt>
-                                <dd className="text-foreground min-w-0 truncate font-mono">
-                                  {formatMetadataValue(value)}
-                                </dd>
-                              </div>
-                            ))}
-                          </dl>
-                        </details>
-                      ) : null}
-                    </div>
-                  </DataTableBodyCell>
-                  <DataTableBodyCell>
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium">
-                        {getUserLabel(event.actor, unknownUserLabel)}
-                      </p>
-                      {getSecondaryLabel(event.actor) ? (
-                        <p className="text-muted-foreground truncate text-xs">
-                          {getSecondaryLabel(event.actor)}
-                        </p>
-                      ) : null}
-                    </div>
-                  </DataTableBodyCell>
-                  <DataTableBodyCell>
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium">
-                        {getUserLabel(event.target, unknownUserLabel)}
-                      </p>
-                      {getSecondaryLabel(event.target) ? (
-                        <p className="text-muted-foreground truncate text-xs">
-                          {getSecondaryLabel(event.target)}
-                        </p>
-                      ) : null}
-                    </div>
-                  </DataTableBodyCell>
-                  <DataTableBodyCell>
-                    <div className="min-w-0">
-                      <p className="truncate text-sm font-medium">
-                        {entityDisplay.label}
-                      </p>
-                      {entityDisplay.detail ? (
-                        <p className="text-muted-foreground truncate text-xs">
-                          {entityDisplay.detail}
-                        </p>
-                      ) : null}
-                    </div>
-                  </DataTableBodyCell>
-                  <DataTableBodyCell className="text-right text-xs whitespace-nowrap">
-                    {formatDateTime(event.createdAt)}
-                  </DataTableBodyCell>
-                </TableRow>
-              );
-            })
-          ) : (
-            <DataTableEmptyState colSpan={5} message={t("table.noEvents")} />
-          )}
-        </TableBody>
-      </DataTableFrame>
+      <DataTable
+        table={table}
+        rows={filteredRows}
+        columnsLength={columns.length}
+        emptyMessage={t("table.noEvents")}
+        minWidthClassName="min-w-[980px]"
+      />
     </div>
   );
 }

--- a/src/components/dashboard/tables/AuditEventsTable.tsx
+++ b/src/components/dashboard/tables/AuditEventsTable.tsx
@@ -79,9 +79,9 @@ export default function DashboardAuditEventsTable({
     selectedActors.length === 0 ||
     selectedActors.includes(getActorFilterValue(event));
 
-  const categoryFacetRows = rowsForCurrentSearch.filter((row) =>
-    byEventType(row.original)
-  ).filter((row) => byActor(row.original));
+  const categoryFacetRows = rowsForCurrentSearch
+    .filter((row) => byEventType(row.original))
+    .filter((row) => byActor(row.original));
   const eventTypeFacetRows = rowsForCurrentSearch
     .filter((row) => byCategory(row.original))
     .filter((row) => byActor(row.original));


### PR DESCRIPTION
## Summary

Extracts dashboard table column definitions and helper formatting into route-local column modules for the API keys, audit, gallery, and users dashboard surfaces.

Also adds a shared dashboard page intro component and applies it to the existing dashboard management pages so those views have consistent page-level context.

## Validation

- `git diff --check`
- `npm run type`
- `npm run lint`