### PR TITLE
feat: Add dashboard share management

### DIFF
--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -5,6 +5,7 @@
     "nav": {
       "overview": "Overview",
       "gallery": "Gallery",
+      "shares": "Shares",
       "users": "Users",
       "apiKeys": "API Keys",
       "audit": "Audit",
@@ -33,6 +34,8 @@
     "metrics": "Metrics",
     "gallery": "Gallery",
     "galleryIntro": "Published tracks visible to everyone on the public gallery. Feature, list, hide, or remove entries from public discovery.",
+    "shares": "Shares",
+    "sharesIntro": "Every share link, public or private. View, copy, revoke, or permanently delete share access.",
     "emailPreview": "Email Preview"
   },
   "overview": {
@@ -50,8 +53,8 @@
         "sub": "live share links"
       },
       "gallery": {
-        "label": "Gallery",
-        "sub": "{featured} featured · {hidden} hidden"
+        "label": "Public gallery",
+        "sub": "{featured} featured · {unlisted} private"
       },
       "comparison": {
         "vsPrevMonth": "vs prev month"
@@ -333,6 +336,7 @@
     "categoryValues": {
       "Account": "Account",
       "Gallery": "Gallery",
+      "Share": "Share",
       "System": "System"
     },
     "labels": {
@@ -370,12 +374,15 @@
       "galleryEntryUnfeatured": "Gallery entry unfeatured",
       "galleryEntryHidden": "Gallery entry hidden",
       "galleryEntryRestored": "Gallery entry restored",
-      "galleryEntryDeleted": "Gallery entry deleted"
+      "galleryEntryDeleted": "Gallery entry deleted",
+      "shareRevoked": "Share revoked",
+      "sharePurged": "Share permanently deleted"
     },
     "entityLabels": {
       "accountRole": "Account role",
       "galleryEntry": "Gallery entry",
-      "account": "Account"
+      "account": "Account",
+      "share": "Share"
     },
     "entity": {
       "share": "Share {token}",
@@ -434,7 +441,6 @@
       "filtered": "No gallery entries match the current filters."
     },
     "status": {
-      "cleanupNotice": "Changes apply immediately to the public gallery. {expired} expired and {revoked} revoked linked shares are visible here for operator cleanup.",
       "showing": "Showing {filtered} of {total} gallery entries."
     },
     "lifecycle": {
@@ -516,6 +522,89 @@
       "cancel": "Cancel",
       "deleting": "Deleting…",
       "deleteEntry": "Delete entry"
+    }
+  },
+  "shares": {
+    "filters": {
+      "searchPlaceholder": "Search title, owner or token...",
+      "status": "Status",
+      "type": "Type"
+    },
+    "statusValues": {
+      "active": "Active",
+      "expired": "Expired",
+      "revoked": "Revoked"
+    },
+    "typeValues": {
+      "published": "Published",
+      "temporary": "Temporary"
+    },
+    "galleryValues": {
+      "unlisted": "Private"
+    },
+    "table": {
+      "track": "Track",
+      "type": "Type",
+      "status": "Status",
+      "gallery": "Gallery",
+      "notInGallery": "Not in gallery",
+      "created": "Created"
+    },
+    "owner": {
+      "anonymous": "Anonymous"
+    },
+    "actions": {
+      "copyLink": "Copy link",
+      "open": "Open share",
+      "revoke": "Revoke",
+      "purge": "Delete permanently",
+      "openMenu": "Open share actions"
+    },
+    "restrictions": {
+      "manage": "Only moderators and admins can manage shares.",
+      "purge": "Only admins can permanently delete shares."
+    },
+    "messages": {
+      "revokeFailed": "Failed to revoke share.",
+      "revokeSuccess": "Share revoked.",
+      "purgeFailed": "Failed to permanently delete share.",
+      "purgeSuccess": "Share permanently deleted.",
+      "copyLinkSuccess": "Share link copied.",
+      "copyLinkFailed": "Could not copy the share link."
+    },
+    "aria": {
+      "row": "Share {title}"
+    },
+    "empty": {
+      "default": "No shares yet.",
+      "filtered": "No shares match the current filters."
+    },
+    "status": {
+      "showing": "Showing {filtered} of {total} shares."
+    },
+    "lifecycle": {
+      "revokedOn": "Revoked {date}",
+      "expiredOn": "Expired {date}",
+      "expiresOn": "Expires {date}",
+      "noExpiry": "No expiry"
+    },
+    "revokeDialog": {
+      "title": "Revoke share?",
+      "description": "This immediately disables <strong>{title}</strong>. The link stops working and any linked gallery listing is removed. This cannot be undone.",
+      "fallbackTitle": "this share",
+      "owner": "Owner:",
+      "cancel": "Cancel",
+      "revoking": "Revoking…",
+      "revokeShare": "Revoke share"
+    },
+    "purgeDialog": {
+      "title": "Delete share permanently?",
+      "description": "This permanently removes the database record for <strong>{title}</strong>. This is irreversible and skips the normal 30-day cleanup window. Only revoked shares can be deleted this way.",
+      "fallbackTitle": "this share",
+      "owner": "Owner:",
+      "cancel": "Cancel",
+      "purging": "Deleting…",
+      "purgeShare": "Delete permanently"
     }
   },
   "emailPreview": {

--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -441,7 +441,6 @@
       "filtered": "No gallery entries match the current filters."
     },
     "status": {
-      "cleanupNotice": "Cleanup candidates: {expired} expired shares, {revoked} revoked shares.",
       "showing": "Showing {filtered} of {total} gallery entries."
     },
     "lifecycle": {

--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -441,6 +441,7 @@
       "filtered": "No gallery entries match the current filters."
     },
     "status": {
+      "cleanupNotice": "Cleanup candidates: {expired} expired shares, {revoked} revoked shares.",
       "showing": "Showing {filtered} of {total} gallery entries."
     },
     "lifecycle": {

--- a/src/app/api/dashboard/shares/[token]/route.ts
+++ b/src/app/api/dashboard/shares/[token]/route.ts
@@ -1,0 +1,164 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createAuditEvent } from "@/lib/server/audit";
+import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
+import { hasCapability } from "@/lib/server/authorization";
+import { isTrustedRequest } from "@/lib/server/csrf";
+import {
+  purgeRevokedShare,
+  resolveStoredShare,
+  revokeShare,
+} from "@/lib/server/shares";
+
+type DashboardShareRouteContext = {
+  params: Promise<{
+    token: string;
+  }>;
+};
+
+const updateShareActionSchema = z.object({
+  action: z.literal("revoke"),
+});
+
+function unauthorizedResponse() {
+  return NextResponse.json(
+    { ok: false, error: "Authentication required" },
+    { status: 401 }
+  );
+}
+
+function forbiddenResponse(error: string) {
+  return NextResponse.json({ ok: false, error }, { status: 403 });
+}
+
+export async function PATCH(
+  request: Request,
+  context: DashboardShareRouteContext
+) {
+  if (!isTrustedRequest(request)) {
+    return NextResponse.json(
+      { ok: false, error: "Forbidden" },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const actor = await getCurrentUserFromHeaders(request.headers);
+    if (!actor) {
+      return unauthorizedResponse();
+    }
+
+    if (!hasCapability(actor.role, "shares.update")) {
+      return forbiddenResponse("Only moderators and admins can manage shares.");
+    }
+
+    updateShareActionSchema.parse(await request.json());
+    const { token } = await context.params;
+
+    if (!token.trim()) {
+      return NextResponse.json(
+        { ok: false, error: "Missing share token" },
+        { status: 400 }
+      );
+    }
+
+    const resolved = await resolveStoredShare(token);
+    if (resolved.status === "missing") {
+      return NextResponse.json(
+        { ok: false, error: "Share not found" },
+        { status: 404 }
+      );
+    }
+
+    if (resolved.status !== "revoked") {
+      await revokeShare(token);
+
+      await createAuditEvent({
+        actorUserId: actor.id,
+        targetUserId: resolved.share.ownerUserId,
+        eventType: "share.revoked",
+        entityType: "share",
+        entityId: resolved.share.id,
+        metadata: { token },
+      });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const message =
+      error instanceof z.ZodError
+        ? "Invalid share action payload"
+        : "Failed to update share";
+    console.error("[TrackDraw] Failed to update share", { error });
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  context: DashboardShareRouteContext
+) {
+  if (!isTrustedRequest(request)) {
+    return NextResponse.json(
+      { ok: false, error: "Forbidden" },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const actor = await getCurrentUserFromHeaders(request.headers);
+    if (!actor) {
+      return unauthorizedResponse();
+    }
+
+    if (!hasCapability(actor.role, "shares.delete")) {
+      return forbiddenResponse("Only admins can permanently delete shares.");
+    }
+
+    const { token } = await context.params;
+
+    if (!token.trim()) {
+      return NextResponse.json(
+        { ok: false, error: "Missing share token" },
+        { status: 400 }
+      );
+    }
+
+    const resolved = await resolveStoredShare(token);
+    if (resolved.status === "missing") {
+      return NextResponse.json(
+        { ok: false, error: "Share not found" },
+        { status: 404 }
+      );
+    }
+
+    if (resolved.status !== "revoked") {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: "Only revoked shares can be permanently deleted",
+        },
+        { status: 400 }
+      );
+    }
+
+    await purgeRevokedShare(token);
+
+    await createAuditEvent({
+      actorUserId: actor.id,
+      targetUserId: resolved.share.ownerUserId,
+      eventType: "share.purged",
+      entityType: "share",
+      entityId: resolved.share.id,
+      metadata: { token },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[TrackDraw] Failed to purge share", { error });
+    return NextResponse.json(
+      { ok: false, error: "Failed to permanently delete share" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/dashboard/audit/columns.tsx
+++ b/src/app/dashboard/audit/columns.tsx
@@ -26,11 +26,12 @@ export type DashboardAuditEvent = {
   target: AuditEventActor;
 };
 
-export type AuditEventCategory = "Account" | "Gallery" | "System";
+export type AuditEventCategory = "Account" | "Gallery" | "Share" | "System";
 
 export const categoryFilterValues: AuditEventCategory[] = [
   "Account",
   "Gallery",
+  "Share",
   "System",
 ];
 export const unknownActorValue = "__unknown_actor__";
@@ -110,6 +111,8 @@ const EVENT_TITLE_KEYS: Record<string, string> = {
   "gallery.entry.hidden": "galleryEntryHidden",
   "gallery.entry.restored": "galleryEntryRestored",
   "gallery.entry.deleted": "galleryEntryDeleted",
+  "share.revoked": "shareRevoked",
+  "share.purged": "sharePurged",
 };
 
 export function getEventTitle(eventType: string, t: Translate) {
@@ -121,6 +124,7 @@ export function getEventTitle(eventType: string, t: Translate) {
 export function getEventCategory(eventType: string): AuditEventCategory {
   if (eventType.startsWith("account.")) return "Account";
   if (eventType.startsWith("gallery.")) return "Gallery";
+  if (eventType.startsWith("share.")) return "Share";
   return "System";
 }
 
@@ -163,9 +167,10 @@ export function getEventDetailLabel(
     return `${previousState} -> ${nextState}`;
   }
 
-  if (event.metadata?.shareToken) {
+  const shareToken = event.metadata?.shareToken ?? event.metadata?.token;
+  if (shareToken) {
     return t("filters.share", {
-      token: formatMetadataValue(event.metadata.shareToken),
+      token: formatMetadataValue(shareToken),
     });
   }
 
@@ -180,6 +185,8 @@ export function getEntityTypeLabel(entityType: string, t: Translate) {
       return t("entityLabels.account");
     case "gallery_entry":
       return t("entityLabels.galleryEntry");
+    case "share":
+      return t("entityLabels.share");
     default:
       return formatMetadataLabel(entityType);
   }
@@ -206,6 +213,20 @@ export function getEntityDisplay(event: DashboardAuditEvent, t: Translate) {
 
     return {
       label: t("entityLabels.galleryEntry"),
+      detail: shareToken ?? (event.entityId ? shortenId(event.entityId) : null),
+    };
+  }
+
+  if (event.entityType === "share") {
+    const shareToken =
+      typeof event.metadata?.shareToken === "string"
+        ? event.metadata.shareToken
+        : typeof event.metadata?.token === "string"
+          ? event.metadata.token
+          : null;
+
+    return {
+      label: t("entityLabels.share"),
       detail: shareToken ?? (event.entityId ? shortenId(event.entityId) : null),
     };
   }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/server/authorization";
 import { countActiveApiKeysForAdmin } from "@/lib/server/api-keys";
 import { getGalleryOverviewStats } from "@/lib/server/gallery";
+import { countActiveSharesForAdmin } from "@/lib/server/shares";
 import { countUsersForAdmin } from "@/lib/server/users";
 import LanguageProvider from "@/i18n/LanguageProvider";
 
@@ -35,11 +36,15 @@ export default async function DashboardLayout({
     user.name?.trim() || user.email?.trim() || t("fallbackUserName");
   const currentUserEmail = user.email?.trim() || "dashboard@trackdraw.local";
   const visibleModules = getVisibleDashboardModules(user.role);
-  const [galleryStats, totalUsers, activeApiKeys] = await Promise.all([
-    visibleModules.includes("gallery") ? getGalleryOverviewStats() : null,
-    hasCapability(user.role, "admin.users.read") ? countUsersForAdmin() : null,
-    visibleModules.includes("api-keys") ? countActiveApiKeysForAdmin() : null,
-  ]);
+  const [galleryStats, totalUsers, activeApiKeys, activeShares] =
+    await Promise.all([
+      visibleModules.includes("gallery") ? getGalleryOverviewStats() : null,
+      hasCapability(user.role, "admin.users.read")
+        ? countUsersForAdmin()
+        : null,
+      visibleModules.includes("api-keys") ? countActiveApiKeysForAdmin() : null,
+      visibleModules.includes("shares") ? countActiveSharesForAdmin() : null,
+    ]);
 
   return (
     <LanguageProvider namespaces={["common", "dashboard"]}>
@@ -59,9 +64,10 @@ export default async function DashboardLayout({
           }}
           visibleModules={visibleModules}
           itemBadges={{
-            ...(galleryStats ? { gallery: galleryStats.total } : {}),
+            ...(galleryStats ? { gallery: galleryStats.public } : {}),
             ...(totalUsers !== null ? { users: totalUsers } : {}),
             ...(activeApiKeys !== null ? { "api-keys": activeApiKeys } : {}),
+            ...(activeShares !== null ? { shares: activeShares } : {}),
           }}
         />
         <SidebarInset className="ml-0!">{children}</SidebarInset>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -175,20 +175,20 @@ function KpiCard({
           <p className="text-muted-foreground truncate text-xs font-medium">
             {label}
           </p>
-          <p className="text-2xl leading-tight font-bold tabular-nums">
-            {value}
-          </p>
-          {sub ? (
-            <p className="text-muted-foreground mt-0.5 text-xs">{sub}</p>
-          ) : null}
-          {trend ? (
-            <div className="mt-1">
+          <div className="flex items-baseline gap-2">
+            <p className="text-2xl leading-tight font-bold tabular-nums">
+              {value}
+            </p>
+            {trend ? (
               <KpiTrend
                 current={trend.current}
                 previous={trend.previous}
                 vsPrevMonthLabel={vsPrevMonthLabel ?? ""}
               />
-            </div>
+            ) : null}
+          </div>
+          {sub ? (
+            <p className="text-muted-foreground mt-0.5 text-xs">{sub}</p>
           ) : null}
         </div>
       </div>
@@ -435,10 +435,10 @@ export default async function DashboardPage() {
           <Reveal delay={0.12}>
             <KpiCard
               label={t("kpi.gallery.label")}
-              value={galleryStats.total}
+              value={galleryStats.public}
               sub={t("kpi.gallery.sub", {
                 featured: galleryStats.featured,
-                hidden: galleryStats.hidden,
+                unlisted: galleryStats.unlisted,
               })}
               icon={ImageIcon}
               accent="bg-sky-500"

--- a/src/app/dashboard/shares/columns.tsx
+++ b/src/app/dashboard/shares/columns.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import Link from "next/link";
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+  ArrowUpDown,
+  Ban,
+  ExternalLink,
+  Link2,
+  Loader2,
+  MoreHorizontal,
+  Trash2,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/AppTooltip";
+import { dataTableSortButtonClassName } from "@/components/data-table/DataTableLayout";
+import type { GalleryState } from "@/lib/server/gallery";
+import type { DashboardShare } from "@/lib/server/shares";
+
+export type ShareLifecycleState = "active" | "expired" | "revoked";
+export type Translate = (key: string, values?: Record<string, unknown>) => string;
+
+export function getOwnerLabel(share: DashboardShare, t: Translate) {
+  if (!share.ownerUserId) return t("owner.anonymous");
+  return (
+    share.ownerName?.trim() || share.ownerEmail?.trim() || share.ownerUserId
+  );
+}
+
+export function getLifecycleState(share: DashboardShare): ShareLifecycleState {
+  if (share.revokedAt) return "revoked";
+  if (share.expiresAt && new Date(share.expiresAt).getTime() <= Date.now()) {
+    return "expired";
+  }
+  return "active";
+}
+
+function getLifecycleVariant(
+  state: ShareLifecycleState
+): "default" | "muted" | "outline" {
+  if (state === "active") return "outline";
+  return "muted";
+}
+
+function getGalleryStateVariant(
+  state: GalleryState
+): "default" | "muted" | "outline" {
+  if (state === "featured") return "default";
+  if (state === "hidden") return "muted";
+  return "outline";
+}
+
+function getGalleryStateLabel(
+  state: GalleryState,
+  t: Translate,
+  tCommon: Translate
+) {
+  if (state === "unlisted") return t("galleryValues.unlisted");
+  return tCommon(`status.${state}`);
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+
+  try {
+    return new Intl.DateTimeFormat("en-GB", {
+      dateStyle: "medium",
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+}
+
+function getLifecycleDetail(share: DashboardShare, t: Translate) {
+  const state = getLifecycleState(share);
+  if (state === "revoked") {
+    return t("lifecycle.revokedOn", { date: formatDate(share.revokedAt) });
+  }
+  if (state === "expired") {
+    return t("lifecycle.expiredOn", { date: formatDate(share.expiresAt) });
+  }
+  if (share.expiresAt) {
+    return t("lifecycle.expiresOn", { date: formatDate(share.expiresAt) });
+  }
+  return t("lifecycle.noExpiry");
+}
+
+function ActionTooltip({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactElement;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side="top" sideOffset={6}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+type GetSharesColumnsParams = {
+  t: Translate;
+  tCommon: Translate;
+  pendingToken: string | null;
+  canManageShares: boolean;
+  canPurgeShares: boolean;
+  onCopyLink: (token: string) => void;
+  onRevokeCandidate: (share: DashboardShare) => void;
+  onPurgeCandidate: (share: DashboardShare) => void;
+};
+
+export function getSharesColumns({
+  t,
+  tCommon,
+  pendingToken,
+  canManageShares,
+  canPurgeShares,
+  onCopyLink,
+  onRevokeCandidate,
+  onPurgeCandidate,
+}: GetSharesColumnsParams): ColumnDef<DashboardShare>[] {
+  return [
+    {
+      id: "track",
+      accessorFn: (row) => row.title,
+      meta: { className: "w-[28%] min-w-56" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.track")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      cell: ({ row }) => (
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{row.original.title}</p>
+          <p className="text-muted-foreground truncate text-xs">
+            {row.original.token}
+          </p>
+        </div>
+      ),
+    },
+    {
+      id: "owner",
+      accessorFn: (row) => getOwnerLabel(row, t),
+      header: tCommon("labels.owner"),
+      meta: { className: "w-[20%] min-w-44" },
+      cell: ({ row }) => (
+        <div className="min-w-0">
+          <p className="truncate text-sm">{getOwnerLabel(row.original, t)}</p>
+          {row.original.ownerEmail ? (
+            <p className="text-muted-foreground truncate text-xs">
+              {row.original.ownerEmail}
+            </p>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      id: "type",
+      accessorFn: (row) => row.shareType,
+      header: t("table.type"),
+      meta: { className: "w-28" },
+      cell: ({ row }) => (
+        <Badge
+          variant={row.original.shareType === "published" ? "outline" : "muted"}
+        >
+          {t(`typeValues.${row.original.shareType}`)}
+        </Badge>
+      ),
+    },
+    {
+      id: "status",
+      accessorFn: (row) => getLifecycleState(row),
+      header: t("table.status"),
+      meta: { className: "w-56" },
+      cell: ({ row }) => {
+        const state = getLifecycleState(row.original);
+        return (
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+            <Badge variant={getLifecycleVariant(state)} className="shrink-0">
+              {t(`statusValues.${state}`)}
+            </Badge>
+            <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs">
+              {getLifecycleDetail(row.original, t)}
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      id: "gallery",
+      accessorFn: (row) => row.galleryState ?? "none",
+      header: t("table.gallery"),
+      meta: { className: "w-32" },
+      cell: ({ row }) =>
+        row.original.galleryState ? (
+          <Badge variant={getGalleryStateVariant(row.original.galleryState)}>
+            {getGalleryStateLabel(row.original.galleryState, t, tCommon)}
+          </Badge>
+        ) : (
+          <span className="text-muted-foreground text-xs">
+            {t("table.notInGallery")}
+          </span>
+        ),
+    },
+    {
+      id: "created",
+      meta: { className: "w-32" },
+      header: ({ column }) => (
+        <Button
+          variant="ghost"
+          size="sm"
+          className={dataTableSortButtonClassName}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        >
+          {t("table.created")}
+          <ArrowUpDown className="text-muted-foreground ml-1 size-3.5" />
+        </Button>
+      ),
+      accessorFn: (row) => row.createdAt,
+      cell: ({ row }) => (
+        <span className="text-muted-foreground text-xs">
+          {formatDate(row.original.createdAt)}
+        </span>
+      ),
+    },
+    {
+      id: "actions",
+      header: "",
+      meta: { className: "w-32 text-right" },
+      cell: ({ row }) => {
+        const share = row.original;
+        const isPending = pendingToken === share.token;
+        const isRevoked = getLifecycleState(share) === "revoked";
+
+        return (
+          <div
+            className="flex justify-end"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="hidden items-center justify-end gap-1 md:flex">
+              {isRevoked ? null : (
+                <>
+                  <ActionTooltip label={t("actions.copyLink")}>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="hover:bg-muted hover:text-foreground size-7"
+                      onClick={() => onCopyLink(share.token)}
+                    >
+                      <Link2 className="size-4" />
+                    </Button>
+                  </ActionTooltip>
+                  <ActionTooltip label={t("actions.open")}>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="hover:bg-muted hover:text-foreground size-7"
+                      asChild
+                    >
+                      <Link
+                        href={`/share/${share.token}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <ExternalLink className="size-4" />
+                      </Link>
+                    </Button>
+                  </ActionTooltip>
+                </>
+              )}
+              {isRevoked ? null : (
+                <ActionTooltip label={t("actions.revoke")}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="text-destructive hover:bg-muted hover:text-destructive size-7"
+                    disabled={isPending || !canManageShares}
+                    aria-label={`${t("actions.revoke")} ${share.title}`}
+                    onClick={() => onRevokeCandidate(share)}
+                  >
+                    {isPending ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Ban className="size-4" />
+                    )}
+                  </Button>
+                </ActionTooltip>
+              )}
+              {isRevoked ? (
+                <ActionTooltip label={t("actions.purge")}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="text-destructive hover:bg-muted hover:text-destructive size-7"
+                    disabled={isPending || !canPurgeShares}
+                    aria-label={`${t("actions.purge")} ${share.title}`}
+                    onClick={() => onPurgeCandidate(share)}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </ActionTooltip>
+              ) : null}
+            </div>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-muted-foreground hover:text-foreground ml-auto size-8 p-0 md:hidden"
+                  aria-label={t("actions.openMenu")}
+                >
+                  <MoreHorizontal className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-44">
+                {isRevoked ? null : (
+                  <>
+                    <DropdownMenuItem onClick={() => onCopyLink(share.token)}>
+                      <Link2 className="size-4" />
+                      {t("actions.copyLink")}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem asChild>
+                      <Link
+                        href={`/share/${share.token}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <ExternalLink className="size-4" />
+                        {t("actions.open")}
+                      </Link>
+                    </DropdownMenuItem>
+                  </>
+                )}
+                {isRevoked ? null : (
+                  <DropdownMenuItem
+                    disabled={!canManageShares}
+                    onClick={() => onRevokeCandidate(share)}
+                    className="text-destructive focus:text-destructive"
+                  >
+                    <Ban className="size-4" />
+                    {t("actions.revoke")}
+                  </DropdownMenuItem>
+                )}
+                {isRevoked ? (
+                  <DropdownMenuItem
+                    disabled={!canPurgeShares}
+                    onClick={() => onPurgeCandidate(share)}
+                    className="text-destructive focus:text-destructive"
+                  >
+                    <Trash2 className="size-4" />
+                    {t("actions.purge")}
+                  </DropdownMenuItem>
+                ) : null}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        );
+      },
+    },
+  ];
+}

--- a/src/app/dashboard/shares/columns.tsx
+++ b/src/app/dashboard/shares/columns.tsx
@@ -29,7 +29,10 @@ import type { GalleryState } from "@/lib/server/gallery";
 import type { DashboardShare } from "@/lib/server/shares";
 
 export type ShareLifecycleState = "active" | "expired" | "revoked";
-export type Translate = (key: string, values?: Record<string, unknown>) => string;
+export type Translate = (
+  key: string,
+  values?: Record<string, unknown>
+) => string;
 
 export function getOwnerLabel(share: DashboardShare, t: Translate) {
   if (!share.ownerUserId) return t("owner.anonymous");

--- a/src/app/dashboard/shares/columns.tsx
+++ b/src/app/dashboard/shares/columns.tsx
@@ -267,6 +267,7 @@ export function getSharesColumns({
                       variant="ghost"
                       size="icon"
                       className="hover:bg-muted hover:text-foreground size-7"
+                      aria-label={`${t("actions.copyLink")} ${share.title}`}
                       onClick={() => onCopyLink(share.token)}
                     >
                       <Link2 className="size-4" />
@@ -284,6 +285,7 @@ export function getSharesColumns({
                         href={`/share/${share.token}`}
                         target="_blank"
                         rel="noopener noreferrer"
+                        aria-label={`${t("actions.open")} ${share.title}`}
                       >
                         <ExternalLink className="size-4" />
                       </Link>

--- a/src/app/dashboard/shares/page.tsx
+++ b/src/app/dashboard/shares/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+import { Link2 } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import DashboardPageIntro from "@/components/dashboard/PageIntro";
+import DashboardSharesManager from "@/components/dashboard/SharesManager";
+import DashboardSiteHeader from "@/components/dashboard/SiteHeader";
+import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
+import { hasCapability } from "@/lib/server/authorization";
+import { listSharesForDashboard } from "@/lib/server/shares";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("dashboard");
+  const tCommon = await getTranslations("common");
+
+  return {
+    title: `${tCommon("labels.dashboard")} ${t("pages.shares")}`,
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
+
+export default async function DashboardSharesPage() {
+  const requestHeaders = new Headers(await headers());
+  const currentUser = await getCurrentUserFromHeaders(requestHeaders);
+
+  if (!currentUser || !hasCapability(currentUser.role, "shares.read")) {
+    notFound();
+  }
+
+  const shares = await listSharesForDashboard();
+  const t = await getTranslations("dashboard");
+  const tCommon = await getTranslations("common");
+
+  return (
+    <>
+      <DashboardSiteHeader
+        parent={{ label: tCommon("labels.dashboard"), href: "/dashboard" }}
+        title={t("pages.shares")}
+      />
+      <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
+        <DashboardPageIntro
+          icon={Link2}
+          title={t("pages.shares")}
+          description={t("pages.sharesIntro")}
+          accent="bg-orange-500/10 text-orange-600 dark:text-orange-400"
+        />
+        <DashboardSharesManager
+          currentUserRole={currentUser.role}
+          initialShares={shares}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/components/dashboard/AppSidebar.tsx
+++ b/src/components/dashboard/AppSidebar.tsx
@@ -11,6 +11,7 @@ import {
   Image as ImageIcon,
   KeyRound,
   LayoutDashboard,
+  Link2,
   Mail,
   PenLine,
   Users,
@@ -102,6 +103,13 @@ const topNavItems: NavItem[] = [
     href: "/dashboard/gallery",
     icon: ImageIcon,
     activePrefix: "/dashboard/gallery",
+  },
+  {
+    key: "shares",
+    titleKey: "shares",
+    href: "/dashboard/shares",
+    icon: Link2,
+    activePrefix: "/dashboard/shares",
   },
 ] as const;
 
@@ -231,6 +239,7 @@ export default function DashboardAppSidebar({
   const filteredTopItems = topNavItems.filter((item) => {
     if (item.key === "overview") return visibleModules.includes("overview");
     if (item.key === "gallery") return visibleModules.includes("gallery");
+    if (item.key === "shares") return visibleModules.includes("shares");
     return true;
   });
 

--- a/src/components/dashboard/GalleryManager.tsx
+++ b/src/components/dashboard/GalleryManager.tsx
@@ -367,12 +367,6 @@ export default function DashboardGalleryManager({
       (row) => getShareLifecycleState(row.original) === value
     ).length,
   }));
-  const expiredShareCount = entries.filter(
-    (entry) => getShareLifecycleState(entry) === "expired"
-  ).length;
-  const revokedShareCount = entries.filter(
-    (entry) => getShareLifecycleState(entry) === "revoked"
-  ).length;
   const emptyMessage =
     entries.length === 0 ? t("empty.default") : t("empty.filtered");
   const inspectShareLifecycle = inspectCandidate
@@ -405,13 +399,6 @@ export default function DashboardGalleryManager({
           onChange={setSelectedShareLifecycles}
         />
       </DataTableToolbar>
-
-      <p className="text-muted-foreground text-xs">
-        {t("status.cleanupNotice", {
-          expired: expiredShareCount,
-          revoked: revokedShareCount,
-        })}
-      </p>
 
       <DataTable
         table={table}

--- a/src/components/dashboard/SharesManager.tsx
+++ b/src/components/dashboard/SharesManager.tsx
@@ -66,8 +66,9 @@ export default function DashboardSharesManager({
   const [selectedTypes, setSelectedTypes] = useState<ShareTypeFilterValue[]>(
     []
   );
-  const [revokeCandidate, setRevokeCandidate] =
-    useState<DashboardShare | null>(null);
+  const [revokeCandidate, setRevokeCandidate] = useState<DashboardShare | null>(
+    null
+  );
   const [purgeCandidate, setPurgeCandidate] = useState<DashboardShare | null>(
     null
   );
@@ -94,8 +95,7 @@ export default function DashboardSharesManager({
       );
 
       const payload = (await response.json()) as
-        | { ok: true }
-        | { ok: false; error?: string };
+        { ok: true } | { ok: false; error?: string };
 
       if (!response.ok || !payload.ok) {
         throw new Error(
@@ -142,8 +142,7 @@ export default function DashboardSharesManager({
       );
 
       const payload = (await response.json()) as
-        | { ok: true }
-        | { ok: false; error?: string };
+        { ok: true } | { ok: false; error?: string };
 
       if (!response.ok || !payload.ok) {
         throw new Error(
@@ -153,7 +152,9 @@ export default function DashboardSharesManager({
         );
       }
 
-      setShares((previous) => previous.filter((share) => share.token !== token));
+      setShares((previous) =>
+        previous.filter((share) => share.token !== token)
+      );
       setPurgeCandidate(null);
       toast.success(t("messages.purgeSuccess"));
     } catch (error) {
@@ -296,7 +297,8 @@ export default function DashboardSharesManager({
             <DialogTitle>{t("revokeDialog.title")}</DialogTitle>
             <DialogDescription>
               {t.rich("revokeDialog.description", {
-                title: revokeCandidate?.title ?? t("revokeDialog.fallbackTitle"),
+                title:
+                  revokeCandidate?.title ?? t("revokeDialog.fallbackTitle"),
                 strong: (chunks) => (
                   <span className="text-foreground font-medium">{chunks}</span>
                 ),

--- a/src/components/dashboard/SharesManager.tsx
+++ b/src/components/dashboard/SharesManager.tsx
@@ -169,7 +169,7 @@ export default function DashboardSharesManager({
     const href = `${window.location.origin}/share/${token}`;
 
     try {
-      await navigator.clipboard.writeText(href);
+      await window.navigator.clipboard.writeText(href);
       toast.success(t("messages.copyLinkSuccess"));
     } catch {
       toast.error(t("messages.copyLinkFailed"));

--- a/src/components/dashboard/SharesManager.tsx
+++ b/src/components/dashboard/SharesManager.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  getCoreRowModel,
+  getFilteredRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import {
+  getLifecycleState,
+  getOwnerLabel,
+  getSharesColumns,
+  type ShareLifecycleState,
+  type Translate,
+} from "@/app/dashboard/shares/columns";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import DataTable from "@/components/data-table/DataTable";
+import DataTableFacetFilter from "@/components/data-table/DataTableFacetFilter";
+import DataTableToolbar from "@/components/data-table/DataTableToolbar";
+import type { AccountRole } from "@/lib/account/roles";
+import type { DashboardShare } from "@/lib/server/shares";
+
+type DashboardSharesManagerProps = {
+  currentUserRole: AccountRole;
+  initialShares: DashboardShare[];
+};
+
+type ShareTypeFilterValue = "published" | "temporary";
+
+const sharesManagerRoles: AccountRole[] = ["moderator", "admin"];
+const purgeManagerRoles: AccountRole[] = ["admin"];
+const lifecycleFilterValues: ShareLifecycleState[] = [
+  "active",
+  "expired",
+  "revoked",
+];
+const typeFilterValues: ShareTypeFilterValue[] = ["published", "temporary"];
+
+export default function DashboardSharesManager({
+  currentUserRole,
+  initialShares,
+}: DashboardSharesManagerProps) {
+  const t = useTranslations("dashboard.shares");
+  const tCommon = useTranslations("common");
+  const [shares, setShares] = useState(initialShares);
+  const [globalFilter, setGlobalFilter] = useState("");
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [pendingToken, setPendingToken] = useState<string | null>(null);
+  const [selectedLifecycles, setSelectedLifecycles] = useState<
+    ShareLifecycleState[]
+  >([]);
+  const [selectedTypes, setSelectedTypes] = useState<ShareTypeFilterValue[]>(
+    []
+  );
+  const [revokeCandidate, setRevokeCandidate] =
+    useState<DashboardShare | null>(null);
+  const [purgeCandidate, setPurgeCandidate] = useState<DashboardShare | null>(
+    null
+  );
+
+  const canManageShares = sharesManagerRoles.includes(currentUserRole);
+  const canPurgeShares = purgeManagerRoles.includes(currentUserRole);
+
+  const revoke = async (token: string) => {
+    if (!canManageShares) {
+      toast.error(t("restrictions.manage"));
+      return;
+    }
+
+    setPendingToken(token);
+
+    try {
+      const response = await fetch(
+        `/api/dashboard/shares/${encodeURIComponent(token)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "revoke" }),
+        }
+      );
+
+      const payload = (await response.json()) as
+        | { ok: true }
+        | { ok: false; error?: string };
+
+      if (!response.ok || !payload.ok) {
+        throw new Error(
+          payload.ok
+            ? t("messages.revokeFailed")
+            : (payload.error ?? t("messages.revokeFailed"))
+        );
+      }
+
+      setShares((previous) =>
+        previous.map((share) =>
+          share.token === token
+            ? {
+                ...share,
+                revokedAt: new Date().toISOString(),
+                galleryState: null,
+              }
+            : share
+        )
+      );
+      setRevokeCandidate(null);
+      toast.success(t("messages.revokeSuccess"));
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : t("messages.revokeFailed")
+      );
+    } finally {
+      setPendingToken(null);
+    }
+  };
+
+  const purge = async (token: string) => {
+    if (!canPurgeShares) {
+      toast.error(t("restrictions.purge"));
+      return;
+    }
+
+    setPendingToken(token);
+
+    try {
+      const response = await fetch(
+        `/api/dashboard/shares/${encodeURIComponent(token)}`,
+        { method: "DELETE" }
+      );
+
+      const payload = (await response.json()) as
+        | { ok: true }
+        | { ok: false; error?: string };
+
+      if (!response.ok || !payload.ok) {
+        throw new Error(
+          payload.ok
+            ? t("messages.purgeFailed")
+            : (payload.error ?? t("messages.purgeFailed"))
+        );
+      }
+
+      setShares((previous) => previous.filter((share) => share.token !== token));
+      setPurgeCandidate(null);
+      toast.success(t("messages.purgeSuccess"));
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : t("messages.purgeFailed")
+      );
+    } finally {
+      setPendingToken(null);
+    }
+  };
+
+  const copyShareLink = async (token: string) => {
+    const href = `${window.location.origin}/share/${token}`;
+
+    try {
+      await navigator.clipboard.writeText(href);
+      toast.success(t("messages.copyLinkSuccess"));
+    } catch {
+      toast.error(t("messages.copyLinkFailed"));
+    }
+  };
+
+  const columns = getSharesColumns({
+    t: t as unknown as Translate,
+    tCommon: tCommon as unknown as Translate,
+    pendingToken,
+    canManageShares,
+    canPurgeShares,
+    onCopyLink: (token) => void copyShareLink(token),
+    onRevokeCandidate: setRevokeCandidate,
+    onPurgeCandidate: setPurgeCandidate,
+  });
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data: shares,
+    columns,
+    state: { globalFilter, sorting },
+    onGlobalFilterChange: setGlobalFilter,
+    onSortingChange: setSorting,
+    globalFilterFn: (row, _columnId, filterValue: string) => {
+      const share = row.original;
+      const q = filterValue.toLowerCase();
+      return (
+        share.title.toLowerCase().includes(q) ||
+        share.token.toLowerCase().includes(q) ||
+        getOwnerLabel(share, t as unknown as Translate)
+          .toLowerCase()
+          .includes(q)
+      );
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  const rowsForCurrentSearch = table.getRowModel().rows;
+  const lifecycleFilteredRows = rowsForCurrentSearch.filter((row) =>
+    selectedLifecycles.length === 0
+      ? true
+      : selectedLifecycles.includes(getLifecycleState(row.original))
+  );
+  const filteredRows = lifecycleFilteredRows.filter((row) =>
+    selectedTypes.length === 0
+      ? true
+      : selectedTypes.includes(row.original.shareType)
+  );
+  const lifecycleFacetRows = rowsForCurrentSearch.filter((row) =>
+    selectedTypes.length === 0
+      ? true
+      : selectedTypes.includes(row.original.shareType)
+  );
+  const typeFacetRows = rowsForCurrentSearch.filter((row) =>
+    selectedLifecycles.length === 0
+      ? true
+      : selectedLifecycles.includes(getLifecycleState(row.original))
+  );
+  const lifecycleFilterOptions = lifecycleFilterValues.map((value) => ({
+    value,
+    label: t(`statusValues.${value}`),
+    count: lifecycleFacetRows.filter(
+      (row) => getLifecycleState(row.original) === value
+    ).length,
+  }));
+  const typeFilterOptions = typeFilterValues.map((value) => ({
+    value,
+    label: t(`typeValues.${value}`),
+    count: typeFacetRows.filter((row) => row.original.shareType === value)
+      .length,
+  }));
+  const emptyMessage =
+    shares.length === 0 ? t("empty.default") : t("empty.filtered");
+
+  return (
+    <div className="space-y-4">
+      <DataTableToolbar
+        searchValue={globalFilter}
+        onSearchChange={setGlobalFilter}
+        searchPlaceholder={t("filters.searchPlaceholder")}
+      >
+        <DataTableFacetFilter
+          title={t("filters.status")}
+          selected={selectedLifecycles}
+          options={lifecycleFilterOptions}
+          onChange={setSelectedLifecycles}
+        />
+        <DataTableFacetFilter
+          title={t("filters.type")}
+          selected={selectedTypes}
+          options={typeFilterOptions}
+          onChange={setSelectedTypes}
+        />
+      </DataTableToolbar>
+
+      <DataTable
+        table={table}
+        rows={filteredRows}
+        columnsLength={columns.length}
+        emptyMessage={emptyMessage}
+        minWidthClassName="min-w-[920px]"
+        emptyClassName="py-8"
+        getRowAriaLabel={(row) => t("aria.row", { title: row.original.title })}
+      />
+
+      <p className="text-muted-foreground text-xs">
+        {t("status.showing", {
+          filtered: filteredRows.length,
+          total: shares.length,
+        })}
+      </p>
+
+      <Dialog
+        open={revokeCandidate !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevokeCandidate(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("revokeDialog.title")}</DialogTitle>
+            <DialogDescription>
+              {t.rich("revokeDialog.description", {
+                title: revokeCandidate?.title ?? t("revokeDialog.fallbackTitle"),
+                strong: (chunks) => (
+                  <span className="text-foreground font-medium">{chunks}</span>
+                ),
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="text-muted-foreground space-y-2 text-sm">
+            <p>
+              {t("revokeDialog.owner")}{" "}
+              <span className="text-foreground">
+                {revokeCandidate
+                  ? getOwnerLabel(revokeCandidate, t as unknown as Translate)
+                  : t("owner.anonymous")}
+              </span>
+            </p>
+          </div>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">{t("revokeDialog.cancel")}</Button>
+            </DialogClose>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={
+                !revokeCandidate ||
+                pendingToken === revokeCandidate.token ||
+                !canManageShares
+              }
+              onClick={() => {
+                if (!revokeCandidate) return;
+                void revoke(revokeCandidate.token);
+              }}
+            >
+              {revokeCandidate && pendingToken === revokeCandidate.token ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  {t("revokeDialog.revoking")}
+                </>
+              ) : (
+                t("revokeDialog.revokeShare")
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={purgeCandidate !== null}
+        onOpenChange={(open) => {
+          if (!open) setPurgeCandidate(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("purgeDialog.title")}</DialogTitle>
+            <DialogDescription>
+              {t.rich("purgeDialog.description", {
+                title: purgeCandidate?.title ?? t("purgeDialog.fallbackTitle"),
+                strong: (chunks) => (
+                  <span className="text-foreground font-medium">{chunks}</span>
+                ),
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="text-muted-foreground space-y-2 text-sm">
+            <p>
+              {t("purgeDialog.owner")}{" "}
+              <span className="text-foreground">
+                {purgeCandidate
+                  ? getOwnerLabel(purgeCandidate, t as unknown as Translate)
+                  : t("owner.anonymous")}
+              </span>
+            </p>
+          </div>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">{t("purgeDialog.cancel")}</Button>
+            </DialogClose>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={
+                !purgeCandidate ||
+                pendingToken === purgeCandidate.token ||
+                !canPurgeShares
+              }
+              onClick={() => {
+                if (!purgeCandidate) return;
+                void purge(purgeCandidate.token);
+              }}
+            >
+              {purgeCandidate && pendingToken === purgeCandidate.token ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  {t("purgeDialog.purging")}
+                </>
+              ) : (
+                t("purgeDialog.purgeShare")
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/lib/server/authorization.ts
+++ b/src/lib/server/authorization.ts
@@ -9,6 +9,9 @@ export type AuthorizationCapability =
   | "gallery.entries.read"
   | "gallery.entries.update"
   | "gallery.entries.delete"
+  | "shares.read"
+  | "shares.update"
+  | "shares.delete"
   | "admin.users.read"
   | "admin.users.update"
   | "admin.metrics.read"
@@ -17,13 +20,16 @@ export type AuthorizationCapability =
   | "account.role.assign";
 
 export type DashboardModule =
-  "overview" | "gallery" | "users" | "audit" | "metrics" | "api-keys";
+  "overview" | "gallery" | "shares" | "users" | "audit" | "metrics" | "api-keys";
 
 const capabilityRoles: Record<AuthorizationCapability, AccountRole[]> = {
   "dashboard.overview.read": ["moderator", "admin"],
   "gallery.entries.read": ["moderator", "admin"],
   "gallery.entries.update": ["moderator", "admin"],
   "gallery.entries.delete": ["moderator", "admin"],
+  "shares.read": ["moderator", "admin"],
+  "shares.update": ["moderator", "admin"],
+  "shares.delete": ["admin"],
   "admin.users.read": ["admin"],
   "admin.users.update": ["admin"],
   "admin.metrics.read": ["admin"],
@@ -54,6 +60,10 @@ export function getVisibleDashboardModules(
 
   if (hasCapability(role, "gallery.entries.read")) {
     modules.push("gallery");
+  }
+
+  if (hasCapability(role, "shares.read")) {
+    modules.push("shares");
   }
 
   if (hasCapability(role, "admin.users.read")) {

--- a/src/lib/server/authorization.ts
+++ b/src/lib/server/authorization.ts
@@ -20,7 +20,13 @@ export type AuthorizationCapability =
   | "account.role.assign";
 
 export type DashboardModule =
-  "overview" | "gallery" | "shares" | "users" | "audit" | "metrics" | "api-keys";
+  | "overview"
+  | "gallery"
+  | "shares"
+  | "users"
+  | "audit"
+  | "metrics"
+  | "api-keys";
 
 const capabilityRoles: Record<AuthorizationCapability, AccountRole[]> = {
   "dashboard.overview.read": ["moderator", "admin"],

--- a/src/lib/server/gallery.ts
+++ b/src/lib/server/gallery.ts
@@ -116,6 +116,7 @@ export type PublicGalleryEntry = StoredGalleryEntry & {
 
 export type GalleryOverviewStats = {
   total: number;
+  public: number;
   listed: number;
   featured: number;
   hidden: number;
@@ -313,6 +314,7 @@ export const getGalleryOverviewStats = cache(
 
     const stats: GalleryOverviewStats = {
       total: 0,
+      public: 0,
       listed: 0,
       featured: 0,
       hidden: 0,
@@ -325,6 +327,9 @@ export const getGalleryOverviewStats = cache(
 
       stats[state] += count;
       stats.total += count;
+      if (isPublicGalleryState(state)) {
+        stats.public += count;
+      }
     }
 
     return stats;

--- a/src/lib/server/shares.ts
+++ b/src/lib/server/shares.ts
@@ -11,6 +11,7 @@ import {
   deleteGalleryEntry,
   getGalleryEntryByShareToken,
   parseGalleryState,
+  type GalleryState,
 } from "@/lib/server/gallery";
 import { getShareDescription, getShareTitle } from "@/lib/share";
 import type { SerializedTrackDesign, TrackDesign } from "@/lib/types";
@@ -309,6 +310,112 @@ export async function revokeShare(token: string) {
     .run();
 
   await deleteGalleryEntry(token);
+}
+
+export async function purgeRevokedShare(token: string) {
+  const db = await getDatabase();
+
+  await db
+    .prepare(
+      `
+        delete from shares
+        where token = ? and revoked_at is not null
+      `
+    )
+    .bind(token)
+    .run();
+}
+
+type DashboardShareRow = {
+  token: string;
+  title: string | null;
+  created_at: string;
+  expires_at: string | null;
+  revoked_at: string | null;
+  share_type: string | null;
+  owner_user_id: string | null;
+  owner_name: string | null;
+  owner_email: string | null;
+  gallery_state: string | null;
+};
+
+export type DashboardShare = {
+  token: string;
+  title: string;
+  createdAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  shareType: ShareType;
+  ownerUserId: string | null;
+  ownerName: string | null;
+  ownerEmail: string | null;
+  galleryState: GalleryState | null;
+};
+
+function mapDashboardShareRow(row: DashboardShareRow): DashboardShare {
+  return {
+    token: row.token,
+    title: row.title?.trim() || "Untitled track",
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    revokedAt: row.revoked_at,
+    shareType: parseShareType(row.share_type),
+    ownerUserId: row.owner_user_id,
+    ownerName: row.owner_name,
+    ownerEmail: row.owner_email,
+    galleryState: row.gallery_state ? parseGalleryState(row.gallery_state) : null,
+  };
+}
+
+export async function listSharesForDashboard(
+  options: { limit?: number } = {}
+): Promise<DashboardShare[]> {
+  const db = await getDatabase();
+  const limit = options.limit ?? 500;
+
+  const rows = await db
+    .prepare(
+      `
+        select
+          s.token,
+          s.title,
+          s.created_at,
+          s.expires_at,
+          s.revoked_at,
+          s.share_type,
+          s.owner_user_id,
+          u.name as owner_name,
+          u.email as owner_email,
+          g.gallery_state
+        from shares s
+        left join users u on u.id = s.owner_user_id
+        left join gallery_entries g on g.share_token = s.token
+        order by s.created_at desc
+        limit ?
+      `
+    )
+    .bind(limit)
+    .all<DashboardShareRow>();
+
+  return (rows.results ?? []).map(mapDashboardShareRow);
+}
+
+export async function countActiveSharesForAdmin(): Promise<number> {
+  const db = await getDatabase();
+  const now = nowIso();
+
+  const row = await db
+    .prepare(
+      `
+        select count(*) as count
+        from shares s
+        where ${ACTIVE_USER_SHARE_WHERE}
+      `
+    )
+    .bind(now)
+    .first<{ count: number }>();
+
+  return Number(row?.count ?? 0);
 }
 
 type CreateShareOptions = {

--- a/src/lib/server/shares.ts
+++ b/src/lib/server/shares.ts
@@ -363,7 +363,9 @@ function mapDashboardShareRow(row: DashboardShareRow): DashboardShare {
     ownerUserId: row.owner_user_id,
     ownerName: row.owner_name,
     ownerEmail: row.owner_email,
-    galleryState: row.gallery_state ? parseGalleryState(row.gallery_state) : null,
+    galleryState: row.gallery_state
+      ? parseGalleryState(row.gallery_state)
+      : null,
   };
 }
 

--- a/tests/app/api/dashboard/shares.route.test.ts
+++ b/tests/app/api/dashboard/shares.route.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/server/csrf", () => ({ isTrustedRequest: vi.fn(() => true) }));
+
+vi.mock("@/lib/server/audit", () => ({
+  createAuditEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/server/auth-session", () => ({
+  getCurrentUserFromHeaders: vi.fn(),
+}));
+
+vi.mock("@/lib/server/authorization", () => ({
+  hasCapability: vi.fn(),
+}));
+
+vi.mock("@/lib/server/shares", () => ({
+  purgeRevokedShare: vi.fn(),
+  resolveStoredShare: vi.fn(),
+  revokeShare: vi.fn(),
+}));
+
+import { DELETE, PATCH } from "@/app/api/dashboard/shares/[token]/route";
+import { createAuditEvent } from "@/lib/server/audit";
+import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
+import { hasCapability } from "@/lib/server/authorization";
+import {
+  purgeRevokedShare,
+  resolveStoredShare,
+  revokeShare,
+} from "@/lib/server/shares";
+import {
+  adminActor,
+  createStoredShareFixture,
+  moderatorActor,
+  routeContext,
+} from "../../../helpers/api-routes";
+
+const storedShare = createStoredShareFixture({
+  id: "share-id",
+  token: "share-token",
+  ownerUserId: "owner-1",
+  revokedAt: null,
+});
+
+const revokedStoredShare = createStoredShareFixture({
+  id: "share-id",
+  token: "share-token",
+  ownerUserId: "owner-1",
+  revokedAt: "2026-04-21T10:00:00.000Z",
+});
+
+function patchRequest(action = "revoke") {
+  return new Request("http://localhost/api/dashboard/shares/share-token", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action }),
+  });
+}
+
+function deleteRequest() {
+  return new Request("http://localhost/api/dashboard/shares/share-token", {
+    method: "DELETE",
+  });
+}
+
+function context(token = "share-token") {
+  return routeContext({ token });
+}
+
+describe("dashboard shares API route", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(moderatorActor);
+    vi.mocked(hasCapability).mockReturnValue(true);
+    vi.mocked(resolveStoredShare).mockResolvedValue({
+      status: "available",
+      share: storedShare,
+    });
+  });
+
+  it("returns 401 when the actor is missing", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
+
+    const response = await PATCH(patchRequest(), context());
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Authentication required",
+    });
+  });
+
+  it("returns 403 when the actor cannot manage shares", async () => {
+    vi.mocked(hasCapability).mockReturnValue(false);
+
+    const response = await PATCH(patchRequest(), context());
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Only moderators and admins can manage shares.",
+    });
+  });
+
+  it("returns 400 when the share token is missing", async () => {
+    const response = await PATCH(patchRequest(), context(" "));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Missing share token",
+    });
+  });
+
+  it("returns 404 when the share is missing", async () => {
+    vi.mocked(resolveStoredShare).mockResolvedValue({ status: "missing" });
+
+    const response = await PATCH(patchRequest(), context());
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Share not found",
+    });
+  });
+
+  it("revokes shares and writes an audit event", async () => {
+    const response = await PATCH(patchRequest(), context());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(resolveStoredShare).toHaveBeenCalledWith("share-token");
+    expect(revokeShare).toHaveBeenCalledWith("share-token");
+    expect(createAuditEvent).toHaveBeenCalledWith({
+      actorUserId: moderatorActor.id,
+      targetUserId: storedShare.ownerUserId,
+      eventType: "share.revoked",
+      entityType: "share",
+      entityId: storedShare.id,
+      metadata: { token: "share-token" },
+    });
+  });
+
+  it("purges revoked shares for admins and writes an audit event", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
+    vi.mocked(resolveStoredShare).mockResolvedValue({
+      status: "revoked",
+      share: revokedStoredShare,
+    });
+
+    const response = await DELETE(deleteRequest(), context());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(resolveStoredShare).toHaveBeenCalledWith("share-token");
+    expect(purgeRevokedShare).toHaveBeenCalledWith("share-token");
+    expect(createAuditEvent).toHaveBeenCalledWith({
+      actorUserId: adminActor.id,
+      targetUserId: revokedStoredShare.ownerUserId,
+      eventType: "share.purged",
+      entityType: "share",
+      entityId: revokedStoredShare.id,
+      metadata: { token: "share-token" },
+    });
+  });
+
+  it("returns 400 when deleting a share that is not revoked", async () => {
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
+
+    const response = await DELETE(deleteRequest(), context());
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Only revoked shares can be permanently deleted",
+    });
+    expect(purgeRevokedShare).not.toHaveBeenCalled();
+  });
+});

--- a/tests/components/dashboard/SharesManager.test.tsx
+++ b/tests/components/dashboard/SharesManager.test.tsx
@@ -1,0 +1,200 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import DashboardSharesManager from "@/components/dashboard/SharesManager";
+import type { DashboardShare } from "@/lib/server/shares";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    render,
+    children,
+  }: {
+    render?: React.ReactElement;
+    children?: React.ReactNode;
+  }) => render ?? <>{children}</>,
+  TooltipContent: () => null,
+}));
+
+vi.mock("@/components/AppTooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({
+    children,
+  }: {
+    asChild?: boolean;
+    children?: React.ReactNode;
+  }) => <>{children}</>,
+  TooltipContent: () => null,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({
+    open,
+    children,
+  }: {
+    open?: boolean;
+    children: React.ReactNode;
+  }) => (open ? <div>{children}</div> : null),
+  DialogClose: ({
+    asChild,
+    children,
+  }: {
+    asChild?: boolean;
+    children: React.ReactNode;
+  }) => (asChild ? <>{children}</> : <button type="button">{children}</button>),
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
+  DialogFooter: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+}));
+
+const activeShare: DashboardShare = {
+  token: "share-token",
+  title: "Track One",
+  createdAt: "2026-04-20T10:00:00.000Z",
+  expiresAt: null,
+  revokedAt: null,
+  shareType: "published",
+  ownerUserId: "owner-1",
+  ownerName: "Owner One",
+  ownerEmail: "owner@trackdraw.local",
+  galleryState: "listed",
+};
+
+const revokedShare: DashboardShare = {
+  ...activeShare,
+  token: "revoked-token",
+  title: "Revoked Track",
+  revokedAt: "2026-04-21T10:00:00.000Z",
+  galleryState: null,
+};
+
+describe("DashboardSharesManager", () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    writeText.mockResolvedValue(undefined);
+    const clipboardNavigator = { clipboard: { writeText } };
+    Object.defineProperty(window, "navigator", {
+      configurable: true,
+      value: clipboardNavigator,
+    });
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: clipboardNavigator,
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        Response.json({
+          ok: true,
+        })
+      )
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("copies active share links with an accessible action label", async () => {
+    render(
+      <DashboardSharesManager
+        currentUserRole="moderator"
+        initialShares={[activeShare]}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText("Copy link Track One"));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        "http://localhost:3000/share/share-token"
+      )
+    );
+    expect(
+      screen.getByLabelText("Open share Track One").getAttribute("href")
+    ).toBe("/share/share-token");
+  });
+
+  it("revokes active shares with a PATCH request", async () => {
+    const user = userEvent.setup();
+    render(
+      <DashboardSharesManager
+        currentUserRole="moderator"
+        initialShares={[activeShare]}
+      />
+    );
+
+    await user.click(screen.getByLabelText("Revoke Track One"));
+    expect(screen.getByText("Revoke share?")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Revoke share" }));
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    expect(fetch).toHaveBeenCalledWith("/api/dashboard/shares/share-token", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: "revoke" }),
+    });
+  });
+
+  it("purges revoked shares for admins only", async () => {
+    const user = userEvent.setup();
+    render(
+      <DashboardSharesManager
+        currentUserRole="admin"
+        initialShares={[revokedShare]}
+      />
+    );
+
+    await user.click(screen.getByLabelText("Delete permanently Revoked Track"));
+    expect(screen.getByText("Delete share permanently?")).toBeTruthy();
+
+    await user.click(
+      screen.getByRole("button", { name: "Delete permanently" })
+    );
+
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    expect(fetch).toHaveBeenCalledWith("/api/dashboard/shares/revoked-token", {
+      method: "DELETE",
+    });
+  });
+
+  it("disables purge actions for moderators", () => {
+    render(
+      <DashboardSharesManager
+        currentUserRole="moderator"
+        initialShares={[revokedShare]}
+      />
+    );
+
+    expect(
+      (screen.getByLabelText(
+        "Delete permanently Revoked Track"
+      ) as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+});

--- a/tests/components/dashboard/SharesManager.test.tsx
+++ b/tests/components/dashboard/SharesManager.test.tsx
@@ -192,9 +192,11 @@ describe("DashboardSharesManager", () => {
     );
 
     expect(
-      (screen.getByLabelText(
-        "Delete permanently Revoked Track"
-      ) as HTMLButtonElement).disabled
+      (
+        screen.getByLabelText(
+          "Delete permanently Revoked Track"
+        ) as HTMLButtonElement
+      ).disabled
     ).toBe(true);
   });
 });

--- a/tests/lib/server/authorization.test.ts
+++ b/tests/lib/server/authorization.test.ts
@@ -29,10 +29,12 @@ describe("authorization helpers", () => {
     expect(getVisibleDashboardModules("moderator")).toEqual([
       "overview",
       "gallery",
+      "shares",
     ]);
     expect(getVisibleDashboardModules("admin")).toEqual([
       "overview",
       "gallery",
+      "shares",
       "users",
       "metrics",
       "audit",

--- a/tests/lib/server/gallery.test.ts
+++ b/tests/lib/server/gallery.test.ts
@@ -175,6 +175,7 @@ describe("gallery server helpers", () => {
 
     expect(stats).toEqual({
       total: 6,
+      public: 5,
       listed: 3,
       featured: 2,
       hidden: 1,


### PR DESCRIPTION
## Summary

Adds a dashboard Shares module for moderators and admins to inspect share links, copy/open active shares, revoke shares, and permanently purge revoked shares as an admin-only action.

The PR also wires share capabilities into dashboard navigation, badges, server-side share listing/count helpers, audit events, and dashboard copy. This is stacked on `codex/dashboard-table-columns` so the diff excludes the table extraction and shared page intro setup from PR #537.

## Validation

- `git diff --check`
- `npm run type`
- `npm run lint`