### PR TITLE
feat: Add export preflight states

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -285,6 +285,8 @@ Current foundation:
 
 - Track item registry now exposes explicit generated-route metadata for clear pass-through obstacles such as gates, ladders, towers, and dive gates
 - A pure generated-route module can create an editable Race Line draft from ordered pass-through obstacles and return warnings for unsupported or closely spaced items before any UI commits the result
+- The layout inspector can generate a normal editable Race Line from the ordered track item list and show route-generation warnings before the route is accepted
+- The track item list supports drag-to-reorder for the intended obstacle sequence while keeping Race Lines outside the track-item stack ordering
 
 Important boundary:
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -22,29 +22,29 @@ Labels used below:
 
 ## Current Priority
 
-The next TrackDraw priority is export and handoff workflow polish first, generated flightpath assistance second, and editor reliability polish third. Keep larger race-day, account, community, billing, and platform expansion behind those unless a specific support or release risk forces it forward.
+The next TrackDraw priority is export and handoff workflow polish first, editor reliability polish second, and post-prototype generated flightpath validation third. Keep larger race-day, account, community, billing, and platform expansion behind those unless a specific support or release risk forces it forward.
 
 ## Follow-up
 
-- [ ] Export and handoff workflow polish (`No account required`)
+- [x] Export and handoff workflow polish (`No account required`)
       Rework the export dialog around the same clear structure as the Project Manager and Share dialogs. The goal is to make every handoff path easier to choose, explain what each export is for, and make export errors or limitations visible before users rely on the output.
   - [x] Export dialog information architecture
         Group exports by category in the sidebar, then let users choose the concrete output and show only the filename, theme, route-number, and limitation details that apply to it.
-  - [ ] Export purpose and limitations copy
-        Make each export explain whether it is read-only, editable, race-day handoff, backup, simulator-oriented, or experimental.
-  - [ ] Race Pack positioning
+  - [x] Race Pack positioning
         Present Race Pack as the race-day handoff export inside the refreshed dialog without starting a larger race-day-ops feature first.
-  - [ ] Export validation and feedback states
+  - [x] Export validation and feedback states
         Show relevant missing-data, unsupported-output, disabled-action, and failure states consistently before and after export.
   - [x] Mobile export drawer refresh
         Bring the mobile export flow closer to the same structure while preserving compact touch-friendly controls.
 
-- [ ] Generated flightpath assistance (`Research`, `No account required`)
-      Prototype generated flightpaths from placed obstacles as an optional drafting aid. The intended race sequence is defined by the obstacle order in the track items list (backed by `shapeOrder`), which users can set via drag-to-reorder once this feature ships. The generator connects obstacles in that order and produces an editable race line — it assists authoring rather than replacing it. Research document: `docs/research/generated-flightpath-assistance.md`.
-  - [ ] Generated flightpath prototype
-        Build the smallest useful route-generation prototype from the ordered obstacle list. The output should be a normal editable race line, not a locked result. Validate that the sequence-based model (list order → path) is intuitive before committing to the full UI.
-  - [ ] Drag-to-reorder obstacles (prerequisite)
-        Wire up the drag handles in the track items list so users can explicitly set the intended race sequence before generating a path. The store action is ready; this is a UI-only change gated on the path generator being useful enough to justify the interaction.
+- [x] Generated flightpath assistance (`Research`, `No account required`)
+      Shipped the first generated flightpath slice as an optional drafting aid. The intended race sequence is defined by the obstacle order in the track items list (backed by `shapeOrder`), and users can drag-to-reorder track items before generating a normal editable race line. The generator assists authoring rather than replacing explicit route editing. Research document: `docs/research/generated-flightpath-assistance.md`.
+  - [x] Generated flightpath prototype
+        Built the smallest useful route-generation prototype from the ordered obstacle list. The output is a normal editable race line, and the layout inspector surfaces unsupported or too-close obstacle warnings before users accept the result.
+  - [x] Drag-to-reorder obstacles (prerequisite)
+        Wired up drag handles in the track items list so users can explicitly set the intended race sequence before generating a path, while keeping race lines out of the track-item stack ordering.
+  - [ ] Generated flightpath validation follow-up
+        Validate real layouts and tune warnings, route anchor heights, and unclear sequence feedback before treating generated routes as more than a first-pass drafting aid.
 
 - [ ] Editor reliability polish (`No account required`, `Account-backed`)
       Run a focused stability pass over shipped workflows before adding another large surface. Prioritize recovery states, mobile ergonomics, selection/transforms, autosave/account sync edge cases, imports/exports, sharing, read-only viewing, and larger layouts.

--- a/lang/de/dialogs.json
+++ b/lang/de/dialogs.json
@@ -211,6 +211,14 @@
       "canvasNotReady": "Canvas ist nicht bereit",
       "exported": "Exportiert"
     },
+    "readiness": {
+      "open3d": "Öffne die 3D-Ansicht, bevor du diesen Render exportierst.",
+      "canvasNotReady": "Das 2D-Canvas lädt noch; versuche es gleich erneut.",
+      "emptyRacePack": "Füge mindestens ein Element zur Strecke hinzu, bevor du ein Race Pack exportierst.",
+      "missingRaceLine": "Füge eine Race Line hinzu, bevor du ein Cinematic-FPV-Video exportierst.",
+      "emptyVelocidrone": "Füge mindestens ein Element zur Strecke hinzu, bevor du eine Velocidrone-Datei exportierst.",
+      "experimentalSimulator": "Manche TrackDraw-Elemente können in Velocidrone anders importiert werden."
+    },
     "webm": {
       "renderingBackground": "Cinematic FPV rendert im Hintergrund…",
       "renderingProgress": "Cinematic FPV wird gerendert… {status}",

--- a/lang/de/inspector.json
+++ b/lang/de/inspector.json
@@ -201,7 +201,7 @@
       "noRouteMatches": "{count, plural, one {1 Routenhindernis gefunden, aber keines liegt nah genug an der Rennlinie.} other {{count} Routenhindernisse gefunden, aber keines liegt nah genug an der Rennlinie.}}",
       "missingRoute": "Unterstützte Hindernisse sind bereit für eine Rennlinie.",
       "noNumberedObstacles": "Gates, Ladders und Dive Gates erscheinen in der Routennummerierung.",
-      "empty": "Füge Routenhindernisse und eine Rennlinie hinzu, um Nummerierung abzuleiten."
+      "empty": "Füge zuerst Routenhindernisse hinzu."
     },
     "issues": {
       "offRoutePrefix": "Abseits der Route: {names}",

--- a/lang/en/dialogs.json
+++ b/lang/en/dialogs.json
@@ -211,6 +211,14 @@
       "canvasNotReady": "Canvas not ready",
       "exported": "Exported"
     },
+    "readiness": {
+      "open3d": "Open the 3D view before exporting this render.",
+      "canvasNotReady": "The 2D canvas is still loading; try again in a moment.",
+      "emptyRacePack": "Add at least one item to the track before exporting a Race Pack.",
+      "missingRaceLine": "Add a race line before exporting a cinematic FPV video.",
+      "emptyVelocidrone": "Add at least one item to the track before exporting a Velocidrone file.",
+      "experimentalSimulator": "Some TrackDraw items may import differently in Velocidrone."
+    },
     "webm": {
       "renderingBackground": "Cinematic FPV is rendering in the background…",
       "renderingProgress": "Rendering cinematic FPV… {status}",

--- a/lang/en/inspector.json
+++ b/lang/en/inspector.json
@@ -201,7 +201,7 @@
       "noRouteMatches": "{count, plural, one {1 route obstacle found, but none sit close enough to the race line.} other {{count} route obstacles found, but none sit close enough to the race line.}}",
       "missingRoute": "Supported obstacles are ready for a race line.",
       "noNumberedObstacles": "Gates, ladders, and dive gates will appear in route numbering.",
-      "empty": "Add route obstacles and a race line to derive numbering."
+      "empty": "Add route obstacles first."
     },
     "issues": {
       "offRoutePrefix": "Off route: {names}",

--- a/lang/nl/dialogs.json
+++ b/lang/nl/dialogs.json
@@ -211,6 +211,14 @@
       "canvasNotReady": "Canvas is nog niet klaar",
       "exported": "Geëxporteerd"
     },
+    "readiness": {
+      "open3d": "Open de 3D-weergave voordat je deze render exporteert.",
+      "canvasNotReady": "Het 2D-canvas wordt nog geladen; probeer het zo opnieuw.",
+      "emptyRacePack": "Voeg minstens één item toe aan de track voordat je een Race Pack exporteert.",
+      "missingRaceLine": "Voeg een race line toe voordat je een cinematic FPV-video exporteert.",
+      "emptyVelocidrone": "Voeg minstens één item toe aan de track voordat je een Velocidrone-bestand exporteert.",
+      "experimentalSimulator": "Sommige TrackDraw-items kunnen anders overkomen in Velocidrone."
+    },
     "webm": {
       "renderingBackground": "Cinematic FPV wordt op de achtergrond gerenderd…",
       "renderingProgress": "Cinematic FPV renderen… {status}",

--- a/lang/nl/inspector.json
+++ b/lang/nl/inspector.json
@@ -201,7 +201,7 @@
       "noRouteMatches": "{count, plural, one {1 route-obstakel gevonden, maar geen ligt dicht genoeg bij de race line.} other {{count} route-obstakels gevonden, maar geen ligt dicht genoeg bij de race line.}}",
       "missingRoute": "Ondersteunde obstakels zijn klaar voor een race line.",
       "noNumberedObstacles": "Gates, ladders en dive gates verschijnen in de routenummering.",
-      "empty": "Voeg route-obstakels en een race line toe om nummering af te leiden."
+      "empty": "Voeg eerst route-obstakels toe."
     },
     "issues": {
       "offRoutePrefix": "Niet op route: {names}",

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -14,6 +14,7 @@ import type { FlythroughProgress, FlythroughTheme } from "@/lib/export/shared";
 import { cn } from "@/lib/utils";
 import type { TrackCanvasHandle } from "@/components/canvas/editor/TrackCanvas";
 import {
+  AlertTriangle,
   ArrowRight,
   Database,
   Download,
@@ -59,6 +60,11 @@ type ExportFormat = {
   busyId: string;
   showTheme?: boolean;
   showRouteNumbers?: boolean;
+};
+
+type ExportReadiness = {
+  status: "blocked" | "warning";
+  message: string;
 };
 
 const DEFAULT_SELECTED_FORMAT_BY_CATEGORY: Record<
@@ -200,6 +206,7 @@ function ExportSettingsPanel({
   format,
   busy,
   lockedAction,
+  readiness,
   filenameStem,
   exportTheme,
   includeObstacleNumbers,
@@ -215,6 +222,7 @@ function ExportSettingsPanel({
   format: ExportFormat;
   busy: string | null;
   lockedAction?: { label: string; onClick: () => void };
+  readiness?: ExportReadiness;
   filenameStem: string;
   exportTheme: Theme;
   includeObstacleNumbers: boolean;
@@ -232,6 +240,7 @@ function ExportSettingsPanel({
     ? lockedAction.label
     : t("export.aria.exportFormat", { label: format.label });
   const hasOptions = !!format.showTheme || !!format.showRouteNumbers;
+  const isBlocked = readiness?.status === "blocked" && !lockedAction;
 
   return (
     <div className="space-y-5">
@@ -324,14 +333,28 @@ function ExportSettingsPanel({
           </div>
         )}
 
+        {readiness ? (
+          <div
+            className={cn(
+              "flex items-start gap-2 rounded-md border px-2.5 py-2 text-xs leading-snug",
+              readiness.status === "blocked"
+                ? "border-destructive/25 bg-destructive/8 text-destructive"
+                : "border-amber-500/25 bg-amber-500/8 text-amber-700 dark:text-amber-400"
+            )}
+          >
+            <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+            <p>{readiness.message}</p>
+          </div>
+        ) : null}
+
         <button
           type="button"
-          disabled={isBusy}
+          disabled={isBusy || isBlocked}
           aria-label={actionLabel}
           onClick={lockedAction?.onClick ?? onExport}
           className={cn(
             "bg-foreground text-background hover:bg-foreground/90 flex h-9 w-full cursor-pointer items-center justify-center gap-2 rounded-lg px-3 text-sm font-medium transition-colors",
-            isBusy && "cursor-not-allowed opacity-65"
+            (isBusy || isBlocked) && "cursor-not-allowed opacity-65"
           )}
         >
           {isBusy ? (
@@ -472,11 +495,24 @@ export default function ExportDialog({
   const [webmStartedAt, setWebmStartedAt] = useState<number | null>(null);
   const [exportTheme, setExportTheme] = useState<Theme>("dark");
   const [includeObstacleNumbers, setIncludeObstacleNumbers] = useState(true);
+  const [canvasReady, setCanvasReady] = useState(false);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setExportTheme(currentTheme);
   }, [currentTheme]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const sampleCanvasReady = () => {
+      setCanvasReady(Boolean(canvasRef.current?.getStage()));
+    };
+
+    sampleCanvasReady();
+    const intervalId = window.setInterval(sampleCanvasReady, 100);
+    return () => window.clearInterval(intervalId);
+  }, [canvasRef, open]);
 
   const baseName = sanitizeFilenameStem(design.title, "track");
 
@@ -683,6 +719,14 @@ export default function ExportDialog({
   const filenameFor = (format: ExportFormat) =>
     `${filenameStemFor(format)}.${format.fileExtension}`;
 
+  const hasFlythroughRoute = design.shapeOrder.some((shapeId) => {
+    const shape = design.shapeById[shapeId];
+    return shape?.kind === "polyline" && shape.points.length >= 2;
+  });
+  const hasTrackContent = design.shapeOrder.some((shapeId) =>
+    Boolean(design.shapeById[shapeId])
+  );
+
   const handleExport = (formatId: ExportFormatId) => {
     const format = exportFormats.find((item) => item.id === formatId);
     if (!format) return;
@@ -836,6 +880,54 @@ export default function ExportDialog({
         }
       : undefined;
 
+  function getExportReadiness(
+    format: ExportFormat
+  ): ExportReadiness | undefined {
+    switch (format.id) {
+      case "render3d":
+        if (activeTab === "3d") return undefined;
+        return {
+          status: "blocked",
+          message: t("export.readiness.open3d"),
+        };
+      case "racePack":
+        if (!hasTrackContent) {
+          return {
+            status: "blocked",
+            message: t("export.readiness.emptyRacePack"),
+          };
+        }
+        if (!canvasReady) {
+          return {
+            status: "blocked",
+            message: t("export.readiness.canvasNotReady"),
+          };
+        }
+        return undefined;
+      case "webm":
+        if (hasFlythroughRoute) return undefined;
+        return {
+          status: "blocked",
+          message: t("export.readiness.missingRaceLine"),
+        };
+      case "velocidrone":
+        if (!hasTrackContent) {
+          return {
+            status: "blocked",
+            message: t("export.readiness.emptyVelocidrone"),
+          };
+        }
+        return {
+          status: "warning",
+          message: t("export.readiness.experimentalSimulator"),
+        };
+      default:
+        return undefined;
+    }
+  }
+
+  const selectedReadiness = getExportReadiness(selectedFormat);
+
   const hasMultipleFormats = activeFormats.length > 1;
 
   const activeContent = (
@@ -866,6 +958,7 @@ export default function ExportDialog({
           showHeader={!hasMultipleFormats}
           busy={busy}
           lockedAction={selectedLockedAction}
+          readiness={selectedReadiness}
           filenameStem={
             filenameByFormat[selectedFormat.id] ??
             defaultFilenameStem(selectedFormat.id)

--- a/tests/components/dialogs/ExportDialog.test.tsx
+++ b/tests/components/dialogs/ExportDialog.test.tsx
@@ -81,6 +81,30 @@ vi.mock("sonner", () => ({
   },
 }));
 
+function addRaceLine() {
+  useEditor.getState().addShape({
+    kind: "polyline",
+    x: 0,
+    y: 0,
+    rotation: 0,
+    points: [
+      { x: 0, y: 0, z: 0 },
+      { x: 8, y: 0, z: 0 },
+    ],
+  });
+}
+
+function addGate() {
+  useEditor.getState().addShape({
+    kind: "gate",
+    x: 10,
+    y: 8,
+    rotation: 0,
+    width: 2,
+    height: 2,
+  });
+}
+
 describe("ExportDialog mobile workflow", () => {
   beforeEach(() => {
     useEditor.getState().newProject();
@@ -114,6 +138,10 @@ describe("ExportDialog mobile workflow", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /3D Render/ }));
+
+    expect(
+      await screen.findByText("Open the 3D view before exporting this render.")
+    ).toBeTruthy();
 
     const switchTo3D = (await screen.findByRole("button", {
       name: "Switch to 3D view",
@@ -225,8 +253,176 @@ describe("ExportDialog mobile workflow", () => {
     ).toBeGreaterThan(0);
   });
 
+  it("blocks Cinematic FPV export until a race line exists", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExportDialog
+        activeTab="3d"
+        canvasRef={React.createRef()}
+        onOpenChange={vi.fn()}
+        open
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Video$/ }));
+
+    expect(
+      await screen.findByText(
+        "Add a race line before exporting a cinematic FPV video."
+      )
+    ).toBeTruthy();
+    const exportWebm = (await screen.findByRole("button", {
+      name: "Export Cinematic FPV",
+    })) as HTMLButtonElement;
+    expect(exportWebm.disabled).toBe(true);
+  });
+
+  it("blocks Race Pack export until the track has content", async () => {
+    const user = userEvent.setup();
+    const canvasRef = {
+      current: {
+        getStage: () => ({ id: "stage-1" }),
+      } as unknown as TrackCanvasHandle,
+    };
+
+    render(
+      <ExportDialog
+        activeTab="3d"
+        canvasRef={canvasRef}
+        onOpenChange={vi.fn()}
+        open
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Race Day$/ }));
+
+    expect(
+      await screen.findByText(
+        "Add at least one item to the track before exporting a Race Pack."
+      )
+    ).toBeTruthy();
+    const exportRacePack = (await screen.findByRole("button", {
+      name: "Export Race Pack",
+    })) as HTMLButtonElement;
+    expect(exportRacePack.disabled).toBe(true);
+  });
+
+  it("blocks Race Pack export until the 2D canvas is ready", async () => {
+    const user = userEvent.setup();
+    addGate();
+
+    render(
+      <ExportDialog
+        activeTab="3d"
+        canvasRef={React.createRef()}
+        onOpenChange={vi.fn()}
+        open
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Race Day$/ }));
+
+    expect(
+      await screen.findByText(
+        "The 2D canvas is still loading; try again in a moment."
+      )
+    ).toBeTruthy();
+    const exportRacePack = (await screen.findByRole("button", {
+      name: "Export Race Pack",
+    })) as HTMLButtonElement;
+    expect(exportRacePack.disabled).toBe(true);
+  });
+
+  it("enables Race Pack export when the 2D stage becomes ready after opening", async () => {
+    const user = userEvent.setup();
+    addGate();
+    const canvasRef: { current: TrackCanvasHandle | null } = { current: null };
+
+    render(
+      <ExportDialog
+        activeTab="3d"
+        canvasRef={canvasRef}
+        onOpenChange={vi.fn()}
+        open
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Race Day$/ }));
+
+    const exportRacePack = (await screen.findByRole("button", {
+      name: "Export Race Pack",
+    })) as HTMLButtonElement;
+    expect(exportRacePack.disabled).toBe(true);
+
+    canvasRef.current = {
+      getStage: () => ({ id: "stage-1" }),
+    } as unknown as TrackCanvasHandle;
+
+    await waitFor(() => {
+      expect(exportRacePack.disabled).toBe(false);
+    });
+    expect(
+      screen.queryByText(
+        "The 2D canvas is still loading; try again in a moment."
+      )
+    ).toBeNull();
+  });
+
+  it("blocks Velocidrone export until the track has content", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ExportDialog
+        activeTab="3d"
+        canvasRef={React.createRef()}
+        onOpenChange={vi.fn()}
+        open
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Experimental$/ }));
+
+    expect(
+      await screen.findByText(
+        "Add at least one item to the track before exporting a Velocidrone file."
+      )
+    ).toBeTruthy();
+    const exportVelocidrone = (await screen.findByRole("button", {
+      name: "Export Velocidrone",
+    })) as HTMLButtonElement;
+    expect(exportVelocidrone.disabled).toBe(true);
+  });
+
+  it("warns that Velocidrone export is experimental without blocking track content", async () => {
+    const user = userEvent.setup();
+    addGate();
+
+    render(
+      <ExportDialog
+        activeTab="3d"
+        canvasRef={React.createRef()}
+        onOpenChange={vi.fn()}
+        open
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /^Experimental$/ }));
+
+    expect(
+      await screen.findByText(
+        "Some TrackDraw items may import differently in Velocidrone."
+      )
+    ).toBeTruthy();
+    const exportVelocidrone = (await screen.findByRole("button", {
+      name: "Export Velocidrone",
+    })) as HTMLButtonElement;
+    expect(exportVelocidrone.disabled).toBe(false);
+  });
+
   it("includes the selected theme in default WebM filenames", async () => {
     const user = userEvent.setup();
+    addRaceLine();
 
     render(
       <ExportDialog
@@ -317,6 +513,7 @@ describe("ExportDialog mobile workflow", () => {
     viewport.isMobile = false;
     const user = userEvent.setup();
     const onOpenChange = vi.fn();
+    addGate();
     const stage = { id: "stage-1" };
     const canvasRef = {
       current: {


### PR DESCRIPTION
## Summary
- Add inline export preflight feedback for blocked export actions in the export dialog.
- Block Race Pack and Velocidrone exports for empty tracks, block Cinematic FPV without a race line, and keep the 3D render switch-to-3D corrective action.
- Update related EN/NL/DE copy, inspector empty-state wording, tests, and mark the export workflow roadmap item complete.

## Validation
- `npm run test -- tests/components/dialogs/ExportDialog.test.tsx`
- `npm run type`
- `npm run lint`
- `npx prettier --check src/components/dialogs/ExportDialog.tsx tests/components/dialogs/ExportDialog.test.tsx lang/en/dialogs.json lang/nl/dialogs.json lang/de/dialogs.json`
- `npx prettier --check lang/en/inspector.json lang/nl/inspector.json lang/de/inspector.json`