### PR TITLE
fix: Hide empty resource bucket in metrics charts

### DIFF
--- a/src/components/dashboard/MetricsCharts.tsx
+++ b/src/components/dashboard/MetricsCharts.tsx
@@ -462,7 +462,10 @@ function ResourceCard({
 }) {
   const t = useTranslations("dashboard.metrics.planLimit");
   const distConfig = { users: { label: t("usersAxis") } } satisfies ChartConfig;
-  const histogram = useMemo(() => buildHistogram(counts), [counts]);
+  const histogram = useMemo(
+    () => buildHistogram(counts).filter((entry) => entry.bucket !== 0),
+    [counts]
+  );
   const affected = useMemo(
     () => counts.filter((c) => c > limit).length,
     [counts, limit]


### PR DESCRIPTION
## Summary

Filters the zero bucket out of the resource distribution histogram in the dashboard metrics chart so the visualization focuses on accounts with actual usage.

## Validation

- `git diff --check`
- `npm run type`
- `npm run lint`