### PR TITLE
feat: Add user account moderation

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -17,7 +17,7 @@ TrackDraw is now strong in these areas:
 - Account-backed REST API with API key management and a live race overlay data endpoint
 - Catalog-backed official MultiGP obstacles including gates, ladders, flags, dive gate, launch gate, and a barrier category for hurdles, banners, fencing, and nets
 - Account-backed user presets where users save and reuse named canvas selections across devices
-- EN/NL multilingual product experience with explicit language choice, route-scoped message loading, and CI checks for catalog parity and new hardcoded UI copy
+- English, Dutch, and German multilingual product experience with explicit language choice, route-scoped message loading, and CI checks for catalog parity and new hardcoded UI copy
 
 The most useful next product move is deepening the race-day workflow, keeping the editor dependable, refining the account-backed project model, and completing the remaining 3D item control and path geometry work:
 
@@ -206,12 +206,19 @@ Why:
 - Locale-aware defaults, preference storage, shared formatting helpers, and text boundaries created for unit support can reduce the later cost of full i18n
 - Translation touches high-risk surfaces such as editor tools, import/export recovery, share pages, Race Pack/PDF copy, dashboard moderation, and legal pages, so it needs deliberate QA rather than ad hoc string replacement
 
-Focus:
+Current shipped foundation:
 
-- Add an i18n architecture that moves hard-coded product copy behind typed message catalogs while preserving existing route behavior and metadata quality
-- Use browser language as a first-run default only when no saved language preference exists, and keep manual language selection separate from measurement units
-- Start with a small language set chosen from actual user demand and maintenance capacity, with English as the stable fallback for incomplete translations
-- Review translated UI on desktop and mobile, including compact buttons, inspector panels, dialogs, share pages, exported PDFs/Race Packs, and legal pages where applicable
+- `next-intl` is integrated without locale routing, preserving existing `/studio`, `/gallery`, `/share/[token]`, and `/embed/[token]` URLs
+- Browser language provides the first-run default when no saved language preference exists, while manual language choice remains separate from measurement units
+- English, Dutch, and German catalogs cover the public site, editor, share/embed/gallery surfaces, dashboard, dialogs, inspector, exported handoff copy, and metadata/API docs surfaces
+- English remains the stable fallback baseline, with route-scoped message loading and a centralized i18n catalog policy
+- Locale parity/unresolved-key validation and hardcoded-copy scanning run in CI so new UI copy is intentionally cataloged or explicitly allowlisted
+
+Maintenance focus:
+
+- Keep new product copy behind typed message catalogs instead of reopening hardcoded-copy debt
+- Add future languages only when there is enough user demand and maintenance capacity to review FPV terminology, compact UI labels, and export/legal copy
+- Continue checking translated UI on desktop and mobile, especially tight inspector panels, buttons, dialogs, share pages, exported PDFs/Race Packs, and legal pages where applicable
 
 Important boundary:
 
@@ -393,6 +400,10 @@ Focus:
 - Keep local-first publish flows simple for unauthenticated use
 - Improve operator visibility for temporary, published, revoked, gallery-linked, and embedded share states before adding deeper share administration
 
+Possible later idea (not yet scoped, separate task):
+
+- Retention policy for long-inactive published shares, roughly a one-year inactivity window, distinct from the existing 30-day cleanup of revoked/expired shares — needs its own definition of "inactive" and an owner notice before anything is removed
+
 #### Share Version History (`Lower priority`)
 
 Account-backed shares should support deliberate publish history so owners can update a published track without making existing links feel mysterious or losing the last known-good public version.
@@ -505,7 +516,7 @@ Diagnostics boundary:
 - Do not create a standalone diagnostics dashboard page as the first slice
 - Do not let operators edit a user's private project design from diagnostics surfaces
 - Do not expose API key secrets, local-only browser projects, private map location metadata beyond existing owner-visible surfaces, or raw project JSON by default
-- Do not add account takeover, password/session management, or billing support flows in this slice
+- Do not add account takeover or password/session management flows in this slice
 
 Important boundary:
 
@@ -684,6 +695,45 @@ Likely account-backed follow-up:
 - Curated gallery collections
 - Shared venue or club records, including shared inventory profiles
 - Identity-aware comments and review threads
+
+## v1.12.0 Archive
+
+<details>
+<summary>Completed release work to archive with v1.12.0</summary>
+
+### Multilingual Product Experience (`No account required`)
+
+TrackDraw now has a full multilingual product layer across the public site, Studio, share/embed/gallery surfaces, dashboard, dialogs, inspector, exported handoff copy, and metadata/API docs. English, Dutch, and German are supported through explicit language choice and browser-language first-run defaults, while existing routes such as `/studio`, `/gallery`, `/share/[token]`, and `/embed/[token]` stay unchanged.
+
+Included:
+
+- next-intl integration without locale routing, preserving existing route and share-link compatibility
+- Route-scoped message loading, persisted locale preference, server-side locale/message resolution, and a language picker that works without an account
+- Dutch rollout across editor, dialogs, inspector, dashboard, gallery, share/embed views, export/PDF/Race Pack copy, and shared shape/tool vocabulary
+- German locale support on the same route-stable i18n foundation
+- Follow-up copy QA for Dutch and German terminology, missed strings, compact labels, account/delete/export copy, and `Path`/`waypoint` terminology
+- Centralized i18n catalog policy, locale parity/unresolved-key checks, hardcoded-copy scanning in CI, and an exception-only hardcoded allowlist baseline
+
+### Open-Source Licensing Update
+
+TrackDraw source code is now licensed under AGPL-3.0-only. Package metadata, README license copy, and NOTICE guidance were updated to clarify source-code licensing versus the TrackDraw name, logo, brand assets, hosted service, and user-created content.
+
+### Research And Roadmap Alignment (`Research`)
+
+Added product-shape research for generated flightpath assistance, the presets store, and RotorHazard event viewer integration, then refreshed roadmap/research references so those future tracks are documented without turning them into the current build target.
+
+### User Account Moderation (`Account-backed`)
+
+Admins can now temporarily ban or permanently delete a user account from the Users dashboard, alongside the existing role-change action. Ban and deletion are separate, individually confirmed, individually audited actions, and both block targeting your own account the same way role changes already do.
+
+Included:
+
+- Temporary ban via `banned_at` plus a reason chosen from a predefined list (with a free-text "Other" option), ending active sessions immediately and fully reversible without touching any owned data
+- Permanent deletion that cascade-deletes owned projects, shares, gallery entries (including R2 preview images), and API keys, following the app's existing explicit-cascade pattern rather than relying on DB-level FK cascades
+- A delete confirmation dialog requiring the account's email to be typed, showing live counts of what will be removed, and explicitly warning that published gallery tracks and embeds disappear too
+- A compact moderation row in the Users inspect sheet, alongside the existing change-role action
+
+</details>
 
 ## v1.11.0 Archive
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -22,7 +22,7 @@ Labels used below:
 
 ## Current Priority
 
-The completed release-sized work is archived below. The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, remaining focused 3D item controls, generated flightpath assistance, account-backed project lifecycle depth beyond the shipped conflict/retry baseline, and powerloop 3D curve replacement in the route path.
+The next TrackDraw priority is race-day workflow depth, editor reliability follow-up, remaining focused 3D item controls, generated flightpath assistance, account-backed project lifecycle depth beyond the shipped conflict/retry baseline, and powerloop 3D curve replacement in the route path.
 
 ## Follow-up
 
@@ -54,21 +54,6 @@ The completed release-sized work is archived below. The next TrackDraw priority 
         Prototype flightpath generation from the ordered obstacle list as an assistive review/drafting feature. The output should be an editable race line, not a locked result. Validate that the sequence-based model (list order → path) is intuitive before committing to the full UI.
   - [ ] Drag-to-reorder obstacles (prerequisite)
         Wire up the drag handles in the track items list so users can explicitly set the intended race sequence before generating a path. The store action is ready; this is a UI-only change gated on the path generator being useful enough to justify the interaction.
-
-- [x] Multilingual product experience (`No account required`)
-      Shipped the EN/NL i18n layer for the public site, editor, share/embed/gallery surfaces, dashboard, dialogs, inspector, exported handoff copy, and validation tooling. Architecture and review notes: [I18n Multilingual PVA](../pva/i18n-multilingual-pva.md).
-  - [x] I18n architecture + editor pilot
-        Installed next-intl without locale routing, added persisted language preference handling, wired route-scoped message providers, and migrated the editor pilot surfaces behind message catalogs.
-  - [x] Inspector + dialogs namespace
-        Migrated inspector panels and the share, account, project, import/export, keyboard shortcut, and profile dialogs to the message catalog.
-  - [x] Landing page namespace
-        Migrated landing, login, legal/static public copy, and placeholder content to the message catalog.
-  - [x] Dashboard + remaining surfaces
-        Migrated dashboard/admin, gallery, share/embed, metadata, API docs, mobile editor, export/PDF/Race Pack, developer HUD, and remaining hardcoded UI surfaces.
-  - [x] First language rollout
-        Shipped English and Dutch with English as the stable baseline and Dutch copy reviewed for FPV terminology such as `track`, `path`, `waypoint`, `gate`, and `race line`.
-  - [x] Translation QA boundary
-        Added locale parity/unresolved-key validation and a hardcoded-copy scan in CI. The remaining hardcoded allowlist baseline is exception-only: brand alt text, shortcuts/units, technical tokens, and design-system primitive defaults.
 
 ## Later Product Follow-up
 
@@ -173,6 +158,37 @@ The completed release-sized work is archived below. The next TrackDraw priority 
   - [ ] Platform recommendation
         Recommend web-first, Electron, Capacitor, or no wrapper for now.
 
+## v1.12.0 Archive
+
+<details>
+<summary>Completed release work to archive with v1.12.0</summary>
+
+- [x] Multilingual product experience (`No account required`)
+      TrackDraw now has a full multilingual product layer across the public site, Studio, share/embed/gallery surfaces, dashboard, dialogs, inspector, exported handoff copy, and metadata/API docs. English, Dutch, and German are supported through explicit language choice and browser-language first-run defaults, while existing routes such as `/studio`, `/gallery`, `/share/[token]`, and `/embed/[token]` stay unchanged.
+  - [x] I18n architecture
+        Added next-intl without locale routing, route-scoped message loading, a persisted locale preference, server-side locale/message resolution, and a language picker that works without an account.
+  - [x] Dutch rollout and copy QA
+        Migrated the editor, dialogs, inspector, dashboard, gallery, share/embed views, export/PDF/Race Pack copy, and shared shape/tool vocabulary to message catalogs. Follow-up QA tightened Dutch FPV terminology, fixed missed strings, and corrected account/delete/export copy issues surfaced by the rollout.
+  - [x] German locale
+        Added German message catalogs on the same route-stable i18n foundation, with follow-up copy tightening across Dutch and German.
+  - [x] Translation guardrails
+        Centralized the i18n catalog policy, added locale parity and unresolved-key checks, kept hardcoded-copy scanning in CI, and reduced the hardcoded allowlist to intentional exceptions such as brand alt text, shortcuts, units, technical tokens, and design-system primitive defaults.
+
+- [x] Open-source licensing update
+      Relicensed the source code under AGPL-3.0-only, updated package metadata and README license copy, and added NOTICE guidance clarifying source-code licensing versus TrackDraw name, logo, brand assets, hosted service, and user-created content.
+
+- [x] Research and roadmap alignment (`Research`)
+      Added product-shape research for generated flightpath assistance, the presets store, and RotorHazard event viewer integration, then refreshed roadmap/research references so those future tracks are documented without turning them into the current build target.
+
+- [x] User account moderation (`Account-backed`)
+      Admins can now temporarily ban or permanently delete a user account from the Users dashboard, alongside the existing role-change action. Ban and deletion are separate, individually confirmed, individually audited actions, and both block targeting your own account the same way role changes already do.
+  - [x] Temporary ban
+        Blocks sign-in via `banned_at` plus a reason chosen from a predefined list (with a free-text "Other" option), ends active sessions immediately, and is fully reversible without touching any owned data.
+  - [x] Permanent deletion
+        Removes a user and cascade-deletes owned projects, shares, gallery entries (including R2 preview images), and API keys, following the app's existing explicit-cascade pattern rather than relying on DB-level FK cascades. The confirmation dialog requires typing the account's email, shows live counts of what will be removed, and explicitly warns that published gallery tracks and embeds disappear too.
+
+</details>
+
 ## v1.11.0 Archive
 
 <details>
@@ -229,36 +245,5 @@ The completed release-sized work is archived below. The next TrackDraw priority 
 
 - [x] Automatic curve smoothing (`No account required`)
       Catmull-Rom splines (chord-length parameterized) are now the sole rendering path for committed polylines. The drawing overlay also uses the smooth preview exclusively, making the curve shape visible from the first waypoint.
-
-</details>
-
-## v1.9.0 Archive
-
-<details>
-<summary>Completed release work archived with v1.9.0</summary>
-
-- [x] MultiGP obstacle catalog expansion (`No account required`)
-      Extended the catalog with official MultiGP Corner Flags, Standard Ladder 5x5, Championship Ladder 7x6, and Topless Ladder 7x6. These entries use the same catalog-backed identity, source references, inspector treatment, in-place type switching, and export/share compatibility as the existing official gates.
-  - [x] MultiGP Corner Flag
-        Added a 10 ft feather flag with realistic textured 3D rendering, catalog identity, inspector type switching, and an official source link.
-  - [x] MultiGP ladder variants
-        Added Standard Ladder 5x5, Championship Ladder 7x6, and Topless Ladder 7x6 with panel-frame 3D rendering that matches the real obstacles.
-
-- [x] 3D obstacle realism and loading (`No account required`)
-      Improved catalog-backed 3D rendering with texture-backed panels and more dependable direct manipulation around official obstacles. The 3D view now warms only the textures used by the current design so textured obstacles load more smoothly without delaying lighter scene details.
-  - [x] Texture-backed MultiGP obstacles
-        Render catalog-backed gates, ladders, and corner flags with panel artwork and shared layout helpers in the live 3D preview and flythrough export.
-  - [x] Focused 3D reliability fixes
-        Restored real-time flag rotation updates and improved selection, rotation, and ladder elevation behavior around catalog obstacles.
-
-- [x] Catalog editing and track item list improvements (`No account required`)
-      Catalog type switching now works better after placement, including batch edits. The track items list shows catalog-aware names and supports filters that make placed elements easier to find and inspect.
-  - [x] Batch catalog type editing
-        Let users change sets of gates, flags, or ladders without deleting and rebuilding them.
-  - [x] Catalog-aware item names and filters
-        Show clearer item names and let users focus the list on race obstacles or all elements.
-
-- [x] Path and route reliability follow-up (`No account required`)
-      Improved waypoint and path selection reliability, especially on mobile and when adjusting route elevation in 3D. Route warning geometry now shares the same 3D height offset as the visible route line and preview points.
 
 </details>

--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -214,7 +214,8 @@
       "projects": "Projects",
       "role": "Role",
       "joined": "Joined",
-      "lastLogin": "Last login"
+      "lastLogin": "Last login",
+      "banned": "Banned"
     },
     "selfBadge": "(you)",
     "fallback": {
@@ -257,16 +258,50 @@
         "copyUserId": "Copy user ID",
         "changeRole": "Change role",
         "save": "Save",
-        "viewFullAuditTrail": "View full audit trail"
+        "viewFullAuditTrail": "View full audit trail",
+        "moderation": "Moderation",
+        "ban": "Ban",
+        "unban": "Unban",
+        "delete": "Delete"
+      },
+      "badges": {
+        "banned": "Banned"
       },
       "messages": {
         "cannotChangeOwnRole": "Cannot change own role",
-        "noAuditEvents": "No audit events recorded."
+        "noAuditEvents": "No audit events recorded.",
+        "cannotModerateSelf": "You cannot ban or delete your own account.",
+        "bannedSince": "Banned since {date} · {reason}"
       },
       "relation": {
         "actor": "Actor",
         "target": "Target"
       }
+    },
+    "banDialog": {
+      "title": "Ban this account?",
+      "description": "This blocks <strong>{name}</strong> from signing in and ends any active sessions immediately. It does not delete any data and can be reversed at any time.",
+      "reasonLabel": "Reason (recorded in the audit log)",
+      "reasonDetailLabel": "Details",
+      "reasonPlaceholder": "Describe the reason for this ban",
+      "cancel": "Cancel",
+      "banning": "Banning…",
+      "confirmBan": "Ban account",
+      "banFailed": "Could not ban the account.",
+      "banSuccess": "{name} has been banned.",
+      "unbanFailed": "Could not unban the account.",
+      "unbanSuccess": "{name} has been unbanned."
+    },
+    "deleteDialog": {
+      "title": "Delete this account permanently?",
+      "description": "This permanently removes <strong>{name}</strong>, including owned projects, share links, API keys, and gallery entries. Any published gallery tracks and embeds owned by this account will also disappear. This cannot be undone.",
+      "galleryWarning": "Published gallery tracks and embeds owned by this account will be removed along with everything else.",
+      "confirmLabel": "Type <strong>{email}</strong> to confirm",
+      "cancel": "Cancel",
+      "deleting": "Deleting…",
+      "confirmDelete": "Delete permanently",
+      "deleteFailed": "Could not delete the account.",
+      "deleteSuccess": "{name} has been permanently deleted."
     }
   },
   "apiKeys": {
@@ -370,6 +405,9 @@
     },
     "eventTitles": {
       "accountRoleChanged": "Role changed",
+      "accountBanned": "Account banned",
+      "accountUnbanned": "Account unbanned",
+      "accountDeleted": "Account deleted",
       "galleryEntryFeatured": "Gallery entry featured",
       "galleryEntryUnfeatured": "Gallery entry unfeatured",
       "galleryEntryHidden": "Gallery entry hidden",

--- a/migrations/0011_user_moderation.sql
+++ b/migrations/0011_user_moderation.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users ADD COLUMN banned_at TEXT;
+ALTER TABLE users ADD COLUMN ban_reason TEXT;
+
+CREATE INDEX IF NOT EXISTS users_banned_at_idx ON users(banned_at);

--- a/src/app/api/dashboard/users/[userId]/route.ts
+++ b/src/app/api/dashboard/users/[userId]/route.ts
@@ -154,6 +154,19 @@ export async function PATCH(
         );
       }
 
+      if (existingUser.role === "admin") {
+        const adminCount = await countUsersByRole("admin");
+        if (adminCount <= 1) {
+          return NextResponse.json(
+            {
+              ok: false,
+              error: "TrackDraw must always keep at least one admin account.",
+            },
+            { status: 400 }
+          );
+        }
+      }
+
       const updatedUser = await banUser(userId, body.reason);
       if (!updatedUser) {
         return NextResponse.json(

--- a/src/app/api/dashboard/users/[userId]/route.ts
+++ b/src/app/api/dashboard/users/[userId]/route.ts
@@ -9,9 +9,12 @@ import {
   canAssignAccountRole,
 } from "@/lib/server/authorization";
 import {
+  banUser,
   countUsersByRole,
+  deleteUserAccount,
   getAdminUserById,
   getUserContextStats,
+  unbanUser,
   updateUserRole,
 } from "@/lib/server/users";
 
@@ -25,6 +28,21 @@ const updateUserRoleSchema = z.object({
   role: z.enum(accountRoles),
 });
 
+const banUserActionSchema = z.object({
+  action: z.literal("ban"),
+  reason: z.string().trim().min(1).max(500),
+});
+
+const unbanUserActionSchema = z.object({
+  action: z.literal("unban"),
+});
+
+const patchUserSchema = z.union([
+  updateUserRoleSchema,
+  banUserActionSchema,
+  unbanUserActionSchema,
+]);
+
 function unauthorizedResponse() {
   return NextResponse.json(
     { ok: false, error: "Authentication required" },
@@ -32,11 +50,11 @@ function unauthorizedResponse() {
   );
 }
 
-function forbiddenResponse() {
+function forbiddenResponse(error?: string) {
   return NextResponse.json(
     {
       ok: false,
-      error: "You do not have permission to perform this action.",
+      error: error ?? "You do not have permission to perform this action.",
     },
     { status: 403 }
   );
@@ -106,24 +124,104 @@ export async function PATCH(
       return unauthorizedResponse();
     }
 
-    const body = updateUserRoleSchema.parse(await request.json());
+    const body = patchUserSchema.parse(await request.json());
+    const { userId } = await context.params;
+
+    if (!userId.trim()) {
+      return NextResponse.json(
+        { ok: false, error: "Missing user id" },
+        { status: 400 }
+      );
+    }
+
+    if ("action" in body && body.action === "ban") {
+      if (!hasCapability(actor.role, "account.ban.assign")) {
+        return forbiddenResponse();
+      }
+
+      if (actor.id === userId) {
+        return NextResponse.json(
+          { ok: false, error: "You cannot ban your own account." },
+          { status: 403 }
+        );
+      }
+
+      const existingUser = await getAdminUserById(userId);
+      if (!existingUser) {
+        return NextResponse.json(
+          { ok: false, error: "User not found" },
+          { status: 404 }
+        );
+      }
+
+      const updatedUser = await banUser(userId, body.reason);
+      if (!updatedUser) {
+        return NextResponse.json(
+          { ok: false, error: "Failed to ban user" },
+          { status: 500 }
+        );
+      }
+
+      await createAuditEvent({
+        actorUserId: actor.id,
+        targetUserId: updatedUser.id,
+        eventType: "account.banned",
+        entityType: "user",
+        entityId: updatedUser.id,
+        metadata: { reason: body.reason },
+      });
+
+      return NextResponse.json({ ok: true, user: updatedUser });
+    }
+
+    if ("action" in body && body.action === "unban") {
+      if (!hasCapability(actor.role, "account.ban.assign")) {
+        return forbiddenResponse();
+      }
+
+      const existingUser = await getAdminUserById(userId);
+      if (!existingUser) {
+        return NextResponse.json(
+          { ok: false, error: "User not found" },
+          { status: 404 }
+        );
+      }
+
+      const updatedUser = await unbanUser(userId);
+      if (!updatedUser) {
+        return NextResponse.json(
+          { ok: false, error: "Failed to unban user" },
+          { status: 500 }
+        );
+      }
+
+      await createAuditEvent({
+        actorUserId: actor.id,
+        targetUserId: updatedUser.id,
+        eventType: "account.unbanned",
+        entityType: "user",
+        entityId: updatedUser.id,
+        metadata: null,
+      });
+
+      return NextResponse.json({ ok: true, user: updatedUser });
+    }
+
+    if (!("role" in body)) {
+      return NextResponse.json(
+        { ok: false, error: "Invalid role update payload" },
+        { status: 400 }
+      );
+    }
 
     if (!canAssignAccountRole(actor, body.role)) {
       return forbiddenResponse();
     }
 
-    const { userId } = await context.params;
-
     if (actor.id === userId) {
       return NextResponse.json(
         { ok: false, error: "You cannot change your own role." },
         { status: 403 }
-      );
-    }
-    if (!userId.trim()) {
-      return NextResponse.json(
-        { ok: false, error: "Missing user id" },
-        { status: 400 }
       );
     }
 
@@ -176,9 +274,97 @@ export async function PATCH(
   } catch (error) {
     const message =
       error instanceof z.ZodError
-        ? "Invalid role update payload"
-        : "Failed to update user role";
-    console.error("[TrackDraw] Failed to update user role", { error });
+        ? "Invalid user update payload"
+        : "Failed to update user";
+    console.error("[TrackDraw] Failed to update user", { error });
     return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  context: DashboardUserRouteContext
+) {
+  if (!isTrustedRequest(request)) {
+    return NextResponse.json(
+      { ok: false, error: "Forbidden" },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const actor = await getCurrentUserFromHeaders(request.headers);
+
+    if (!actor) {
+      return unauthorizedResponse();
+    }
+
+    if (!hasCapability(actor.role, "account.delete.assign")) {
+      return forbiddenResponse(
+        "Only admins can permanently delete user accounts."
+      );
+    }
+
+    const { userId } = await context.params;
+
+    if (!userId.trim()) {
+      return NextResponse.json(
+        { ok: false, error: "Missing user id" },
+        { status: 400 }
+      );
+    }
+
+    if (actor.id === userId) {
+      return NextResponse.json(
+        { ok: false, error: "You cannot delete your own account." },
+        { status: 403 }
+      );
+    }
+
+    const existingUser = await getAdminUserById(userId);
+    if (!existingUser) {
+      return NextResponse.json(
+        { ok: false, error: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    if (existingUser.role === "admin") {
+      const adminCount = await countUsersByRole("admin");
+      if (adminCount <= 1) {
+        return NextResponse.json(
+          {
+            ok: false,
+            error: "TrackDraw must always keep at least one admin account.",
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    const stats = await getUserContextStats(userId);
+
+    await deleteUserAccount(userId);
+
+    await createAuditEvent({
+      actorUserId: actor.id,
+      targetUserId: null,
+      eventType: "account.deleted",
+      entityType: "user",
+      entityId: userId,
+      metadata: {
+        email: existingUser.email,
+        role: existingUser.role,
+        ...stats,
+      },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[TrackDraw] Failed to delete user", { error });
+    return NextResponse.json(
+      { ok: false, error: "Failed to permanently delete user" },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/dashboard/audit/columns.tsx
+++ b/src/app/dashboard/audit/columns.tsx
@@ -106,6 +106,9 @@ export function formatEventType(value: string) {
 
 const EVENT_TITLE_KEYS: Record<string, string> = {
   "account.role.changed": "accountRoleChanged",
+  "account.banned": "accountBanned",
+  "account.unbanned": "accountUnbanned",
+  "account.deleted": "accountDeleted",
   "gallery.entry.featured": "galleryEntryFeatured",
   "gallery.entry.unfeatured": "galleryEntryUnfeatured",
   "gallery.entry.hidden": "galleryEntryHidden",

--- a/src/app/dashboard/users/columns.tsx
+++ b/src/app/dashboard/users/columns.tsx
@@ -112,12 +112,22 @@ export function getUsersColumns({
       header: t("table.role"),
       meta: { className: "w-32" },
       cell: ({ row }) => (
-        <Badge
-          variant="outline"
-          className={roleBadgeClassName(row.original.role)}
-        >
-          {getAccountRoleLabel(row.original.role)}
-        </Badge>
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge
+            variant="outline"
+            className={roleBadgeClassName(row.original.role)}
+          >
+            {getAccountRoleLabel(row.original.role)}
+          </Badge>
+          {row.original.bannedAt && (
+            <Badge
+              variant="outline"
+              className="border-destructive/25 bg-destructive/10 text-destructive"
+            >
+              {t("table.banned")}
+            </Badge>
+          )}
+        </div>
       ),
     },
     {

--- a/src/components/dashboard/UsersManager.tsx
+++ b/src/components/dashboard/UsersManager.tsx
@@ -284,11 +284,14 @@ export default function DashboardUsersManager({
     setPendingBanUserId(userId);
 
     try {
-      const response = await fetch(`/api/dashboard/users/${userId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "ban", reason }),
-      });
+      const response = await fetch(
+        `/api/dashboard/users/${encodeURIComponent(userId)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "ban", reason }),
+        }
+      );
 
       const payload = (await response.json()) as {
         ok: boolean;
@@ -325,11 +328,14 @@ export default function DashboardUsersManager({
     setPendingBanUserId(userId);
 
     try {
-      const response = await fetch(`/api/dashboard/users/${userId}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ action: "unban" }),
-      });
+      const response = await fetch(
+        `/api/dashboard/users/${encodeURIComponent(userId)}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ action: "unban" }),
+        }
+      );
 
       const payload = (await response.json()) as {
         ok: boolean;
@@ -364,9 +370,10 @@ export default function DashboardUsersManager({
     setPendingDeleteUserId(user.id);
 
     try {
-      const response = await fetch(`/api/dashboard/users/${user.id}`, {
-        method: "DELETE",
-      });
+      const response = await fetch(
+        `/api/dashboard/users/${encodeURIComponent(user.id)}`,
+        { method: "DELETE" }
+      );
 
       const payload = (await response.json()) as {
         ok: boolean;

--- a/src/components/dashboard/UsersManager.tsx
+++ b/src/components/dashboard/UsersManager.tsx
@@ -10,7 +10,15 @@ import {
   type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import { ChevronDown, Copy, ExternalLink, Loader2 } from "lucide-react";
+import {
+  Ban,
+  ChevronDown,
+  Copy,
+  ExternalLink,
+  Loader2,
+  ShieldCheck,
+  Trash2,
+} from "lucide-react";
 import { toast } from "sonner";
 import {
   formatDate,
@@ -19,6 +27,11 @@ import {
   roleBadgeClassName,
   type Translate,
 } from "@/app/dashboard/users/columns";
+import {
+  banReasonCodes,
+  getBanReasonLabel,
+  type BanReasonCode,
+} from "@/lib/account/ban-reasons";
 import {
   accountRoles,
   getAccountRoleLabel,
@@ -34,12 +47,29 @@ import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import {
   Sheet,
   SheetContent,
@@ -94,6 +124,61 @@ export default function DashboardUsersManager({
   );
   const [inspectData, setInspectData] = useState<UserContextData | null>(null);
   const [inspectLoading, setInspectLoading] = useState(false);
+  const [banCandidate, setBanCandidate] = useState<AdminUser | null>(null);
+  const [banReasonCode, setBanReasonCode] = useState<BanReasonCode>("spam");
+  const [banReasonDetail, setBanReasonDetail] = useState("");
+  const [pendingBanUserId, setPendingBanUserId] = useState<string | null>(
+    null
+  );
+  const [deleteCandidate, setDeleteCandidate] = useState<AdminUser | null>(
+    null
+  );
+  const [deleteConfirmValue, setDeleteConfirmValue] = useState("");
+  const [pendingDeleteUserId, setPendingDeleteUserId] = useState<
+    string | null
+  >(null);
+  const [deleteStats, setDeleteStats] = useState<UserContextStats | null>(
+    null
+  );
+  const [deleteStatsLoading, setDeleteStatsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!deleteCandidate) {
+      setDeleteStats(null);
+      return;
+    }
+
+    let cancelled = false;
+    setDeleteStatsLoading(true);
+    setDeleteStats(null);
+
+    fetch(`/api/dashboard/users/${encodeURIComponent(deleteCandidate.id)}`)
+      .then(async (res) => {
+        const payload = (await res.json()) as {
+          ok: boolean;
+          error?: string;
+          stats?: UserContextStats;
+        };
+        if (cancelled) return;
+        if (!res.ok || !payload.ok) {
+          toast.error(payload.error ?? t("messages.loadFailed"));
+          return;
+        }
+        if (payload.stats) {
+          setDeleteStats(payload.stats);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) toast.error(t("messages.loadFailed"));
+      })
+      .finally(() => {
+        if (!cancelled) setDeleteStatsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [deleteCandidate, t]);
 
   useEffect(() => {
     if (!inspectCandidate) {
@@ -191,6 +276,127 @@ export default function DashboardUsersManager({
     }
   };
 
+  const resolveBanReason = () =>
+    banReasonCode === "other"
+      ? banReasonDetail.trim()
+      : getBanReasonLabel(banReasonCode);
+
+  const submitBan = async (userId: string) => {
+    const reason = resolveBanReason();
+    if (!reason) return;
+
+    setPendingBanUserId(userId);
+
+    try {
+      const response = await fetch(`/api/dashboard/users/${userId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "ban", reason }),
+      });
+
+      const payload = (await response.json()) as {
+        ok: boolean;
+        error?: string;
+        user?: AdminUser;
+      };
+
+      if (!response.ok || !payload.ok || !payload.user) {
+        throw new Error(payload.error ?? t("banDialog.banFailed"));
+      }
+
+      const updated = payload.user;
+      setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)));
+      setInspectCandidate((prev) =>
+        prev?.id === updated.id ? { ...prev, ...updated } : prev
+      );
+      setBanCandidate(null);
+      setBanReasonDetail("");
+      toast.success(
+        t("banDialog.banSuccess", {
+          name: getUserLabel(updated, t("fallback.unnamedUser")),
+        })
+      );
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("banDialog.banFailed"));
+    } finally {
+      setPendingBanUserId(null);
+    }
+  };
+
+  const submitUnban = async (userId: string) => {
+    setPendingBanUserId(userId);
+
+    try {
+      const response = await fetch(`/api/dashboard/users/${userId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "unban" }),
+      });
+
+      const payload = (await response.json()) as {
+        ok: boolean;
+        error?: string;
+        user?: AdminUser;
+      };
+
+      if (!response.ok || !payload.ok || !payload.user) {
+        throw new Error(payload.error ?? t("banDialog.unbanFailed"));
+      }
+
+      const updated = payload.user;
+      setUsers((prev) => prev.map((u) => (u.id === updated.id ? updated : u)));
+      setInspectCandidate((prev) =>
+        prev?.id === updated.id ? { ...prev, ...updated } : prev
+      );
+      toast.success(
+        t("banDialog.unbanSuccess", {
+          name: getUserLabel(updated, t("fallback.unnamedUser")),
+        })
+      );
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : t("banDialog.unbanFailed")
+      );
+    } finally {
+      setPendingBanUserId(null);
+    }
+  };
+
+  const submitDelete = async (user: AdminUser) => {
+    setPendingDeleteUserId(user.id);
+
+    try {
+      const response = await fetch(`/api/dashboard/users/${user.id}`, {
+        method: "DELETE",
+      });
+
+      const payload = (await response.json()) as {
+        ok: boolean;
+        error?: string;
+      };
+
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.error ?? t("deleteDialog.deleteFailed"));
+      }
+
+      setUsers((prev) => prev.filter((u) => u.id !== user.id));
+      setDeleteCandidate(null);
+      setDeleteConfirmValue("");
+      setInspectCandidate((prev) => (prev?.id === user.id ? null : prev));
+      toast.success(
+        t("deleteDialog.deleteSuccess", {
+          name: getUserLabel(user, t("fallback.unnamedUser")),
+        })
+      );
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : t("deleteDialog.deleteFailed")
+      );
+    } finally {
+      setPendingDeleteUserId(null);
+    }
+  };
+
   const columns = getUsersColumns({
     t: t as unknown as Translate,
     currentUserId,
@@ -275,15 +481,33 @@ export default function DashboardUsersManager({
                     </AvatarFallback>
                   </Avatar>
                   <div className="min-w-0">
-                    <SheetTitle className="truncate text-base leading-tight">
-                      {getUserLabel(
-                        inspectCandidate,
-                        t("fallback.unnamedUser")
+                    <div className="flex items-center gap-1.5">
+                      <SheetTitle className="truncate text-base leading-tight">
+                        {getUserLabel(
+                          inspectCandidate,
+                          t("fallback.unnamedUser")
+                        )}
+                      </SheetTitle>
+                      {inspectCandidate.bannedAt && (
+                        <Badge
+                          variant="outline"
+                          className="border-destructive/25 bg-destructive/10 text-destructive h-5 shrink-0 px-1.5 text-[10px]"
+                        >
+                          {t("panel.badges.banned")}
+                        </Badge>
                       )}
-                    </SheetTitle>
+                    </div>
                     <SheetDescription className="truncate text-xs">
                       {inspectCandidate.email ?? inspectCandidate.id}
                     </SheetDescription>
+                    {inspectCandidate.bannedAt && (
+                      <p className="text-destructive/80 mt-0.5 truncate text-[11px]">
+                        {t("panel.messages.bannedSince", {
+                          date: formatDate(inspectCandidate.bannedAt),
+                          reason: inspectCandidate.banReason ?? "—",
+                        })}
+                      </p>
+                    )}
                   </div>
                 </div>
               </SheetHeader>
@@ -473,6 +697,64 @@ export default function DashboardUsersManager({
                       )}
                     </div>
 
+                    <div className="flex items-center justify-between gap-4 px-6 py-2.5">
+                      <dt className="text-muted-foreground shrink-0 text-xs">
+                        {t("panel.actions.moderation")}
+                      </dt>
+                      {inspectCandidate.id === currentUserId ? (
+                        <dd className="text-muted-foreground text-xs">
+                          {t("panel.messages.cannotModerateSelf")}
+                        </dd>
+                      ) : (
+                        <dd className="flex items-center gap-1.5">
+                          {inspectCandidate.bannedAt ? (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="hover:bg-muted hover:text-foreground h-7 cursor-pointer gap-1.5 rounded-md px-2.5 text-xs shadow-none"
+                              disabled={pendingBanUserId === inspectCandidate.id}
+                              onClick={() =>
+                                void submitUnban(inspectCandidate.id)
+                              }
+                            >
+                              {pendingBanUserId === inspectCandidate.id ? (
+                                <Loader2 className="size-3.5 animate-spin" />
+                              ) : (
+                                <ShieldCheck className="size-3.5" />
+                              )}
+                              {t("panel.actions.unban")}
+                            </Button>
+                          ) : (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="hover:bg-muted hover:text-foreground h-7 cursor-pointer gap-1.5 rounded-md px-2.5 text-xs shadow-none"
+                              onClick={() => {
+                                setBanReasonCode("spam");
+                                setBanReasonDetail("");
+                                setBanCandidate(inspectCandidate);
+                              }}
+                            >
+                              <Ban className="size-3.5" />
+                              {t("panel.actions.ban")}
+                            </Button>
+                          )}
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="text-destructive hover:bg-destructive/10 hover:text-destructive h-7 cursor-pointer gap-1.5 rounded-md px-2.5 text-xs shadow-none"
+                            onClick={() => {
+                              setDeleteConfirmValue("");
+                              setDeleteCandidate(inspectCandidate);
+                            }}
+                          >
+                            <Trash2 className="size-3.5" />
+                            {t("panel.actions.delete")}
+                          </Button>
+                        </dd>
+                      )}
+                    </div>
+
                     <div className="space-y-3 px-6 py-5">
                       <p className="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
                         {t("panel.sections.recentActivity")}
@@ -525,6 +807,220 @@ export default function DashboardUsersManager({
           ) : null}
         </SheetContent>
       </Sheet>
+
+      <Dialog
+        open={banCandidate !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setBanCandidate(null);
+            setBanReasonDetail("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("banDialog.title")}</DialogTitle>
+            <DialogDescription>
+              {t.rich("banDialog.description", {
+                name: banCandidate
+                  ? getUserLabel(banCandidate, t("fallback.unnamedUser"))
+                  : "",
+                strong: (chunks) => (
+                  <span className="text-foreground font-medium">{chunks}</span>
+                ),
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <label className="text-muted-foreground text-xs font-medium">
+              {t("banDialog.reasonLabel")}
+            </label>
+            <Select
+              value={banReasonCode}
+              onValueChange={(value) =>
+                setBanReasonCode(value as BanReasonCode)
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {banReasonCodes.map((code) => (
+                  <SelectItem key={code} value={code}>
+                    {getBanReasonLabel(code)}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {banReasonCode === "other" && (
+            <div className="space-y-2">
+              <label
+                htmlFor="ban-reason-detail"
+                className="text-muted-foreground text-xs font-medium"
+              >
+                {t("banDialog.reasonDetailLabel")}
+              </label>
+              <Input
+                id="ban-reason-detail"
+                value={banReasonDetail}
+                onChange={(event) => setBanReasonDetail(event.target.value)}
+                placeholder={t("banDialog.reasonPlaceholder")}
+                maxLength={500}
+              />
+            </div>
+          )}
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">{t("banDialog.cancel")}</Button>
+            </DialogClose>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={
+                !banCandidate ||
+                !resolveBanReason() ||
+                pendingBanUserId === banCandidate.id
+              }
+              onClick={() => {
+                if (!banCandidate) return;
+                void submitBan(banCandidate.id);
+              }}
+            >
+              {banCandidate && pendingBanUserId === banCandidate.id ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  {t("banDialog.banning")}
+                </>
+              ) : (
+                t("banDialog.confirmBan")
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={deleteCandidate !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteCandidate(null);
+            setDeleteConfirmValue("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("deleteDialog.title")}</DialogTitle>
+            <DialogDescription>
+              {t.rich("deleteDialog.description", {
+                name: deleteCandidate
+                  ? getUserLabel(deleteCandidate, t("fallback.unnamedUser"))
+                  : "",
+                strong: (chunks) => (
+                  <span className="text-foreground font-medium">{chunks}</span>
+                ),
+              })}
+            </DialogDescription>
+          </DialogHeader>
+
+          {deleteCandidate && (
+            <div className="grid grid-cols-4 divide-x rounded-md border">
+              {[
+                {
+                  label: t("panel.stats.projects"),
+                  value: deleteStats?.projectCount,
+                },
+                {
+                  label: t("panel.stats.shares"),
+                  value: deleteStats?.activeShareCount,
+                },
+                {
+                  label: t("panel.stats.gallery"),
+                  value: deleteStats?.galleryEntryCount,
+                },
+                {
+                  label: t("panel.stats.apiKeys"),
+                  value: deleteStats?.apiKeyCount,
+                },
+              ].map(({ label, value }) => (
+                <div
+                  key={label}
+                  className="flex flex-col items-center gap-0.5 py-3"
+                >
+                  <span className="text-lg font-semibold tabular-nums">
+                    {deleteStatsLoading ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      (value ?? "—")
+                    )}
+                  </span>
+                  <span className="text-muted-foreground text-[10px] font-medium tracking-wide uppercase">
+                    {label}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <p className="text-muted-foreground text-sm">
+            {t("deleteDialog.galleryWarning")}
+          </p>
+
+          <div className="space-y-2">
+            <label
+              htmlFor="delete-confirm"
+              className="text-muted-foreground text-xs font-medium"
+            >
+              {t.rich("deleteDialog.confirmLabel", {
+                email: deleteCandidate?.email ?? "",
+                strong: (chunks) => (
+                  <span className="text-foreground font-medium">{chunks}</span>
+                ),
+              })}
+            </label>
+            <Input
+              id="delete-confirm"
+              value={deleteConfirmValue}
+              onChange={(event) => setDeleteConfirmValue(event.target.value)}
+              placeholder={deleteCandidate?.email ?? ""}
+              autoComplete="off"
+            />
+          </div>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button variant="outline">{t("deleteDialog.cancel")}</Button>
+            </DialogClose>
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={
+                !deleteCandidate ||
+                !deleteCandidate.email ||
+                deleteConfirmValue.trim() !== deleteCandidate.email ||
+                pendingDeleteUserId === deleteCandidate.id
+              }
+              onClick={() => {
+                if (!deleteCandidate) return;
+                void submitDelete(deleteCandidate);
+              }}
+            >
+              {deleteCandidate && pendingDeleteUserId === deleteCandidate.id ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  {t("deleteDialog.deleting")}
+                </>
+              ) : (
+                t("deleteDialog.confirmDelete")
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/dashboard/UsersManager.tsx
+++ b/src/components/dashboard/UsersManager.tsx
@@ -127,19 +127,15 @@ export default function DashboardUsersManager({
   const [banCandidate, setBanCandidate] = useState<AdminUser | null>(null);
   const [banReasonCode, setBanReasonCode] = useState<BanReasonCode>("spam");
   const [banReasonDetail, setBanReasonDetail] = useState("");
-  const [pendingBanUserId, setPendingBanUserId] = useState<string | null>(
-    null
-  );
+  const [pendingBanUserId, setPendingBanUserId] = useState<string | null>(null);
   const [deleteCandidate, setDeleteCandidate] = useState<AdminUser | null>(
     null
   );
   const [deleteConfirmValue, setDeleteConfirmValue] = useState("");
-  const [pendingDeleteUserId, setPendingDeleteUserId] = useState<
-    string | null
-  >(null);
-  const [deleteStats, setDeleteStats] = useState<UserContextStats | null>(
+  const [pendingDeleteUserId, setPendingDeleteUserId] = useState<string | null>(
     null
   );
+  const [deleteStats, setDeleteStats] = useState<UserContextStats | null>(null);
   const [deleteStatsLoading, setDeleteStatsLoading] = useState(false);
 
   useEffect(() => {
@@ -317,7 +313,9 @@ export default function DashboardUsersManager({
         })
       );
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : t("banDialog.banFailed"));
+      toast.error(
+        err instanceof Error ? err.message : t("banDialog.banFailed")
+      );
     } finally {
       setPendingBanUserId(null);
     }
@@ -712,7 +710,9 @@ export default function DashboardUsersManager({
                               size="sm"
                               variant="outline"
                               className="hover:bg-muted hover:text-foreground h-7 cursor-pointer gap-1.5 rounded-md px-2.5 text-xs shadow-none"
-                              disabled={pendingBanUserId === inspectCandidate.id}
+                              disabled={
+                                pendingBanUserId === inspectCandidate.id
+                              }
                               onClick={() =>
                                 void submitUnban(inspectCandidate.id)
                               }

--- a/src/lib/account/admin-users.ts
+++ b/src/lib/account/admin-users.ts
@@ -10,4 +10,6 @@ export type AdminUser = {
   updatedAt: string;
   lastLoginAt: string | null;
   projectCount: number;
+  bannedAt: string | null;
+  banReason: string | null;
 };

--- a/src/lib/account/ban-reasons.ts
+++ b/src/lib/account/ban-reasons.ts
@@ -1,0 +1,34 @@
+export const banReasonCodes = [
+  "spam",
+  "harassment",
+  "tos_violation",
+  "fraudulent_content",
+  "security_risk",
+  "other",
+] as const;
+
+export type BanReasonCode = (typeof banReasonCodes)[number];
+
+export function isBanReasonCode(value: unknown): value is BanReasonCode {
+  return (
+    typeof value === "string" &&
+    banReasonCodes.includes(value as BanReasonCode)
+  );
+}
+
+export function getBanReasonLabel(code: BanReasonCode) {
+  switch (code) {
+    case "spam":
+      return "Spam or abuse";
+    case "harassment":
+      return "Harassment or abusive behavior";
+    case "tos_violation":
+      return "Terms of service violation";
+    case "fraudulent_content":
+      return "Fraudulent or malicious content";
+    case "security_risk":
+      return "Security risk";
+    case "other":
+      return "Other";
+  }
+}

--- a/src/lib/account/ban-reasons.ts
+++ b/src/lib/account/ban-reasons.ts
@@ -11,8 +11,7 @@ export type BanReasonCode = (typeof banReasonCodes)[number];
 
 export function isBanReasonCode(value: unknown): value is BanReasonCode {
   return (
-    typeof value === "string" &&
-    banReasonCodes.includes(value as BanReasonCode)
+    typeof value === "string" && banReasonCodes.includes(value as BanReasonCode)
   );
 }
 

--- a/src/lib/server/auth-session.ts
+++ b/src/lib/server/auth-session.ts
@@ -18,6 +18,7 @@ type SessionUserRow = {
   image: string | null;
   role: string | null;
   expiresAt: string;
+  bannedAt: string | null;
 };
 
 const SESSION_COOKIE_NAMES = [
@@ -144,6 +145,7 @@ export async function getCurrentUserFromHeaders(
           u.name,
           u.image,
           u.role,
+          u.banned_at as bannedAt,
           s.expiresAt
         from sessions s
         inner join users u on u.id = s.userId
@@ -159,6 +161,10 @@ export async function getCurrentUserFromHeaders(
   }
 
   if (new Date(row.expiresAt).getTime() <= Date.now()) {
+    return null;
+  }
+
+  if (row.bannedAt) {
     return null;
   }
 

--- a/src/lib/server/authorization.ts
+++ b/src/lib/server/authorization.ts
@@ -17,7 +17,9 @@ export type AuthorizationCapability =
   | "admin.metrics.read"
   | "admin.api-keys.read"
   | "audit.read"
-  | "account.role.assign";
+  | "account.role.assign"
+  | "account.ban.assign"
+  | "account.delete.assign";
 
 export type DashboardModule =
   | "overview"
@@ -42,6 +44,8 @@ const capabilityRoles: Record<AuthorizationCapability, AccountRole[]> = {
   "admin.api-keys.read": ["admin"],
   "audit.read": ["admin"],
   "account.role.assign": ["admin"],
+  "account.ban.assign": ["admin"],
+  "account.delete.assign": ["admin"],
 };
 
 export function hasCapability(

--- a/src/lib/server/shares.ts
+++ b/src/lib/server/shares.ts
@@ -326,6 +326,34 @@ export async function purgeRevokedShare(token: string) {
     .run();
 }
 
+export async function deleteSharesOwnedByUser(userId: string) {
+  const db = await getDatabase();
+
+  const rows = await db
+    .prepare(
+      `
+        select token
+        from shares
+        where owner_user_id = ?
+      `
+    )
+    .bind(userId)
+    .all<{ token: string }>();
+
+  for (const row of rows.results ?? []) {
+    await deleteGalleryEntry(row.token);
+    await db
+      .prepare(
+        `
+          delete from shares
+          where token = ?
+        `
+      )
+      .bind(row.token)
+      .run();
+  }
+}
+
 type DashboardShareRow = {
   token: string;
   title: string | null;

--- a/src/lib/server/users.ts
+++ b/src/lib/server/users.ts
@@ -265,16 +265,6 @@ export async function deleteUserAccount(userId: string): Promise<void> {
   await db
     .prepare(
       `
-        delete from gallery_entries
-        where owner_user_id = ?
-      `
-    )
-    .bind(userId)
-    .run();
-
-  await db
-    .prepare(
-      `
         delete from apikey
         where referenceId = ?
       `

--- a/src/lib/server/users.ts
+++ b/src/lib/server/users.ts
@@ -4,6 +4,7 @@ import { cache } from "react";
 import { parseAccountRole, type AccountRole } from "@/lib/account/roles";
 import type { AdminUser } from "@/lib/account/admin-users";
 import { getDatabase } from "@/lib/server/db";
+import { deleteSharesOwnedByUser } from "@/lib/server/shares";
 
 type UserRoleRow = {
   role: string | null;
@@ -30,6 +31,8 @@ type AdminUserRow = {
   updatedAt: string;
   lastLoginAt: string | null;
   projectCount: number;
+  bannedAt: string | null;
+  banReason: string | null;
 };
 
 function mapAdminUser(row: AdminUserRow): AdminUser {
@@ -43,6 +46,8 @@ function mapAdminUser(row: AdminUserRow): AdminUser {
     updatedAt: row.updatedAt,
     lastLoginAt: row.lastLoginAt ?? null,
     projectCount: Number(row.projectCount ?? 0),
+    bannedAt: row.bannedAt ?? null,
+    banReason: row.banReason ?? null,
   };
 }
 
@@ -76,6 +81,8 @@ export async function listUsersForAdmin(): Promise<AdminUser[]> {
           u.role,
           u.createdAt,
           u.updatedAt,
+          u.banned_at as bannedAt,
+          u.ban_reason as banReason,
           ls.lastLoginAt,
           coalesce(pc.cnt, 0) as projectCount
         from users u
@@ -127,6 +134,8 @@ export async function getAdminUserById(
           u.role,
           u.createdAt,
           u.updatedAt,
+          u.banned_at as bannedAt,
+          u.ban_reason as banReason,
           ls.lastLoginAt,
           coalesce(pc.cnt, 0) as projectCount
         from users u
@@ -182,13 +191,116 @@ export async function updateUserRole(
         update users
         set role = ?, updatedAt = ?
         where id = ?
-        returning id, name, email, image, role, createdAt, updatedAt
+        returning
+          id, name, email, image, role, createdAt, updatedAt,
+          banned_at as bannedAt, ban_reason as banReason
       `
     )
     .bind(role, now, userId)
     .first<AdminUserRow>();
 
   return row ? mapAdminUser(row) : null;
+}
+
+export async function banUser(
+  userId: string,
+  reason: string
+): Promise<AdminUser | null> {
+  const db = await getDatabase();
+  const now = new Date().toISOString();
+
+  const row = await db
+    .prepare(
+      `
+        update users
+        set banned_at = ?, ban_reason = ?, updatedAt = ?
+        where id = ?
+        returning
+          id, name, email, image, role, createdAt, updatedAt,
+          banned_at as bannedAt, ban_reason as banReason
+      `
+    )
+    .bind(now, reason, now, userId)
+    .first<AdminUserRow>();
+
+  await db
+    .prepare(
+      `
+        delete from sessions
+        where userId = ?
+      `
+    )
+    .bind(userId)
+    .run();
+
+  return row ? mapAdminUser(row) : null;
+}
+
+export async function unbanUser(userId: string): Promise<AdminUser | null> {
+  const db = await getDatabase();
+  const now = new Date().toISOString();
+
+  const row = await db
+    .prepare(
+      `
+        update users
+        set banned_at = null, ban_reason = null, updatedAt = ?
+        where id = ?
+        returning
+          id, name, email, image, role, createdAt, updatedAt,
+          banned_at as bannedAt, ban_reason as banReason
+      `
+    )
+    .bind(now, userId)
+    .first<AdminUserRow>();
+
+  return row ? mapAdminUser(row) : null;
+}
+
+export async function deleteUserAccount(userId: string): Promise<void> {
+  const db = await getDatabase();
+
+  await deleteSharesOwnedByUser(userId);
+
+  await db
+    .prepare(
+      `
+        delete from gallery_entries
+        where owner_user_id = ?
+      `
+    )
+    .bind(userId)
+    .run();
+
+  await db
+    .prepare(
+      `
+        delete from apikey
+        where referenceId = ?
+      `
+    )
+    .bind(userId)
+    .run();
+
+  await db
+    .prepare(
+      `
+        delete from projects
+        where owner_user_id = ?
+      `
+    )
+    .bind(userId)
+    .run();
+
+  await db
+    .prepare(
+      `
+        delete from users
+        where id = ?
+      `
+    )
+    .bind(userId)
+    .run();
 }
 
 export async function getUserContextStats(

--- a/tests/app/api/dashboard/users.route.test.ts
+++ b/tests/app/api/dashboard/users.route.test.ts
@@ -13,9 +13,13 @@ vi.mock("@/lib/server/authorization", () => ({
 }));
 
 vi.mock("@/lib/server/users", () => ({
+  banUser: vi.fn(),
   countUsersByRole: vi.fn(),
+  deleteUserAccount: vi.fn(),
   getAdminUserById: vi.fn(),
+  getUserContextStats: vi.fn(),
   listUsersForAdmin: vi.fn(),
+  unbanUser: vi.fn(),
   updateUserRole: vi.fn(),
 }));
 
@@ -24,7 +28,7 @@ vi.mock("@/lib/server/audit", () => ({
 }));
 
 import { GET } from "@/app/api/dashboard/users/route";
-import { PATCH } from "@/app/api/dashboard/users/[userId]/route";
+import { DELETE, PATCH } from "@/app/api/dashboard/users/[userId]/route";
 import { createAuditEvent } from "@/lib/server/audit";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 import {
@@ -32,9 +36,13 @@ import {
   hasCapability,
 } from "@/lib/server/authorization";
 import {
+  banUser,
   countUsersByRole,
+  deleteUserAccount,
   getAdminUserById,
+  getUserContextStats,
   listUsersForAdmin,
+  unbanUser,
   updateUserRole,
 } from "@/lib/server/users";
 import {
@@ -50,6 +58,25 @@ const targetUser = createAdminUserFixture();
 function patchRoleRequest(role: string) {
   return jsonRequest("http://localhost/api/dashboard/users/user-2", "PATCH", {
     role,
+  });
+}
+
+function patchBanRequest(reason: string) {
+  return jsonRequest("http://localhost/api/dashboard/users/user-2", "PATCH", {
+    action: "ban",
+    reason,
+  });
+}
+
+function patchUnbanRequest() {
+  return jsonRequest("http://localhost/api/dashboard/users/user-2", "PATCH", {
+    action: "unban",
+  });
+}
+
+function deleteUserRequest() {
+  return new Request("http://localhost/api/dashboard/users/user-2", {
+    method: "DELETE",
   });
 }
 
@@ -210,6 +237,239 @@ describe("dashboard users API routes", () => {
         metadata: {
           previousRole: "user",
           nextRole: "moderator",
+        },
+      });
+    });
+
+    it("returns 403 when the actor cannot ban accounts", async () => {
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(moderatorActor);
+      vi.mocked(hasCapability).mockReturnValue(false);
+
+      const response = await PATCH(
+        patchBanRequest("Spam or abuse"),
+        userContext()
+      );
+
+      expect(response.status).toBe(403);
+      expect(banUser).not.toHaveBeenCalled();
+    });
+
+    it("blocks banning your own account", async () => {
+      const selfActor = { ...adminActor, id: "user-2" };
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(selfActor);
+      vi.mocked(hasCapability).mockReturnValue(true);
+
+      const response = await PATCH(
+        patchBanRequest("Spam or abuse"),
+        userContext()
+      );
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: "You cannot ban your own account.",
+      });
+      expect(banUser).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the target user does not exist", async () => {
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
+      vi.mocked(hasCapability).mockReturnValue(true);
+      vi.mocked(getAdminUserById).mockResolvedValue(null);
+
+      const response = await PATCH(
+        patchBanRequest("Spam or abuse"),
+        userContext()
+      );
+
+      expect(response.status).toBe(404);
+      expect(banUser).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 when the ban reason is missing", async () => {
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
+
+      const response = await PATCH(patchBanRequest(""), userContext());
+
+      expect(response.status).toBe(500);
+      expect(banUser).not.toHaveBeenCalled();
+    });
+
+    it("bans the user and writes an audit event with the reason", async () => {
+      const bannedUser = createAdminUserFixture({
+        bannedAt: "2026-06-09T00:00:00.000Z",
+        banReason: "Spam or abuse",
+      });
+
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
+      vi.mocked(hasCapability).mockReturnValue(true);
+      vi.mocked(getAdminUserById).mockResolvedValue(targetUser);
+      vi.mocked(banUser).mockResolvedValue(bannedUser);
+
+      const response = await PATCH(
+        patchBanRequest("Spam or abuse"),
+        userContext()
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        ok: true,
+        user: bannedUser,
+      });
+      expect(banUser).toHaveBeenCalledWith("user-2", "Spam or abuse");
+      expect(createAuditEvent).toHaveBeenCalledWith({
+        actorUserId: adminActor.id,
+        targetUserId: bannedUser.id,
+        eventType: "account.banned",
+        entityType: "user",
+        entityId: bannedUser.id,
+        metadata: { reason: "Spam or abuse" },
+      });
+    });
+
+    it("returns 403 when the actor cannot unban accounts", async () => {
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(moderatorActor);
+      vi.mocked(hasCapability).mockReturnValue(false);
+
+      const response = await PATCH(patchUnbanRequest(), userContext());
+
+      expect(response.status).toBe(403);
+      expect(unbanUser).not.toHaveBeenCalled();
+    });
+
+    it("unbans the user and writes an audit event without metadata", async () => {
+      const unbannedUser = createAdminUserFixture({
+        bannedAt: null,
+        banReason: null,
+      });
+
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
+      vi.mocked(hasCapability).mockReturnValue(true);
+      vi.mocked(getAdminUserById).mockResolvedValue(
+        createAdminUserFixture({
+          bannedAt: "2026-06-01T00:00:00.000Z",
+          banReason: "Spam or abuse",
+        })
+      );
+      vi.mocked(unbanUser).mockResolvedValue(unbannedUser);
+
+      const response = await PATCH(patchUnbanRequest(), userContext());
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        ok: true,
+        user: unbannedUser,
+      });
+      expect(unbanUser).toHaveBeenCalledWith("user-2");
+      expect(createAuditEvent).toHaveBeenCalledWith({
+        actorUserId: adminActor.id,
+        targetUserId: unbannedUser.id,
+        eventType: "account.unbanned",
+        entityType: "user",
+        entityId: unbannedUser.id,
+        metadata: null,
+      });
+    });
+  });
+
+  describe("DELETE /api/dashboard/users/[userId]", () => {
+    it("returns 401 when the actor is missing", async () => {
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
+
+      const response = await DELETE(deleteUserRequest(), userContext());
+
+      expect(response.status).toBe(401);
+      expect(deleteUserAccount).not.toHaveBeenCalled();
+    });
+
+    it("returns 403 when the actor cannot delete accounts", async () => {
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(moderatorActor);
+      vi.mocked(hasCapability).mockReturnValue(false);
+
+      const response = await DELETE(deleteUserRequest(), userContext());
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: "Only admins can permanently delete user accounts.",
+      });
+      expect(deleteUserAccount).not.toHaveBeenCalled();
+    });
+
+    it("blocks deleting your own account", async () => {
+      const selfActor = { ...adminActor, id: "user-2" };
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(selfActor);
+      vi.mocked(hasCapability).mockReturnValue(true);
+
+      const response = await DELETE(deleteUserRequest(), userContext());
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: "You cannot delete your own account.",
+      });
+      expect(deleteUserAccount).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 when the target user does not exist", async () => {
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
+      vi.mocked(hasCapability).mockReturnValue(true);
+      vi.mocked(getAdminUserById).mockResolvedValue(null);
+
+      const response = await DELETE(deleteUserRequest(), userContext());
+
+      expect(response.status).toBe(404);
+      expect(deleteUserAccount).not.toHaveBeenCalled();
+    });
+
+    it("prevents deleting the last admin", async () => {
+      const loneAdminUser = createAdminUserFixture({ role: "admin" });
+
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
+      vi.mocked(hasCapability).mockReturnValue(true);
+      vi.mocked(getAdminUserById).mockResolvedValue(loneAdminUser);
+      vi.mocked(countUsersByRole).mockResolvedValue(1);
+
+      const response = await DELETE(deleteUserRequest(), userContext());
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: "TrackDraw must always keep at least one admin account.",
+      });
+      expect(deleteUserAccount).not.toHaveBeenCalled();
+      expect(createAuditEvent).not.toHaveBeenCalled();
+    });
+
+    it("deletes the account and writes an audit event with pre-deletion stats", async () => {
+      const stats = {
+        projectCount: 2,
+        activeShareCount: 1,
+        galleryEntryCount: 3,
+        apiKeyCount: 0,
+      };
+
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
+      vi.mocked(hasCapability).mockReturnValue(true);
+      vi.mocked(getAdminUserById).mockResolvedValue(targetUser);
+      vi.mocked(getUserContextStats).mockResolvedValue(stats);
+      vi.mocked(deleteUserAccount).mockResolvedValue(undefined);
+
+      const response = await DELETE(deleteUserRequest(), userContext());
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ ok: true });
+      expect(deleteUserAccount).toHaveBeenCalledWith("user-2");
+      expect(createAuditEvent).toHaveBeenCalledWith({
+        actorUserId: adminActor.id,
+        targetUserId: null,
+        eventType: "account.deleted",
+        entityType: "user",
+        entityId: "user-2",
+        metadata: {
+          email: targetUser.email,
+          role: targetUser.role,
+          ...stats,
         },
       });
     });

--- a/tests/app/api/dashboard/users.route.test.ts
+++ b/tests/app/api/dashboard/users.route.test.ts
@@ -286,6 +286,28 @@ describe("dashboard users API routes", () => {
       expect(banUser).not.toHaveBeenCalled();
     });
 
+    it("prevents banning the last admin", async () => {
+      const loneAdminUser = createAdminUserFixture({ role: "admin" });
+
+      vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
+      vi.mocked(hasCapability).mockReturnValue(true);
+      vi.mocked(getAdminUserById).mockResolvedValue(loneAdminUser);
+      vi.mocked(countUsersByRole).mockResolvedValue(1);
+
+      const response = await PATCH(
+        patchBanRequest("Spam or abuse"),
+        userContext()
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        ok: false,
+        error: "TrackDraw must always keep at least one admin account.",
+      });
+      expect(banUser).not.toHaveBeenCalled();
+      expect(createAuditEvent).not.toHaveBeenCalled();
+    });
+
     it("returns 500 when the ban reason is missing", async () => {
       vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(adminActor);
 

--- a/tests/helpers/api-routes.ts
+++ b/tests/helpers/api-routes.ts
@@ -120,6 +120,8 @@ export function createAdminUserFixture(
     updatedAt: "2026-01-01T00:00:00.000Z",
     lastLoginAt: null,
     projectCount: 0,
+    bannedAt: null,
+    banReason: null,
     ...overrides,
   };
 }

--- a/tests/lib/account-ban-reasons.test.ts
+++ b/tests/lib/account-ban-reasons.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  banReasonCodes,
+  getBanReasonLabel,
+  isBanReasonCode,
+} from "@/lib/account/ban-reasons";
+
+describe("ban reason helpers", () => {
+  it("exposes 'other' as the last code so it reads as the catch-all option", () => {
+    expect(banReasonCodes[banReasonCodes.length - 1]).toBe("other");
+  });
+
+  it("recognizes every known ban reason code", () => {
+    for (const code of banReasonCodes) {
+      expect(isBanReasonCode(code)).toBe(true);
+    }
+  });
+
+  it("rejects unknown or non-string values", () => {
+    expect(isBanReasonCode("unknown")).toBe(false);
+    expect(isBanReasonCode(123)).toBe(false);
+    expect(isBanReasonCode(null)).toBe(false);
+    expect(isBanReasonCode(undefined)).toBe(false);
+  });
+
+  it("returns a distinct, non-empty label for every code", () => {
+    const labels = banReasonCodes.map(getBanReasonLabel);
+    expect(new Set(labels).size).toBe(banReasonCodes.length);
+    for (const label of labels) {
+      expect(label.trim().length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/lib/server/auth-session.test.ts
+++ b/tests/lib/server/auth-session.test.ts
@@ -95,6 +95,33 @@ describe("auth session resolver", () => {
     });
   });
 
+  it("rejects banned users after loading the session row", async () => {
+    vi.stubEnv("BETTER_AUTH_SECRET", "test-secret");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T12:00:00.000Z"));
+    installD1Statements(mocks.prepare, [
+      createD1Statement({
+        first: {
+          id: "user-1",
+          email: "pilot@example.com",
+          name: null,
+          image: null,
+          role: "user",
+          expiresAt: "2026-06-09T13:00:00.000Z",
+          bannedAt: "2026-06-01T00:00:00.000Z",
+        },
+      }),
+    ]);
+
+    await expect(
+      getCurrentUserFromHeaders(
+        new Headers({
+          cookie: await signedSessionCookie("session-token", "test-secret"),
+        })
+      )
+    ).resolves.toBeNull();
+  });
+
   it("rejects expired sessions after loading the session row", async () => {
     vi.stubEnv("BETTER_AUTH_SECRET", "test-secret");
     vi.useFakeTimers();

--- a/tests/lib/server/shares.test.ts
+++ b/tests/lib/server/shares.test.ts
@@ -42,6 +42,7 @@ vi.mock("@/lib/server/gallery", () => ({
 
 import {
   createShare,
+  deleteSharesOwnedByUser,
   getSharesByUserId,
   resolveStoredShare,
   revokeShare,
@@ -194,6 +195,42 @@ describe("revokeShare", () => {
       "tok-revoke"
     );
     expect(mocks.deleteGalleryEntry).toHaveBeenCalledWith("tok-revoke");
+  });
+});
+
+describe("deleteSharesOwnedByUser", () => {
+  beforeEach(() => {
+    mocks.prepare.mockReset();
+    mocks.deleteGalleryEntry.mockReset();
+  });
+
+  it("does nothing when the user owns no shares", async () => {
+    const selectStmt = createD1AllStatement([]);
+    installStatements([selectStmt]);
+
+    await deleteSharesOwnedByUser("user-1");
+
+    expect(mocks.deleteGalleryEntry).not.toHaveBeenCalled();
+  });
+
+  it("deletes the gallery entry and share row for every owned share", async () => {
+    const selectStmt = createD1AllStatement([
+      { token: "tok-a" },
+      { token: "tok-b" },
+    ]);
+    const deleteA = createStatement();
+    const deleteB = createStatement();
+    installStatements([selectStmt, deleteA, deleteB]);
+
+    await deleteSharesOwnedByUser("user-1");
+
+    expect(selectStmt.bind).toHaveBeenCalledWith("user-1");
+    expect(mocks.deleteGalleryEntry).toHaveBeenNthCalledWith(1, "tok-a");
+    expect(deleteA.bind).toHaveBeenCalledWith("tok-a");
+    expect(deleteA.run).toHaveBeenCalledOnce();
+    expect(mocks.deleteGalleryEntry).toHaveBeenNthCalledWith(2, "tok-b");
+    expect(deleteB.bind).toHaveBeenCalledWith("tok-b");
+    expect(deleteB.run).toHaveBeenCalledOnce();
   });
 });
 

--- a/tests/lib/server/users.test.ts
+++ b/tests/lib/server/users.test.ts
@@ -314,14 +314,12 @@ describe("unbanUser", () => {
 });
 
 describe("deleteUserAccount", () => {
-  it("deletes shares, gallery entries, api keys, and projects before deleting the user row", async () => {
+  it("deletes shares (which cascades gallery entries), api keys, and projects before deleting the user row", async () => {
     mocks.deleteSharesOwnedByUser.mockResolvedValue(undefined);
-    const galleryStatement = createD1Statement();
     const apiKeyStatement = createD1Statement();
     const projectsStatement = createD1Statement();
     const usersStatement = createD1Statement();
     installD1Statements(mocks.prepare, [
-      galleryStatement,
       apiKeyStatement,
       projectsStatement,
       usersStatement,
@@ -330,15 +328,29 @@ describe("deleteUserAccount", () => {
     await deleteUserAccount("user-4");
 
     expect(mocks.deleteSharesOwnedByUser).toHaveBeenCalledWith("user-4");
-    expect(galleryStatement.sql).toContain("delete from gallery_entries");
-    expect(galleryStatement.bind).toHaveBeenCalledWith("user-4");
-    expect(galleryStatement.run).toHaveBeenCalledOnce();
     expect(apiKeyStatement.sql).toContain("delete from apikey");
     expect(apiKeyStatement.bind).toHaveBeenCalledWith("user-4");
+    expect(apiKeyStatement.run).toHaveBeenCalledOnce();
     expect(projectsStatement.sql).toContain("delete from projects");
     expect(projectsStatement.bind).toHaveBeenCalledWith("user-4");
     expect(usersStatement.sql).toContain("delete from users");
     expect(usersStatement.bind).toHaveBeenCalledWith("user-4");
     expect(usersStatement.run).toHaveBeenCalledOnce();
+  });
+
+  it("does not issue a raw gallery_entries delete (relies on deleteGalleryEntry for preview-image cleanup)", async () => {
+    mocks.deleteSharesOwnedByUser.mockResolvedValue(undefined);
+    installD1Statements(mocks.prepare, [
+      createD1Statement(),
+      createD1Statement(),
+      createD1Statement(),
+    ]);
+
+    await deleteUserAccount("user-4");
+
+    const sqlCalls = mocks.prepare.mock.calls.map(([sql]) => String(sql));
+    expect(
+      sqlCalls.some((sql) => sql.includes("delete from gallery_entries"))
+    ).toBe(false);
   });
 });

--- a/tests/lib/server/users.test.ts
+++ b/tests/lib/server/users.test.ts
@@ -1,10 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createD1AllStatement, createD1Statement } from "../../helpers/d1";
+import {
+  createD1AllStatement,
+  createD1Statement,
+  installD1Statements,
+} from "../../helpers/d1";
 
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
   prepare: vi.fn(),
+  deleteSharesOwnedByUser: vi.fn(),
 }));
 
 vi.mock("@/lib/server/db", () => ({
@@ -13,17 +18,25 @@ vi.mock("@/lib/server/db", () => ({
   })),
 }));
 
+vi.mock("@/lib/server/shares", () => ({
+  deleteSharesOwnedByUser: mocks.deleteSharesOwnedByUser,
+}));
+
 import {
+  banUser,
   countUsersByRole,
   countUsersForAdmin,
+  deleteUserAccount,
   getAdminUserById,
   getUserRoleById,
   listUsersForAdmin,
+  unbanUser,
   updateUserRole,
 } from "@/lib/server/users";
 
 beforeEach(() => {
   mocks.prepare.mockReset();
+  mocks.deleteSharesOwnedByUser.mockReset();
 });
 
 describe("getUserRoleById", () => {
@@ -213,5 +226,119 @@ describe("updateUserRole", () => {
       name: "Carol",
       role: "admin",
     });
+  });
+});
+
+describe("banUser", () => {
+  it("returns null when the user is not found", async () => {
+    installD1Statements(mocks.prepare, [
+      createD1Statement({ first: null }),
+      createD1Statement(),
+    ]);
+
+    const result = await banUser("missing", "Spam or abuse");
+    expect(result).toBeNull();
+  });
+
+  it("updates banned_at/ban_reason, deletes active sessions, and returns the banned user", async () => {
+    const updateStatement = createD1Statement({
+      first: {
+        id: "user-3",
+        name: "Carol",
+        email: "carol@example.com",
+        image: null,
+        role: "user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-06-09T00:00:00.000Z",
+        bannedAt: "2026-06-09T00:00:00.000Z",
+        banReason: "Spam or abuse",
+      },
+    });
+    const deleteSessionsStatement = createD1Statement();
+    installD1Statements(mocks.prepare, [
+      updateStatement,
+      deleteSessionsStatement,
+    ]);
+
+    const result = await banUser("user-3", "Spam or abuse");
+
+    expect(updateStatement.bind).toHaveBeenCalledWith(
+      expect.any(String),
+      "Spam or abuse",
+      expect.any(String),
+      "user-3"
+    );
+    expect(deleteSessionsStatement.bind).toHaveBeenCalledWith("user-3");
+    expect(deleteSessionsStatement.run).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      id: "user-3",
+      bannedAt: "2026-06-09T00:00:00.000Z",
+      banReason: "Spam or abuse",
+    });
+  });
+});
+
+describe("unbanUser", () => {
+  it("returns null when the user is not found", async () => {
+    mocks.prepare.mockReturnValue(createD1Statement({ first: null }));
+
+    const result = await unbanUser("missing");
+    expect(result).toBeNull();
+  });
+
+  it("clears banned_at/ban_reason and returns the updated user", async () => {
+    const statement = createD1Statement({
+      first: {
+        id: "user-3",
+        name: "Carol",
+        email: "carol@example.com",
+        image: null,
+        role: "user",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-06-10T00:00:00.000Z",
+        bannedAt: null,
+        banReason: null,
+      },
+    });
+    mocks.prepare.mockReturnValue(statement);
+
+    const result = await unbanUser("user-3");
+
+    expect(statement.bind).toHaveBeenCalledWith(expect.any(String), "user-3");
+    expect(result).toMatchObject({
+      id: "user-3",
+      bannedAt: null,
+      banReason: null,
+    });
+  });
+});
+
+describe("deleteUserAccount", () => {
+  it("deletes shares, gallery entries, api keys, and projects before deleting the user row", async () => {
+    mocks.deleteSharesOwnedByUser.mockResolvedValue(undefined);
+    const galleryStatement = createD1Statement();
+    const apiKeyStatement = createD1Statement();
+    const projectsStatement = createD1Statement();
+    const usersStatement = createD1Statement();
+    installD1Statements(mocks.prepare, [
+      galleryStatement,
+      apiKeyStatement,
+      projectsStatement,
+      usersStatement,
+    ]);
+
+    await deleteUserAccount("user-4");
+
+    expect(mocks.deleteSharesOwnedByUser).toHaveBeenCalledWith("user-4");
+    expect(galleryStatement.sql).toContain("delete from gallery_entries");
+    expect(galleryStatement.bind).toHaveBeenCalledWith("user-4");
+    expect(galleryStatement.run).toHaveBeenCalledOnce();
+    expect(apiKeyStatement.sql).toContain("delete from apikey");
+    expect(apiKeyStatement.bind).toHaveBeenCalledWith("user-4");
+    expect(projectsStatement.sql).toContain("delete from projects");
+    expect(projectsStatement.bind).toHaveBeenCalledWith("user-4");
+    expect(usersStatement.sql).toContain("delete from users");
+    expect(usersStatement.bind).toHaveBeenCalledWith("user-4");
+    expect(usersStatement.run).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

Adds the user account moderation slice from the roadmap.

- Add admin ban/unban and permanent account deletion actions to the Users dashboard
- Store ban state with `banned_at` and `ban_reason`, block banned sessions, and end active sessions on ban
- Explicitly delete owned projects, shares, gallery entries, preview media references, and API keys during permanent account deletion
- Add audit event labels, dashboard copy, and roadmap archive notes for the moderation work

## Validation

- `npm run i18n:check`
- `npm run lint`
- `npm run type`
- `npm run test`
- `npm run build`