### PR TITLE
feat: Generate race lines from obstacles

### DIFF
--- a/lang/de/inspector.json
+++ b/lang/de/inspector.json
@@ -199,7 +199,7 @@
       "ready": "{count, plural, one {1 Routenhindernis nummeriert.} other {{count} Routenhindernisse nummeriert.}}",
       "partial": "{mapped} von {total} Routenhindernissen sind nummeriert.",
       "noRouteMatches": "{count, plural, one {1 Routenhindernis gefunden, aber keines liegt nah genug an der Rennlinie.} other {{count} Routenhindernisse gefunden, aber keines liegt nah genug an der Rennlinie.}}",
-      "missingRoute": "{count, plural, one {1 Routenhindernis benötigt eine Rennlinie, bevor die Nummerierung abgeleitet werden kann.} other {{count} Routenhindernisse benötigen eine Rennlinie, bevor die Nummerierung abgeleitet werden kann.}}",
+      "missingRoute": "Unterstützte Hindernisse sind bereit für eine Rennlinie.",
       "noNumberedObstacles": "Gates, Ladders und Dive Gates erscheinen in der Routennummerierung.",
       "empty": "Füge Routenhindernisse und eine Rennlinie hinzu, um Nummerierung abzuleiten."
     },
@@ -209,7 +209,21 @@
     },
     "meta": {
       "numbered": "Nummeriert",
-      "issues": "Probleme"
+      "issues": "Probleme",
+      "raceLine": "Rennlinie"
+    },
+    "generate": {
+      "button": "Rennlinie generieren",
+      "regenerateButton": "Rennlinie erneut generieren",
+      "success": "Rennlinie generiert.",
+      "errors": {
+        "noObstacles": "Rennlinie konnte nicht generiert werden — füge zuerst mindestens zwei unterstützte Hindernisse hinzu (Gates, Ladders oder Dive Gates)."
+      },
+      "warnings": {
+        "unsupportedShapes": "{count, plural, one {1 Hindernis wird noch nicht unterstützt und wurde übersprungen.} other {{count} Hindernisse werden noch nicht unterstützt und wurden übersprungen.}}",
+        "tooFewObstacles": "Füge weitere unterstützte Hindernisse hinzu für eine nützlichere Rennlinie.",
+        "closeObstacles": "{count, plural, one {1 Hindernispaar liegt sehr nah beieinander — prüfe den generierten Pfad.} other {{count} Hindernispaare liegen sehr nah beieinander — prüfe den generierten Pfad.}}"
+      }
     }
   },
   "elevationChart": {

--- a/lang/en/inspector.json
+++ b/lang/en/inspector.json
@@ -199,7 +199,7 @@
       "ready": "{count, plural, one {1 route obstacle numbered.} other {{count} route obstacles numbered.}}",
       "partial": "{mapped} of {total} route obstacles are numbered.",
       "noRouteMatches": "{count, plural, one {1 route obstacle found, but none sit close enough to the race line.} other {{count} route obstacles found, but none sit close enough to the race line.}}",
-      "missingRoute": "{count, plural, one {1 route obstacle needs a race line before numbering can be derived.} other {{count} route obstacles need a race line before numbering can be derived.}}",
+      "missingRoute": "Supported obstacles are ready for a race line.",
       "noNumberedObstacles": "Gates, ladders, and dive gates will appear in route numbering.",
       "empty": "Add route obstacles and a race line to derive numbering."
     },
@@ -209,7 +209,21 @@
     },
     "meta": {
       "numbered": "Numbered",
-      "issues": "Issues"
+      "issues": "Issues",
+      "raceLine": "Race line"
+    },
+    "generate": {
+      "button": "Generate race line",
+      "regenerateButton": "Regenerate race line",
+      "success": "Race line generated.",
+      "errors": {
+        "noObstacles": "Couldn't generate a race line — add at least two supported obstacles (gates, ladders, or dive gates) first."
+      },
+      "warnings": {
+        "unsupportedShapes": "{count, plural, one {1 obstacle isn't supported yet and was skipped.} other {{count} obstacles aren't supported yet and were skipped.}}",
+        "tooFewObstacles": "Add more supported obstacles for a more useful race line.",
+        "closeObstacles": "{count, plural, one {1 pair of obstacles is very close together — check the generated path.} other {{count} pairs of obstacles are very close together — check the generated path.}}"
+      }
     }
   },
   "elevationChart": {

--- a/lang/nl/inspector.json
+++ b/lang/nl/inspector.json
@@ -199,7 +199,7 @@
       "ready": "{count, plural, one {1 route-obstakel genummerd.} other {{count} route-obstakels genummerd.}}",
       "partial": "{mapped} van {total} route-obstakels zijn genummerd.",
       "noRouteMatches": "{count, plural, one {1 route-obstakel gevonden, maar geen ligt dicht genoeg bij de race line.} other {{count} route-obstakels gevonden, maar geen ligt dicht genoeg bij de race line.}}",
-      "missingRoute": "{count, plural, one {1 route-obstakel heeft een race line nodig voordat nummering kan worden afgeleid.} other {{count} route-obstakels hebben een race line nodig voordat nummering kan worden afgeleid.}}",
+      "missingRoute": "Ondersteunde obstakels zijn klaar voor een race line.",
       "noNumberedObstacles": "Gates, ladders en dive gates verschijnen in de routenummering.",
       "empty": "Voeg route-obstakels en een race line toe om nummering af te leiden."
     },
@@ -209,7 +209,21 @@
     },
     "meta": {
       "numbered": "Genummerd",
-      "issues": "Problemen"
+      "issues": "Problemen",
+      "raceLine": "Race line"
+    },
+    "generate": {
+      "button": "Race line genereren",
+      "regenerateButton": "Race line opnieuw genereren",
+      "success": "Race line gegenereerd.",
+      "errors": {
+        "noObstacles": "Kan geen race line genereren — voeg eerst minimaal twee ondersteunde obstakels toe (gates, ladders of dive gates)."
+      },
+      "warnings": {
+        "unsupportedShapes": "{count, plural, one {1 obstakel wordt nog niet ondersteund en is overgeslagen.} other {{count} obstakels worden nog niet ondersteund en zijn overgeslagen.}}",
+        "tooFewObstacles": "Voeg meer ondersteunde obstakels toe voor een bruikbaardere race line.",
+        "closeObstacles": "{count, plural, one {1 paar obstakels staat erg dicht bij elkaar — controleer het gegenereerde pad.} other {{count} paar obstakels staan erg dicht bij elkaar — controleer het gegenereerde pad.}}"
+      }
     }
   },
   "elevationChart": {

--- a/src/components/canvas/renderers/polyline-shape.tsx
+++ b/src/components/canvas/renderers/polyline-shape.tsx
@@ -507,16 +507,10 @@ export function PolylineShapeContent({
       const selection = selectNearestSegment(pointer);
       if (!selection) return;
       event.cancelBubble = true;
-      if (!isSelected) setSelection([path.id]);
+      setSelection([path.id]);
       commitSegmentSelection(selection);
     },
-    [
-      commitSegmentSelection,
-      isSelected,
-      path.id,
-      selectNearestSegment,
-      setSelection,
-    ]
+    [commitSegmentSelection, path.id, selectNearestSegment, setSelection]
   );
 
   const handlePathContextMenu = useCallback(
@@ -526,13 +520,12 @@ export function PolylineShapeContent({
       const selection = selectNearestSegment(pointer);
       if (!selection) return;
       event.cancelBubble = true;
-      if (!isSelected) setSelection([path.id]);
+      setSelection([path.id]);
       commitSegmentSelection(selection);
       onPathContextMenu?.(selection.segmentIndex);
     },
     [
       commitSegmentSelection,
-      isSelected,
       onPathContextMenu,
       path.id,
       selectNearestSegment,

--- a/src/components/canvas/renderers/shape-node.tsx
+++ b/src/components/canvas/renderers/shape-node.tsx
@@ -272,6 +272,7 @@ function TrackShapeNodeComponent({
           // Preserve an existing multiselect when starting a drag from within it.
           return;
         } else if (selected && selectionCount === 1) {
+          onSelectOnly(shape.id);
           return;
         } else {
           onSelectOnly(shape.id);
@@ -293,6 +294,7 @@ function TrackShapeNodeComponent({
           return;
         }
         if (selected && selectionCount === 1) {
+          onSelectOnly(shape.id);
           return;
         }
         onSelectOnly(shape.id);

--- a/src/components/inspector/Inspector.tsx
+++ b/src/components/inspector/Inspector.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { memo, useCallback, useEffect, useState, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { motion } from "framer-motion";
 import {
   MultiInspectorView,
@@ -61,6 +68,8 @@ function Inspector({
     setMapReferenceVisibility,
     setMapReferenceOpacity,
     setMapReferenceRotation,
+    addShape,
+    reorderShapes,
   } = useTrackActions();
   const { setSelection } = useSessionActions();
   const { setHoveredShapeId, setHoveredWaypoint } = useUiActions();
@@ -75,6 +84,7 @@ function Inspector({
   const [panelOverride, setPanelOverride] = useState<
     "project" | "layout" | "selection" | null
   >(null);
+  const hasObservedSelectionRef = useRef(false);
   const [saveAsPresetOpen, setSaveAsPresetOpen] = useState(false);
   const { addUserPreset, canSavePresets } = useAccountPresetSync();
   const { pending: savePresetPending, reset: resetSavePresetTrigger } =
@@ -87,6 +97,28 @@ function Inspector({
       resetSavePresetTrigger();
     }
   }, [savePresetPending, canSavePresets, resetSavePresetTrigger]);
+
+  useEffect(() => {
+    if (!hasObservedSelectionRef.current) {
+      hasObservedSelectionRef.current = true;
+      return;
+    }
+
+    if (selection.length > 0) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setPanelOverride("selection");
+    }
+  }, [selection]);
+
+  const selectAndOpenSelectionPanel = useCallback(
+    (ids: string[]) => {
+      setSelection(ids);
+      if (ids.length > 0) {
+        setPanelOverride("selection");
+      }
+    },
+    [setSelection]
+  );
 
   const handleSaveAsPreset = useCallback(
     (name: string) => {
@@ -130,7 +162,7 @@ function Inspector({
         joinPolylines={joinPolylines}
         removeShapes={removeShapes}
         setGroupName={setGroupName}
-        setSelection={setSelection}
+        setSelection={selectAndOpenSelectionPanel}
         ungroupSelection={ungroupSelection}
         updateShapesCatalogType={updateShapesCatalogType}
         onSaveAsPreset={
@@ -161,7 +193,7 @@ function Inspector({
         duplicateShapes={duplicateShapes}
         removeShapes={removeShapes}
         setGroupName={setGroupName}
-        setSelection={setSelection}
+        setSelection={selectAndOpenSelectionPanel}
         ungroupSelection={ungroupSelection}
         setHoveredWaypoint={setHoveredWaypoint}
         onResumeSelectedPath={onResumeSelectedPath}
@@ -243,7 +275,7 @@ function Inspector({
             panel={panel}
             design={design}
             shapes={designShapes}
-            setSelection={setSelection}
+            setSelection={selectAndOpenSelectionPanel}
             updateField={updateField}
             updateDesignMeta={updateDesignMeta}
             setMapReference={setMapReference}
@@ -253,6 +285,8 @@ function Inspector({
             setMapReferenceRotation={setMapReferenceRotation}
             removeShapes={removeShapes}
             setHoveredShapeId={setHoveredShapeId}
+            addShape={addShape}
+            reorderShapes={reorderShapes}
           />
         ) : (
           selectionView

--- a/src/components/inspector/views/list-panel.tsx
+++ b/src/components/inspector/views/list-panel.tsx
@@ -94,11 +94,23 @@ export function getListableTrackItems(shapes: Shape[]): Shape[] {
 
 export function computeReorderBeforeId(
   orderedShapes: Shape[],
-  draggedId: string
+  draggedId: string,
+  fullOrderedShapes: Shape[] = orderedShapes
 ): string | null {
-  const index = orderedShapes.findIndex((shape) => shape.id === draggedId);
-  if (index === -1 || index === orderedShapes.length - 1) return null;
-  return orderedShapes[index + 1].id;
+  if (!orderedShapes.some((shape) => shape.id === draggedId)) return null;
+
+  const nextListableShapes = [...orderedShapes];
+  const mergedOrder =
+    fullOrderedShapes.length === orderedShapes.length
+      ? orderedShapes
+      : fullOrderedShapes.map((shape) => {
+          if (shape.kind === "polyline") return shape;
+          return nextListableShapes.shift() ?? shape;
+        });
+
+  const index = mergedOrder.findIndex((shape) => shape.id === draggedId);
+  if (index === -1 || index === mergedOrder.length - 1) return null;
+  return mergedOrder[index + 1].id;
 }
 
 function ItemRow({
@@ -335,7 +347,7 @@ export function ItemOverviewList({
   const removeItemTitle = t("actions.removeItem");
 
   function handleDragEnd(draggedId: string) {
-    const beforeId = computeReorderBeforeId(localOrder, draggedId);
+    const beforeId = computeReorderBeforeId(localOrder, draggedId, shapes);
     reorderShapes(draggedId, beforeId);
   }
 

--- a/src/components/inspector/views/list-panel.tsx
+++ b/src/components/inspector/views/list-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { Reorder, useDragControls } from "framer-motion";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
@@ -87,12 +88,168 @@ function getShapeDisplayName(shape: Shape, t: Translate): string {
 
 type ViewFilter = "all" | "obstacles";
 
+export function getListableTrackItems(shapes: Shape[]): Shape[] {
+  return shapes.filter((shape) => shape.kind !== "polyline");
+}
+
+export function computeReorderBeforeId(
+  orderedShapes: Shape[],
+  draggedId: string
+): string | null {
+  const index = orderedShapes.findIndex((shape) => shape.id === draggedId);
+  if (index === -1 || index === orderedShapes.length - 1) return null;
+  return orderedShapes[index + 1].id;
+}
+
+function ItemRow({
+  shape,
+  orderLabel,
+  displayName,
+  kindLabel,
+  pathNumber,
+  isUnmapped,
+  routeStatusOff,
+  removeItemTitle,
+  isDraggable,
+  onDragEnd,
+  setSelection,
+  setHoveredShapeId,
+  removeShapes,
+}: {
+  shape: Shape;
+  orderLabel: number | undefined;
+  displayName: string;
+  kindLabel: string;
+  pathNumber: number | undefined;
+  isUnmapped: boolean;
+  routeStatusOff: string;
+  removeItemTitle: string;
+  isDraggable: boolean;
+  onDragEnd: (id: string) => void;
+  setSelection: (ids: string[]) => void;
+  setHoveredShapeId: (shapeId: string | null) => void;
+  removeShapes: (ids: string[]) => void;
+}) {
+  const dragControls = useDragControls();
+  const rowClassName =
+    "group/item hover:bg-brand-primary/8 focus-visible:ring-brand-primary/20 relative grid w-full grid-cols-[32px_minmax(0,1fr)_48px_28px] items-center gap-3 px-3 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:outline-hidden";
+
+  const content = (
+    <>
+      <span className="bg-brand-primary absolute top-1.5 bottom-1.5 left-0 w-0.5 rounded-r-full opacity-0 transition-opacity group-hover/item:opacity-100" />
+      <div className="flex min-w-0 items-center">
+        <span
+          className={cn(
+            "border-border/30 bg-muted/35 text-muted-foreground/85 flex h-5 w-6 shrink-0 items-center justify-center rounded-md border font-mono text-[10px]",
+            isDraggable && "cursor-grab touch-none active:cursor-grabbing"
+          )}
+          onPointerDown={
+            isDraggable
+              ? (event) => {
+                  event.stopPropagation();
+                  dragControls.start(event);
+                }
+              : undefined
+          }
+        >
+          {orderLabel}
+        </span>
+      </div>
+      <div className="flex min-w-0 items-center">
+        <div className="min-w-0">
+          <p className="text-foreground truncate text-[11px] font-medium">
+            {displayName}
+          </p>
+          <p className="text-muted-foreground/60 truncate text-[10px] tracking-[0.06em] uppercase">
+            {kindLabel}
+          </p>
+        </div>
+      </div>
+      {typeof pathNumber === "number" ? (
+        <span className="border-brand-primary/20 bg-brand-primary/8 text-brand-primary flex h-5 w-12 shrink-0 items-center justify-center rounded-md border font-mono text-[10px]">
+          #{pathNumber}
+        </span>
+      ) : isUnmapped ? (
+        <span
+          title={routeStatusOff}
+          className="flex h-5 w-12 shrink-0 items-center justify-center truncate rounded-md border border-amber-500/25 bg-amber-500/10 px-1 font-mono text-[10px] font-medium text-amber-500"
+        >
+          {routeStatusOff}
+        </span>
+      ) : (
+        <span className="text-muted-foreground/30 flex h-5 w-12 shrink-0 items-center justify-center font-mono text-[10px]">
+          –
+        </span>
+      )}
+      <div className="flex items-center justify-end opacity-100 transition-opacity lg:opacity-0 lg:group-hover/item:opacity-100">
+        <button
+          type="button"
+          title={removeItemTitle}
+          className="text-muted-foreground/55 hover:bg-brand-primary/10 hover:text-brand-primary flex size-5 items-center justify-center rounded-md transition-colors"
+          onClick={(event) => {
+            event.stopPropagation();
+            removeShapes([shape.id]);
+            setHoveredShapeId(null);
+          }}
+        >
+          <X className="size-3" />
+        </button>
+      </div>
+    </>
+  );
+
+  if (isDraggable) {
+    return (
+      <Reorder.Item
+        as="div"
+        value={shape}
+        dragListener={false}
+        dragControls={dragControls}
+        onDragEnd={() => onDragEnd(shape.id)}
+        role="button"
+        tabIndex={0}
+        onClick={() => setSelection([shape.id])}
+        className={rowClassName}
+        onMouseEnter={() => setHoveredShapeId(shape.id)}
+        onMouseLeave={() => setHoveredShapeId(null)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            setSelection([shape.id]);
+          }
+        }}
+      >
+        {content}
+      </Reorder.Item>
+    );
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => setSelection([shape.id])}
+      className={rowClassName}
+      onMouseEnter={() => setHoveredShapeId(shape.id)}
+      onMouseLeave={() => setHoveredShapeId(null)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          setSelection([shape.id]);
+        }
+      }}
+    >
+      {content}
+    </div>
+  );
+}
+
 export function ItemOverviewList({
   design,
   shapes,
   setSelection,
   removeShapes,
-
+  reorderShapes,
   setHoveredShapeId,
   grow = false,
   obstacleNumberingReport,
@@ -101,6 +258,7 @@ export function ItemOverviewList({
   shapes: Shape[];
   setSelection: (ids: string[]) => void;
   removeShapes: (ids: string[]) => void;
+  reorderShapes: (fromId: string, beforeId: string | null) => void;
   setHoveredShapeId: (shapeId: string | null) => void;
   grow?: boolean;
   obstacleNumberingReport?: ObstacleNumberingReport;
@@ -109,6 +267,13 @@ export function ItemOverviewList({
   const tShapes = useTranslations("shapes") as unknown as Translate;
   const [query, setQuery] = useState("");
   const [viewFilter, setViewFilter] = useState<ViewFilter>("all");
+  const listShapes = useMemo(() => getListableTrackItems(shapes), [shapes]);
+  const [localOrder, setLocalOrder] = useState<Shape[]>(listShapes);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLocalOrder(listShapes);
+  }, [listShapes]);
 
   const VIEW_FILTERS: { value: ViewFilter; label: string }[] = [
     { value: "all", label: t("listPanel.filterAll") },
@@ -118,8 +283,9 @@ export function ItemOverviewList({
   const normalizedQuery = query.trim().toLowerCase();
 
   const shapeOrder = useMemo(
-    () => new Map(shapes.map((shape, index) => [shape.id, index + 1] as const)),
-    [shapes]
+    () =>
+      new Map(listShapes.map((shape, index) => [shape.id, index + 1] as const)),
+    [listShapes]
   );
 
   const numberingReport = useMemo(
@@ -131,6 +297,7 @@ export function ItemOverviewList({
     () =>
       new Set(
         shapes
+          .filter((shape) => shape.kind !== "polyline")
           .filter(
             (shape) =>
               isNumberedObstacle(shape) &&
@@ -143,12 +310,12 @@ export function ItemOverviewList({
   );
 
   const obstacleCount = useMemo(
-    () => shapes.filter(isNumberedObstacle).length,
-    [shapes]
+    () => listShapes.filter(isNumberedObstacle).length,
+    [listShapes]
   );
 
   const filteredShapes = useMemo(() => {
-    return shapes.filter((shape) => {
+    return listShapes.filter((shape) => {
       if (viewFilter === "obstacles" && !isNumberedObstacle(shape))
         return false;
       if (!normalizedQuery) return true;
@@ -161,7 +328,16 @@ export function ItemOverviewList({
         position.includes(normalizedQuery)
       );
     });
-  }, [shapes, viewFilter, normalizedQuery, tShapes]);
+  }, [listShapes, viewFilter, normalizedQuery, tShapes]);
+
+  const isDraggable = filteredShapes.length === listShapes.length;
+  const routeStatusOff = t("listPanel.routeStatus.off");
+  const removeItemTitle = t("actions.removeItem");
+
+  function handleDragEnd(draggedId: string) {
+    const beforeId = computeReorderBeforeId(localOrder, draggedId);
+    reorderShapes(draggedId, beforeId);
+  }
 
   return (
     <Section
@@ -179,13 +355,14 @@ export function ItemOverviewList({
             className="bg-background border-border/40 focus-visible:border-border/80 focus-visible:ring-ring/20 h-8 rounded-md px-2.5 text-[11px] shadow-none focus-visible:ring-1 lg:h-7 lg:px-2"
           />
           <MetaPill>
-            {filteredShapes.length}/{shapes.length}
+            {filteredShapes.length}/{listShapes.length}
           </MetaPill>
         </div>
 
         <div className="flex shrink-0 items-center gap-1">
           {VIEW_FILTERS.map(({ value, label }) => {
-            const count = value === "obstacles" ? obstacleCount : shapes.length;
+            const count =
+              value === "obstacles" ? obstacleCount : listShapes.length;
             return (
               <button
                 key={value}
@@ -220,7 +397,7 @@ export function ItemOverviewList({
           grow={grow}
           meta={
             <span className="text-muted-foreground/65 text-[11px]">
-              {shapes.length}
+              {listShapes.length}
             </span>
           }
         >
@@ -243,88 +420,67 @@ export function ItemOverviewList({
                 : "max-h-128 overflow-y-auto"
             )}
           >
-            <div className="divide-border/15 divide-y">
-              {filteredShapes.length ? (
-                filteredShapes.map((shape) => {
-                  const displayName = getShapeDisplayName(shape, tShapes);
-                  const kindLabel = getShapeKindLabel(shape.kind, tShapes);
-                  const pathNumber = numberingReport.obstacleNumberMap.get(
-                    shape.id
-                  );
-                  const routeStatusOff = t("listPanel.routeStatus.off");
-                  return (
-                    <div
+            {filteredShapes.length ? (
+              isDraggable ? (
+                <Reorder.Group
+                  as="div"
+                  axis="y"
+                  values={localOrder}
+                  onReorder={setLocalOrder}
+                  className="divide-border/15 divide-y"
+                >
+                  {localOrder.map((shape) => (
+                    <ItemRow
                       key={shape.id}
-                      role="button"
-                      tabIndex={0}
-                      onClick={() => setSelection([shape.id])}
-                      className="group/item hover:bg-brand-primary/8 focus-visible:ring-brand-primary/20 relative grid w-full grid-cols-[32px_minmax(0,1fr)_48px_28px] items-center gap-3 px-3 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:outline-hidden"
-                      onMouseEnter={() => setHoveredShapeId(shape.id)}
-                      onMouseLeave={() => setHoveredShapeId(null)}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter" || event.key === " ") {
-                          event.preventDefault();
-                          setSelection([shape.id]);
-                        }
-                      }}
-                    >
-                      <span className="bg-brand-primary absolute top-1.5 bottom-1.5 left-0 w-0.5 rounded-r-full opacity-0 transition-opacity group-hover/item:opacity-100" />
-                      <div className="flex min-w-0 items-center">
-                        <span className="border-border/30 bg-muted/35 text-muted-foreground/85 flex h-5 w-6 shrink-0 items-center justify-center rounded-md border font-mono text-[10px]">
-                          {shapeOrder.get(shape.id)}
-                        </span>
-                      </div>
-                      <div className="flex min-w-0 items-center">
-                        <div className="min-w-0">
-                          <p className="text-foreground truncate text-[11px] font-medium">
-                            {displayName}
-                          </p>
-                          <p className="text-muted-foreground/60 truncate text-[10px] tracking-[0.06em] uppercase">
-                            {kindLabel}
-                          </p>
-                        </div>
-                      </div>
-                      {typeof pathNumber === "number" ? (
-                        <span className="border-brand-primary/20 bg-brand-primary/8 text-brand-primary flex h-5 w-12 shrink-0 items-center justify-center rounded-md border font-mono text-[10px]">
-                          #{pathNumber}
-                        </span>
-                      ) : unmappedObstacleIds.has(shape.id) ? (
-                        <span
-                          title={routeStatusOff}
-                          className="flex h-5 w-12 shrink-0 items-center justify-center truncate rounded-md border border-amber-500/25 bg-amber-500/10 px-1 font-mono text-[10px] font-medium text-amber-500"
-                        >
-                          {routeStatusOff}
-                        </span>
-                      ) : (
-                        <span className="text-muted-foreground/30 flex h-5 w-12 shrink-0 items-center justify-center font-mono text-[10px]">
-                          –
-                        </span>
+                      shape={shape}
+                      orderLabel={shapeOrder.get(shape.id)}
+                      displayName={getShapeDisplayName(shape, tShapes)}
+                      kindLabel={getShapeKindLabel(shape.kind, tShapes)}
+                      pathNumber={numberingReport.obstacleNumberMap.get(
+                        shape.id
                       )}
-                      <div className="flex items-center justify-end opacity-100 transition-opacity lg:opacity-0 lg:group-hover/item:opacity-100">
-                        <button
-                          type="button"
-                          title={t("actions.removeItem")}
-                          className="text-muted-foreground/55 hover:bg-brand-primary/10 hover:text-brand-primary flex size-5 items-center justify-center rounded-md transition-colors"
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            removeShapes([shape.id]);
-                            setHoveredShapeId(null);
-                          }}
-                        >
-                          <X className="size-3" />
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })
+                      isUnmapped={unmappedObstacleIds.has(shape.id)}
+                      routeStatusOff={routeStatusOff}
+                      removeItemTitle={removeItemTitle}
+                      isDraggable
+                      onDragEnd={handleDragEnd}
+                      setSelection={setSelection}
+                      setHoveredShapeId={setHoveredShapeId}
+                      removeShapes={removeShapes}
+                    />
+                  ))}
+                </Reorder.Group>
               ) : (
-                <div className="px-3 py-4 text-center">
-                  <p className="text-muted-foreground/55 text-[11px]">
-                    {t("listPanel.noItemsMatchFilter")}
-                  </p>
+                <div className="divide-border/15 divide-y">
+                  {filteredShapes.map((shape) => (
+                    <ItemRow
+                      key={shape.id}
+                      shape={shape}
+                      orderLabel={shapeOrder.get(shape.id)}
+                      displayName={getShapeDisplayName(shape, tShapes)}
+                      kindLabel={getShapeKindLabel(shape.kind, tShapes)}
+                      pathNumber={numberingReport.obstacleNumberMap.get(
+                        shape.id
+                      )}
+                      isUnmapped={unmappedObstacleIds.has(shape.id)}
+                      routeStatusOff={routeStatusOff}
+                      removeItemTitle={removeItemTitle}
+                      isDraggable={false}
+                      onDragEnd={handleDragEnd}
+                      setSelection={setSelection}
+                      setHoveredShapeId={setHoveredShapeId}
+                      removeShapes={removeShapes}
+                    />
+                  ))}
                 </div>
-              )}
-            </div>
+              )
+            ) : (
+              <div className="px-3 py-4 text-center">
+                <p className="text-muted-foreground/55 text-[11px]">
+                  {t("listPanel.noItemsMatchFilter")}
+                </p>
+              </div>
+            )}
           </div>
         </ListPanel>
       </div>

--- a/src/components/inspector/views/project-layout.tsx
+++ b/src/components/inspector/views/project-layout.tsx
@@ -1,11 +1,22 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { Eye, EyeOff, MapPinned, Trash2 } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Eye,
+  EyeOff,
+  MapPinned,
+  Route,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
 import ElevationChart from "@/components/inspector/ElevationChart";
 import { MeasurementUnitToggle } from "@/components/MeasurementUnitToggle";
 import { MapReferenceDialog } from "@/components/map-reference/MapReferenceDialog";
 import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 import { getShapeKindLabel, type Translate } from "@/lib/track/items/registry";
 import {
   getInventoryComparison,
@@ -13,11 +24,18 @@ import {
   normalizeInventoryProfile,
 } from "@/lib/planning/inventory";
 import { getObstacleNumberingReport } from "@/lib/track/obstacleNumbering";
+import {
+  generateRaceLineDraft,
+  isGeneratedRaceLine,
+  type GeneratedRouteWarning,
+} from "@/lib/track/generated-route";
 import type {
   FieldSpec,
   InventoryShapeKind,
   MapReference,
+  PolylineShape,
   Shape,
+  ShapeDraft,
   TrackDesign,
 } from "@/lib/types";
 import {
@@ -36,7 +54,11 @@ import {
   InspectorScrollBody,
   useIsDesktopInspector,
 } from "./layout";
-import { type DesignMetaPatch, ItemOverviewList } from "./list-panel";
+import {
+  getListableTrackItems,
+  type DesignMetaPatch,
+  ItemOverviewList,
+} from "./list-panel";
 import { useTranslations } from "next-intl";
 
 function getShapeDisplayName(shape: Shape, index: number, t: Translate) {
@@ -189,15 +211,56 @@ function MapReferenceSection({
   );
 }
 
+function summarizeGeneratedRouteWarnings(
+  warnings: GeneratedRouteWarning[],
+  t: ReturnType<typeof useTranslations<"inspector">>
+): string {
+  const unsupportedCount = warnings.filter(
+    (warning) => warning.type === "unsupported-shape"
+  ).length;
+  const tooFewObstacles = warnings.some(
+    (warning) => warning.type === "too-few-obstacles"
+  );
+  const closeObstacleCount = warnings.filter(
+    (warning) => warning.type === "close-obstacles"
+  ).length;
+
+  const parts: string[] = [];
+  if (unsupportedCount > 0) {
+    parts.push(
+      t("routeNumbering.generate.warnings.unsupportedShapes", {
+        count: unsupportedCount,
+      })
+    );
+  }
+  if (tooFewObstacles) {
+    parts.push(t("routeNumbering.generate.warnings.tooFewObstacles"));
+  }
+  if (closeObstacleCount > 0) {
+    parts.push(
+      t("routeNumbering.generate.warnings.closeObstacles", {
+        count: closeObstacleCount,
+      })
+    );
+  }
+
+  return parts.join(" ");
+}
+
 function RouteNumberingOverview({
   design,
   shapes,
+  addShape,
+  removeShapes,
+  setSelection,
 }: {
   design: TrackDesign;
   shapes: Shape[];
+  addShape: (draft: ShapeDraft<PolylineShape>) => string;
+  removeShapes: (ids: string[]) => void;
+  setSelection: (ids: string[]) => void;
 }) {
   const t = useTranslations("inspector");
-  const tCommon = useTranslations("common");
   const tShapes = useTranslations("shapes") as unknown as Translate;
   const report = useMemo(() => getObstacleNumberingReport(design), [design]);
   const shapeOrder = useMemo(
@@ -215,6 +278,13 @@ function RouteNumberingOverview({
     report.status === "ready" ||
     report.status === "empty" ||
     report.status === "no-numbered-obstacles";
+  const hasExistingRaceLine = Boolean(report.primaryPolylineId);
+  const generatedRaceLine = shapes.find(isGeneratedRaceLine) ?? null;
+  const hasGeneratedRaceLine = Boolean(generatedRaceLine);
+  const hasWarnings =
+    report.status === "partial" ||
+    report.status === "no-route-matches" ||
+    report.status === "missing-route";
   const statusLabel =
     report.status === "ready"
       ? t("routeNumbering.status.ready")
@@ -242,25 +312,114 @@ function RouteNumberingOverview({
               count: report.totalNumberedObstacleCount,
             })
           : report.status === "missing-route"
-            ? t("routeNumbering.messages.missingRoute", {
-                count: report.totalNumberedObstacleCount,
-              })
+            ? t("routeNumbering.messages.missingRoute")
             : report.status === "no-numbered-obstacles"
               ? t("routeNumbering.messages.noNumberedObstacles")
               : t("routeNumbering.messages.empty");
 
+  const canGenerate =
+    report.status === "missing-route" ||
+    report.status === "ready" ||
+    report.status === "partial" ||
+    report.status === "no-route-matches";
+
+  function handleGenerateRaceLine() {
+    const { draft, report: genReport } = generateRaceLineDraft(design);
+    if (!draft) {
+      toast.error(t("routeNumbering.generate.errors.noObstacles"));
+      return;
+    }
+
+    if (generatedRaceLine) {
+      removeShapes([generatedRaceLine.id]);
+    }
+
+    const newId = addShape(draft);
+    setSelection([newId]);
+
+    const warningText = summarizeGeneratedRouteWarnings(genReport.warnings, t);
+    toast.success(
+      warningText
+        ? `${t("routeNumbering.generate.success")}. ${warningText}`
+        : t("routeNumbering.generate.success")
+    );
+  }
+
   return (
     <Section title={t("layout.sections.routeNumbering")}>
-      <div className="space-y-2">
-        <div className="grid grid-cols-3 gap-2">
-          <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
-            <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
-              {tCommon("labels.status")}
-            </p>
-            <p className="text-foreground text-[12px] font-semibold">
-              {statusLabel}
-            </p>
+      <div className="space-y-3">
+        <div
+          className={cn(
+            "rounded-md border px-2.5 py-2",
+            hasWarnings
+              ? "border-amber-500/25 bg-amber-500/8"
+              : isClear
+                ? "border-emerald-500/20 bg-emerald-500/8"
+                : "border-border/40 bg-muted/25"
+          )}
+        >
+          <div className="flex items-start gap-2">
+            <span
+              className={cn(
+                "mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-sm",
+                hasWarnings
+                  ? "bg-amber-500/12 text-amber-600"
+                  : isClear
+                    ? "bg-emerald-500/12 text-emerald-600"
+                    : "bg-muted text-muted-foreground"
+              )}
+              aria-hidden="true"
+            >
+              {hasWarnings ? (
+                <AlertTriangle className="size-3" />
+              ) : isClear ? (
+                <CheckCircle2 className="size-3" />
+              ) : (
+                <Route className="size-3" />
+              )}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                <p
+                  className={cn(
+                    "text-[12px] font-semibold",
+                    hasWarnings
+                      ? "text-amber-600"
+                      : isClear
+                        ? "text-emerald-600"
+                        : "text-foreground"
+                  )}
+                >
+                  {statusLabel}
+                </p>
+                {hasExistingRaceLine ? (
+                  <span className="border-border/45 bg-background/65 text-muted-foreground inline-flex items-center rounded-sm border px-1.5 py-px text-[10px] font-medium">
+                    {t("routeNumbering.meta.raceLine")}
+                  </span>
+                ) : null}
+                {message ? (
+                  <span className="text-muted-foreground/80 text-[11px] leading-snug">
+                    {message}
+                  </span>
+                ) : null}
+              </div>
+              {issueNames.length > 0 ? (
+                <p className="mt-1 text-[10px] leading-snug text-amber-600/85">
+                  {t("routeNumbering.issues.offRoutePrefix", {
+                    names: issueNames.join(", "),
+                  })}
+                  {extraIssueCount > 0
+                    ? t("routeNumbering.issues.moreSuffix", {
+                        count: extraIssueCount,
+                      })
+                    : ""}
+                </p>
+              ) : null}
+            </div>
           </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
           <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
             <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
               {t("routeNumbering.meta.numbered")}
@@ -278,27 +437,26 @@ function RouteNumberingOverview({
             </p>
           </div>
         </div>
-        <div
-          className={
-            isClear
-              ? "rounded-md border border-emerald-500/20 bg-emerald-500/8 px-2.5 py-2 text-emerald-500"
-              : "rounded-md border border-amber-500/25 bg-amber-500/10 px-2.5 py-2 text-amber-500"
-          }
-        >
-          <p className="text-[11px] leading-relaxed">{message}</p>
-          {issueNames.length > 0 ? (
-            <p className="mt-1 text-[10px] leading-relaxed opacity-80">
-              {t("routeNumbering.issues.offRoutePrefix", {
-                names: issueNames.join(", "),
-              })}
-              {extraIssueCount > 0
-                ? t("routeNumbering.issues.moreSuffix", {
-                    count: extraIssueCount,
-                  })
-                : ""}
-            </p>
-          ) : null}
-        </div>
+
+        {canGenerate ? (
+          <button
+            type="button"
+            onClick={handleGenerateRaceLine}
+            className={cn(
+              "inline-flex h-11 w-full items-center justify-center gap-1.5 rounded-lg border px-3 text-xs font-medium transition-colors lg:h-8 lg:text-[11px]",
+              hasWarnings
+                ? "border-amber-500/25 bg-amber-500/10 text-amber-700 hover:bg-amber-500/16 dark:text-amber-400"
+                : "border-emerald-500/25 bg-emerald-500/8 text-emerald-700 hover:bg-emerald-500/14 dark:text-emerald-400"
+            )}
+          >
+            <Sparkles className="size-4 lg:size-3" />
+            <span>
+              {hasGeneratedRaceLine
+                ? t("routeNumbering.generate.regenerateButton")
+                : t("routeNumbering.generate.button")}
+            </span>
+          </button>
+        ) : null}
       </div>
     </Section>
   );
@@ -318,6 +476,8 @@ export interface ProjectLayoutInspectorViewProps {
   setMapReferenceRotation: (rotationDeg: number) => void;
   removeShapes: (ids: string[]) => void;
   setHoveredShapeId: (shapeId: string | null) => void;
+  addShape: (draft: ShapeDraft<PolylineShape>) => string;
+  reorderShapes: (fromId: string, beforeId: string | null) => void;
   mobileInline?: boolean;
 }
 
@@ -335,6 +495,8 @@ export function ProjectLayoutInspectorView({
   setMapReferenceRotation,
   removeShapes,
   setHoveredShapeId,
+  addShape,
+  reorderShapes,
   mobileInline = false,
 }: ProjectLayoutInspectorViewProps) {
   const t = useTranslations("inspector");
@@ -356,6 +518,10 @@ export function ProjectLayoutInspectorView({
   const obstacleNumberingReport = useMemo(
     () => getObstacleNumberingReport(design),
     [design]
+  );
+  const trackItemShapes = useMemo(
+    () => getListableTrackItems(shapes),
+    [shapes]
   );
 
   const updateInventoryCount = (kind: InventoryShapeKind, value: number) => {
@@ -537,7 +703,7 @@ export function ProjectLayoutInspectorView({
         title={t("layout.overview.title")}
         subtitle={t("layout.overview.subtitle")}
         meta={[
-          t("layout.meta.itemsCount", { count: shapes.length }),
+          t("layout.meta.itemsCount", { count: trackItemShapes.length }),
           totalMissing === 0
             ? t("layout.meta.buildable")
             : t("layout.meta.shortItems", { count: totalMissing }),
@@ -563,8 +729,14 @@ export function ProjectLayoutInspectorView({
           setMapReferenceOpacity={setMapReferenceOpacity}
           setMapReferenceRotation={setMapReferenceRotation}
         />
-        <RouteNumberingOverview design={design} shapes={shapes} />
-        {shapes.length > 0 ? (
+        <RouteNumberingOverview
+          design={design}
+          shapes={shapes}
+          addShape={addShape}
+          removeShapes={removeShapes}
+          setSelection={setSelection}
+        />
+        {trackItemShapes.length > 0 ? (
           <ItemOverviewList
             design={design}
             shapes={shapes}
@@ -572,6 +744,7 @@ export function ProjectLayoutInspectorView({
             removeShapes={removeShapes}
             setHoveredShapeId={setHoveredShapeId}
             obstacleNumberingReport={obstacleNumberingReport}
+            reorderShapes={reorderShapes}
           />
         ) : (
           <div className="border-border/40 rounded-lg border border-dashed px-3 py-4 text-center">

--- a/src/lib/track/generated-route.ts
+++ b/src/lib/track/generated-route.ts
@@ -1,0 +1,220 @@
+import { distance2D } from "@/lib/track/geometry";
+import { getGeneratedRouteProfile } from "@/lib/track/items/registry";
+import type {
+  PolylinePoint,
+  PolylineShape,
+  Shape,
+  ShapeDraft,
+  TrackDesign,
+} from "@/lib/types";
+
+const MIN_SEGMENT_DISTANCE_METERS = 0.25;
+
+export type GeneratedRouteWarningType =
+  "unsupported-shape" | "too-few-obstacles" | "close-obstacles";
+
+export type GeneratedRouteWarning = {
+  type: GeneratedRouteWarningType;
+  shapeId?: string;
+  shapeIds?: string[];
+};
+
+export type GeneratedRouteReport = {
+  totalShapeCount: number;
+  supportedObstacleIds: string[];
+  unsupportedShapeIds: string[];
+  warnings: GeneratedRouteWarning[];
+};
+
+export type GeneratedRouteResult = {
+  draft: ShapeDraft<PolylineShape> | null;
+  report: GeneratedRouteReport;
+};
+
+export function isGeneratedRaceLine(shape: Shape | null | undefined): boolean {
+  if (!shape || shape.kind !== "polyline") return false;
+  if (shape.meta?.generatedRoute === true) return true;
+
+  // Legacy generated routes did not have metadata. They were smooth,
+  // arrowed, and intentionally left without a fixed color so elevation
+  // coloring could show through.
+  return shape.smooth === true && shape.showArrows === true && !shape.color;
+}
+
+function degToRad(deg: number) {
+  return (deg * Math.PI) / 180;
+}
+
+function getHeadingUnitVector(headingDeg: number) {
+  const radians = degToRad(headingDeg);
+  return {
+    x: Math.cos(radians),
+    y: Math.sin(radians),
+  };
+}
+
+function pointAlongHeading(
+  anchor: PolylinePoint,
+  headingDeg: number,
+  distance: number
+): PolylinePoint {
+  const unit = getHeadingUnitVector(headingDeg);
+  return {
+    x: anchor.x + unit.x * distance,
+    y: anchor.y + unit.y * distance,
+    z: anchor.z,
+  };
+}
+
+function appendPoint(points: PolylinePoint[], point: PolylinePoint) {
+  const previous = points.at(-1);
+  if (previous && distance2D(previous, point) < MIN_SEGMENT_DISTANCE_METERS) {
+    return;
+  }
+
+  points.push(point);
+}
+
+function getOrderedShapes(design: TrackDesign): Shape[] {
+  return design.shapeOrder
+    .map((shapeId) => design.shapeById[shapeId])
+    .filter((shape): shape is Shape => Boolean(shape));
+}
+
+function getBearingDeg(from: PolylinePoint, to: PolylinePoint): number {
+  return (Math.atan2(to.y - from.y, to.x - from.x) * 180) / Math.PI;
+}
+
+type SupportedRouteItem = {
+  shape: Shape;
+  anchor: PolylinePoint;
+  traversal: "through" | "marker";
+  headingDeg?: number;
+  approachDistance?: number;
+};
+
+export function generateRaceLineDraft(
+  design: TrackDesign
+): GeneratedRouteResult {
+  const warnings: GeneratedRouteWarning[] = [];
+  const unsupportedShapeIds: string[] = [];
+  const points: PolylinePoint[] = [];
+  const orderedShapes = getOrderedShapes(design);
+  const supportedItems: SupportedRouteItem[] = [];
+
+  for (const shape of orderedShapes) {
+    if (shape.kind === "polyline") continue;
+
+    const profile = getGeneratedRouteProfile(shape);
+    if (
+      !profile ||
+      (profile.traversal !== "through" && profile.traversal !== "marker")
+    ) {
+      unsupportedShapeIds.push(shape.id);
+      warnings.push({ type: "unsupported-shape", shapeId: shape.id });
+      continue;
+    }
+
+    const anchor = profile.getAnchor?.(shape) ?? {
+      x: shape.x,
+      y: shape.y,
+      z: 1,
+    };
+
+    supportedItems.push({
+      shape,
+      anchor,
+      traversal: profile.traversal,
+      headingDeg: profile.getHeadingDeg?.(shape),
+      approachDistance: profile.getApproachDistance?.(shape),
+    });
+  }
+
+  supportedItems.forEach((item, index) => {
+    if (item.traversal === "marker") {
+      // A marker (e.g. a flag) isn't flown through, so route around it
+      // instead of straight over its exact position. Which side to pass on
+      // depends entirely on where it was placed relative to the rest of the
+      // track, which no fixed geometric rule can guess reliably, so prefer
+      // the marker's own facing direction (set by rotating it on canvas,
+      // fully under the user's control) and only fall back to a guess based
+      // on the local direction of travel when the shape has no facing.
+      const previousAnchor = supportedItems[index - 1]?.anchor;
+      const nextAnchor = supportedItems[index + 1]?.anchor;
+      const fallbackBearingDeg = previousAnchor
+        ? getBearingDeg(previousAnchor, item.anchor)
+        : nextAnchor
+          ? getBearingDeg(item.anchor, nextAnchor)
+          : item.shape.rotation;
+      const offsetHeadingDeg = item.headingDeg ?? fallbackBearingDeg;
+      const clearance = Math.max(1, item.approachDistance ?? 1);
+
+      appendPoint(
+        points,
+        pointAlongHeading(item.anchor, offsetHeadingDeg, clearance)
+      );
+      return;
+    }
+
+    const headingDeg = item.headingDeg ?? item.shape.rotation;
+    const approachDistance = Math.max(1, item.approachDistance ?? 2);
+
+    if (index === 0) {
+      appendPoint(
+        points,
+        pointAlongHeading(item.anchor, headingDeg, -approachDistance)
+      );
+    }
+    appendPoint(points, item.anchor);
+    if (index === supportedItems.length - 1 && supportedItems.length > 1) {
+      appendPoint(
+        points,
+        pointAlongHeading(item.anchor, headingDeg, approachDistance)
+      );
+    }
+  });
+
+  const supportedObstacleIds = supportedItems.map((item) => item.shape.id);
+
+  if (supportedObstacleIds.length < 2) {
+    warnings.push({ type: "too-few-obstacles" });
+  }
+
+  for (let index = 1; index < supportedObstacleIds.length; index += 1) {
+    const previous = design.shapeById[supportedObstacleIds[index - 1]];
+    const current = design.shapeById[supportedObstacleIds[index]];
+    if (previous && current && distance2D(previous, current) < 2) {
+      warnings.push({
+        type: "close-obstacles",
+        shapeIds: [previous.id, current.id],
+      });
+    }
+  }
+
+  const report: GeneratedRouteReport = {
+    totalShapeCount: orderedShapes.filter((shape) => shape.kind !== "polyline")
+      .length,
+    supportedObstacleIds,
+    unsupportedShapeIds,
+    warnings,
+  };
+
+  if (points.length < 2) {
+    return { draft: null, report };
+  }
+
+  return {
+    draft: {
+      kind: "polyline",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      points,
+      closed: false,
+      smooth: true,
+      showArrows: true,
+      meta: { generatedRoute: true },
+    },
+    report,
+  };
+}

--- a/src/lib/track/items/registry.ts
+++ b/src/lib/track/items/registry.ts
@@ -208,10 +208,7 @@ function getLadderRouteElevation(shape: LadderShape): number {
     return Math.max(0.4, (shape.elevation ?? 0) + openingHeight * 1.25);
   }
 
-  return Math.max(
-    0.4,
-    (shape.elevation ?? 0) + openingHeight / 2
-  );
+  return Math.max(0.4, (shape.elevation ?? 0) + openingHeight / 2);
 }
 
 function getDiveGateRouteElevation(shape: DiveGateShape): number {

--- a/src/lib/track/items/registry.ts
+++ b/src/lib/track/items/registry.ts
@@ -10,10 +10,25 @@ import {
   TRACKDRAW_TOWER_ELEMENT_ID,
   type TrackElementCatalogId,
 } from "@/lib/track/elements/catalog";
+import { POLYLINE_3D_HEIGHT_OFFSET } from "@/lib/track/constants";
+import {
+  getDiveGateVisualSpec,
+  getGateVisualSpec,
+  getLadderVisualSpec,
+  getTowerVisualSpec,
+} from "@/lib/track/elements/visual";
+import {
+  getMultiGpDiveGateArchLayout,
+  getMultiGpLaunchGateLayout,
+  getPanelFrameLadderLayout,
+} from "@/lib/track/render3d-layout";
 import type {
   DiveGateShape,
+  FlagShape,
+  GateShape,
   InventoryShapeKind,
   LadderShape,
+  PolylinePoint,
   Shape,
   ShapeKind,
   TowerShape,
@@ -50,6 +65,15 @@ export type SetupProfile = {
   complexity: SetupComplexity;
 };
 
+export type RouteGenerationTraversal = "through" | "around" | "marker" | "none";
+
+export type RouteGenerationProfile = {
+  traversal: RouteGenerationTraversal;
+  getAnchor?: (shape: Shape) => PolylinePoint;
+  getHeadingDeg?: (shape: Shape) => number;
+  getApproachDistance?: (shape: Shape) => number;
+};
+
 export interface TrackItemAdapter {
   kind: ShapeKind;
   label: string;
@@ -68,6 +92,7 @@ export interface TrackItemAdapter {
   timingMarker?: boolean;
   setupHardObstacle?: boolean;
   rotateHandle3d?: boolean;
+  generatedRoute?: RouteGenerationProfile;
   catalogPatch?: {
     preserveDiveGateTopY?: boolean;
   };
@@ -94,6 +119,156 @@ function getNoSetupProfile(t: Translate): SetupProfile {
   };
 }
 
+function getShapeAnchorAtElevation(
+  shape: Shape,
+  targetRouteElevation: number
+): PolylinePoint {
+  return {
+    x: shape.x,
+    y: shape.y,
+    z: toGeneratedRouteWaypointElevation(targetRouteElevation),
+  };
+}
+
+function toGeneratedRouteWaypointElevation(targetRouteElevation: number) {
+  return Math.max(0, targetRouteElevation - POLYLINE_3D_HEIGHT_OFFSET);
+}
+
+function getGateRouteAnchor(shape: Shape): PolylinePoint {
+  return getShapeAnchorAtElevation(
+    shape,
+    getGateRouteElevation(shape as GateShape)
+  );
+}
+
+function getTowerRouteAnchor(shape: Shape): PolylinePoint {
+  return getShapeAnchorAtElevation(
+    shape,
+    getTowerRouteElevation(shape as TowerShape)
+  );
+}
+
+function getFlagRouteAnchor(shape: Shape): PolylinePoint {
+  return getShapeAnchorAtElevation(shape, getFlagRouteElevation());
+}
+
+function getLadderRouteAnchor(shape: Shape): PolylinePoint {
+  return getShapeAnchorAtElevation(
+    shape,
+    getLadderRouteElevation(shape as LadderShape)
+  );
+}
+
+function getDiveGateRouteAnchor(shape: Shape): PolylinePoint {
+  return getShapeAnchorAtElevation(
+    shape,
+    getDiveGateRouteElevation(shape as DiveGateShape)
+  );
+}
+
+function getGateRouteElevation(shape: GateShape): number {
+  const visual = getGateVisualSpec(shape);
+  if (visual.variant === "frame-only") {
+    return 0;
+  }
+
+  return Math.max(0.4, shape.height / 2);
+}
+
+function getFlagRouteElevation(): number {
+  return 0;
+}
+
+function getTowerRouteElevation(shape: TowerShape): number {
+  const visual = getTowerVisualSpec(shape);
+  if (visual?.variant === "panel-frame") {
+    // MultiGP tower visuals add a lower banner panel for a single-level tower,
+    // but the generated route should target the nominal elevated opening, not
+    // drift upward by the banner height.
+    return Math.max(0.4, Math.max(shape.elevation ?? 0, 0) + shape.height / 2);
+  }
+
+  return Math.max(0.4, (shape.elevation ?? 0) + shape.height / 2);
+}
+
+function getLadderRouteElevation(shape: LadderShape): number {
+  const visual = getLadderVisualSpec(shape);
+  if (visual?.variant === "panel-frame") {
+    const layout = getPanelFrameLadderLayout(shape, visual);
+    const lowerSection = layout.sections[0];
+    return Math.max(
+      0.4,
+      layout.baseY + (lowerSection?.openingMidY ?? layout.openingH)
+    );
+  }
+
+  const rungs = Math.max(1, Math.round(shape.rungs ?? 1));
+  const openingHeight = shape.height / rungs;
+  if (rungs > 1) {
+    return Math.max(0.4, (shape.elevation ?? 0) + openingHeight * 1.25);
+  }
+
+  return Math.max(
+    0.4,
+    (shape.elevation ?? 0) + openingHeight / 2
+  );
+}
+
+function getDiveGateRouteElevation(shape: DiveGateShape): number {
+  const visual = getDiveGateVisualSpec(shape);
+  if (visual?.variant === "arch") {
+    return Math.max(0.4, getMultiGpDiveGateArchLayout(shape).centerY);
+  }
+  if (visual?.variant === "launch") {
+    return Math.max(0.4, getMultiGpLaunchGateLayout(shape).topY);
+  }
+
+  return Math.max(0.4, shape.elevation ?? (shape.height ?? shape.width) * 0.5);
+}
+
+function getRouteHeadingDeg(shape: Shape): number {
+  return (
+    shape.rotation +
+    getShapeOrientationBaseOffset(shape.kind, "canvasGuide") +
+    (shape.frontOffsetDeg ?? 0) +
+    180
+  );
+}
+
+function getRouteMarkerOffsetHeadingDeg(shape: Shape): number {
+  return (
+    shape.rotation +
+    getShapeOrientationBaseOffset(shape.kind, "canvasGuide") +
+    (shape.frontOffsetDeg ?? 0) +
+    180
+  );
+}
+
+function getGateApproachDistance(shape: Shape): number {
+  const gate = shape as GateShape;
+  return Math.max(2, gate.width * 0.8);
+}
+
+function getTowerApproachDistance(shape: Shape): number {
+  const tower = shape as TowerShape;
+  return Math.max(2.5, tower.width * 0.75);
+}
+
+function getLadderApproachDistance(shape: Shape): number {
+  const ladder = shape as LadderShape;
+  return Math.max(2.5, ladder.width * 0.75);
+}
+
+function getDiveGateApproachDistance(shape: Shape): number {
+  const diveGate = shape as DiveGateShape;
+  return Math.max(3, diveGate.width * 0.75);
+}
+
+function getFlagClearanceDistance(shape: Shape): number {
+  const flag = shape as FlagShape;
+  return Math.max(1, (flag.radius ?? 0.25) + 0.8);
+}
+
 export const trackItemAdapters = [
   {
     kind: "gate",
@@ -112,6 +287,12 @@ export const trackItemAdapters = [
     timingMarker: true,
     setupHardObstacle: true,
     rotateHandle3d: true,
+    generatedRoute: {
+      traversal: "through",
+      getAnchor: getGateRouteAnchor,
+      getHeadingDeg: getRouteHeadingDeg,
+      getApproachDistance: getGateApproachDistance,
+    },
     canvasRenderRotationOffsetDeg: 180,
     mobileTouchTargetMinScreenPx: 44,
     routeToleranceWidthFactor: 0.42,
@@ -138,6 +319,12 @@ export const trackItemAdapters = [
     numberedObstacle: true,
     setupHardObstacle: true,
     rotateHandle3d: true,
+    generatedRoute: {
+      traversal: "through",
+      getAnchor: getTowerRouteAnchor,
+      getHeadingDeg: getRouteHeadingDeg,
+      getApproachDistance: getTowerApproachDistance,
+    },
     canvasRenderRotationOffsetDeg: 180,
     mobileTouchTargetMinScreenPx: 44,
     routeToleranceWidthFactor: 0.42,
@@ -167,6 +354,13 @@ export const trackItemAdapters = [
     },
     orientation: { facing: 0, canvasGuide: 0, previewGuide: -90 },
     rotateHandle3d: true,
+    numberedObstacle: true,
+    generatedRoute: {
+      traversal: "marker",
+      getAnchor: getFlagRouteAnchor,
+      getHeadingDeg: getRouteMarkerOffsetHeadingDeg,
+      getApproachDistance: getFlagClearanceDistance,
+    },
     getSetupProfile: (_shape, t) => ({
       priority: 4,
       prepMinutes: 1,
@@ -251,6 +445,12 @@ export const trackItemAdapters = [
     numberedObstacle: true,
     setupHardObstacle: true,
     rotateHandle3d: true,
+    generatedRoute: {
+      traversal: "through",
+      getAnchor: getLadderRouteAnchor,
+      getHeadingDeg: getRouteHeadingDeg,
+      getApproachDistance: getLadderApproachDistance,
+    },
     canvasRenderRotationOffsetDeg: 180,
     routeToleranceWidthFactor: 0.42,
     getSetupProfile: (shape, t) => {
@@ -281,6 +481,12 @@ export const trackItemAdapters = [
     numberedObstacle: true,
     setupHardObstacle: true,
     rotateHandle3d: true,
+    generatedRoute: {
+      traversal: "through",
+      getAnchor: getDiveGateRouteAnchor,
+      getHeadingDeg: getRouteHeadingDeg,
+      getApproachDistance: getDiveGateApproachDistance,
+    },
     catalogPatch: { preserveDiveGateTopY: true },
     routeToleranceWidthFactor: 0.38,
     getSetupProfile: (shape, t) => {
@@ -410,6 +616,13 @@ export function has3dRotateHandle(shape: Shape): boolean {
 
 export function getObstacleRouteToleranceWidthFactor(shape: Shape): number {
   return getTrackItemAdapterForShape(shape).routeToleranceWidthFactor ?? 0;
+}
+
+export function getGeneratedRouteProfile(
+  shape: Shape
+): RouteGenerationProfile | null {
+  const profile = getTrackItemAdapterForShape(shape).generatedRoute;
+  return profile?.traversal === "none" ? null : (profile ?? null);
 }
 
 export function getCatalogPlacementToolIds(): CatalogPlacementToolId[] {

--- a/tests/components/inspector/Inspector.test.tsx
+++ b/tests/components/inspector/Inspector.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment happy-dom
 
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Inspector from "@/components/inspector/Inspector";
 import { useEditor } from "@/store/editor";

--- a/tests/components/inspector/Inspector.test.tsx
+++ b/tests/components/inspector/Inspector.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Inspector from "@/components/inspector/Inspector";
+import { useEditor } from "@/store/editor";
+import { gateDraft, resetEditorStore } from "../../helpers/editor-store";
+
+vi.mock("@/components/inspector/ElevationChart", () => ({
+  default: () => <div data-testid="elevation-chart" />,
+}));
+
+vi.mock("@/components/editor/SaveAsPresetDialog", () => ({
+  SaveAsPresetDialog: () => null,
+}));
+
+describe("Inspector tab switching", () => {
+  beforeEach(() => {
+    resetEditorStore();
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        addEventListener: vi.fn(),
+        matches: false,
+        removeEventListener: vi.fn(),
+      })
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("returns to the selection tab when a selected track item is clicked again", () => {
+    const gateId = useEditor.getState().addShape(gateDraft());
+    act(() => {
+      useEditor.getState().setSelection([gateId]);
+    });
+
+    render(<Inspector mobileInline />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Layout" }));
+    expect(
+      screen.getByRole("tab", { name: "Layout" }).getAttribute("aria-selected")
+    ).toBe("true");
+
+    act(() => {
+      useEditor.getState().setSelection([gateId]);
+    });
+
+    expect(
+      screen
+        .getByRole("tab", { name: "Selection" })
+        .getAttribute("aria-selected")
+    ).toBe("true");
+  });
+});

--- a/tests/components/inspector/ProjectLayoutInspectorView.test.tsx
+++ b/tests/components/inspector/ProjectLayoutInspectorView.test.tsx
@@ -31,11 +31,13 @@ function withMapReference(): TrackDesign {
 function renderProjectLayoutInspector(design = withMapReference()) {
   render(
     <ProjectLayoutInspectorView
+      addShape={vi.fn()}
       clearMapReference={vi.fn()}
       design={design}
       mobileInline
       panel="layout"
       removeShapes={vi.fn()}
+      reorderShapes={vi.fn()}
       setHoveredShapeId={vi.fn()}
       setMapReference={vi.fn()}
       setMapReferenceOpacity={vi.fn()}

--- a/tests/components/inspector/RouteNumberingOverview.test.tsx
+++ b/tests/components/inspector/RouteNumberingOverview.test.tsx
@@ -1,0 +1,254 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectLayoutInspectorView } from "@/components/inspector/views/project-layout";
+import { createDefaultDesign } from "@/lib/track/design";
+import type {
+  PolylineShape,
+  Shape,
+  ShapeDraft,
+  TrackDesign,
+} from "@/lib/types";
+
+const mocks = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock("@/components/inspector/ElevationChart", () => ({
+  default: () => <div data-testid="elevation-chart" />,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
+}));
+
+function gate(
+  id: string,
+  x: number,
+  y: number
+): Extract<Shape, { kind: "gate" }> {
+  return { id, kind: "gate", x, y, rotation: 0, width: 2, height: 2 };
+}
+
+function designWithGates(gates: Shape[]): TrackDesign {
+  return {
+    ...createDefaultDesign(),
+    shapeOrder: gates.map((shape) => shape.id),
+    shapeById: Object.fromEntries(gates.map((shape) => [shape.id, shape])),
+  };
+}
+
+function renderProjectLayoutInspector(
+  design: TrackDesign,
+  shapes: Shape[],
+  overrides: {
+    addShape?: (draft: ShapeDraft<PolylineShape>) => string;
+    removeShapes?: (ids: string[]) => void;
+    setSelection?: (ids: string[]) => void;
+  } = {}
+) {
+  render(
+    <ProjectLayoutInspectorView
+      addShape={overrides.addShape ?? vi.fn()}
+      clearMapReference={vi.fn()}
+      design={design}
+      mobileInline
+      panel="layout"
+      removeShapes={overrides.removeShapes ?? vi.fn()}
+      reorderShapes={vi.fn()}
+      setHoveredShapeId={vi.fn()}
+      setMapReference={vi.fn()}
+      setMapReferenceOpacity={vi.fn()}
+      setMapReferenceRotation={vi.fn()}
+      setMapReferenceVisibility={vi.fn()}
+      setSelection={overrides.setSelection ?? vi.fn()}
+      shapes={shapes}
+      updateDesignMeta={vi.fn()}
+      updateField={vi.fn()}
+    />
+  );
+}
+
+describe("RouteNumberingOverview generate race line action", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({
+        addEventListener: vi.fn(),
+        matches: false,
+        removeEventListener: vi.fn(),
+      })
+    );
+    mocks.toastError.mockReset();
+    mocks.toastSuccess.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("generates and selects a race line from placed obstacles", async () => {
+    const user = userEvent.setup();
+    const gates = [gate("gate-1", 0, 0), gate("gate-2", 10, 0)];
+    const design = designWithGates(gates);
+    const addShape = vi.fn().mockReturnValue("new-polyline-id");
+    const setSelection = vi.fn();
+
+    renderProjectLayoutInspector(design, gates, { addShape, setSelection });
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate race line" })
+    );
+
+    expect(addShape).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "polyline" })
+    );
+    expect(setSelection).toHaveBeenCalledWith(["new-polyline-id"]);
+    expect(mocks.toastSuccess).toHaveBeenCalled();
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("still generates a race line but surfaces a warning when only one obstacle is placed", async () => {
+    const user = userEvent.setup();
+    const gates = [gate("gate-1", 0, 0)];
+    const design = designWithGates(gates);
+    const addShape = vi.fn().mockReturnValue("new-polyline-id");
+    const setSelection = vi.fn();
+
+    renderProjectLayoutInspector(design, gates, { addShape, setSelection });
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate race line" })
+    );
+
+    expect(addShape).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "polyline" })
+    );
+    expect(setSelection).toHaveBeenCalledWith(["new-polyline-id"]);
+    expect(mocks.toastSuccess).toHaveBeenCalledWith(
+      expect.stringContaining("more useful race line")
+    );
+    expect(mocks.toastError).not.toHaveBeenCalled();
+  });
+
+  it("keeps a manual race line when generating a generated race line", async () => {
+    const user = userEvent.setup();
+    const gates = [gate("gate-1", 0, 0), gate("gate-2", 10, 0)];
+    const polyline = {
+      id: "existing-line",
+      kind: "polyline" as const,
+      x: 0,
+      y: 0,
+      rotation: 0,
+      points: [
+        { x: 0, y: 0, z: 1 },
+        { x: 10, y: 0, z: 1 },
+      ],
+    };
+    const design = designWithGates([...gates, polyline]);
+    const addShape = vi.fn().mockReturnValue("new-polyline-id");
+    const removeShapes = vi.fn();
+
+    renderProjectLayoutInspector(design, [...gates, polyline], {
+      addShape,
+      removeShapes,
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: "Generate race line" })
+    );
+
+    expect(removeShapes).not.toHaveBeenCalled();
+    expect(addShape).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "polyline" })
+    );
+  });
+
+  it("replaces only the generated race line when multiple paths exist", async () => {
+    const user = userEvent.setup();
+    const gates = [gate("gate-1", 0, 0), gate("gate-2", 10, 0)];
+    const manualPolyline = {
+      id: "manual-line",
+      kind: "polyline" as const,
+      x: 0,
+      y: 0,
+      rotation: 0,
+      points: [
+        { x: 0, y: 0, z: 1 },
+        { x: 10, y: 0, z: 1 },
+      ],
+      color: "#3b82f6",
+    };
+    const generatedPolyline = {
+      id: "generated-line",
+      kind: "polyline" as const,
+      x: 0,
+      y: 0,
+      rotation: 0,
+      points: [
+        { x: 0, y: 1, z: 1 },
+        { x: 10, y: 1, z: 1 },
+      ],
+      smooth: true,
+      showArrows: true,
+      meta: { generatedRoute: true },
+    };
+    const design = designWithGates([
+      ...gates,
+      manualPolyline,
+      generatedPolyline,
+    ]);
+    const addShape = vi.fn().mockReturnValue("new-polyline-id");
+    const removeShapes = vi.fn();
+
+    renderProjectLayoutInspector(
+      design,
+      [...gates, manualPolyline, generatedPolyline],
+      {
+        addShape,
+        removeShapes,
+      }
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: "Regenerate race line" })
+    );
+
+    expect(removeShapes).toHaveBeenCalledWith(["generated-line"]);
+    expect(addShape).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "polyline" })
+    );
+  });
+
+  it("labels the action as regenerate when the existing race line was generated", async () => {
+    const gates = [gate("gate-1", 0, 0), gate("gate-2", 10, 0)];
+    const polyline = {
+      id: "existing-generated-line",
+      kind: "polyline" as const,
+      x: 0,
+      y: 0,
+      rotation: 0,
+      points: [
+        { x: 0, y: 0, z: 1 },
+        { x: 10, y: 0, z: 1 },
+      ],
+      smooth: true,
+      showArrows: true,
+      meta: { generatedRoute: true },
+    };
+    const design = designWithGates([...gates, polyline]);
+
+    renderProjectLayoutInspector(design, [...gates, polyline]);
+
+    expect(
+      screen.getByRole("button", { name: "Regenerate race line" })
+    ).toBeTruthy();
+  });
+});

--- a/tests/components/inspector/list-panel.test.tsx
+++ b/tests/components/inspector/list-panel.test.tsx
@@ -5,8 +5,8 @@ import {
 } from "@/components/inspector/views/list-panel";
 import type { Shape } from "@/lib/types";
 
-function fakeShape(id: string): Shape {
-  return { id } as unknown as Shape;
+function fakeShape(id: string, kind: Shape["kind"] = "gate"): Shape {
+  return { id, kind } as unknown as Shape;
 }
 
 describe("computeReorderBeforeId", () => {
@@ -18,6 +18,16 @@ describe("computeReorderBeforeId", () => {
   it("returns null when the dragged item is now last", () => {
     const order = [fakeShape("b"), fakeShape("c"), fakeShape("a")];
     expect(computeReorderBeforeId(order, "a")).toBeNull();
+  });
+
+  it("keeps track items before trailing race lines when the dragged item is last in the visible list", () => {
+    const route = fakeShape("route-1", "polyline");
+    const gate = fakeShape("gate-1");
+    const flag = fakeShape("flag-1", "flag");
+
+    expect(
+      computeReorderBeforeId([flag, gate], "gate-1", [gate, flag, route])
+    ).toBe("route-1");
   });
 
   it("returns null when the dragged item isn't found", () => {

--- a/tests/components/inspector/list-panel.test.tsx
+++ b/tests/components/inspector/list-panel.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeReorderBeforeId,
+  getListableTrackItems,
+} from "@/components/inspector/views/list-panel";
+import type { Shape } from "@/lib/types";
+
+function fakeShape(id: string): Shape {
+  return { id } as unknown as Shape;
+}
+
+describe("computeReorderBeforeId", () => {
+  it("returns the id of the item now immediately after the dragged item", () => {
+    const order = [fakeShape("a"), fakeShape("b"), fakeShape("c")];
+    expect(computeReorderBeforeId(order, "a")).toBe("b");
+  });
+
+  it("returns null when the dragged item is now last", () => {
+    const order = [fakeShape("b"), fakeShape("c"), fakeShape("a")];
+    expect(computeReorderBeforeId(order, "a")).toBeNull();
+  });
+
+  it("returns null when the dragged item isn't found", () => {
+    const order = [fakeShape("a"), fakeShape("b")];
+    expect(computeReorderBeforeId(order, "missing")).toBeNull();
+  });
+
+  it("returns the same next id when the order is unchanged", () => {
+    const order = [fakeShape("a"), fakeShape("b"), fakeShape("c")];
+    expect(computeReorderBeforeId(order, "b")).toBe("c");
+  });
+});
+
+describe("getListableTrackItems", () => {
+  it("excludes race lines from the track item list", () => {
+    const gate = { id: "gate-1", kind: "gate" } as Shape;
+    const route = { id: "route-1", kind: "polyline" } as Shape;
+    const flag = { id: "flag-1", kind: "flag" } as Shape;
+
+    expect(getListableTrackItems([gate, route, flag])).toEqual([gate, flag]);
+  });
+});

--- a/tests/lib/track/generated-route.test.ts
+++ b/tests/lib/track/generated-route.test.ts
@@ -335,12 +335,7 @@ describe("generateRaceLineDraft", () => {
     );
     const topless = generateRaceLineDraft(
       makeDesign([
-        catalogShape(
-          "ladder-1",
-          MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID,
-          30,
-          12
-        ),
+        catalogShape("ladder-1", MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID, 30, 12),
       ])
     );
 
@@ -393,10 +388,7 @@ describe("generateRaceLineDraft", () => {
 
     const anchorPoint = result.draft?.points[1];
     expect(anchorPoint).toMatchObject({ x: 30, y: 12 });
-    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(
-      feetToMeters(15),
-      5
-    );
+    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(feetToMeters(15), 5);
   });
 
   it("routes around a flag on the side its own rotation points to, not straight through it", () => {

--- a/tests/lib/track/generated-route.test.ts
+++ b/tests/lib/track/generated-route.test.ts
@@ -1,0 +1,505 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateRaceLineDraft,
+  isGeneratedRaceLine,
+} from "@/lib/track/generated-route";
+import { POLYLINE_3D_HEIGHT_OFFSET } from "@/lib/track/constants";
+import { normalizeDesign } from "@/lib/track/design";
+import {
+  createCatalogShapeDraft,
+  MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+  MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID,
+  MULTIGP_DIVE_GATE_7X6_ELEMENT_ID,
+  MULTIGP_DOUBLE_GATE_TOWER_5X5_ELEMENT_ID,
+  MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID,
+  MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID,
+  MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID,
+  MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID,
+  MULTIGP_TOWER_5X5_ELEMENT_ID,
+  type TrackElementCatalogId,
+} from "@/lib/track/elements/catalog";
+import { feetToMeters } from "@/lib/track/units";
+import type { Shape, TrackDesign } from "@/lib/types";
+
+const inventory = {
+  gate: 4,
+  flag: 2,
+  cone: 2,
+  startfinish: 1,
+  ladder: 2,
+  divegate: 2,
+  barrier: 0,
+};
+
+function makeDesign(shapes: Shape[]): TrackDesign {
+  return normalizeDesign({
+    id: "generated-route-test",
+    version: 2,
+    title: "Generated route test",
+    description: "",
+    tags: [],
+    authorName: "",
+    inventory,
+    field: { width: 60, height: 40, origin: "tl", gridStep: 1, ppm: 20 },
+    shapes,
+    createdAt: "2026-07-03T10:00:00.000Z",
+    updatedAt: "2026-07-03T10:00:00.000Z",
+  });
+}
+
+function gate(
+  id: string,
+  x: number,
+  y: number,
+  rotation = 0
+): Extract<Shape, { kind: "gate" }> {
+  return {
+    id,
+    kind: "gate",
+    x,
+    y,
+    rotation,
+    width: 2,
+    height: 2,
+  };
+}
+
+function ladder(
+  id: string,
+  x: number,
+  y: number,
+  rotation = 90
+): Extract<Shape, { kind: "ladder" }> {
+  return {
+    id,
+    kind: "ladder",
+    x,
+    y,
+    rotation,
+    width: 2.5,
+    height: 6,
+    rungs: 3,
+  };
+}
+
+function tower(
+  id: string,
+  x: number,
+  y: number,
+  rotation = 90
+): Extract<Shape, { kind: "tower" }> {
+  return {
+    id,
+    kind: "tower",
+    x,
+    y,
+    rotation,
+    width: 2.5,
+    height: 2,
+    levels: 1,
+    elevation: 1.5,
+  };
+}
+
+function diveGate(
+  id: string,
+  x: number,
+  y: number,
+  rotation = 90
+): Extract<Shape, { kind: "divegate" }> {
+  return {
+    id,
+    kind: "divegate",
+    x,
+    y,
+    rotation,
+    width: 2,
+    height: 2,
+    elevation: 3,
+  };
+}
+
+function flag(
+  id: string,
+  x: number,
+  y: number,
+  rotation = 0
+): Extract<Shape, { kind: "flag" }> {
+  return { id, kind: "flag", x, y, rotation, radius: 0.25 };
+}
+
+function catalogShape(
+  id: string,
+  entryId: TrackElementCatalogId,
+  x: number,
+  y: number,
+  rotation = 90
+): Shape {
+  return {
+    id,
+    ...createCatalogShapeDraft(entryId, {
+      x,
+      y,
+      rotation,
+      includeCatalogMetadata: true,
+    }),
+  } as Shape;
+}
+
+function renderedLineElevation(point: { z?: number } | undefined): number {
+  return Math.max(point?.z ?? 0, 0) + POLYLINE_3D_HEIGHT_OFFSET;
+}
+
+describe("generateRaceLineDraft", () => {
+  it("builds an editable polyline from supported obstacles in shape order", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([
+        gate("gate-2", 20, 8),
+        gate("gate-1", 8, 8),
+        ladder("ladder-1", 30, 12),
+      ])
+    );
+
+    expect(result.report.supportedObstacleIds).toEqual([
+      "gate-2",
+      "gate-1",
+      "ladder-1",
+    ]);
+    expect(result.report.unsupportedShapeIds).toEqual([]);
+    expect(result.draft).toMatchObject({
+      kind: "polyline",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      closed: false,
+      smooth: true,
+      showArrows: true,
+      meta: { generatedRoute: true },
+    });
+    expect(
+      isGeneratedRaceLine(
+        result.draft
+          ? ({ id: "generated-route", ...result.draft } as Shape)
+          : null
+      )
+    ).toBe(true);
+    expect(result.draft?.points).toHaveLength(5);
+    expect(result.draft?.points[1]).toMatchObject({ x: 20, y: 8 });
+    expect(result.draft?.points[2]).toMatchObject({ x: 8, y: 8 });
+    expect(result.draft?.points[3]).toMatchObject({ x: 30, y: 12 });
+  });
+
+  it("keeps generated waypoints compact for smoother flythroughs", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([
+        gate("gate-1", 5, 8),
+        gate("gate-2", 12, 8),
+        ladder("ladder-1", 20, 12),
+        tower("tower-1", 28, 12),
+      ])
+    );
+
+    // Entry + four obstacle anchors + exit. Middle obstacles do not get
+    // separate approach/depart points, keeping each item at one or two
+    // waypoints instead of three.
+    expect(result.draft?.points).toHaveLength(6);
+    expect(result.draft?.points[1]).toMatchObject({ x: 5, y: 8 });
+    expect(result.draft?.points[2]).toMatchObject({ x: 12, y: 8 });
+    expect(result.draft?.points[3]).toMatchObject({ x: 20, y: 12 });
+    expect(result.draft?.points[4]).toMatchObject({ x: 28, y: 12 });
+  });
+
+  it("keeps TrackDraw gates on the low legacy 3D route anchor", () => {
+    const result = generateRaceLineDraft(makeDesign([gate("gate-1", 30, 12)]));
+
+    const anchorPoint = result.draft?.points[1];
+    expect(anchorPoint).toMatchObject({ x: 30, y: 12 });
+    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(
+      POLYLINE_3D_HEIGHT_OFFSET,
+      5
+    );
+  });
+
+  it("routes MultiGP panel gates through their opening centers in 3D", () => {
+    const standard = generateRaceLineDraft(
+      makeDesign([
+        catalogShape("gate-1", MULTIGP_STANDARD_GATE_5X5_ELEMENT_ID, 30, 12),
+      ])
+    );
+    const championship = generateRaceLineDraft(
+      makeDesign([
+        catalogShape(
+          "gate-1",
+          MULTIGP_CHAMPIONSHIP_GATE_7X6_ELEMENT_ID,
+          30,
+          12
+        ),
+      ])
+    );
+
+    expect(renderedLineElevation(standard.draft?.points[1])).toBeCloseTo(
+      feetToMeters(2.5),
+      5
+    );
+    expect(renderedLineElevation(championship.draft?.points[1])).toBeCloseTo(
+      feetToMeters(3),
+      5
+    );
+  });
+
+  it("routes TrackDraw ladders through the lower half of the middle opening", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([ladder("ladder-1", 30, 12)])
+    );
+
+    const anchorPoint = result.draft?.points[1];
+    expect(anchorPoint).toMatchObject({ x: 30, y: 12 });
+    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(2.5, 5);
+  });
+
+  it("routes TrackDraw towers through the elevated opening center in 3D", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([tower("tower-1", 30, 12)])
+    );
+
+    const anchorPoint = result.draft?.points[1];
+    expect(anchorPoint).toMatchObject({ x: 30, y: 12 });
+    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(2.5, 5);
+  });
+
+  it("routes MultiGP ladders so the 3D line passes the visual lower opening center", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([
+        catalogShape(
+          "ladder-1",
+          MULTIGP_STANDARD_LADDER_5X5_ELEMENT_ID,
+          30,
+          12
+        ),
+      ])
+    );
+
+    const anchorPoint = result.draft?.points[1];
+    expect(anchorPoint).toMatchObject({ x: 30, y: 12 });
+    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(
+      feetToMeters(2.5),
+      5
+    );
+  });
+
+  it("routes MultiGP towers so the 3D line passes the nominal elevated opening center", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([
+        catalogShape("tower-1", MULTIGP_TOWER_5X5_ELEMENT_ID, 30, 12),
+      ])
+    );
+
+    const anchorPoint = result.draft?.points[1];
+    expect(anchorPoint).toMatchObject({ x: 30, y: 12 });
+    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(
+      feetToMeters(7.5),
+      5
+    );
+  });
+
+  it("routes MultiGP double towers through the first opening center in 3D", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([
+        catalogShape(
+          "tower-1",
+          MULTIGP_DOUBLE_GATE_TOWER_5X5_ELEMENT_ID,
+          30,
+          12
+        ),
+      ])
+    );
+
+    const anchorPoint = result.draft?.points[1];
+    expect(anchorPoint).toMatchObject({ x: 30, y: 12 });
+    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(
+      feetToMeters(2.5),
+      5
+    );
+  });
+
+  it("routes MultiGP championship and topless ladders through the lower visual opening center", () => {
+    const championship = generateRaceLineDraft(
+      makeDesign([
+        catalogShape(
+          "ladder-1",
+          MULTIGP_CHAMPIONSHIP_LADDER_7X6_ELEMENT_ID,
+          30,
+          12
+        ),
+      ])
+    );
+    const topless = generateRaceLineDraft(
+      makeDesign([
+        catalogShape(
+          "ladder-1",
+          MULTIGP_TOPLESS_LADDER_7X6_ELEMENT_ID,
+          30,
+          12
+        ),
+      ])
+    );
+
+    expect(renderedLineElevation(championship.draft?.points[1])).toBeCloseTo(
+      feetToMeters(3),
+      5
+    );
+    expect(renderedLineElevation(topless.draft?.points[1])).toBeCloseTo(
+      feetToMeters(3),
+      5
+    );
+  });
+
+  it("routes TrackDraw dive gates through their frame center in 3D", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([diveGate("divegate-1", 30, 12)])
+    );
+
+    const anchorPoint = result.draft?.points[1];
+    expect(anchorPoint).toMatchObject({ x: 30, y: 12 });
+    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(3, 5);
+  });
+
+  it("routes MultiGP dive gate arches so the 3D line passes the visual opening center", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([
+        catalogShape("divegate-1", MULTIGP_DIVE_GATE_7X6_ELEMENT_ID, 30, 12),
+      ])
+    );
+
+    const anchorPoint = result.draft?.points[1];
+    expect(anchorPoint).toMatchObject({ x: 30, y: 12 });
+    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(
+      feetToMeters(13.5),
+      5
+    );
+  });
+
+  it("keeps MultiGP launch gate line height on the top frame", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([
+        catalogShape(
+          "launchgate-1",
+          MULTIGP_LAUNCH_GATE_7X6_ELEMENT_ID,
+          30,
+          12
+        ),
+      ])
+    );
+
+    const anchorPoint = result.draft?.points[1];
+    expect(anchorPoint).toMatchObject({ x: 30, y: 12 });
+    expect(renderedLineElevation(anchorPoint)).toBeCloseTo(
+      feetToMeters(15),
+      5
+    );
+  });
+
+  it("routes around a flag on the side its own rotation points to, not straight through it", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([
+        gate("gate-1", 0, 0),
+        flag("flag-1", 10, 0, 90),
+        gate("gate-2", 20, 0),
+      ])
+    );
+
+    expect(result.report.supportedObstacleIds).toEqual([
+      "gate-1",
+      "flag-1",
+      "gate-2",
+    ]);
+    // Points: gate-1 approach/anchor (2), flag marker (1), gate-2
+    // anchor/depart (2).
+    const flagPoint = result.draft?.points[2];
+    expect(flagPoint).toBeDefined();
+    // The flag is rotated 90deg, so the route should offset toward the side
+    // it's actually facing (-y, since the canvas-guide direction points
+    // outward from the front and is flipped 180deg) rather than sitting on
+    // the flag's own coordinates or guessing a side from travel direction.
+    expect(flagPoint?.x).toBeCloseTo(10, 5);
+    expect(flagPoint?.y).toBeLessThan(-0.5);
+  });
+
+  it("reports unsupported non-route shapes without blocking supported obstacles", () => {
+    const label: Extract<Shape, { kind: "label" }> = {
+      id: "label-1",
+      kind: "label",
+      x: 12,
+      y: 10,
+      rotation: 0,
+      text: "Briefing note",
+    };
+
+    const result = generateRaceLineDraft(
+      makeDesign([gate("gate-1", 8, 8), label, gate("gate-2", 20, 8)])
+    );
+
+    expect(result.draft).not.toBeNull();
+    expect(result.report.supportedObstacleIds).toEqual(["gate-1", "gate-2"]);
+    expect(result.report.unsupportedShapeIds).toEqual(["label-1"]);
+    expect(result.report.warnings).toContainEqual({
+      type: "unsupported-shape",
+      shapeId: "label-1",
+    });
+  });
+
+  it("returns no draft when no supported obstacles exist", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([
+        {
+          id: "cone-1",
+          kind: "cone",
+          x: 10,
+          y: 10,
+          rotation: 0,
+          radius: 0.3,
+        },
+      ])
+    );
+
+    expect(result.draft).toBeNull();
+    expect(result.report.supportedObstacleIds).toEqual([]);
+    expect(result.report.warnings.map((warning) => warning.type)).toEqual([
+      "unsupported-shape",
+      "too-few-obstacles",
+    ]);
+  });
+
+  it("keeps a one-obstacle draft explicit but warns that the route needs review", () => {
+    const result = generateRaceLineDraft(makeDesign([gate("gate-1", 8, 8)]));
+
+    expect(result.draft?.points).toHaveLength(2);
+    expect(result.report.warnings).toContainEqual({
+      type: "too-few-obstacles",
+    });
+  });
+
+  it("approaches a gate head-on from the front, not sideways or from the back", () => {
+    const result = generateRaceLineDraft(makeDesign([gate("gate-1", 8, 8, 0)]));
+
+    const points = result.draft?.points ?? [];
+    expect(points).toHaveLength(2);
+    // A gate at rotation 0 gets a compact entry + anchor path. The entry
+    // point stays on the gate heading, not sideways along x.
+    expect(points[0].x).toBeCloseTo(8, 5);
+    expect(points[0].y).toBeCloseTo(10, 5);
+    expect(points[1].x).toBeCloseTo(8, 5);
+    expect(points[1].y).toBeCloseTo(8, 5);
+  });
+
+  it("warns when consecutive supported obstacles are too close together", () => {
+    const result = generateRaceLineDraft(
+      makeDesign([gate("gate-1", 8, 8), gate("gate-2", 9, 8)])
+    );
+
+    expect(result.report.warnings).toContainEqual({
+      type: "close-obstacles",
+      shapeIds: ["gate-1", "gate-2"],
+    });
+  });
+});

--- a/tests/lib/track/items/registry.test.ts
+++ b/tests/lib/track/items/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  getGeneratedRouteProfile,
   getCatalogPlacementToolConfigs,
   getInventoryKinds,
   hasCatalogPlacement,
@@ -42,6 +43,44 @@ describe("track item adapters", () => {
       expect(entry).toBeTruthy();
       expect(entry?.kind).toBe(adapter?.kind);
     }
+  });
+
+  it("marks only clear pass-through obstacles for generated routes", () => {
+    const generatedRouteKinds = trackItemAdapters
+      .filter((adapter) => adapter.generatedRoute?.traversal === "through")
+      .map((adapter) => adapter.kind)
+      .sort();
+
+    expect(generatedRouteKinds).toEqual([
+      "divegate",
+      "gate",
+      "ladder",
+      "tower",
+    ]);
+  });
+
+  it("exposes generated route profiles through shapes", () => {
+    expect(
+      getGeneratedRouteProfile({
+        id: "gate-1",
+        kind: "gate",
+        x: 10,
+        y: 8,
+        rotation: 0,
+        width: 2,
+        height: 2,
+      })?.traversal
+    ).toBe("through");
+    expect(
+      getGeneratedRouteProfile({
+        id: "cone-1",
+        kind: "cone",
+        x: 10,
+        y: 8,
+        rotation: 0,
+        radius: 0.25,
+      })
+    ).toBeNull();
   });
 });
 

--- a/tests/lib/track/obstacleNumbering.test.ts
+++ b/tests/lib/track/obstacleNumbering.test.ts
@@ -117,9 +117,9 @@ describe("obstacle numbering", () => {
   });
 
   it("keeps non-numbered layouts idle", () => {
-    const flagOnly: Shape = {
-      id: "flag-1",
-      kind: "flag",
+    const coneOnly: Shape = {
+      id: "cone-1",
+      kind: "cone",
       x: 5,
       y: 5,
       rotation: 0,
@@ -128,12 +128,32 @@ describe("obstacle numbering", () => {
 
     expect(getObstacleNumberingReport(makeDesign([])).status).toBe("empty");
     expect(
-      getObstacleNumberingReport(makeDesign([raceLine, flagOnly]))
+      getObstacleNumberingReport(makeDesign([raceLine, coneOnly]))
     ).toMatchObject({
       issueCount: 0,
       mappedObstacleCount: 0,
       status: "no-numbered-obstacles",
       totalNumberedObstacleCount: 0,
+    });
+  });
+
+  it("numbers flags placed near the race line", () => {
+    const flagOnRoute: Shape = {
+      id: "flag-1",
+      kind: "flag",
+      x: 5,
+      y: 5,
+      rotation: 0,
+      radius: 0.25,
+    };
+
+    expect(
+      getObstacleNumberingReport(makeDesign([raceLine, flagOnRoute]))
+    ).toMatchObject({
+      issueCount: 0,
+      mappedObstacleCount: 1,
+      status: "ready",
+      totalNumberedObstacleCount: 1,
     });
   });
 


### PR DESCRIPTION
## Summary

Adds generated race-line support from placed route obstacles and exposes it from the project layout inspector.

## Changes

- Adds generated route drafting with per-item route anchors for gates, towers, flags, ladders, and dive gates.
- Adds inspector controls to generate or regenerate a race line, with warnings for unsupported or sparse obstacle layouts.
- Keeps generated paths identifiable while preserving manual race lines.
- Excludes race lines from the track item list and supports reordering track items separately.
- Adds focused coverage for route generation, registry profiles, inspector actions, list ordering, and numbering behavior.

## Validation

- `npm run test -- tests/lib/track/generated-route.test.ts tests/lib/track/items/registry.test.ts`
- `npm run type`
- `npm run lint`
- `npm run test`
- `npm run build`
- `git diff --check`