### PR TITLE
fix: Correct dashboard user metrics

### DIFF
--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -75,7 +75,8 @@
     },
     "fallback": {
       "untitled": "Untitled",
-      "unknownOwner": "Unknown"
+      "unknownOwner": "Unknown",
+      "unknownUser": "Unknown user"
     },
     "galleryState": {
       "featured": "Featured",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -277,9 +277,7 @@ function RecentSignups({
               {initial}
             </span>
             <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-medium">
-                {displayName}
-              </p>
+              <p className="truncate text-sm font-medium">{displayName}</p>
               {user.name?.trim() && email ? (
                 <p className="text-muted-foreground truncate text-xs">
                   {email}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -263,7 +263,10 @@ function RecentSignups({
   return (
     <ul className="divide-y">
       {users.map((user, index) => {
-        const initial = (user.name ?? user.email)[0]?.toUpperCase() ?? "?";
+        const displayName =
+          user.name?.trim() || user.email?.trim() || t("fallback.unknownUser");
+        const email = user.email?.trim();
+        const initial = displayName[0]?.toUpperCase() ?? "U";
         return (
           <RevealListItem
             key={user.id}
@@ -275,11 +278,11 @@ function RecentSignups({
             </span>
             <div className="min-w-0 flex-1">
               <p className="truncate text-sm font-medium">
-                {user.name ?? user.email}
+                {displayName}
               </p>
-              {user.name ? (
+              {user.name?.trim() && email ? (
                 <p className="text-muted-foreground truncate text-xs">
-                  {user.email}
+                  {email}
                 </p>
               ) : null}
             </div>

--- a/src/lib/server/metrics.ts
+++ b/src/lib/server/metrics.ts
@@ -98,7 +98,7 @@ export async function getAdminMetrics(): Promise<AdminMetrics> {
         select
           count(*) as total,
           sum(case when createdAt > datetime('now', '-7 days') then 1 else 0 end) as new_this_week,
-          sum(case when createdAt > datetime('now', '-30 days') then 1 else 0 end) as new_this_month
+          sum(case when createdAt >= date('now', 'start of month') then 1 else 0 end) as new_this_month
         from users
       `
       )
@@ -319,7 +319,7 @@ function buildCumulativeGrowth(
 export type RecentUser = {
   id: string;
   name: string | null;
-  email: string;
+  email: string | null;
   createdAt: string;
 };
 
@@ -340,8 +340,8 @@ export async function getOverviewStats(): Promise<OverviewStats> {
         .prepare(
           `select
             count(*) as total,
-            sum(case when createdAt > datetime('now', '-30 days') then 1 else 0 end) as new_this_month,
-            sum(case when createdAt between datetime('now', '-60 days') and datetime('now', '-30 days') then 1 else 0 end) as new_last_month
+            sum(case when createdAt >= date('now', 'start of month') then 1 else 0 end) as new_this_month,
+            sum(case when createdAt >= date('now', 'start of month', '-1 month') and createdAt < date('now', 'start of month') then 1 else 0 end) as new_last_month
            from users`
         )
         .first<{
@@ -369,7 +369,7 @@ export async function getOverviewStats(): Promise<OverviewStats> {
         .all<{
           id: string;
           name: string | null;
-          email: string;
+          email: string | null;
           createdAt: string;
         }>(),
     ]

--- a/tests/lib/server/metrics.test.ts
+++ b/tests/lib/server/metrics.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createD1AllStatement,
+  createD1Statement,
+  installD1Statements,
+} from "../../helpers/d1";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  prepare: vi.fn(),
+}));
+
+vi.mock("@/lib/server/db", () => ({
+  getDatabase: vi.fn(async () => ({
+    prepare: mocks.prepare,
+  })),
+}));
+
+import { getAdminMetrics, getOverviewStats } from "@/lib/server/metrics";
+
+beforeEach(() => {
+  mocks.prepare.mockReset();
+});
+
+describe("dashboard metrics", () => {
+  it("counts new users this month by calendar month instead of rolling 30 days", async () => {
+    installD1Statements(mocks.prepare, [
+      createD1Statement({
+        first: { total: 12, new_this_week: 2, new_this_month: 4 },
+      }),
+      createD1Statement({ first: { count: 3 } }),
+      createD1Statement({ first: { count: 5 } }),
+      createD1Statement({
+        first: { total: 8, active: 7, archived: 1 },
+      }),
+      createD1Statement({
+        first: { avg_per_user: 1.2, max_per_user: 4 },
+      }),
+      createD1Statement({
+        first: { total_active: 6, revoked: 2 },
+      }),
+      createD1Statement({
+        first: { avg_per_user: 0.8, max_per_user: 3 },
+      }),
+      createD1Statement({ first: { total: 4 } }),
+      createD1Statement({
+        first: { avg_per_user: 0.5, max_per_user: 2 },
+      }),
+      createD1Statement({
+        first: { total: 3, listed: 2, featured: 1, hidden: 0 },
+      }),
+      createD1Statement({ first: { active: 1, total: 2 } }),
+      createD1AllStatement([{ proj_cnt: 1, share_cnt: 0, preset_cnt: 0 }]),
+    ]);
+
+    const metrics = await getAdminMetrics();
+
+    expect(metrics.users.newThisMonth).toBe(4);
+    expect(String(mocks.prepare.mock.calls[0][0])).toContain(
+      "createdAt >= date('now', 'start of month')"
+    );
+    expect(String(mocks.prepare.mock.calls[0][0])).not.toContain("-30 days");
+  });
+
+  it("uses calendar month buckets in overview stats and tolerates incomplete recent user rows", async () => {
+    installD1Statements(mocks.prepare, [
+      createD1Statement({
+        first: { total: 12, new_this_month: 4, new_last_month: 3 },
+      }),
+      createD1Statement({ first: { count: 7 } }),
+      createD1Statement({ first: { count: 5 } }),
+      createD1AllStatement([
+        {
+          id: "user-1",
+          name: null,
+          email: null,
+          createdAt: "2026-07-07T10:00:00.000Z",
+        },
+      ]),
+    ]);
+
+    const stats = await getOverviewStats();
+
+    expect(stats.newUsersThisMonth).toBe(4);
+    expect(stats.newUsersLastMonth).toBe(3);
+    expect(stats.recentUsers[0]).toMatchObject({
+      id: "user-1",
+      name: null,
+      email: null,
+    });
+    expect(String(mocks.prepare.mock.calls[0][0])).toContain(
+      "createdAt >= date('now', 'start of month')"
+    );
+    expect(String(mocks.prepare.mock.calls[0][0])).toContain(
+      "createdAt >= date('now', 'start of month', '-1 month')"
+    );
+    expect(String(mocks.prepare.mock.calls[0][0])).not.toContain("-30 days");
+  });
+});


### PR DESCRIPTION
## Summary

- Count dashboard "this month" users by calendar month instead of a rolling 30-day window.
- Use the previous calendar month for overview comparison metrics.
- Make recent sign-ups resilient to blank names by falling back to email, then `Unknown user`.
- Add focused server metrics coverage for the calendar-month SQL and incomplete recent user rows.

## Validation

- `npm run test -- tests/lib/server/metrics.test.ts`
- `npm run lint`
- `npm run type`
- `git diff --check`