### PR TITLE
fix: Complete editor reliability polish

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -150,6 +150,7 @@ Suggested focused slices:
   - Completed with existing route snapping and context-menu coverage still passing alongside the expanded store regression coverage
 - Transform and snapping regression pass
   - Validate move, nudge, rotate, resize handles, snapping, grouped selections, mixed locked/editable selections, and no-op history behavior
+  - Completed with no-op nudge/rotation history guards, mixed locked/editable rotate/resize/nudge coverage, grouped transform undo/redo coverage, and snap helper coverage for grid, object, route-line, route-waypoint, selected-item exclusion, and snap-toggle behavior
 - Mobile editor ergonomics pass
   - Started with larger, more consistent mobile app-menu touch targets for project, share, transfer, account, dashboard, and sign-out actions
   - Added steadier touch targets for path builder, quick adjust, and multi-select overlay actions during mobile editing

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -165,6 +165,7 @@ Suggested focused slices:
 - Large-layout stability pass
   - Started with bounded dense-grid rendering for SVG/PDF/PNG exports so fine grid settings do not explode export payload size
   - Added long-route obstacle-numbering coverage with bounded route-segment scans for dense gate layouts
+  - Completed with bounded map-reference tile coverage for large high-density fields, duplicate in-flight map tile load prevention, and existing dense SVG/PDF export, long-route numbering, and large 3D preview coverage still passing
 - Export/share confidence pass
   - Started by clarifying which exports are read-only visuals, which JSON files are editable backups, what Race Pack is for, and where simulator export remains experimental
   - Moved the export dialog onto the same sidebar-and-panel structure used by Share and Project Manager, with export categories in the sidebar and available outputs plus per-export filename, theme, and route-number settings in the main panel

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -154,6 +154,7 @@ Suggested first slices:
 - Selection and transform reliability pass
   - Started with store-level locked-shape guards for direct patches, batch patches, and route waypoint edits
   - Added locked-selection guards and shortcut feedback for duplicate/delete paths so shortcuts, context menus, and mobile overlays cannot mutate selections that include locked shapes
+  - Extended locked-selection guards to path-combine actions so path joining and path closing respect locked route objects while grouping remains available as an organization action
 - Export/share confidence pass
   - Started by clarifying which exports are read-only visuals, which JSON files are editable backups, what Race Pack is for, and where simulator export remains experimental
   - Moved the export dialog onto the same sidebar-and-panel structure used by Share and Project Manager, with export categories in the sidebar and available outputs plus per-export filename, theme, and route-number settings in the main panel

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -157,6 +157,7 @@ Suggested focused slices:
   - Improved mobile map-reference controls with larger action targets and easier opacity adjustment
   - Enlarged mobile inspector section headers so collapsible panels are easier to open and close on touch screens
   - Improved mobile Project Manager action targets for opening and scanning local-project actions
+  - Completed with steadier mobile drawer/input handling, larger and fixed mobile tool/view controls, truncation-safe path and multi-select overlay labels, grouped-selection naming touch targets, bottom toolbar sizing, and existing Project Manager/map reference/inspector mobile coverage still passing
 - Recovery and failure states
   - Started with a local autosave failure state that reports storage/quota failures and offers retry before users continue editing blindly
   - Added clearer import failure states for invalid JSON, wrong file types, unreadable files, and non-TrackDraw project data

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -146,6 +146,8 @@ Suggested focused slices:
 - Route editing regression pass
   - Harden waypoint insert, delete, drag, segment and vertex selection clearing, route close/join, snapping, undo/redo, and mobile path controls
   - Started by clearing stale segment and vertex selections after structural route edits such as waypoint insert/remove, append, reverse, route close, and route join
+  - Added route insert bounds guards and undo/redo coverage for route reverse, close, and join
+  - Completed with existing route snapping and context-menu coverage still passing alongside the expanded store regression coverage
 - Transform and snapping regression pass
   - Validate move, nudge, rotate, resize handles, snapping, grouped selections, mixed locked/editable selections, and no-op history behavior
 - Mobile editor ergonomics pass

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -139,30 +139,32 @@ Important boundary:
 - Do not use this track to introduce new editing modes, social features, or simulation-heavy analysis
 - Keep changes small enough that import/export, autosave, share publish/read, read-only viewing, and mobile editor flows can be validated after each slice
 
-Suggested first slices:
+Suggested focused slices:
 
-- Editor recovery and failure states
-  - Started with a local autosave failure state that reports storage/quota failures and offers retry before users continue editing blindly
-  - Added clearer import failure states for invalid JSON, wrong file types, unreadable files, and non-TrackDraw project data
-  - Added shared JSON export feedback so Project Manager export failures are reported instead of silently ignored
+- Locked selection action safeguards
+  - Locked selections consistently block destructive or confusing actions such as duplicate, delete, route join, and route close across store actions, shortcuts, context menus, inspector controls, item lists, and mobile overlays, while group organization remains available
+- Route editing regression pass
+  - Harden waypoint insert, delete, drag, segment and vertex selection clearing, route close/join, snapping, undo/redo, and mobile path controls
+- Transform and snapping regression pass
+  - Validate move, nudge, rotate, resize handles, snapping, grouped selections, mixed locked/editable selections, and no-op history behavior
 - Mobile editor ergonomics pass
   - Started with larger, more consistent mobile app-menu touch targets for project, share, transfer, account, dashboard, and sign-out actions
   - Added steadier touch targets for path builder, quick adjust, and multi-select overlay actions during mobile editing
   - Improved mobile map-reference controls with larger action targets and easier opacity adjustment
   - Enlarged mobile inspector section headers so collapsible panels are easier to open and close on touch screens
   - Improved mobile Project Manager action targets for opening and scanning local-project actions
-- Selection and transform reliability pass
-  - Started with store-level locked-shape guards for direct patches, batch patches, and route waypoint edits
-  - Added locked-selection guards and shortcut feedback for duplicate/delete paths so shortcuts, context menus, and mobile overlays cannot mutate selections that include locked shapes
-  - Extended locked-selection guards to path-combine actions so path joining and path closing respect locked route objects while grouping remains available as an organization action
+- Recovery and failure states
+  - Started with a local autosave failure state that reports storage/quota failures and offers retry before users continue editing blindly
+  - Added clearer import failure states for invalid JSON, wrong file types, unreadable files, and non-TrackDraw project data
+  - Added shared JSON export feedback so Project Manager export failures are reported instead of silently ignored
+- Large-layout stability pass
+  - Started with bounded dense-grid rendering for SVG/PDF/PNG exports so fine grid settings do not explode export payload size
+  - Added long-route obstacle-numbering coverage with bounded route-segment scans for dense gate layouts
 - Export/share confidence pass
   - Started by clarifying which exports are read-only visuals, which JSON files are editable backups, what Race Pack is for, and where simulator export remains experimental
   - Moved the export dialog onto the same sidebar-and-panel structure used by Share and Project Manager, with export categories in the sidebar and available outputs plus per-export filename, theme, and route-number settings in the main panel
   - Calmed the export dialog visuals: flattened the nested format/settings cards, gave the format picker a responsive layout (stacked tiles on mobile, inline row on desktop), and gave default export filenames a consistent theme suffix plus a date stamp so repeat exports do not silently overwrite each other
   - Clarified managed shares as read-only review links and JSON export as the editable handoff path
-- Performance and large-layout stability
-  - Started with bounded dense-grid rendering for SVG/PDF/PNG exports so fine grid settings do not explode export payload size
-  - Added long-route obstacle-numbering coverage with bounded route-segment scans for dense gate layouts
 
 #### Regional Measurement Units
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -145,6 +145,7 @@ Suggested focused slices:
   - Locked selections consistently block destructive or confusing actions such as duplicate, delete, route join, and route close across store actions, shortcuts, context menus, inspector controls, item lists, and mobile overlays, while group organization remains available
 - Route editing regression pass
   - Harden waypoint insert, delete, drag, segment and vertex selection clearing, route close/join, snapping, undo/redo, and mobile path controls
+  - Started by clearing stale segment and vertex selections after structural route edits such as waypoint insert/remove, append, reverse, route close, and route join
 - Transform and snapping regression pass
   - Validate move, nudge, rotate, resize handles, snapping, grouped selections, mixed locked/editable selections, and no-op history behavior
 - Mobile editor ergonomics pass

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -56,8 +56,7 @@ The next TrackDraw priority is export and handoff workflow polish first, editor 
         Validate move, nudge, rotate, resize handles, snapping, grouped selections, mixed locked/editable selections, and no-op history behavior.
   - [x] Mobile editor ergonomics pass
         Tighten drawers, touch targets, compact labels, Project Manager flows, path tools, multi-select actions, map reference controls, and inspector panels.
-        Completed with steadier mobile drawer/input handling, larger and fixed mobile tool/view controls, truncation-safe path and multi-select overlay labels, grouped-selection naming touch targets, bottom toolbar sizing, and existing Project Manager/map reference/inspector mobile coverage still passing.
-  - [ ] Recovery and failure states
+  - [x] Recovery and failure states
         Make autosave, import, export, share, account sync, and runtime failures explain what happened and what the user can do next.
   - [ ] Large-layout stability pass
         Stress-test dense layouts, long routes, map references, 3D preview, PDF/export, and make targeted performance or debounce fixes.

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -52,6 +52,7 @@ The next TrackDraw priority is export and handoff workflow polish first, editor 
         Locked selections consistently block destructive or confusing actions such as duplicate, delete, route join, and route close across store actions, shortcuts, context menus, inspector controls, item lists, and mobile overlays, while group organization remains available.
   - [ ] Route editing regression pass
         Harden waypoint insert, delete, drag, segment and vertex selection clearing, route close/join, snapping, undo/redo, and mobile path controls.
+        Started by clearing stale segment and vertex selections after structural route edits such as waypoint insert/remove, append, reverse, route close, and route join.
   - [ ] Transform and snapping regression pass
         Validate move, nudge, rotate, resize handles, snapping, grouped selections, mixed locked/editable selections, and no-op history behavior.
   - [ ] Mobile editor ergonomics pass

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -50,9 +50,8 @@ The next TrackDraw priority is export and handoff workflow polish first, editor 
       Run focused stability passes over shipped editor workflows before adding another large surface. Keep each slice small enough to validate without risking import/export, autosave, share publish/read, read-only viewing, or mobile editor flows.
   - [x] Locked selection action safeguards
         Locked selections consistently block destructive or confusing actions such as duplicate, delete, route join, and route close across store actions, shortcuts, context menus, inspector controls, item lists, and mobile overlays, while group organization remains available.
-  - [ ] Route editing regression pass
+  - [x] Route editing regression pass
         Harden waypoint insert, delete, drag, segment and vertex selection clearing, route close/join, snapping, undo/redo, and mobile path controls.
-        Started by clearing stale segment and vertex selections after structural route edits such as waypoint insert/remove, append, reverse, route close, and route join.
   - [ ] Transform and snapping regression pass
         Validate move, nudge, rotate, resize handles, snapping, grouped selections, mixed locked/editable selections, and no-op history behavior.
   - [ ] Mobile editor ergonomics pass

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -47,15 +47,19 @@ The next TrackDraw priority is export and handoff workflow polish first, editor 
         Validate real layouts and tune warnings, route anchor heights, and unclear sequence feedback before treating generated routes as more than a first-pass drafting aid.
 
 - [ ] Editor reliability polish (`No account required`, `Account-backed`)
-      Run a focused stability pass over shipped workflows before adding another large surface. Prioritize recovery states, mobile ergonomics, selection/transforms, autosave/account sync edge cases, imports/exports, sharing, read-only viewing, and larger layouts.
-  - [ ] Recovery and failure states
-        Make autosave, import, export, share, account sync, and runtime failures explain what happened and what the user can do next.
+      Run focused stability passes over shipped editor workflows before adding another large surface. Keep each slice small enough to validate without risking import/export, autosave, share publish/read, read-only viewing, or mobile editor flows.
+  - [x] Locked selection action safeguards
+        Locked selections consistently block destructive or confusing actions such as duplicate, delete, route join, and route close across store actions, shortcuts, context menus, inspector controls, item lists, and mobile overlays, while group organization remains available.
+  - [ ] Route editing regression pass
+        Harden waypoint insert, delete, drag, segment and vertex selection clearing, route close/join, snapping, undo/redo, and mobile path controls.
+  - [ ] Transform and snapping regression pass
+        Validate move, nudge, rotate, resize handles, snapping, grouped selections, mixed locked/editable selections, and no-op history behavior.
   - [ ] Mobile editor ergonomics pass
         Tighten drawers, touch targets, compact labels, Project Manager flows, path tools, multi-select actions, map reference controls, and inspector panels.
-  - [ ] Selection and transform regression pass
-        Harden locked objects, grouped selections, route waypoint editing, snapping, rotation, resize handles, undo/redo, shortcuts, and mobile overlays.
-    - [x] Locked selection action safeguards
-          Locked selections now consistently block destructive or confusing actions such as duplicate, delete, route join, and route close across store actions, shortcuts, context menus, inspector controls, item lists, and mobile overlays, while group organization remains available.
+  - [ ] Recovery and failure states
+        Make autosave, import, export, share, account sync, and runtime failures explain what happened and what the user can do next.
+  - [ ] Large-layout stability pass
+        Stress-test dense layouts, long routes, map references, 3D preview, PDF/export, and make targeted performance or debounce fixes.
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -54,8 +54,9 @@ The next TrackDraw priority is export and handoff workflow polish first, editor 
         Harden waypoint insert, delete, drag, segment and vertex selection clearing, route close/join, snapping, undo/redo, and mobile path controls.
   - [x] Transform and snapping regression pass
         Validate move, nudge, rotate, resize handles, snapping, grouped selections, mixed locked/editable selections, and no-op history behavior.
-  - [ ] Mobile editor ergonomics pass
+  - [x] Mobile editor ergonomics pass
         Tighten drawers, touch targets, compact labels, Project Manager flows, path tools, multi-select actions, map reference controls, and inspector panels.
+        Completed with steadier mobile drawer/input handling, larger and fixed mobile tool/view controls, truncation-safe path and multi-select overlay labels, grouped-selection naming touch targets, bottom toolbar sizing, and existing Project Manager/map reference/inspector mobile coverage still passing.
   - [ ] Recovery and failure states
         Make autosave, import, export, share, account sync, and runtime failures explain what happened and what the user can do next.
   - [ ] Large-layout stability pass

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -52,7 +52,7 @@ The next TrackDraw priority is export and handoff workflow polish first, editor 
         Locked selections consistently block destructive or confusing actions such as duplicate, delete, route join, and route close across store actions, shortcuts, context menus, inspector controls, item lists, and mobile overlays, while group organization remains available.
   - [x] Route editing regression pass
         Harden waypoint insert, delete, drag, segment and vertex selection clearing, route close/join, snapping, undo/redo, and mobile path controls.
-  - [ ] Transform and snapping regression pass
+  - [x] Transform and snapping regression pass
         Validate move, nudge, rotate, resize handles, snapping, grouped selections, mixed locked/editable selections, and no-op history behavior.
   - [ ] Mobile editor ergonomics pass
         Tighten drawers, touch targets, compact labels, Project Manager flows, path tools, multi-select actions, map reference controls, and inspector panels.

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -46,7 +46,7 @@ The next TrackDraw priority is export and handoff workflow polish first, editor 
   - [ ] Generated flightpath validation follow-up
         Validate real layouts and tune warnings, route anchor heights, and unclear sequence feedback before treating generated routes as more than a first-pass drafting aid.
 
-- [ ] Editor reliability polish (`No account required`, `Account-backed`)
+- [x] Editor reliability polish (`No account required`, `Account-backed`)
       Run focused stability passes over shipped editor workflows before adding another large surface. Keep each slice small enough to validate without risking import/export, autosave, share publish/read, read-only viewing, or mobile editor flows.
   - [x] Locked selection action safeguards
         Locked selections consistently block destructive or confusing actions such as duplicate, delete, route join, and route close across store actions, shortcuts, context menus, inspector controls, item lists, and mobile overlays, while group organization remains available.
@@ -58,7 +58,7 @@ The next TrackDraw priority is export and handoff workflow polish first, editor 
         Tighten drawers, touch targets, compact labels, Project Manager flows, path tools, multi-select actions, map reference controls, and inspector panels.
   - [x] Recovery and failure states
         Make autosave, import, export, share, account sync, and runtime failures explain what happened and what the user can do next.
-  - [ ] Large-layout stability pass
+  - [x] Large-layout stability pass
         Stress-test dense layouts, long routes, map references, 3D preview, PDF/export, and make targeted performance or debounce fixes.
 
 - [ ] Focused 3D item controls (`No account required`)

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -54,6 +54,8 @@ The next TrackDraw priority is export and handoff workflow polish first, editor 
         Tighten drawers, touch targets, compact labels, Project Manager flows, path tools, multi-select actions, map reference controls, and inspector panels.
   - [ ] Selection and transform regression pass
         Harden locked objects, grouped selections, route waypoint editing, snapping, rotation, resize handles, undo/redo, shortcuts, and mobile overlays.
+    - [x] Locked selection action safeguards
+          Locked selections now consistently block destructive or confusing actions such as duplicate, delete, route join, and route close across store actions, shortcuts, context menus, inspector controls, item lists, and mobile overlays, while group organization remains available.
 
 - [ ] Focused 3D item controls (`No account required`)
       Add direct 3D controls for common obstacle edits where they are faster than inspector-only editing and still respect lock state, undo/redo, and mobile constraints.

--- a/lang/de/common.json
+++ b/lang/de/common.json
@@ -62,6 +62,14 @@
       "openReleaseNotesForCommit": "Commit {sha} · Release Notes auf GitHub öffnen"
     }
   },
+  "runtimeError": {
+    "badge": "Laufzeitfehler",
+    "title": "TrackDraw ist in dieser Ansicht abgestürzt.",
+    "description": "Der aktuelle Bildschirm konnte nicht weiter gerendert werden. Deine lokalen Projektdaten sind normalerweise weiterhin in diesem Browser gespeichert, aber schließe den Tab erst, nachdem du die Wiederherstellung versucht hast.",
+    "tryAgain": "Erneut versuchen",
+    "openStudio": "Studio öffnen",
+    "nextStep": "Wenn das weiter passiert, öffne Studio erneut und exportiere ein JSON-Backup, bevor du größere Änderungen machst."
+  },
   "status": {
     "active": "Aktiv",
     "expired": "Abgelaufen",

--- a/lang/de/dialogs.json
+++ b/lang/de/dialogs.json
@@ -280,7 +280,8 @@
       }
     },
     "errors": {
-      "exportFailed": "Export fehlgeschlagen: {message}"
+      "exportFailed": "Export fehlgeschlagen",
+      "exportFailedDescription": "{message} Versuche es erneut, wechsle das Exportformat oder exportiere die Projekt-JSON als manuelles Backup."
     }
   },
   "import": {
@@ -289,9 +290,13 @@
     "dropFile": "Datei hier ablegen",
     "browseFile": "oder klicken zum Durchsuchen",
     "errorInvalidJson": "Ungültige JSON-Datei.",
+    "errorInvalidJsonHelp": "Ungültige JSON-Datei. Wähle einen vollständigen .json-Export aus TrackDraw und versuche es erneut.",
     "errorInvalidProject": "Das sieht nicht wie ein TrackDraw-Projekt aus.",
+    "errorInvalidProjectHelp": "Das sieht nicht wie ein TrackDraw-Projekt aus. Wähle eine JSON-Projektdatei, die aus TrackDraw exportiert wurde.",
     "errorUnsupportedFile": "Nur TrackDraw-JSON-Projektdateien werden unterstützt.",
+    "errorUnsupportedFileHelp": "Nur TrackDraw-JSON-Projektdateien werden unterstützt. Wähle ein aus TrackDraw exportiertes .json-Backup.",
     "errorReadFailed": "TrackDraw konnte diese Datei nicht lesen.",
+    "errorReadFailedHelp": "TrackDraw konnte diese Datei nicht lesen. Versuche es erneut oder wähle ein anderes Backup.",
     "toastImportFailed": "Import fehlgeschlagen",
     "toastUnsupportedFile": "Wähle eine aus TrackDraw exportierte .json-Datei.",
     "toastInvalidJson": "TrackDraw konnte diese JSON-Datei nicht lesen. Prüfe die Datei und versuche es erneut.",
@@ -520,12 +525,23 @@
     },
     "errors": {
       "createFailed": "Share-Link konnte nicht erstellt werden",
+      "createFailedDescription": "TrackDraw konnte den aktuellen Snapshot nicht veröffentlichen. Prüfe deine Verbindung und versuche es erneut; exportiere JSON, wenn du den Track jetzt weitergeben musst.",
       "copyFailed": "Link konnte nicht kopiert werden",
+      "copyFailedDescription": "Der Link ist möglicherweise noch im Feld verfügbar. Markiere ihn und kopiere manuell, wenn der Browser den Clipboard-Zugriff blockiert.",
+      "nativeShareFailed": "Teilen konnte nicht geöffnet werden",
+      "nativeShareFailedDescription": "Dieser Browser konnte das System-Teilen nicht öffnen. Kopiere stattdessen den Link.",
       "revokeFailed": "Link konnte nicht widerrufen werden",
+      "revokeFailedDescription": "Der Link ist möglicherweise noch aktiv. Versuche es erneut in diesem Dialog oder im Freigaben-Tab des Projektmanagers.",
       "embedCopyFailed": "Embed-Code konnte nicht kopiert werden",
+      "embedCopyFailedDescription": "Der Embed-Code ist weiterhin sichtbar. Markiere ihn und kopiere manuell, wenn der Browser den Clipboard-Zugriff blockiert.",
       "galleryListFailed": "Konnte nicht in Galerie gelistet werden",
+      "galleryListFailedDescription": "Der Share-Link wurde nicht zur öffentlichen Galerie hinzugefügt. Prüfe Titel, Beschreibung, Vorschau und Verbindung, bevor du es erneut versuchst.",
+      "galleryRemoveFailed": "Konnte nicht aus Galerie entfernt werden",
+      "galleryRemoveFailedDescription": "Der Galerieeintrag ist möglicherweise noch sichtbar. Versuche es erneut oder widerrufe den Share-Link, wenn er nicht mehr erreichbar sein darf.",
       "galleryUpdateFailed": "Galeriedetails konnten nicht aktualisiert werden",
-      "unableToReadLink": "Aktueller Share-Link konnte nicht gelesen werden"
+      "galleryUpdateFailedDescription": "Die veröffentlichte Galerie-Karte wurde nicht geändert. Prüfe Titel und Beschreibung und versuche es erneut.",
+      "unableToReadLink": "Aktueller Share-Link konnte nicht gelesen werden",
+      "unableToReadLinkDescription": "Lade diese Share-Seite neu oder öffne den Link über den Projektmanager, wenn es eine über das Konto veröffentlichte Freigabe ist."
     },
     "success": {
       "linkUpdated": "Link aktualisiert",
@@ -657,8 +673,10 @@
       },
       "messages": {
         "loadFailed": "Kontoprojekte konnten nicht geladen werden",
+        "loadFailedDescription": "Lokale Projekte auf diesem Gerät bleiben verfügbar. Prüfe deine Verbindung oder melde dich erneut an und öffne danach den Projektmanager erneut.",
         "conflictWarning": "Dieses Projekt wurde auf einem anderen Gerät geändert, während du abgemeldet warst",
         "syncError": "Neueste Änderungen konnten nicht synchronisiert werden",
+        "localCopySavedAfterFailure": "Neueste lokale Kopie gespeichert {relativeTime}",
         "resolveConflictFirst": "Löse zuerst den Versionskonflikt"
       },
       "actions": {

--- a/lang/de/editor.json
+++ b/lang/de/editor.json
@@ -389,6 +389,16 @@
       },
       "tools": {
         "title": "Werkzeuge",
+        "sections": {
+          "items": "Track-Elemente",
+          "tools": "Canvas-Werkzeuge"
+        },
+        "toolDescriptions": {
+          "startfinish": "Start- oder Timing-Pads markieren",
+          "cone": "Streckenmarkierungen platzieren",
+          "label": "Notizen auf dem Canvas hinzufügen",
+          "polyline": "Rennlinie zeichnen oder bearbeiten"
+        },
         "subtitles": {
           "preview3d": "Projektaktionen für die aktuelle 3D-Sitzung",
           "canvas2d": "Zeichen- und Bearbeitungswerkzeuge"

--- a/lang/de/editor.json
+++ b/lang/de/editor.json
@@ -427,6 +427,7 @@
     "untitledTrack": "Unbenannter Track",
     "untitledFallback": "Unbenannt",
     "exportFailed": "Export fehlgeschlagen",
+    "exportFailedDescription": "{message} Versuche es erneut oder öffne Exportieren und lade dort ein Projekt-JSON-Backup herunter.",
     "exportFailedNoProjectDescription": "TrackDraw konnte dieses lokale Projekt nicht laden. Öffne es zuerst oder wähle ein anderes gespeichertes Projekt.",
     "exportSuccess": "Projekt-JSON exportiert",
     "embeddedTrack": "Eingebetteter Track",

--- a/lang/en/common.json
+++ b/lang/en/common.json
@@ -62,6 +62,14 @@
       "openReleaseNotesForCommit": "commit {sha} · Open release notes on GitHub"
     }
   },
+  "runtimeError": {
+    "badge": "Runtime error",
+    "title": "TrackDraw hit a problem.",
+    "description": "The current screen stopped rendering. Your local project data is usually still stored in this browser, but avoid closing the tab until you have tried to recover.",
+    "tryAgain": "Try again",
+    "openStudio": "Open Studio",
+    "nextStep": "If this keeps happening, reopen Studio and export a JSON backup before continuing with major edits."
+  },
   "status": {
     "active": "Active",
     "expired": "Expired",

--- a/lang/en/dialogs.json
+++ b/lang/en/dialogs.json
@@ -280,7 +280,8 @@
       }
     },
     "errors": {
-      "exportFailed": "Export failed: {message}"
+      "exportFailed": "Export failed",
+      "exportFailedDescription": "{message} Try again, switch export format, or export the project JSON as a manual backup."
     }
   },
   "import": {
@@ -289,9 +290,13 @@
     "dropFile": "Drop a file here",
     "browseFile": "or click to browse",
     "errorInvalidJson": "Invalid JSON file.",
+    "errorInvalidJsonHelp": "Invalid JSON file. Choose a complete .json export from TrackDraw and try again.",
     "errorInvalidProject": "This does not look like a TrackDraw project.",
+    "errorInvalidProjectHelp": "This does not look like a TrackDraw project. Choose a JSON project file exported from TrackDraw.",
     "errorUnsupportedFile": "Only TrackDraw JSON project files are supported.",
+    "errorUnsupportedFileHelp": "Only TrackDraw JSON project files are supported. Choose a .json backup exported from TrackDraw.",
     "errorReadFailed": "TrackDraw could not read this file.",
+    "errorReadFailedHelp": "TrackDraw could not read this file. Try again or choose another backup.",
     "toastImportFailed": "Import failed",
     "toastUnsupportedFile": "Choose a .json file exported from TrackDraw.",
     "toastInvalidJson": "TrackDraw could not read this JSON file. Check the file and try again.",
@@ -519,13 +524,24 @@
       }
     },
     "errors": {
-      "createFailed": "Failed to create share link",
-      "copyFailed": "Failed to copy link",
-      "revokeFailed": "Failed to revoke link",
-      "embedCopyFailed": "Failed to copy embed code",
-      "galleryListFailed": "Failed to list in gallery",
-      "galleryUpdateFailed": "Failed to update gallery details",
-      "unableToReadLink": "Unable to read the current share link"
+      "createFailed": "Could not create share link",
+      "createFailedDescription": "TrackDraw could not publish the current snapshot. Check your connection and try again; export JSON if you need to hand it off now.",
+      "copyFailed": "Could not copy link",
+      "copyFailedDescription": "The link may still be available in the field. Select it and copy manually if the browser blocks clipboard access.",
+      "nativeShareFailed": "Could not open sharing",
+      "nativeShareFailedDescription": "This browser could not open the system share sheet. Copy the link instead.",
+      "revokeFailed": "Could not revoke link",
+      "revokeFailedDescription": "The link may still be active. Try again from this dialog or the Project Manager shares tab.",
+      "embedCopyFailed": "Could not copy embed code",
+      "embedCopyFailedDescription": "The embed code is still visible. Select it and copy manually if the browser blocks clipboard access.",
+      "galleryListFailed": "Could not list in gallery",
+      "galleryListFailedDescription": "The share link was not added to the public gallery. Check the title, description, preview, and connection before trying again.",
+      "galleryRemoveFailed": "Could not remove from gallery",
+      "galleryRemoveFailedDescription": "The gallery entry may still be visible. Try again, or revoke the share link if it must stop being accessible.",
+      "galleryUpdateFailed": "Could not update gallery details",
+      "galleryUpdateFailedDescription": "The published gallery card was not changed. Check the title and description, then try again.",
+      "unableToReadLink": "Unable to read the current share link",
+      "unableToReadLinkDescription": "Reload this share page, or open the link from Project Manager if it is an account-published share."
     },
     "success": {
       "linkUpdated": "Link updated",
@@ -657,8 +673,10 @@
       },
       "messages": {
         "loadFailed": "Could not load account projects",
+        "loadFailedDescription": "Local projects on this device remain available. Check your connection or sign in again, then reopen Project Manager.",
         "conflictWarning": "This project changed on another device while you were signed out",
         "syncError": "Could not sync the latest changes",
+        "localCopySavedAfterFailure": "Latest local copy saved {relativeTime}",
         "resolveConflictFirst": "Resolve the version conflict first"
       },
       "actions": {

--- a/lang/en/editor.json
+++ b/lang/en/editor.json
@@ -389,6 +389,16 @@
       },
       "tools": {
         "title": "Tools",
+        "sections": {
+          "items": "Track items",
+          "tools": "Canvas tools"
+        },
+        "toolDescriptions": {
+          "startfinish": "Mark launch or timing pads",
+          "cone": "Place course markers",
+          "label": "Add notes on the canvas",
+          "polyline": "Draw or edit the race line"
+        },
         "subtitles": {
           "preview3d": "Project actions for the current 3D session",
           "canvas2d": "Drawing and editing tools"

--- a/lang/en/editor.json
+++ b/lang/en/editor.json
@@ -427,6 +427,7 @@
     "untitledTrack": "Untitled track",
     "untitledFallback": "Untitled",
     "exportFailed": "Export failed",
+    "exportFailedDescription": "{message} Try again, or open Export and download a project JSON backup from there.",
     "exportFailedNoProjectDescription": "TrackDraw could not load this local project. Open it first or choose another saved project.",
     "exportSuccess": "Project JSON exported",
     "embeddedTrack": "Embedded track",

--- a/lang/nl/common.json
+++ b/lang/nl/common.json
@@ -62,6 +62,14 @@
       "openReleaseNotesForCommit": "commit {sha} · Release notes openen op GitHub"
     }
   },
+  "runtimeError": {
+    "badge": "Runtimefout",
+    "title": "TrackDraw liep vast op deze weergave.",
+    "description": "Het huidige scherm kon niet verder renderen. Je lokale projectdata staat meestal nog in deze browser, maar sluit het tabblad niet voordat je herstel hebt geprobeerd.",
+    "tryAgain": "Opnieuw proberen",
+    "openStudio": "Studio openen",
+    "nextStep": "Als dit blijft gebeuren, open Studio opnieuw en exporteer een JSON-back-up voordat je grote wijzigingen maakt."
+  },
   "status": {
     "active": "Actief",
     "expired": "Verlopen",

--- a/lang/nl/dialogs.json
+++ b/lang/nl/dialogs.json
@@ -280,7 +280,8 @@
       }
     },
     "errors": {
-      "exportFailed": "Exporteren mislukt: {message}"
+      "exportFailed": "Exporteren mislukt",
+      "exportFailedDescription": "{message} Probeer opnieuw, kies een ander exportformaat of exporteer de project-JSON als handmatige back-up."
     }
   },
   "import": {
@@ -289,9 +290,13 @@
     "dropFile": "Sleep hier een bestand naartoe",
     "browseFile": "of klik om te bladeren",
     "errorInvalidJson": "Ongeldig JSON-bestand.",
+    "errorInvalidJsonHelp": "Ongeldig JSON-bestand. Kies een volledige .json-export uit TrackDraw en probeer opnieuw.",
     "errorInvalidProject": "Dit lijkt geen TrackDraw-project te zijn.",
+    "errorInvalidProjectHelp": "Dit lijkt geen TrackDraw-project te zijn. Kies een JSON-projectbestand dat uit TrackDraw is geëxporteerd.",
     "errorUnsupportedFile": "Alleen TrackDraw JSON-projectbestanden worden ondersteund.",
+    "errorUnsupportedFileHelp": "Alleen TrackDraw JSON-projectbestanden worden ondersteund. Kies een .json-back-up die uit TrackDraw is geëxporteerd.",
     "errorReadFailed": "TrackDraw kon dit bestand niet lezen.",
+    "errorReadFailedHelp": "TrackDraw kon dit bestand niet lezen. Probeer opnieuw of kies een andere back-up.",
     "toastImportFailed": "Importeren mislukt",
     "toastUnsupportedFile": "Kies een .json-bestand dat uit TrackDraw is geëxporteerd.",
     "toastInvalidJson": "TrackDraw kon dit JSON-bestand niet lezen. Controleer het bestand en probeer opnieuw.",
@@ -519,13 +524,24 @@
       }
     },
     "errors": {
-      "createFailed": "Deellink aanmaken mislukt",
-      "copyFailed": "Link kopiëren mislukt",
-      "revokeFailed": "Link intrekken mislukt",
-      "embedCopyFailed": "Insluiting kopiëren mislukt",
-      "galleryListFailed": "Vermelden in galerij mislukt",
-      "galleryUpdateFailed": "Galerij bijwerken mislukt",
-      "unableToReadLink": "Huidige deellink kon niet worden gelezen"
+      "createFailed": "Deellink kon niet worden aangemaakt",
+      "createFailedDescription": "TrackDraw kon de huidige snapshot niet publiceren. Controleer je verbinding en probeer opnieuw; exporteer JSON als je de track nu moet overdragen.",
+      "copyFailed": "Link kon niet worden gekopieerd",
+      "copyFailedDescription": "De link staat mogelijk nog in het veld. Selecteer hem en kopieer handmatig als de browser klembordtoegang blokkeert.",
+      "nativeShareFailed": "Delen kon niet worden geopend",
+      "nativeShareFailedDescription": "Deze browser kon het systeemdeelvenster niet openen. Kopieer de link in plaats daarvan.",
+      "revokeFailed": "Link kon niet worden ingetrokken",
+      "revokeFailedDescription": "De link kan nog actief zijn. Probeer opnieuw vanuit dit venster of via het tabblad Gedeeld in Project Manager.",
+      "embedCopyFailed": "Embedcode kon niet worden gekopieerd",
+      "embedCopyFailedDescription": "De embedcode is nog zichtbaar. Selecteer hem en kopieer handmatig als de browser klembordtoegang blokkeert.",
+      "galleryListFailed": "Kon niet in galerij worden geplaatst",
+      "galleryListFailedDescription": "De deellink is niet toegevoegd aan de publieke galerij. Controleer titel, beschrijving, preview en verbinding voordat je opnieuw probeert.",
+      "galleryRemoveFailed": "Kon niet uit galerij worden verwijderd",
+      "galleryRemoveFailedDescription": "De galerijvermelding kan nog zichtbaar zijn. Probeer opnieuw, of trek de deellink in als deze niet meer toegankelijk mag zijn.",
+      "galleryUpdateFailed": "Galerijgegevens konden niet worden bijgewerkt",
+      "galleryUpdateFailedDescription": "De gepubliceerde galerijkaart is niet gewijzigd. Controleer titel en beschrijving en probeer opnieuw.",
+      "unableToReadLink": "Huidige deellink kon niet worden gelezen",
+      "unableToReadLinkDescription": "Herlaad deze deelpagina, of open de link via Project Manager als dit een accountgepubliceerde share is."
     },
     "success": {
       "linkUpdated": "Link bijgewerkt",
@@ -657,8 +673,10 @@
       },
       "messages": {
         "loadFailed": "Accountprojecten konden niet worden geladen",
+        "loadFailedDescription": "Lokale projecten op dit apparaat blijven beschikbaar. Controleer je verbinding of log opnieuw in en open Project Manager daarna opnieuw.",
         "conflictWarning": "Dit project is op een ander apparaat gewijzigd terwijl je niet was aangemeld",
         "syncError": "Laatste wijzigingen konden niet worden gesynchroniseerd",
+        "localCopySavedAfterFailure": "Nieuwste lokale kopie opgeslagen {relativeTime}",
         "resolveConflictFirst": "Los eerst het versieconflict op"
       },
       "actions": {

--- a/lang/nl/editor.json
+++ b/lang/nl/editor.json
@@ -389,6 +389,16 @@
       },
       "tools": {
         "title": "Tools",
+        "sections": {
+          "items": "Trackitems",
+          "tools": "Canvastools"
+        },
+        "toolDescriptions": {
+          "startfinish": "Markeer start- of timingpads",
+          "cone": "Plaats parcoursmarkeringen",
+          "label": "Voeg notities toe op het canvas",
+          "polyline": "Teken of bewerk de racelijn"
+        },
         "subtitles": {
           "preview3d": "Projectacties voor de huidige 3D-sessie",
           "canvas2d": "Teken- en bewerkingstools"

--- a/lang/nl/editor.json
+++ b/lang/nl/editor.json
@@ -427,6 +427,7 @@
     "untitledTrack": "Naamloze track",
     "untitledFallback": "Naamloos",
     "exportFailed": "Exporteren mislukt",
+    "exportFailedDescription": "{message} Probeer opnieuw, of open Exporteren en download daar een project-JSON-back-up.",
     "exportFailedNoProjectDescription": "TrackDraw kon dit lokale project niet laden. Open het eerst of kies een ander opgeslagen project.",
     "exportSuccess": "Project-JSON geëxporteerd",
     "embeddedTrack": "Ingesloten track",

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import Link from "next/link";
+import { AlertTriangle, Home, RotateCcw } from "lucide-react";
+import { useTranslations } from "next-intl";
+
+export default function Error({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations("common.runtimeError");
+
+  return (
+    <main className="bg-background text-foreground flex min-h-screen items-center px-6 py-16">
+      <div className="mx-auto w-full max-w-3xl">
+        <div className="border-destructive/20 bg-destructive/8 mb-5 inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-[11px] font-semibold tracking-[0.16em] uppercase">
+          <AlertTriangle className="size-3.5" />
+          {t("badge")}
+        </div>
+
+        <div className="space-y-4">
+          <h1 className="max-w-2xl text-4xl leading-tight font-semibold text-balance sm:text-5xl">
+            {t("title")}
+          </h1>
+          <p className="text-muted-foreground max-w-2xl text-sm leading-7 sm:text-base">
+            {t("description")}
+          </p>
+        </div>
+
+        <div className="mt-8 grid max-w-xl gap-3 sm:grid-cols-2">
+          <button
+            type="button"
+            onClick={reset}
+            className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl px-5 text-sm font-medium transition-colors"
+          >
+            <RotateCcw className="size-4" />
+            {t("tryAgain")}
+          </button>
+          <Link
+            href="/studio"
+            className="border-border/50 bg-muted/18 text-foreground hover:bg-muted/28 inline-flex min-h-12 items-center justify-center gap-2 rounded-2xl border px-5 text-sm font-medium transition-colors"
+          >
+            <Home className="size-4" />
+            {t("openStudio")}
+          </Link>
+        </div>
+
+        <p className="text-muted-foreground/70 mt-6 max-w-xl text-xs leading-relaxed">
+          {t("nextStep")}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -792,9 +792,7 @@ const TrackCanvas = memo(
           ids: nextSelection,
           joinablePolylineIds: nextSelection.filter((id) => {
             const shape = shapeById[id];
-            return (
-              shape?.kind === "polyline" && !shape.closed && !shape.locked
-            );
+            return shape?.kind === "polyline" && !shape.closed && !shape.locked;
           }),
           label:
             nextSelection.length > 1

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -731,6 +731,9 @@ const TrackCanvas = memo(
           );
         });
         const selectedShapes = nextSelection.map((id) => shapeById[id]);
+        const selectedHasLockedShapes = selectedShapes.some((shape) =>
+          Boolean(shape?.locked)
+        );
         const selectedGroupIds = Array.from(
           new Set(
             selectedShapes
@@ -785,14 +788,13 @@ const TrackCanvas = memo(
               : null,
           groupLabel,
           hasGroupedShapes: selectionHasGroupedShapes(selectedShapes),
-          hasLockedShapes: nextSelection.some((id) => {
-            const shape = shapeById[id];
-            return Boolean(shape?.locked);
-          }),
+          hasLockedShapes: selectedHasLockedShapes,
           ids: nextSelection,
           joinablePolylineIds: nextSelection.filter((id) => {
             const shape = shapeById[id];
-            return shape?.kind === "polyline" && !shape.closed;
+            return (
+              shape?.kind === "polyline" && !shape.closed && !shape.locked
+            );
           }),
           label:
             nextSelection.length > 1

--- a/src/components/canvas/renderers/map-reference-layer.tsx
+++ b/src/components/canvas/renderers/map-reference-layer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Group, Image as KonvaImage } from "react-konva";
 import {
   getFieldMapTileCoverage,
@@ -25,21 +25,25 @@ export function MapReferenceLayer({
     return getFieldMapTileCoverage({ field, mapReference });
   }, [field, mapReference]);
   const [images, setImages] = useState<Record<string, HTMLImageElement>>({});
+  const pendingTileUrlsRef = useRef(new Set<string>());
 
   useEffect(() => {
     if (!mapReference?.visible) return;
 
     const tileUrls = new Set(tiles.map(getMapReferenceTileUrl));
     let mounted = true;
-    const missingTiles = tiles.filter(
-      (tile) => !images[getMapReferenceTileUrl(tile)]
-    );
+    const missingTiles = tiles.filter((tile) => {
+      const url = getMapReferenceTileUrl(tile);
+      return !images[url] && !pendingTileUrlsRef.current.has(url);
+    });
 
     for (const tile of missingTiles) {
       const url = getMapReferenceTileUrl(tile);
+      pendingTileUrlsRef.current.add(url);
       const image = new window.Image();
       image.crossOrigin = "anonymous";
       image.onload = () => {
+        pendingTileUrlsRef.current.delete(url);
         if (!mounted) return;
         setImages((current) => {
           const next: Record<string, HTMLImageElement> = {};
@@ -49,6 +53,9 @@ export function MapReferenceLayer({
           if (!next[url]) next[url] = image;
           return next;
         });
+      };
+      image.onerror = () => {
+        pendingTileUrlsRef.current.delete(url);
       };
       image.src = url;
     }

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -933,7 +933,7 @@ export default function ExportDialog({
   const activeContent = (
     <div className="space-y-5">
       {hasMultipleFormats ? (
-        <div className="grid gap-1 sm:grid-cols-3">
+        <div className="grid grid-cols-3 gap-1">
           {activeFormats.map((format) => (
             <ExportFormatChoice
               key={format.id}

--- a/src/components/dialogs/ExportDialog.tsx
+++ b/src/components/dialogs/ExportDialog.tsx
@@ -582,12 +582,16 @@ export default function ExportDialog({
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      const description = t("export.errors.exportFailedDescription", {
+        message,
+      });
       if (options?.toastId !== undefined) {
-        toast.error(t("export.errors.exportFailed", { message }), {
+        toast.error(t("export.errors.exportFailed"), {
+          description,
           id: options.toastId,
         });
       } else {
-        toast.error(t("export.errors.exportFailed", { message }));
+        toast.error(t("export.errors.exportFailed"), { description });
       }
     } finally {
       setBusy(null);

--- a/src/components/dialogs/ImportDialog.tsx
+++ b/src/components/dialogs/ImportDialog.tsx
@@ -55,7 +55,7 @@ export default function ImportDialog({
       try {
         data = JSON.parse(text);
       } catch {
-        setError(t("import.errorInvalidJson"));
+        setError(t("import.errorInvalidJsonHelp"));
         setParsed(null);
         reportImportError(
           t("import.toastImportFailed"),
@@ -75,7 +75,7 @@ export default function ImportDialog({
         });
         setError(null);
       } catch {
-        setError(t("import.errorInvalidProject"));
+        setError(t("import.errorInvalidProjectHelp"));
         setParsed(null);
         reportImportError(
           t("import.toastImportFailed"),
@@ -89,7 +89,7 @@ export default function ImportDialog({
   const handleFile = useCallback(
     (file: File) => {
       if (!file.name.endsWith(".json")) {
-        setError(t("import.errorUnsupportedFile"));
+        setError(t("import.errorUnsupportedFileHelp"));
         setParsed(null);
         toast.error(t("import.toastImportFailed"), {
           description: t("import.toastUnsupportedFile"),
@@ -97,7 +97,7 @@ export default function ImportDialog({
         return;
       }
       file.text().then(tryParse, () => {
-        setError(t("import.errorReadFailed"));
+        setError(t("import.errorReadFailedHelp"));
         setParsed(null);
         toast.error(t("import.toastImportFailed"), {
           description: t("import.toastReadFailed"),

--- a/src/components/dialogs/ProjectManager/AccountTab.tsx
+++ b/src/components/dialogs/ProjectManager/AccountTab.tsx
@@ -77,6 +77,9 @@ export function ProjectManagerAccountTab({
           {t("projectManager.account.messages.loadFailed")}
         </p>
         <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
+          {t("projectManager.account.messages.loadFailedDescription")}
+        </p>
+        <p className="text-muted-foreground/70 mt-2 text-[11px] leading-relaxed">
           {error}
         </p>
       </div>
@@ -105,7 +108,9 @@ export function ProjectManagerAccountTab({
         const hasPendingChanges = syncMeta?.status === "pending";
         const lastSyncedAt = syncMeta?.lastSyncedAt ?? proj.updatedAt;
         const fallbackLine = syncMeta?.fallbackSavedAt
-          ? `Latest local copy saved ${formatRelativeTime(syncMeta.fallbackSavedAt)}`
+          ? t("projectManager.account.messages.localCopySavedAfterFailure", {
+              relativeTime: formatRelativeTime(syncMeta.fallbackSavedAt),
+            })
           : null;
         const metaLine = hasConflict
           ? (syncMeta?.error ??

--- a/src/components/dialogs/ShareDialog.tsx
+++ b/src/components/dialogs/ShareDialog.tsx
@@ -478,10 +478,10 @@ export default function ShareDialog({
       toast.success(
         force ? t("share.success.linkUpdated") : t("share.success.linkCreated")
       );
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t("share.errors.createFailed")
-      );
+    } catch {
+      toast.error(t("share.errors.createFailed"), {
+        description: t("share.errors.createFailedDescription"),
+      });
     }
   };
 
@@ -495,10 +495,10 @@ export default function ShareDialog({
       setCopied(true);
       toast.success(t("share.success.linkCopied"));
       setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t("share.errors.copyFailed")
-      );
+    } catch {
+      toast.error(t("share.errors.copyFailed"), {
+        description: t("share.errors.copyFailedDescription"),
+      });
     }
   };
 
@@ -515,7 +515,9 @@ export default function ShareDialog({
       });
     } catch (err) {
       if (err instanceof Error && err.name !== "AbortError") {
-        toast.error(err.message);
+        toast.error(t("share.errors.nativeShareFailed"), {
+          description: t("share.errors.nativeShareFailedDescription"),
+        });
       }
     }
   };
@@ -527,10 +529,10 @@ export default function ShareDialog({
           ? share.url
           : await doPublish(linkNeedsRefresh);
       window.open(url, "_blank", "noopener,noreferrer");
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t("share.errors.createFailed")
-      );
+    } catch {
+      toast.error(t("share.errors.createFailed"), {
+        description: t("share.errors.createFailedDescription"),
+      });
     }
   };
 
@@ -549,10 +551,10 @@ export default function ShareDialog({
       setPublishedDesignToken(null);
       clearAnonShare();
       toast.success(t("share.success.linkRevoked"));
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t("share.errors.revokeFailed")
-      );
+    } catch {
+      toast.error(t("share.errors.revokeFailed"), {
+        description: t("share.errors.revokeFailedDescription"),
+      });
     } finally {
       setRevoking(false);
     }
@@ -566,7 +568,9 @@ export default function ShareDialog({
       toast.success(t("share.success.embedCopied"));
       setTimeout(() => setCopiedEmbed(false), 2000);
     } catch {
-      toast.error(t("share.errors.embedCopyFailed"));
+      toast.error(t("share.errors.embedCopyFailed"), {
+        description: t("share.errors.embedCopyFailedDescription"),
+      });
     }
   };
 
@@ -613,10 +617,10 @@ export default function ShareDialog({
       });
       setShowGalleryForm(false);
       toast.success(t("share.success.galleryListed"));
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : t("share.errors.galleryListFailed")
-      );
+    } catch {
+      toast.error(t("share.errors.galleryListFailed"), {
+        description: t("share.errors.galleryListFailedDescription"),
+      });
     } finally {
       setGalleryUpdating(false);
     }
@@ -652,10 +656,10 @@ export default function ShareDialog({
       });
       setConfirmRemoveFromGallery(false);
       toast.success("Track removed from gallery");
-    } catch (err) {
-      toast.error(
-        err instanceof Error ? err.message : "Failed to remove from gallery"
-      );
+    } catch {
+      toast.error(t("share.errors.galleryRemoveFailed"), {
+        description: t("share.errors.galleryRemoveFailedDescription"),
+      });
     } finally {
       setGalleryUpdating(false);
     }
@@ -704,12 +708,10 @@ export default function ShareDialog({
       });
       setShowGalleryForm(false);
       toast.success(t("share.success.galleryUpdated"));
-    } catch (err) {
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : t("share.errors.galleryUpdateFailed")
-      );
+    } catch {
+      toast.error(t("share.errors.galleryUpdateFailed"), {
+        description: t("share.errors.galleryUpdateFailedDescription"),
+      });
     } finally {
       setGalleryUpdating(false);
     }
@@ -717,7 +719,9 @@ export default function ShareDialog({
 
   const handleCopyCurrentUrl = async () => {
     if (!currentShareUrl) {
-      toast.error(t("share.errors.unableToReadLink"));
+      toast.error(t("share.errors.unableToReadLink"), {
+        description: t("share.errors.unableToReadLinkDescription"),
+      });
       return;
     }
     try {
@@ -726,7 +730,9 @@ export default function ShareDialog({
       toast.success(t("share.success.linkCopied"));
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      toast.error(t("share.errors.copyFailed"));
+      toast.error(t("share.errors.copyFailed"), {
+        description: t("share.errors.copyFailedDescription"),
+      });
     }
   };
 
@@ -740,7 +746,9 @@ export default function ShareDialog({
       });
     } catch (err) {
       if (err instanceof Error && err.name !== "AbortError") {
-        toast.error(err.message);
+        toast.error(t("share.errors.nativeShareFailed"), {
+          description: t("share.errors.nativeShareFailedDescription"),
+        });
       }
     }
   };

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -519,7 +519,9 @@ export default function EditorShell({
       } catch (error) {
         const message =
           error instanceof Error ? error.message : t("shell.exportFailed");
-        toast.error(t("shell.exportFailed"), { description: message });
+        toast.error(t("shell.exportFailed"), {
+          description: t("shell.exportFailedDescription", { message }),
+        });
       }
     },
     [design, t]

--- a/src/components/editor/mobile/EditorMobilePanels.tsx
+++ b/src/components/editor/mobile/EditorMobilePanels.tsx
@@ -199,43 +199,49 @@ function MobileQuickActionsOverlay({
               type="button"
               onClick={onAddWaypoint}
               disabled={selectionHasLockedShapes}
-              className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
+              className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
             >
               <Plus className="size-4" />
-              <span>{t("quickActions.actions.addPoint")}</span>
+              <span className="max-w-full truncate">
+                {t("quickActions.actions.addPoint")}
+              </span>
             </button>
           ) : canResumePathEditing ? (
             <button
               type="button"
               onClick={onResumeSelectedPath}
               disabled={selectionHasLockedShapes}
-              className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
+              className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
             >
               <PencilLine className="size-4" />
-              <span>{t("quickActions.actions.editPath")}</span>
+              <span className="max-w-full truncate">
+                {t("quickActions.actions.editPath")}
+              </span>
             </button>
           ) : (
             <button
               type="button"
               onClick={onDuplicateSelection}
               disabled={selectionHasLockedShapes}
-              className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+              className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
             >
               <Copy className="size-4" />
-              <span>{t("quickActions.actions.duplicate")}</span>
+              <span className="max-w-full truncate">
+                {t("quickActions.actions.duplicate")}
+              </span>
             </button>
           )}
           <button
             type="button"
             onClick={onToggleSelectionLock}
-            className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
+            className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
           >
             {selectionLocked ? (
               <Unlock className="size-4" />
             ) : (
               <Lock className="size-4" />
             )}
-            <span>
+            <span className="max-w-full truncate">
               {selectionLocked
                 ? t("quickActions.actions.unlock")
                 : t("quickActions.actions.lock")}
@@ -245,10 +251,10 @@ function MobileQuickActionsOverlay({
             type="button"
             onClick={canDeleteWaypoint ? onDeleteWaypoint : onDeleteSelection}
             disabled={selectionHasLockedShapes}
-            className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-rose-300 transition-colors hover:bg-rose-400/12 hover:text-rose-200 disabled:text-white/35"
+            className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-rose-300 transition-colors hover:bg-rose-400/12 hover:text-rose-200 disabled:text-white/35"
           >
             <Trash2 className="size-4" />
-            <span>
+            <span className="max-w-full truncate">
               {canDeleteWaypoint
                 ? t("quickActions.actions.deletePoint")
                 : t("quickActions.actions.delete")}
@@ -258,10 +264,12 @@ function MobileQuickActionsOverlay({
             type="button"
             onClick={() => setExpanded(true)}
             disabled={selectionHasLockedShapes}
-            className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+            className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <SlidersHorizontal className="size-4" />
-            <span>{t("quickActions.actions.adjust")}</span>
+            <span className="max-w-full truncate">
+              {t("quickActions.actions.adjust")}
+            </span>
           </button>
         </div>
       ) : (
@@ -269,28 +277,30 @@ function MobileQuickActionsOverlay({
           <button
             type="button"
             onClick={() => setExpanded(false)}
-            className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/62 transition-colors hover:bg-white/10 hover:text-white"
+            className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/62 transition-colors hover:bg-white/10 hover:text-white"
           >
             <ArrowLeft className="size-4" />
-            <span>{t("quickActions.actions.back")}</span>
+            <span className="max-w-full truncate">
+              {t("quickActions.actions.back")}
+            </span>
           </button>
           <button
             type="button"
             onClick={() => onRotateSelection(-15)}
             disabled={!singleSelectionCanRotate}
-            className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+            className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <RotateCcw className="size-4" />
-            <span>-15°</span>
+            <span className="max-w-full truncate">-15°</span>
           </button>
           <button
             type="button"
             onClick={() => onRotateSelection(15)}
             disabled={!singleSelectionCanRotate}
-            className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+            className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <RotateCw className="size-4" />
-            <span>+15°</span>
+            <span className="max-w-full truncate">+15°</span>
           </button>
           <div className="flex items-center justify-center text-[9px] font-medium tracking-[0.08em] text-white/35 uppercase">
             {t("quickActions.adjust.step")}
@@ -299,37 +309,45 @@ function MobileQuickActionsOverlay({
             type="button"
             onClick={() => onNudgeSelection(-mobilePrecisionStep, 0)}
             disabled={!singleSelectionCanNudge}
-            className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+            className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <ArrowLeft className="size-4" />
-            <span>{t("quickActions.adjust.left")}</span>
+            <span className="max-w-full truncate">
+              {t("quickActions.adjust.left")}
+            </span>
           </button>
           <button
             type="button"
             onClick={() => onNudgeSelection(0, -mobilePrecisionStep)}
             disabled={!singleSelectionCanNudge}
-            className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+            className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <ArrowUp className="size-4" />
-            <span>{t("quickActions.adjust.up")}</span>
+            <span className="max-w-full truncate">
+              {t("quickActions.adjust.up")}
+            </span>
           </button>
           <button
             type="button"
             onClick={() => onNudgeSelection(0, mobilePrecisionStep)}
             disabled={!singleSelectionCanNudge}
-            className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+            className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <ArrowDown className="size-4" />
-            <span>{t("quickActions.adjust.down")}</span>
+            <span className="max-w-full truncate">
+              {t("quickActions.adjust.down")}
+            </span>
           </button>
           <button
             type="button"
             onClick={() => onNudgeSelection(mobilePrecisionStep, 0)}
             disabled={!singleSelectionCanNudge}
-            className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+            className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
           >
             <ArrowRight className="size-4" />
-            <span>{t("quickActions.adjust.right")}</span>
+            <span className="max-w-full truncate">
+              {t("quickActions.adjust.right")}
+            </span>
           </button>
         </div>
       )}
@@ -507,25 +525,27 @@ export function EditorMobilePanels({
             className="pointer-events-auto flex w-full max-w-sm items-center gap-1 rounded-[1.35rem] border border-white/10 bg-slate-950/86 p-1.5 text-white shadow-[0_18px_36px_rgba(15,23,42,0.32)] backdrop-blur landscape:max-w-66 landscape:gap-0.5 landscape:px-1 landscape:py-1"
           >
             <button
+              type="button"
               onClick={handleMobileSelectButton}
               className={cn(
-                "flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium transition-colors landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5",
+                "flex min-h-12 min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium transition-colors landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5",
                 activeTool === "select" && !mobileMultiSelectEnabled
                   ? "bg-white text-slate-950"
                   : "text-white/72 hover:bg-white/10 hover:text-white"
               )}
             >
               <SquareMousePointer className="size-3.5" />
-              <span>
+              <span className="max-w-full truncate">
                 {mobileMultiSelectEnabled ? t("nav.exit") : t("nav.select")}
               </span>
             </button>
             <button
+              type="button"
               onClick={openToolsDrawer}
-              className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5"
+              className="flex min-h-12 min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5"
             >
               <LayoutGrid className="size-3.5" />
-              <span>{t("nav.tools")}</span>
+              <span className="max-w-full truncate">{t("nav.tools")}</span>
             </button>
             <div className="min-w-0 flex-[1.25]">
               <div className="mx-auto flex max-w-34 flex-col items-center justify-center rounded-[0.95rem] border border-white/10 bg-white/8 px-1.5 py-1 text-center">
@@ -538,18 +558,20 @@ export function EditorMobilePanels({
               </div>
             </div>
             <button
+              type="button"
               onClick={openInspectorDrawer}
-              className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5"
+              className="flex min-h-12 min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5"
             >
               <SlidersHorizontal className="size-3.5" />
-              <span>{t("nav.inspect")}</span>
+              <span className="max-w-full truncate">{t("nav.inspect")}</span>
             </button>
             <button
+              type="button"
               onClick={openViewDrawer}
-              className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5"
+              className="flex min-h-12 min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white landscape:gap-0.5 landscape:px-1.5 landscape:py-1.5"
             >
               <Scan className="size-3.5" />
-              <span>{t("nav.view")}</span>
+              <span className="max-w-full truncate">{t("nav.view")}</span>
             </button>
           </motion.div>
         </div>
@@ -570,25 +592,27 @@ export function EditorMobilePanels({
             className="pointer-events-auto flex w-full max-w-sm items-center gap-1 rounded-[1.35rem] border border-white/10 bg-slate-950/86 p-1.5 text-white shadow-[0_18px_36px_rgba(15,23,42,0.32)] backdrop-blur"
           >
             <button
+              type="button"
               onClick={openReadOnlyDrawer}
-              className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
+              className="flex min-h-12 min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
             >
               <Scan className="size-3.5" />
-              <span>{t("nav.review")}</span>
+              <span className="max-w-full truncate">{t("nav.review")}</span>
             </button>
             <button
+              type="button"
               onClick={onShare}
-              className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
+              className="flex min-h-12 min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
             >
               <Share2 className="size-3.5" />
-              <span>{t("nav.share")}</span>
+              <span className="max-w-full truncate">{t("nav.share")}</span>
             </button>
             <Link
               href={studioHref}
-              className="flex min-w-0 flex-1 flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
+              className="flex min-h-12 min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white"
             >
               <ArrowRight className="size-3.5" />
-              <span>{t("nav.editCopy")}</span>
+              <span className="max-w-full truncate">{t("nav.editCopy")}</span>
             </Link>
           </motion.div>
         </div>
@@ -694,6 +718,7 @@ export function EditorMobilePanels({
           }
           contentClassName="h-[82dvh] max-h-[92dvh] min-h-[72dvh] overscroll-contain"
           bodyClassName="bg-card min-h-0 touch-pan-y overscroll-y-contain [-webkit-overflow-scrolling:touch] p-0"
+          repositionInputs
         >
           <Inspector
             mobileInline

--- a/src/components/editor/mobile/MultiSelectOverlay.tsx
+++ b/src/components/editor/mobile/MultiSelectOverlay.tsx
@@ -63,7 +63,7 @@ export function MultiSelectOverlay({
             value={selectedGroupName ?? ""}
             onChange={(event) => onSetGroupName(event.target.value)}
             placeholder={t("fields.groupNamePlaceholder")}
-            className="h-9 rounded-[0.9rem] border-white/12 bg-white/8 px-3 text-[12px] text-white placeholder:text-white/38"
+            className="h-11 rounded-[0.9rem] border-white/12 bg-white/8 px-3 text-[13px] text-white placeholder:text-white/38"
           />
         </div>
       ) : null}
@@ -73,23 +73,23 @@ export function MultiSelectOverlay({
           type="button"
           onClick={onDuplicateSelection}
           disabled={selectedCount === 0 || hasLockedSelection}
-          className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+          className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
         >
           <Copy className="size-4" />
-          <span>{t("actions.duplicate")}</span>
+          <span className="max-w-full truncate">{t("actions.duplicate")}</span>
         </button>
         <button
           type="button"
           onClick={canUngroupSelection ? onUngroupSelection : onGroupSelection}
           disabled={selectedCount < 2 && !canUngroupSelection}
-          className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+          className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
         >
           {canUngroupSelection ? (
             <Ungroup className="size-4" />
           ) : (
             <Group className="size-4" />
           )}
-          <span>
+          <span className="max-w-full truncate">
             {canUngroupSelection ? t("actions.ungroup") : t("actions.group")}
           </span>
         </button>
@@ -97,14 +97,14 @@ export function MultiSelectOverlay({
           type="button"
           onClick={onToggleSelectionLock}
           disabled={selectedCount === 0}
-          className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+          className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
         >
           {selectionLocked ? (
             <Unlock className="size-4" />
           ) : (
             <Lock className="size-4" />
           )}
-          <span>
+          <span className="max-w-full truncate">
             {selectionLocked ? t("actions.unlock") : t("actions.lock")}
           </span>
         </button>
@@ -112,10 +112,10 @@ export function MultiSelectOverlay({
           type="button"
           onClick={onDeleteSelection}
           disabled={selectedCount === 0 || hasLockedSelection}
-          className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-rose-300 transition-colors hover:bg-rose-400/12 hover:text-rose-200 disabled:text-white/35"
+          className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-rose-300 transition-colors hover:bg-rose-400/12 hover:text-rose-200 disabled:text-white/35"
         >
           <Trash2 className="size-4" />
-          <span>{t("actions.delete")}</span>
+          <span className="max-w-full truncate">{t("actions.delete")}</span>
         </button>
       </div>
     </motion.div>

--- a/src/components/editor/mobile/PathBuilderOverlay.tsx
+++ b/src/components/editor/mobile/PathBuilderOverlay.tsx
@@ -62,36 +62,38 @@ export function PathBuilderOverlay({
           type="button"
           onClick={onUndoPathPoint}
           disabled={draftPathPointCount === 0}
-          className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/78 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+          className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/78 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
         >
           <ArrowRight className="size-4 rotate-180" />
-          <span>{t("actions.undo")}</span>
+          <span className="max-w-full truncate">{t("actions.undo")}</span>
         </button>
         <button
           type="button"
           onClick={onCloseLoop}
           disabled={draftPathPointCount < 3 || draftPathClosed}
-          className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/78 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+          className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/78 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
         >
           <Link2 className="size-4" />
-          <span>{t("actions.connectEnds")}</span>
+          <span className="max-w-full truncate">
+            {t("actions.connectEnds")}
+          </span>
         </button>
         <button
           type="button"
           onClick={onFinishPath}
           disabled={draftPathPointCount < 2}
-          className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/78 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
+          className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/78 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
         >
           <PencilLine className="size-4" />
-          <span>{t("actions.finish")}</span>
+          <span className="max-w-full truncate">{t("actions.finish")}</span>
         </button>
         <button
           type="button"
           onClick={onCancelPath}
-          className="flex min-h-14 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-rose-300 transition-colors hover:bg-rose-400/12 hover:text-rose-200"
+          className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-rose-300 transition-colors hover:bg-rose-400/12 hover:text-rose-200"
         >
           <X className="size-4" />
-          <span>{t("actions.cancel")}</span>
+          <span className="max-w-full truncate">{t("actions.cancel")}</span>
         </button>
       </div>
     </motion.div>

--- a/src/components/editor/mobile/ToolsControls.tsx
+++ b/src/components/editor/mobile/ToolsControls.tsx
@@ -61,20 +61,22 @@ export function ToolsControls({
       {/* Undo / redo */}
       <div className="grid grid-cols-2 gap-2">
         <button
+          type="button"
           onClick={() => runAction(onUndo)}
           disabled={!canUndo}
-          className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex items-center justify-center gap-1.5 rounded-2xl border px-3 py-2.5 text-[11px] font-medium transition-all disabled:cursor-not-allowed disabled:opacity-40"
+          className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex min-h-12 items-center justify-center gap-1.5 rounded-2xl border px-3 py-2.5 text-[11px] font-medium transition-all disabled:cursor-not-allowed disabled:opacity-40"
         >
           <Undo2 className="size-3.5" />
-          {tCommon("actions.undo")}
+          <span className="max-w-full truncate">{tCommon("actions.undo")}</span>
         </button>
         <button
+          type="button"
           onClick={() => runAction(onRedo)}
           disabled={!canRedo}
-          className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex items-center justify-center gap-1.5 rounded-2xl border px-3 py-2.5 text-[11px] font-medium transition-all disabled:cursor-not-allowed disabled:opacity-40"
+          className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex min-h-12 items-center justify-center gap-1.5 rounded-2xl border px-3 py-2.5 text-[11px] font-medium transition-all disabled:cursor-not-allowed disabled:opacity-40"
         >
           <Redo2 className="size-3.5" />
-          {t("header.redo")}
+          <span className="max-w-full truncate">{t("header.redo")}</span>
         </button>
       </div>
 
@@ -112,7 +114,7 @@ export function ToolsControls({
                   <button
                     type="button"
                     onClick={() => runAction(() => onSelectTool(toolId))}
-                    className="flex w-full items-center gap-3 px-4 py-3 text-left"
+                    className="flex min-h-14 w-full items-center gap-3 px-4 py-3 text-left"
                   >
                     <span
                       className={cn(
@@ -193,7 +195,7 @@ export function ToolsControls({
                                   )
                                 }
                                 className={cn(
-                                  "flex min-h-11 w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors",
+                                  "flex min-h-12 w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-colors",
                                   isActiveType
                                     ? "bg-brand-primary/10 text-foreground"
                                     : "text-muted-foreground hover:bg-muted/40 hover:text-foreground"
@@ -258,17 +260,18 @@ export function ToolsControls({
                 const active = activeTool === tool.id;
                 return (
                   <button
+                    type="button"
                     key={tool.id}
                     onClick={() => runAction(() => onSelectTool(tool.id))}
                     className={cn(
-                      "flex flex-col items-center gap-1.5 rounded-2xl border px-2 py-3 transition-all",
+                      "flex min-h-16 min-w-0 flex-col items-center justify-center gap-1.5 rounded-2xl border px-2 py-3 transition-all",
                       active
                         ? "border-brand-primary/25 bg-brand-primary/8 text-brand-primary"
                         : "border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground"
                     )}
                   >
                     {tool.icon}
-                    <span className="text-[11px] leading-none font-medium">
+                    <span className="max-w-full truncate text-center text-[11px] leading-none font-medium">
                       {tool.label}
                     </span>
                   </button>

--- a/src/components/editor/mobile/ToolsControls.tsx
+++ b/src/components/editor/mobile/ToolsControls.tsx
@@ -14,6 +14,9 @@ import { cn } from "@/lib/utils";
 import type { EditorViewportTab } from "./Panels";
 
 const catalogToolIdSet = new Set<EditorTool>(catalogPlacementToolIds);
+const canvasToolPriority: Partial<Record<EditorTool, number>> = {
+  polyline: 0,
+};
 
 interface ToolsControlsProps {
   activeTool: EditorTool;
@@ -83,7 +86,7 @@ export function ToolsControls({
       {tab === "2d" && (
         <div>
           <p className="text-muted-foreground/60 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
-            {t("mobilePanels.editorPanels.nav.tools")}
+            {t("mobilePanels.editorPanels.tools.sections.items")}
           </p>
 
           {/* Catalog tools — active one auto-expands with type list */}
@@ -116,14 +119,7 @@ export function ToolsControls({
                     onClick={() => runAction(() => onSelectTool(toolId))}
                     className="flex min-h-14 w-full items-center gap-3 px-4 py-3 text-left"
                   >
-                    <span
-                      className={cn(
-                        "flex size-10 shrink-0 items-center justify-center rounded-xl border transition-all",
-                        isActiveTool
-                          ? "border-brand-primary/30 bg-brand-primary/10 text-brand-primary"
-                          : "border-border/45 bg-background/50 text-muted-foreground"
-                      )}
-                    >
+                    <span className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-slate-950 bg-slate-950 text-white shadow-[0_8px_18px_rgba(15,23,42,0.12)] transition-all">
                       {toolEntry?.icon}
                     </span>
                     <div className="min-w-0 flex-1">
@@ -247,8 +243,11 @@ export function ToolsControls({
             })}
           </div>
 
-          {/* Remaining tools — compact 3-col grid */}
-          <div className="grid grid-cols-3 gap-2">
+          {/* Remaining tools — compact rows matching catalog headers */}
+          <p className="text-muted-foreground/60 mt-4 mb-2.5 text-[11px] font-semibold tracking-widest uppercase">
+            {t("mobilePanels.editorPanels.tools.sections.tools")}
+          </p>
+          <div className="space-y-2">
             {mobileToolEntries
               .filter(
                 (tool) =>
@@ -256,23 +255,43 @@ export function ToolsControls({
                   tool.id !== "preset" &&
                   !catalogToolIds.includes(tool.id as EditorTool)
               )
+              .sort(
+                (a, b) =>
+                  (canvasToolPriority[a.id] ?? 1) -
+                  (canvasToolPriority[b.id] ?? 1)
+              )
               .map((tool) => {
                 const active = activeTool === tool.id;
+                const toolDescription = t(
+                  `mobilePanels.editorPanels.tools.toolDescriptions.${tool.id}`
+                );
                 return (
                   <button
                     type="button"
                     key={tool.id}
                     onClick={() => runAction(() => onSelectTool(tool.id))}
                     className={cn(
-                      "flex min-h-16 min-w-0 flex-col items-center justify-center gap-1.5 rounded-2xl border px-2 py-3 transition-all",
+                      "flex min-h-14 w-full items-center gap-3 rounded-2xl border px-4 py-3 text-left transition-all",
                       active
                         ? "border-brand-primary/25 bg-brand-primary/8 text-brand-primary"
                         : "border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground"
                     )}
                   >
-                    {tool.icon}
-                    <span className="max-w-full truncate text-center text-[11px] leading-none font-medium">
-                      {tool.label}
+                    <span className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-slate-950 bg-slate-950 text-white shadow-[0_8px_18px_rgba(15,23,42,0.12)]">
+                      {tool.icon}
+                    </span>
+                    <span
+                      className={cn(
+                        "min-w-0 flex-1",
+                        active ? "text-foreground" : "text-foreground/75"
+                      )}
+                    >
+                      <span className="block truncate text-sm leading-tight font-semibold">
+                        {tool.label}
+                      </span>
+                      <span className="text-muted-foreground/60 mt-0.5 block truncate text-[11px]">
+                        {toolDescription}
+                      </span>
                     </span>
                   </button>
                 );

--- a/src/components/editor/mobile/ViewControls.tsx
+++ b/src/components/editor/mobile/ViewControls.tsx
@@ -43,23 +43,24 @@ function ToggleRow({
 }) {
   return (
     <button
+      type="button"
       onClick={onClick}
       className={cn(
-        "border-border/50 bg-muted/18 mt-2.5 flex w-full items-center justify-between rounded-2xl border px-3 py-2.5 text-left transition-colors",
+        "border-border/50 bg-muted/18 mt-2.5 flex min-h-12 w-full items-center justify-between gap-3 rounded-2xl border px-3 py-2.5 text-left transition-colors",
         enabled
           ? "text-foreground"
           : "text-muted-foreground hover:text-foreground"
       )}
     >
-      <div>
+      <div className="min-w-0">
         <p className="text-[11px] font-medium">{title}</p>
-        <p className="text-muted-foreground/75 pt-0.5 text-[11px]">
+        <p className="text-muted-foreground/75 pt-0.5 text-[11px] leading-snug">
           {description}
         </p>
       </div>
       <div
         className={cn(
-          "flex h-6 w-10 items-center rounded-full p-0.5 transition-colors",
+          "flex h-6 w-10 shrink-0 items-center rounded-full p-0.5 transition-colors",
           enabled
             ? "bg-foreground/90 justify-end"
             : "bg-border/80 justify-start"
@@ -133,42 +134,44 @@ export function ViewControls({
           size="drawer"
         />
         <button
+          type="button"
           onClick={onFitView}
-          className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground mt-2.5 flex w-full items-center justify-between rounded-2xl border px-3 py-2.5 text-left transition-colors"
+          className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground mt-2.5 flex min-h-12 w-full items-center justify-between gap-3 rounded-2xl border px-3 py-2.5 text-left transition-colors"
         >
-          <div>
+          <div className="min-w-0">
             <p className="text-[11px] font-medium">
               {t("controls.fitToField.label")}
             </p>
-            <p className="text-muted-foreground/75 pt-0.5 text-[11px]">
+            <p className="text-muted-foreground/75 pt-0.5 text-[11px] leading-snug">
               {t("controls.fitToField.description")}
             </p>
           </div>
-          <Scan className="size-4" />
+          <Scan className="size-4 shrink-0" />
         </button>
         {tab === "2d" ? (
           <>
             {onToggleSnapEnabled && (
               <button
+                type="button"
                 onClick={onToggleSnapEnabled}
                 className={cn(
-                  "border-border/50 bg-muted/18 mt-2.5 flex w-full items-center justify-between rounded-2xl border px-3 py-2.5 text-left transition-colors",
+                  "border-border/50 bg-muted/18 mt-2.5 flex min-h-12 w-full items-center justify-between gap-3 rounded-2xl border px-3 py-2.5 text-left transition-colors",
                   snapEnabled
                     ? "text-foreground"
                     : "text-muted-foreground hover:text-foreground"
                 )}
               >
-                <div>
+                <div className="min-w-0">
                   <p className="text-[11px] font-medium">
                     {t("controls.snap.label")}
                   </p>
-                  <p className="text-muted-foreground/75 pt-0.5 text-[11px]">
+                  <p className="text-muted-foreground/75 pt-0.5 text-[11px] leading-snug">
                     {t("controls.snap.description")}
                   </p>
                 </div>
                 <div
                   className={cn(
-                    "flex h-6 w-10 items-center rounded-full p-0.5 transition-colors",
+                    "flex h-6 w-10 shrink-0 items-center rounded-full p-0.5 transition-colors",
                     snapEnabled
                       ? "bg-foreground/90 justify-end"
                       : "bg-border/80 justify-start"
@@ -196,23 +199,24 @@ export function ViewControls({
         ) : (
           <>
             <button
+              type="button"
               onClick={() => {
                 closePanel?.();
                 onStartFlyThrough();
               }}
               disabled={!hasPath}
               className={cn(
-                "border-border/50 bg-muted/18 mt-2.5 flex w-full items-center justify-between rounded-2xl border px-3 py-2.5 text-left transition-colors",
+                "border-border/50 bg-muted/18 mt-2.5 flex min-h-12 w-full items-center justify-between gap-3 rounded-2xl border px-3 py-2.5 text-left transition-colors",
                 hasPath
                   ? "text-muted-foreground hover:bg-muted/28 hover:text-foreground"
                   : "text-muted-foreground/45 cursor-not-allowed"
               )}
             >
-              <div>
+              <div className="min-w-0">
                 <p className="text-[11px] font-medium">
                   {t("controls.flyThrough.label")}
                 </p>
-                <p className="text-muted-foreground/75 pt-0.5 text-[11px]">
+                <p className="text-muted-foreground/75 pt-0.5 text-[11px] leading-snug">
                   {hasPath
                     ? t("controls.flyThrough.descriptions.available")
                     : readOnly
@@ -220,7 +224,7 @@ export function ViewControls({
                       : t("controls.flyThrough.descriptions.draw")}
                 </p>
               </div>
-              <Play className="size-4" />
+              <Play className="size-4 shrink-0" />
             </button>
             <ToggleRow
               title={t("controls.gizmo.label")}
@@ -239,19 +243,20 @@ export function ViewControls({
           <div className="grid grid-cols-2 gap-2">
             <Link
               href={studioHref}
-              className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex items-center justify-center gap-1.5 rounded-2xl border px-2 py-3 transition-all"
+              className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex min-h-12 items-center justify-center gap-1.5 rounded-2xl border px-2 py-3 transition-all"
             >
               <ArrowRight className="size-4" />
-              <span className="text-[11px] leading-none font-medium">
+              <span className="max-w-full truncate text-[11px] leading-none font-medium">
                 {t("share.editableCopy")}
               </span>
             </Link>
             <button
+              type="button"
               onClick={onShare}
-              className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex items-center justify-center gap-1.5 rounded-2xl border px-2 py-3 transition-all"
+              className="border-border/50 bg-muted/18 text-muted-foreground hover:bg-muted/28 hover:text-foreground flex min-h-12 items-center justify-center gap-1.5 rounded-2xl border px-2 py-3 transition-all"
             >
               <Share2 className="size-4" />
-              <span className="text-[11px] leading-none font-medium">
+              <span className="max-w-full truncate text-[11px] leading-none font-medium">
                 {t("share.shareButton")}
               </span>
             </button>

--- a/src/components/editor/useAccountProjectSync.ts
+++ b/src/components/editor/useAccountProjectSync.ts
@@ -605,7 +605,7 @@ export function useAccountProjectSync({
           const fallbackSavedAt = saveLocalSyncFallback(targetDesign);
           markProjectSyncFailed(
             targetDesign.id,
-            error instanceof Error ? error.message : "Could not sync project",
+            error instanceof Error ? error.message : "Account sync failed",
             fallbackSavedAt
           );
         }
@@ -645,7 +645,10 @@ export function useAccountProjectSync({
           : loadProject(projectId);
 
       if (!targetDesign) {
-        toast.error("Could not load local project");
+        toast.error("Could not load local project", {
+          description:
+            "TrackDraw could not read the saved copy on this device. Try opening another local project or export a JSON backup from the current canvas.",
+        });
         return;
       }
 
@@ -667,11 +670,11 @@ export function useAccountProjectSync({
 
         markProjectSyncFailed(
           projectId,
-          error instanceof Error ? error.message : "Could not sync project"
+          error instanceof Error ? error.message : "Account sync failed"
         );
-        toast.error("Could not sync project", {
+        toast.error("Account sync failed", {
           description:
-            error instanceof Error ? error.message : "Please try again.",
+            "A local copy was saved on this device. Retry sync when the connection or account service is available, or export JSON if you need a manual backup.",
         });
       } finally {
         setSyncingProjectId(null);
@@ -760,12 +763,12 @@ export function useAccountProjectSync({
 
         markProjectSyncFailed(
           currentDesignId,
-          error instanceof Error ? error.message : "Cloud sync failed"
+          error instanceof Error ? error.message : "Account sync failed"
         );
-        setSaveStatusLabel("Cloud sync failed");
-        toast.error("Could not sync project", {
+        setSaveStatusLabel("Account sync failed; saved locally");
+        toast.error("Account sync failed", {
           description:
-            error instanceof Error ? error.message : "Please try again.",
+            "TrackDraw saved the latest copy on this device, but could not update the account copy. Retry sync when the connection is back.",
           action: {
             label: "Retry",
             onClick: () => {
@@ -842,10 +845,10 @@ export function useAccountProjectSync({
         setProjectVersionConflict(null);
         setSaveStatusLabel("Project opened from account");
         return true;
-      } catch (error) {
+      } catch {
         toast.error("Could not open project", {
           description:
-            error instanceof Error ? error.message : "Please try again.",
+            "TrackDraw could not load the account copy. Try again, or keep working from the local project if one is available.",
         });
         return false;
       }

--- a/src/components/editor/useManualProjectSave.ts
+++ b/src/components/editor/useManualProjectSave.ts
@@ -58,11 +58,12 @@ export function useManualProjectSave({
       }
 
       const message =
-        error instanceof Error ? error.message : "Could not sync project";
+        error instanceof Error ? error.message : "Account sync failed";
       markProjectSyncFailed(design.id, message);
-      setSaveStatusLabel("Cloud sync failed");
-      toast.error("Could not sync project", {
-        description: message,
+      setSaveStatusLabel("Account sync failed; snapshot saved");
+      toast.error("Account sync failed", {
+        description:
+          "TrackDraw saved a snapshot on this device, but could not update the account copy. Retry sync, or export JSON if you need a manual backup.",
       });
     }
   }, [

--- a/src/components/editor/useStarterExperience.ts
+++ b/src/components/editor/useStarterExperience.ts
@@ -89,9 +89,9 @@ export function useStarterExperience({
 
         markProjectSyncFailed(
           nextDesign.id,
-          error instanceof Error ? error.message : "Cloud sync failed"
+          error instanceof Error ? error.message : "Account sync failed"
         );
-        setSaveStatusLabel("Cloud sync failed");
+        setSaveStatusLabel("Account sync failed; saved locally");
         console.error(logLabel, error);
       });
     },

--- a/src/components/inspector/views/list-panel.tsx
+++ b/src/components/inspector/views/list-panel.tsx
@@ -197,9 +197,11 @@ function ItemRow({
         <button
           type="button"
           title={removeItemTitle}
-          className="text-muted-foreground/55 hover:bg-brand-primary/10 hover:text-brand-primary flex size-5 items-center justify-center rounded-md transition-colors"
+          disabled={shape.locked}
+          className="text-muted-foreground/55 hover:bg-brand-primary/10 hover:text-brand-primary flex size-5 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-35"
           onClick={(event) => {
             event.stopPropagation();
+            if (shape.locked) return;
             removeShapes([shape.id]);
             setHoveredShapeId(null);
           }}

--- a/src/components/inspector/views/multi-selection.tsx
+++ b/src/components/inspector/views/multi-selection.tsx
@@ -133,8 +133,11 @@ export function MultiInspectorView({
     }
   );
   const polylineIds = selectedShapes
-    .filter((shape) => shape.kind === "polyline" && !shape.closed)
+    .filter(
+      (shape) => shape.kind === "polyline" && !shape.closed && !shape.locked
+    )
     .map((shape) => shape.id);
+  const hasLockedSelection = selectedShapes.some((shape) => shape.locked);
   const hasGroupedShapes = selectionHasGroupedShapes(selectedShapes);
   const groupCount = new Set(
     selectedShapes.map((shape) => getShapeGroupId(shape)).filter(Boolean)
@@ -211,6 +214,7 @@ export function MultiInspectorView({
                 onClick={() => duplicateShapes(selection)}
                 title={tCommon("actions.duplicate")}
                 aria-label={tCommon("actions.duplicate")}
+                disabled={hasLockedSelection}
                 className={`${inspectorActionBtnClass} min-w-0 flex-1`}
               >
                 <Copy className="size-3 shrink-0" />
@@ -224,6 +228,7 @@ export function MultiInspectorView({
                 }}
                 title={tCommon("actions.delete")}
                 aria-label={tCommon("actions.delete")}
+                disabled={hasLockedSelection}
                 className={`${inspectorActionBtnDangerClass} min-w-0 flex-1`}
               >
                 <Trash2 className="size-3 shrink-0" />

--- a/src/components/inspector/views/single-shape.tsx
+++ b/src/components/inspector/views/single-shape.tsx
@@ -25,6 +25,7 @@ import { buildCatalogTypePatch } from "@/lib/editor/catalog-type-patch";
 import {
   getSingleInspectorViewModel,
   inspectorActionBtnClass,
+  inspectorActionBtnDangerClass,
   inspectorActionBtnPrimaryClass,
 } from "@/lib/inspector/single/view-model";
 import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
@@ -275,6 +276,7 @@ export function SingleInspectorView({
                 onClick={() => duplicateShapes([shape.id])}
                 title={tCommon("actions.duplicate")}
                 aria-label={tCommon("actions.duplicate")}
+                disabled={shape.locked}
                 className={`${actionBtnClass} min-w-0`}
               >
                 <Copy className="size-3 shrink-0" />
@@ -288,7 +290,8 @@ export function SingleInspectorView({
                 }}
                 title={tCommon("actions.delete")}
                 aria-label={tCommon("actions.delete")}
-                className={`${actionBtnClass} min-w-0 border-red-500/20 bg-red-500/6 text-red-500 hover:bg-red-500/12`}
+                disabled={shape.locked}
+                className={`${inspectorActionBtnDangerClass} min-w-0`}
               >
                 <Trash2 className="size-3 shrink-0" />
                 <span className="truncate">{t("actions.deleteShort")}</span>

--- a/src/hooks/editor/useEditorProjects.ts
+++ b/src/hooks/editor/useEditorProjects.ts
@@ -105,29 +105,29 @@ export function useEditorProjects({
     (error: unknown, onRecovered?: () => void) => {
       const localSaveError = toLocalSaveError(error);
 
-      setSaveStatusLabel("Local save failed");
+      setSaveStatusLabel("Local autosave failed");
       console.error("[TrackDraw local autosave]", localSaveError);
-      toast.error("Local save failed", {
+      toast.error("Local autosave failed", {
         description:
-          "TrackDraw could not save the latest local copy. Retry, or export a JSON backup if this keeps happening.",
+          "The latest edits are still on the canvas, but TrackDraw could not save a local copy. Retry now, or export a JSON backup before leaving this browser.",
         action: {
           label: "Retry",
           onClick: () => {
             try {
               saveDesignLocally(useEditor.getState().track.design);
               onRecovered?.();
-              toast.success("Local save recovered", {
+              toast.success("Local autosave recovered", {
                 description: "The latest local copy was saved.",
               });
             } catch (retryError) {
-              setSaveStatusLabel("Local save failed");
+              setSaveStatusLabel("Local autosave failed");
               console.error(
                 "[TrackDraw local autosave retry]",
                 toLocalSaveError(retryError)
               );
-              toast.error("Local save still failing", {
+              toast.error("Local autosave still failing", {
                 description:
-                  "Export a JSON backup before making more changes if storage keeps failing.",
+                  "Export a JSON backup before making more changes if browser storage keeps failing.",
               });
             }
           },

--- a/src/lib/editor/shape-mutations.ts
+++ b/src/lib/editor/shape-mutations.ts
@@ -173,7 +173,9 @@ export function rotateShapes(
     if (shape.kind === "polyline" || shape.kind === "cone" || shape.locked) {
       continue;
     }
-    shape.rotation = (((shape.rotation + delta) % 360) + 360) % 360;
+    const nextRotation = (((shape.rotation + delta) % 360) + 360) % 360;
+    if (Object.is(shape.rotation, nextRotation)) continue;
+    shape.rotation = nextRotation;
     changed = true;
   }
 
@@ -186,6 +188,8 @@ export function nudgeShapes(
   dx: number,
   dy: number
 ) {
+  if (dx === 0 && dy === 0) return false;
+
   let changed = false;
 
   for (const id of ids) {

--- a/src/lib/editor/shape-mutations.ts
+++ b/src/lib/editor/shape-mutations.ts
@@ -132,6 +132,7 @@ export function insertPolylinePoint(
   point: PolylinePoint
 ) {
   if (!shape || shape.kind !== "polyline") return false;
+  if (index < 0 || index > shape.points.length) return false;
   shape.points.splice(index, 0, point);
   return true;
 }

--- a/src/lib/inspector/single/view-model.ts
+++ b/src/lib/inspector/single/view-model.ts
@@ -9,7 +9,7 @@ export const inspectorActionBtnPrimaryClass =
   "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-primary/25 bg-primary/8 px-2.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/12 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8";
 
 export const inspectorActionBtnDangerClass =
-  "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-red-500/20 bg-red-500/6 px-2.5 text-[11px] font-medium text-red-500 transition-colors hover:bg-red-500/12 lg:h-8";
+  "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-red-500/20 bg-red-500/6 px-2.5 text-[11px] font-medium text-red-500 transition-colors hover:bg-red-500/12 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8";
 
 function finiteOrZero(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;

--- a/src/lib/map-reference/geometry.ts
+++ b/src/lib/map-reference/geometry.ts
@@ -10,6 +10,7 @@ import type { FieldSpec, MapReference } from "@/lib/types";
 const EARTH_RADIUS_METERS = 6378137;
 const EARTH_CIRCUMFERENCE_METERS = 2 * Math.PI * EARTH_RADIUS_METERS;
 const MAX_MERCATOR_LAT = 85.05112878;
+export const MAP_REFERENCE_MAX_RENDER_TILES = 64;
 
 export interface GlobalPixel {
   x: number;
@@ -154,17 +155,15 @@ export function getMapReferenceRenderZoom({
   );
 }
 
-export function getFieldMapTileCoverage({
+function getCoverageBounds({
   field,
   mapReference,
+  tileZoom,
 }: {
   field: Pick<FieldSpec, "width" | "height" | "ppm">;
   mapReference: MapReference;
-}): MapReferenceTile[] {
-  const tileZoom = getMapReferenceRenderZoom({
-    lat: mapReference.centerLat,
-    ppm: field.ppm,
-  });
+  tileZoom: number;
+}) {
   const centerPixel = latLngToGlobalPixel(
     mapReference.centerLat,
     mapReference.centerLng,
@@ -177,26 +176,89 @@ export function getFieldMapTileCoverage({
   const tileCanvasSize = MAP_REFERENCE_TILE_SIZE * metersPerPixel * field.ppm;
   const fieldDiagonalMeters = Math.hypot(field.width, field.height);
   const halfFieldDiagonalMapPx = fieldDiagonalMeters / metersPerPixel / 2;
-  const minTileX = Math.floor(
-    (centerPixel.x - halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
-  );
-  const maxTileX = Math.floor(
-    (centerPixel.x + halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
-  );
-  const minTileY = Math.floor(
-    (centerPixel.y - halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
-  );
-  const maxTileY = Math.floor(
-    (centerPixel.y + halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
-  );
+  const minTileX =
+    Math.floor(
+      (centerPixel.x - halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
+    ) - 1;
+  const maxTileX =
+    Math.floor(
+      (centerPixel.x + halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
+    ) + 1;
+  const minTileY =
+    Math.floor(
+      (centerPixel.y - halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
+    ) - 1;
+  const maxTileY =
+    Math.floor(
+      (centerPixel.y + halfFieldDiagonalMapPx) / MAP_REFERENCE_TILE_SIZE
+    ) + 1;
   const maxTile = 2 ** tileZoom;
+  const clampedMinTileY = Math.max(0, minTileY);
+  const clampedMaxTileY = Math.min(maxTile - 1, maxTileY);
+  const tileColumnCount = Math.max(0, maxTileX - minTileX + 1);
+  const tileRowCount =
+    clampedMaxTileY >= clampedMinTileY
+      ? clampedMaxTileY - clampedMinTileY + 1
+      : 0;
+
+  return {
+    centerPixel,
+    clampedMaxTileY,
+    clampedMinTileY,
+    maxTile,
+    maxTileX,
+    metersPerPixel,
+    minTileX,
+    tileCanvasSize,
+    tileCount: tileColumnCount * tileRowCount,
+  };
+}
+
+export function getFieldMapTileCoverage({
+  field,
+  mapReference,
+}: {
+  field: Pick<FieldSpec, "width" | "height" | "ppm">;
+  mapReference: MapReference;
+}): MapReferenceTile[] {
+  if (
+    !Number.isFinite(field.width) ||
+    !Number.isFinite(field.height) ||
+    !Number.isFinite(field.ppm) ||
+    field.width <= 0 ||
+    field.height <= 0 ||
+    field.ppm <= 0
+  ) {
+    return [];
+  }
+
+  let tileZoom = getMapReferenceRenderZoom({
+    lat: mapReference.centerLat,
+    ppm: field.ppm,
+  });
+  let coverage = getCoverageBounds({ field, mapReference, tileZoom });
+  while (
+    coverage.tileCount > MAP_REFERENCE_MAX_RENDER_TILES &&
+    tileZoom > MAP_REFERENCE_MIN_ZOOM
+  ) {
+    tileZoom -= 1;
+    coverage = getCoverageBounds({ field, mapReference, tileZoom });
+  }
+
   const tiles: MapReferenceTile[] = [];
 
-  for (let tileY = minTileY - 1; tileY <= maxTileY + 1; tileY += 1) {
-    if (tileY < 0 || tileY >= maxTile) continue;
-
-    for (let tileX = minTileX - 1; tileX <= maxTileX + 1; tileX += 1) {
-      const wrappedTileX = ((tileX % maxTile) + maxTile) % maxTile;
+  for (
+    let tileY = coverage.clampedMinTileY;
+    tileY <= coverage.clampedMaxTileY;
+    tileY += 1
+  ) {
+    for (
+      let tileX = coverage.minTileX;
+      tileX <= coverage.maxTileX;
+      tileX += 1
+    ) {
+      const wrappedTileX =
+        ((tileX % coverage.maxTile) + coverage.maxTile) % coverage.maxTile;
       const tilePixelX = tileX * MAP_REFERENCE_TILE_SIZE;
       const tilePixelY = tileY * MAP_REFERENCE_TILE_SIZE;
 
@@ -204,9 +266,15 @@ export function getFieldMapTileCoverage({
         x: wrappedTileX,
         y: tileY,
         z: tileZoom,
-        canvasX: (tilePixelX - centerPixel.x) * metersPerPixel * field.ppm,
-        canvasY: (tilePixelY - centerPixel.y) * metersPerPixel * field.ppm,
-        canvasSize: tileCanvasSize,
+        canvasX:
+          (tilePixelX - coverage.centerPixel.x) *
+          coverage.metersPerPixel *
+          field.ppm,
+        canvasY:
+          (tilePixelY - coverage.centerPixel.y) *
+          coverage.metersPerPixel *
+          field.ppm,
+        canvasSize: coverage.tileCanvasSize,
       });
     }
   }

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -152,7 +152,10 @@ function touchTrackDesign(state: EditorState) {
 
 function clearPolylineEditSelections(state: EditorState, ids: string[]) {
   const idSet = new Set(ids);
-  if (state.ui.segmentSelection && idSet.has(state.ui.segmentSelection.shapeId)) {
+  if (
+    state.ui.segmentSelection &&
+    idSet.has(state.ui.segmentSelection.shapeId)
+  ) {
     state.ui.segmentSelection = null;
   }
   if (state.ui.vertexSelection && idSet.has(state.ui.vertexSelection.shapeId)) {

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -150,6 +150,16 @@ function touchTrackDesign(state: EditorState) {
   state.track.design.updatedAt = nowIso();
 }
 
+function clearPolylineEditSelections(state: EditorState, ids: string[]) {
+  const idSet = new Set(ids);
+  if (state.ui.segmentSelection && idSet.has(state.ui.segmentSelection.shapeId)) {
+    state.ui.segmentSelection = null;
+  }
+  if (state.ui.vertexSelection && idSet.has(state.ui.vertexSelection.shapeId)) {
+    state.ui.vertexSelection = null;
+  }
+}
+
 export const useEditor = create<EditorState>()(
   temporal(
     immer<EditorState>((set) => ({
@@ -266,7 +276,7 @@ export const useEditor = create<EditorState>()(
           if (shape?.locked || !insertPolylinePoint(shape, index, point)) {
             return;
           }
-          draft.ui.segmentSelection = null;
+          clearPolylineEditSelections(draft, [id]);
           touchTrackDesign(draft);
         }),
 
@@ -276,7 +286,7 @@ export const useEditor = create<EditorState>()(
           if (shape?.locked || !removePolylinePoint(shape, index)) {
             return;
           }
-          draft.ui.segmentSelection = null;
+          clearPolylineEditSelections(draft, [id]);
           touchTrackDesign(draft);
         }),
 
@@ -286,6 +296,7 @@ export const useEditor = create<EditorState>()(
           if (shape?.locked || !appendPolylinePoint(shape, point)) {
             return;
           }
+          clearPolylineEditSelections(draft, [id]);
           touchTrackDesign(draft);
         }),
 
@@ -293,6 +304,7 @@ export const useEditor = create<EditorState>()(
         set((draft) => {
           const shape = draft.track.design.shapeById[id];
           if (shape?.locked || !reversePolylinePoints(shape)) return;
+          clearPolylineEditSelections(draft, [id]);
           touchTrackDesign(draft);
         }),
 
@@ -467,6 +479,10 @@ export const useEditor = create<EditorState>()(
                 : `Joined ${polylineShapes.length} paths`,
           });
           draft.session.selection = [nextId];
+          clearPolylineEditSelections(
+            draft,
+            polylineShapes.map((shape) => shape.id)
+          );
           touchTrackDesign(draft);
           created = true;
         });
@@ -481,6 +497,7 @@ export const useEditor = create<EditorState>()(
           const shape = getDesignShapeById(draft.track.design, id);
           if (shape?.locked || !closePolyline(shape ?? undefined)) return;
           draft.session.selection = [id];
+          clearPolylineEditSelections(draft, [id]);
           touchTrackDesign(draft);
           closed = true;
         });

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -451,10 +451,13 @@ export const useEditor = create<EditorState>()(
               (shape): shape is PolylineShape =>
                 Boolean(shape) && shape.kind === "polyline"
             );
+          if (polylineShapes.some((shape) => shape.locked)) return;
           const merged = joinPolylineShapes(polylineShapes);
           if (!merged) return;
 
-          ids.forEach((id) => removeShapeRecord(draft.track.design, id));
+          polylineShapes.forEach((shape) =>
+            removeShapeRecord(draft.track.design, shape.id)
+          );
           addShapeRecord(draft.track.design, {
             ...merged,
             id: nextId,
@@ -476,7 +479,7 @@ export const useEditor = create<EditorState>()(
 
         set((draft) => {
           const shape = getDesignShapeById(draft.track.design, id);
-          if (!closePolyline(shape ?? undefined)) return;
+          if (shape?.locked || !closePolyline(shape ?? undefined)) return;
           draft.session.selection = [id];
           touchTrackDesign(draft);
           closed = true;

--- a/tests/components/canvas/MapReferenceLayer.test.tsx
+++ b/tests/components/canvas/MapReferenceLayer.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MapReferenceLayer } from "@/components/canvas/renderers/map-reference-layer";
+import { getFieldMapTileCoverage } from "@/lib/map-reference/geometry";
+import type { MapReference } from "@/lib/types";
+
+vi.mock("react-konva", () => ({
+  Group: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="konva-group">{children}</div>
+  ),
+  Image: ({ image }: { image?: HTMLImageElement }) =>
+    image ? <div data-testid="konva-image" /> : null,
+}));
+
+const mapReference: MapReference = {
+  type: "map",
+  provider: "esri-world-imagery",
+  mapStyle: "satellite",
+  centerLat: 52.1,
+  centerLng: 5.2,
+  zoom: 18,
+  rotationDeg: 0,
+  opacity: 0.35,
+  visible: true,
+  locked: true,
+};
+
+const field = { width: 60, height: 40, ppm: 20 };
+
+const imageInstances: MockImage[] = [];
+
+class MockImage {
+  crossOrigin = "";
+  onerror: (() => void) | null = null;
+  onload: (() => void) | null = null;
+  src = "";
+
+  constructor() {
+    imageInstances.push(this);
+  }
+}
+
+describe("MapReferenceLayer", () => {
+  beforeEach(() => {
+    imageInstances.length = 0;
+    vi.stubGlobal("Image", MockImage);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not duplicate pending tile image requests after partial loads", () => {
+    const expectedTileCount = getFieldMapTileCoverage({
+      field,
+      mapReference,
+    }).length;
+
+    render(
+      <MapReferenceLayer
+        field={field}
+        heightPx={800}
+        mapReference={mapReference}
+        widthPx={1200}
+      />
+    );
+
+    expect(imageInstances).toHaveLength(expectedTileCount);
+
+    act(() => {
+      imageInstances[0]?.onload?.();
+    });
+
+    expect(imageInstances).toHaveLength(expectedTileCount);
+  });
+});

--- a/tests/components/dialogs/ExportDialog.test.tsx
+++ b/tests/components/dialogs/ExportDialog.test.tsx
@@ -474,7 +474,11 @@ describe("ExportDialog mobile workflow", () => {
 
     await waitFor(() => {
       expect(mocks.toastError).toHaveBeenCalledWith(
-        "Export failed: JSON payload could not be serialized"
+        "Export failed",
+        expect.objectContaining({
+          description:
+            "JSON payload could not be serialized Try again, switch export format, or export the project JSON as a manual backup.",
+        })
       );
     });
     expect(onOpenChange).not.toHaveBeenCalledWith(false);

--- a/tests/components/dialogs/ImportDialog.test.tsx
+++ b/tests/components/dialogs/ImportDialog.test.tsx
@@ -52,7 +52,7 @@ describe("ImportDialog", () => {
     );
 
     expect(screen.getByRole("alert").textContent).toContain(
-      "Invalid JSON file."
+      "Invalid JSON file. Choose a complete .json export from TrackDraw and try again."
     );
     expect(toast.error).toHaveBeenCalledWith(
       "Import failed",
@@ -73,7 +73,7 @@ describe("ImportDialog", () => {
     );
 
     expect(screen.getByRole("alert").textContent).toContain(
-      "Only TrackDraw JSON project files are supported."
+      "Only TrackDraw JSON project files are supported. Choose a .json backup exported from TrackDraw."
     );
     expect(toast.error).toHaveBeenCalledWith(
       "Import failed",
@@ -95,7 +95,7 @@ describe("ImportDialog", () => {
     );
 
     expect(screen.getByRole("alert").textContent).toContain(
-      "This does not look like a TrackDraw project."
+      "This does not look like a TrackDraw project. Choose a JSON project file exported from TrackDraw."
     );
     expect(toast.error).toHaveBeenCalledWith(
       "Import failed",
@@ -118,7 +118,7 @@ describe("ImportDialog", () => {
     await user.upload(input, unreadableFile);
 
     expect(screen.getByRole("alert").textContent).toContain(
-      "TrackDraw could not read this file."
+      "TrackDraw could not read this file. Try again or choose another backup."
     );
     expect(toast.error).toHaveBeenCalledWith(
       "Import failed",

--- a/tests/components/dialogs/ShareDialog.test.tsx
+++ b/tests/components/dialogs/ShareDialog.test.tsx
@@ -235,7 +235,13 @@ describe("ShareDialog", () => {
     await user.click(screen.getByRole("button", { name: /Create new link/i }));
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to publish share");
+      expect(toast.error).toHaveBeenCalledWith(
+        "Could not create share link",
+        expect.objectContaining({
+          description:
+            "TrackDraw could not publish the current snapshot. Check your connection and try again; export JSON if you need to hand it off now.",
+        })
+      );
     });
     expect(screen.queryByLabelText("share-url-input")).toBeNull();
     expect(localStorage.getItem("trackdraw-anon-share")).toBeNull();

--- a/tests/components/editor/MobileControls.test.tsx
+++ b/tests/components/editor/MobileControls.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+
+import type React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ToolsControls } from "@/components/editor/mobile/ToolsControls";
+import { ViewControls } from "@/components/editor/mobile/ViewControls";
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const toolProps: React.ComponentProps<typeof ToolsControls> = {
+  activePlacementElementId: {},
+  activeTool: "gate",
+  canRedo: false,
+  canUndo: true,
+  onRedo: vi.fn(),
+  onSelectPlacementElement: vi.fn(),
+  onSelectTool: vi.fn(),
+  onUndo: vi.fn(),
+  tab: "2d",
+};
+
+const viewProps: React.ComponentProps<typeof ViewControls> = {
+  hasPath: true,
+  inspectorHint: "1 selected",
+  mobileGizmoEnabled: false,
+  mobileObstacleNumbersEnabled: true,
+  mobileRulersEnabled: false,
+  onFitView: vi.fn(),
+  onSetMobileGizmoEnabled: vi.fn(),
+  onSetMobileObstacleNumbersEnabled: vi.fn(),
+  onSetMobileRulersEnabled: vi.fn(),
+  onStartFlyThrough: vi.fn(),
+  onTabChange: vi.fn(),
+  onToggleSnapEnabled: vi.fn(),
+  saveStatusLabel: "Saved",
+  snapEnabled: true,
+  tab: "2d",
+};
+
+describe("mobile editor controls", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("keeps tool drawer controls large enough for mobile taps", () => {
+    render(<ToolsControls {...toolProps} />);
+
+    expect(screen.getByRole("button", { name: "Undo" }).className).toContain(
+      "min-h-12"
+    );
+    expect(screen.getByRole("button", { name: "Redo" }).className).toContain(
+      "min-h-12"
+    );
+    expect(
+      screen
+        .getAllByRole("button", { name: /Gate/ })
+        .some((button) => button.className.includes("min-h-14"))
+    ).toBe(true);
+    expect(screen.getByRole("button", { name: "Path" }).className).toContain(
+      "min-h-16"
+    );
+    expect(
+      screen.getByRole("button", { name: "Path" }).querySelector("span")
+        ?.className
+    ).toContain("truncate");
+  });
+
+  it("keeps view drawer actions and toggles at mobile target size", () => {
+    render(<ViewControls {...viewProps} />);
+
+    for (const name of ["Fit to field", "Snap", "Rulers", "Obstacle numbers"]) {
+      expect(
+        screen.getByRole("button", { name: new RegExp(name) }).className
+      ).toContain("min-h-12");
+    }
+  });
+
+  it("keeps read-only share actions compact but touch-friendly", () => {
+    render(
+      <ViewControls
+        {...viewProps}
+        onShare={vi.fn()}
+        readOnly
+        showShareActions
+        studioHref="/studio?from=share"
+      />
+    );
+
+    expect(
+      screen.getByRole("link", { name: "Editable copy" }).className
+    ).toContain("min-h-12");
+    expect(screen.getByRole("button", { name: "Share" }).className).toContain(
+      "min-h-12"
+    );
+  });
+});

--- a/tests/components/editor/MobileControls.test.tsx
+++ b/tests/components/editor/MobileControls.test.tsx
@@ -64,18 +64,40 @@ describe("mobile editor controls", () => {
     expect(screen.getByRole("button", { name: "Redo" }).className).toContain(
       "min-h-12"
     );
+    expect(screen.getByText("Track items")).toBeTruthy();
+    expect(screen.getByText("Canvas tools")).toBeTruthy();
     expect(
       screen
         .getAllByRole("button", { name: /Gate/ })
         .some((button) => button.className.includes("min-h-14"))
     ).toBe(true);
-    expect(screen.getByRole("button", { name: "Path" }).className).toContain(
-      "min-h-16"
+    const catalogToolHeaders = screen
+      .getAllByRole("button")
+      .filter((button) => button.className.includes("min-h-14"));
+    for (const button of catalogToolHeaders) {
+      const iconWrapper = button.querySelector("span");
+      expect(iconWrapper?.className).toContain("bg-slate-950");
+      expect(iconWrapper?.className).toContain("text-white");
+      expect(iconWrapper?.className).not.toContain("opacity-");
+    }
+    const pathButton = screen.getByRole("button", {
+      name: "Path Draw or edit the race line",
+    });
+    const startPadsButton = screen.getByRole("button", {
+      name: "Start Pads Mark launch or timing pads",
+    });
+    const mobileButtons = screen.getAllByRole("button");
+    expect(mobileButtons.indexOf(pathButton)).toBeLessThan(
+      mobileButtons.indexOf(startPadsButton)
     );
-    expect(
-      screen.getByRole("button", { name: "Path" }).querySelector("span")
-        ?.className
-    ).toContain("truncate");
+    expect(pathButton.className).toContain("min-h-14");
+    expect(pathButton.querySelectorAll("span").item(2).className).toContain(
+      "truncate"
+    );
+    expect(pathButton.querySelectorAll("span").item(3).className).toContain(
+      "truncate"
+    );
+    expect(screen.getByText("Draw or edit the race line")).toBeTruthy();
   });
 
   it("keeps view drawer actions and toggles at mobile target size", () => {

--- a/tests/components/editor/MultiSelectOverlay.test.tsx
+++ b/tests/components/editor/MultiSelectOverlay.test.tsx
@@ -60,7 +60,7 @@ describe("MultiSelectOverlay", () => {
     ).toBe(true);
   });
 
-  it("disables destructive actions when any selected item is locked", () => {
+  it("disables duplicate and destructive actions when any selected item is locked", () => {
     renderMultiSelectOverlay({
       hasLockedSelection: true,
       selectionLocked: false,
@@ -74,6 +74,10 @@ describe("MultiSelectOverlay", () => {
       (screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement)
         .disabled
     ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Group" }) as HTMLButtonElement)
+        .disabled
+    ).toBe(false);
     expect(
       (screen.getByRole("button", { name: "Lock" }) as HTMLButtonElement)
         .disabled

--- a/tests/components/editor/MultiSelectOverlay.test.tsx
+++ b/tests/components/editor/MultiSelectOverlay.test.tsx
@@ -88,9 +88,22 @@ describe("MultiSelectOverlay", () => {
     renderMultiSelectOverlay();
 
     for (const label of ["Duplicate", "Group", "Lock", "Delete"]) {
-      expect(screen.getByRole("button", { name: label }).className).toContain(
-        "min-h-14"
-      );
+      const button = screen.getByRole("button", { name: label });
+      expect(button.className).toContain("min-h-14");
+      expect(button.className).toContain("min-w-0");
+      expect(button.querySelector("span")?.className).toContain("truncate");
     }
+  });
+
+  it("keeps grouped selection naming reachable as a mobile touch control", () => {
+    renderMultiSelectOverlay({
+      canUngroupSelection: true,
+      onSetGroupName: vi.fn(),
+      selectedGroupName: "Start section",
+    });
+
+    const input = screen.getByPlaceholderText("Group name");
+    expect(input.className).toContain("h-11");
+    expect(input.className).toContain("text-[13px]");
   });
 });

--- a/tests/components/editor/PathBuilderOverlay.test.tsx
+++ b/tests/components/editor/PathBuilderOverlay.test.tsx
@@ -60,9 +60,10 @@ describe("PathBuilderOverlay", () => {
     renderPathBuilderOverlay();
 
     for (const label of ["Undo", "Connect ends", "Finish", "Cancel"]) {
-      expect(screen.getByRole("button", { name: label }).className).toContain(
-        "min-h-14"
-      );
+      const button = screen.getByRole("button", { name: label });
+      expect(button.className).toContain("min-h-14");
+      expect(button.className).toContain("min-w-0");
+      expect(button.querySelector("span")?.className).toContain("truncate");
     }
   });
 });

--- a/tests/components/editor/useManualProjectSave.test.tsx
+++ b/tests/components/editor/useManualProjectSave.test.tsx
@@ -86,10 +86,11 @@ describe("useManualProjectSave", () => {
       "D1 unavailable"
     );
     expect(options.setSaveStatusLabel).toHaveBeenCalledWith(
-      "Cloud sync failed"
+      "Account sync failed; snapshot saved"
     );
-    expect(toast.error).toHaveBeenCalledWith("Could not sync project", {
-      description: "D1 unavailable",
+    expect(toast.error).toHaveBeenCalledWith("Account sync failed", {
+      description:
+        "TrackDraw saved a snapshot on this device, but could not update the account copy. Retry sync, or export JSON if you need a manual backup.",
     });
   });
 

--- a/tests/components/editor/useStarterExperience.test.tsx
+++ b/tests/components/editor/useStarterExperience.test.tsx
@@ -121,7 +121,7 @@ describe("useStarterExperience", () => {
       "Cloud unavailable"
     );
     expect(options.setSaveStatusLabel).toHaveBeenCalledWith(
-      "Cloud sync failed"
+      "Account sync failed; saved locally"
     );
     expect(consoleError).toHaveBeenCalledWith(
       "[TrackDraw new-project sync]",

--- a/tests/components/inspector/SingleInspectorView.test.tsx
+++ b/tests/components/inspector/SingleInspectorView.test.tsx
@@ -222,6 +222,14 @@ describe("SingleInspectorView race timing controls", () => {
         "Locked on the canvas. Unlock before moving, resizing, or continuing path edits."
       )
     ).toBeTruthy();
+    expect(
+      (screen.getByRole("button", { name: "Duplicate" }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
   });
 
   it("hides fixed official gate size and color controls", () => {

--- a/tests/hooks/useEditorProjects.test.tsx
+++ b/tests/hooks/useEditorProjects.test.tsx
@@ -63,17 +63,19 @@ describe("useEditorProjects", () => {
       vi.advanceTimersByTime(350);
     });
 
-    expect(result.current.saveStatusLabel).toBe("Local save failed");
+    expect(result.current.saveStatusLabel).toBe("Local autosave failed");
     expect(toast.error).toHaveBeenCalledWith(
-      "Local save failed",
+      "Local autosave failed",
       expect.objectContaining({
+        description:
+          "The latest edits are still on the canvas, but TrackDraw could not save a local copy. Retry now, or export a JSON backup before leaving this browser.",
         action: expect.objectContaining({ label: "Retry" }),
       })
     );
 
     const saveFailureToast = vi
       .mocked(toast.error)
-      .mock.calls.find(([message]) => message === "Local save failed");
+      .mock.calls.find(([message]) => message === "Local autosave failed");
     const retryAction = (
       saveFailureToast?.[1] as { action?: { onClick?: () => void } } | undefined
     )?.action;
@@ -89,7 +91,7 @@ describe("useEditorProjects", () => {
     });
 
     expect(toast.success).toHaveBeenCalledWith(
-      "Local save recovered",
+      "Local autosave recovered",
       expect.any(Object)
     );
     expect(result.current.saveStatusLabel).toContain("Saved locally at");

--- a/tests/lib/canvas/snap.test.ts
+++ b/tests/lib/canvas/snap.test.ts
@@ -270,6 +270,34 @@ describe("canvas snap helpers", () => {
     ).toEqual({ x: 8, y: 9 });
   });
 
+  it("excludes selected shape and route ids while resolving snap positions", () => {
+    expect(
+      resolveSnapPosition({
+        pos: { x: 10.2, y: 10.1 },
+        snapToGrid: false,
+        snapToShapes: true,
+        gridStep: 1,
+        magneticRadiusMeters: 1,
+        candidates,
+        routeCandidates: [route],
+        excludeIds: ["gate-1"],
+      })
+    ).toEqual({ x: 10.2, y: 10.1 });
+
+    expect(
+      resolveSnapPosition({
+        pos: { x: 7.3, y: 6.2 },
+        snapToGrid: false,
+        snapToShapes: true,
+        gridStep: 1,
+        magneticRadiusMeters: 1,
+        candidates: [],
+        routeCandidates: [route],
+        excludeIds: ["route-1"],
+      })
+    ).toEqual({ x: 7.3, y: 6.2 });
+  });
+
   it("falls back to grid snapping or raw positions as configured", () => {
     expect(
       resolveSnapPosition({

--- a/tests/lib/editor/shape-mutations.test.ts
+++ b/tests/lib/editor/shape-mutations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   applyShapePatch,
+  insertPolylinePoint,
   setPolylinePoints,
   updatePolylinePoint,
 } from "@/lib/editor/shape-mutations";
@@ -99,6 +100,40 @@ describe("shape mutations", () => {
 
     expect(updatePolylinePoint(polyline, 1, { z: 2 })).toBe(true);
     expect(polyline.points[1]).toEqual({ x: 2, y: 0, z: 2 });
+  });
+
+  it("rejects out-of-range polyline insert positions", () => {
+    const polyline: PolylineShape = {
+      id: "line-5",
+      kind: "polyline",
+      x: 0,
+      y: 0,
+      rotation: 0,
+      points: [
+        { x: 0, y: 0, z: 0 },
+        { x: 2, y: 0, z: 1 },
+      ],
+    };
+
+    expect(
+      insertPolylinePoint(polyline, -1, { x: 1, y: 1, z: 0 })
+    ).toBe(false);
+    expect(
+      insertPolylinePoint(polyline, 3, { x: 1, y: 1, z: 0 })
+    ).toBe(false);
+    expect(polyline.points).toEqual([
+      { x: 0, y: 0, z: 0 },
+      { x: 2, y: 0, z: 1 },
+    ]);
+
+    expect(
+      insertPolylinePoint(polyline, 2, { x: 4, y: 0, z: 0 })
+    ).toBe(true);
+    expect(polyline.points).toEqual([
+      { x: 0, y: 0, z: 0 },
+      { x: 2, y: 0, z: 1 },
+      { x: 4, y: 0, z: 0 },
+    ]);
   });
 
   it("applies and reports real changes", () => {

--- a/tests/lib/editor/shape-mutations.test.ts
+++ b/tests/lib/editor/shape-mutations.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   applyShapePatch,
   insertPolylinePoint,
+  nudgeShapes,
+  rotateShapes,
   setPolylinePoints,
   updatePolylinePoint,
 } from "@/lib/editor/shape-mutations";
-import type { GateShape, PolylineShape } from "@/lib/types";
+import type { GateShape, PolylineShape, TrackDesign } from "@/lib/types";
 
 describe("shape mutations", () => {
   it("returns false for unchanged non-polyline patches", () => {
@@ -149,5 +151,29 @@ describe("shape mutations", () => {
 
     expect(applyShapePatch(shape, { rotation: 15 })).toBe(true);
     expect(shape.rotation).toBe(15);
+  });
+
+  it("reports no-op transform mutations accurately", () => {
+    const gate: GateShape = {
+      id: "gate-3",
+      kind: "gate",
+      x: 3,
+      y: 5,
+      rotation: 45,
+      width: 2,
+      height: 2,
+    };
+    const shapeById: TrackDesign["shapeById"] = {
+      [gate.id]: gate,
+    };
+
+    expect(rotateShapes(shapeById, [gate.id], 0)).toBe(false);
+    expect(rotateShapes(shapeById, [gate.id], 360)).toBe(false);
+    expect(nudgeShapes(shapeById, [gate.id], 0, 0)).toBe(false);
+    expect(gate).toMatchObject({ x: 3, y: 5, rotation: 45 });
+
+    expect(rotateShapes(shapeById, [gate.id], -90)).toBe(true);
+    expect(nudgeShapes(shapeById, [gate.id], 1, -2)).toBe(true);
+    expect(gate).toMatchObject({ x: 4, y: 3, rotation: 315 });
   });
 });

--- a/tests/lib/editor/shape-mutations.test.ts
+++ b/tests/lib/editor/shape-mutations.test.ts
@@ -117,20 +117,14 @@ describe("shape mutations", () => {
       ],
     };
 
-    expect(
-      insertPolylinePoint(polyline, -1, { x: 1, y: 1, z: 0 })
-    ).toBe(false);
-    expect(
-      insertPolylinePoint(polyline, 3, { x: 1, y: 1, z: 0 })
-    ).toBe(false);
+    expect(insertPolylinePoint(polyline, -1, { x: 1, y: 1, z: 0 })).toBe(false);
+    expect(insertPolylinePoint(polyline, 3, { x: 1, y: 1, z: 0 })).toBe(false);
     expect(polyline.points).toEqual([
       { x: 0, y: 0, z: 0 },
       { x: 2, y: 0, z: 1 },
     ]);
 
-    expect(
-      insertPolylinePoint(polyline, 2, { x: 4, y: 0, z: 0 })
-    ).toBe(true);
+    expect(insertPolylinePoint(polyline, 2, { x: 4, y: 0, z: 0 })).toBe(true);
     expect(polyline.points).toEqual([
       { x: 0, y: 0, z: 0 },
       { x: 2, y: 0, z: 1 },

--- a/tests/lib/editor/shell-view-model.test.ts
+++ b/tests/lib/editor/shell-view-model.test.ts
@@ -59,6 +59,28 @@ describe("editor shell view model", () => {
     expect(result.mobilePrecisionStepLabel).toBe("0.1 m");
   });
 
+  it("keeps grouped selection affordances available when the selection is locked", () => {
+    const lockedGate: Shape = {
+      ...gate,
+      locked: true,
+    };
+    const result = getEditorShellSelectionState({
+      activePresetName: null,
+      designGridStep: 0.25,
+      segmentSelection: null,
+      selection: [lockedGate.id, flag.id],
+      shapeById: {
+        [lockedGate.id]: lockedGate,
+        [flag.id]: flag,
+      },
+      vertexSelection: null,
+      t: shapesTranslate,
+    });
+
+    expect(result.canUngroupSelection).toBe(true);
+    expect(result.selectedGroupName).toBe("Section A");
+  });
+
   it("derives polyline editing affordances from single selection", () => {
     const result = getEditorShellSelectionState({
       activePresetName: null,

--- a/tests/lib/map-reference/geometry.test.ts
+++ b/tests/lib/map-reference/geometry.test.ts
@@ -5,6 +5,7 @@ import {
   getMapTileZoom,
   globalPixelToLatLng,
   latLngToGlobalPixel,
+  MAP_REFERENCE_MAX_RENDER_TILES,
   metersPerPixelAtLatitude,
   normalizeMapReference,
   panLatLngByPixels,
@@ -116,6 +117,39 @@ describe("map reference geometry", () => {
       highPickerZoomTiles[0]?.canvasSize ?? 0,
       6
     );
+  });
+
+  it("bounds tile coverage for very large high-density fields", () => {
+    const tiles = getFieldMapTileCoverage({
+      field: { width: 500, height: 500, ppm: 80 },
+      mapReference: reference,
+    });
+    const preferredZoom = getMapReferenceRenderZoom({
+      lat: reference.centerLat,
+      ppm: 80,
+    });
+    const tileZooms = new Set(tiles.map((tile) => tile.z));
+
+    expect(tiles.length).toBeGreaterThan(0);
+    expect(tiles.length).toBeLessThanOrEqual(MAP_REFERENCE_MAX_RENDER_TILES);
+    expect(tileZooms.size).toBe(1);
+    expect(tiles[0]?.z).toBeLessThan(preferredZoom);
+    expect(tiles.every((tile) => tile.canvasSize > 0)).toBe(true);
+  });
+
+  it("skips map tile coverage for invalid field dimensions", () => {
+    expect(
+      getFieldMapTileCoverage({
+        field: { width: 0, height: 40, ppm: 20 },
+        mapReference: reference,
+      })
+    ).toEqual([]);
+    expect(
+      getFieldMapTileCoverage({
+        field: { width: 60, height: 40, ppm: Number.NaN },
+        mapReference: reference,
+      })
+    ).toEqual([]);
   });
 
   it("pans lat/lng by screen pixels", () => {

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -1001,7 +1001,9 @@ describe("editor store history", () => {
     const joinedId = state.joinPolylines([firstId, secondId]);
 
     expect(joinedId).toBeTruthy();
-    expect(useEditor.getState().track.design.shapeById[firstId]).toBeUndefined();
+    expect(
+      useEditor.getState().track.design.shapeById[firstId]
+    ).toBeUndefined();
     expect(
       useEditor.getState().track.design.shapeById[secondId]
     ).toBeUndefined();
@@ -1019,7 +1021,9 @@ describe("editor store history", () => {
     ).toBeUndefined();
 
     runHistoryStep(useEditor.temporal.getState().redo);
-    expect(useEditor.getState().track.design.shapeById[firstId]).toBeUndefined();
+    expect(
+      useEditor.getState().track.design.shapeById[firstId]
+    ).toBeUndefined();
     expect(
       useEditor.getState().track.design.shapeById[secondId]
     ).toBeUndefined();

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -508,10 +508,11 @@ describe("editor store history", () => {
 
   it("does not remove grouped selections when one grouped member is locked", () => {
     const state = useEditor.getState();
-    const lockedId = state.addShape(gateDraft({ x: 5, y: 5, locked: true }));
+    const lockedId = state.addShape(gateDraft({ x: 5, y: 5 }));
     const editableId = state.addShape(flagDraft());
 
     state.groupSelection([lockedId, editableId]);
+    state.setShapesLocked([lockedId], true);
     state.setSelection([lockedId]);
     const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
 
@@ -522,6 +523,29 @@ describe("editor store history", () => {
     expect(nextState.track.design.shapeById[editableId]).toBeTruthy();
     expect(nextState.session.selection).toEqual([lockedId, editableId]);
     expectNoDesignHistoryChange(beforeUpdatedAt);
+  });
+
+  it("groups selections that include locked shapes", () => {
+    const state = useEditor.getState();
+    const lockedId = state.addShape(gateDraft({ x: 5, y: 5, locked: true }));
+    const editableId = state.addShape(flagDraft());
+
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:10:22.000Z");
+
+    const groupId = state.groupSelection([lockedId, editableId]);
+
+    const nextState = useEditor.getState();
+    expect(groupId).toBeTruthy();
+    expect(nextState.track.design.shapeById[lockedId]?.meta).toMatchObject({
+      groupId,
+    });
+    expect(nextState.track.design.shapeById[editableId]?.meta).toMatchObject({
+      groupId,
+    });
+    expect(nextState.session.selection).toEqual([lockedId, editableId]);
+    expectDesignUpdatedAt("2026-04-13T10:10:22.000Z");
+    expectPastStatesCount(1);
   });
 
   it("does not remove locked-only selections or create history", () => {
@@ -576,6 +600,40 @@ describe("editor store history", () => {
     ).toBeUndefined();
   });
 
+  it("renames and ungroups groups with locked members", () => {
+    const state = useEditor.getState();
+    const lockedId = state.addShape(gateDraft({ x: 5, y: 5 }));
+    const editableId = state.addShape(flagDraft());
+    const groupId = state.groupSelection([lockedId, editableId]);
+
+    state.setShapesLocked([lockedId], true);
+    state.clearHistory();
+
+    setEditorTestTime("2026-04-13T10:10:23.000Z");
+    state.setGroupName([editableId], "Locked group");
+
+    let nextDesign = useEditor.getState().track.design;
+    expect(nextDesign.shapeById[lockedId]?.meta).toMatchObject({
+      groupId,
+      groupName: "Locked group",
+    });
+    expect(nextDesign.shapeById[editableId]?.meta).toMatchObject({
+      groupId,
+      groupName: "Locked group",
+    });
+    expectDesignUpdatedAt("2026-04-13T10:10:23.000Z");
+
+    setEditorTestTime("2026-04-13T10:10:24.000Z");
+    state.ungroupSelection([editableId]);
+
+    nextDesign = useEditor.getState().track.design;
+    expect(nextDesign.shapeById[lockedId]?.locked).toBe(true);
+    expect(nextDesign.shapeById[lockedId]?.meta).toBeUndefined();
+    expect(nextDesign.shapeById[editableId]?.meta).toBeUndefined();
+    expectDesignUpdatedAt("2026-04-13T10:10:24.000Z");
+    expectPastStatesCount(2);
+  });
+
   it("joins and closes polylines when possible", () => {
     const state = useEditor.getState();
     const firstId = state.addShape(
@@ -616,6 +674,75 @@ describe("editor store history", () => {
       kind: "polyline",
       closed: true,
     });
+  });
+
+  it("does not join or close locked polylines", () => {
+    const state = useEditor.getState();
+    const lockedId = state.addShape(
+      polylineDraft({
+        locked: true,
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 },
+          { x: 4, y: 0, z: 0 },
+        ],
+      })
+    );
+    const editableId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 4, y: 0, z: 0 },
+          { x: 6, y: 1, z: 0 },
+        ],
+      })
+    );
+
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
+
+    expect(state.joinPolylines([lockedId, editableId])).toBeNull();
+    expect(state.closePolyline(lockedId)).toBe(false);
+
+    const nextDesign = useEditor.getState().track.design;
+    expect(nextDesign.shapeById[lockedId]?.kind).toBe("polyline");
+    expect(nextDesign.shapeById[editableId]?.kind).toBe("polyline");
+    expect(
+      nextDesign.shapeById[lockedId]?.kind === "polyline"
+        ? nextDesign.shapeById[lockedId].closed
+        : null
+    ).toBeFalsy();
+    expectNoDesignHistoryChange(beforeUpdatedAt);
+  });
+
+  it("does not remove or let unrelated locked shapes block joining polylines", () => {
+    const state = useEditor.getState();
+    const firstId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 },
+        ],
+      })
+    );
+    const secondId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 2, y: 0, z: 0 },
+          { x: 4, y: 1, z: 0 },
+        ],
+      })
+    );
+    const gateId = state.addShape(gateDraft({ x: 8, y: 8, locked: true }));
+
+    const joinedId = state.joinPolylines([firstId, gateId, secondId]);
+
+    expect(joinedId).toBeTruthy();
+    expect(useEditor.getState().track.design.shapeById[gateId]).toBeTruthy();
+    expect(
+      useEditor.getState().track.design.shapeById[firstId]
+    ).toBeUndefined();
+    expect(
+      useEditor.getState().track.design.shapeById[secondId]
+    ).toBeUndefined();
   });
 
   it("keeps route waypoint insertion undoable and clears stale segment selection", () => {

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -127,6 +127,44 @@ describe("editor store history", () => {
     expectPastStatesCount(1);
   });
 
+  it("does not create history for no-op rotations", () => {
+    const state = useEditor.getState();
+    const gateId = state.addShape(gateDraft({ rotation: 45 }));
+
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
+
+    state.rotateShapes([gateId], 0);
+    state.rotateShapes([gateId], 360);
+
+    expect(useEditor.getState().track.design.shapeById[gateId]).toMatchObject({
+      rotation: 45,
+    });
+    expectNoDesignHistoryChange(beforeUpdatedAt);
+  });
+
+  it("rotates only editable shapes in a mixed locked selection", () => {
+    const state = useEditor.getState();
+    const lockedGateId = state.addShape(
+      gateDraft({ rotation: 10, locked: true })
+    );
+    const editableGateId = state.addShape(gateDraft({ x: 12, rotation: 20 }));
+
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:06:26.000Z");
+
+    state.rotateShapes([lockedGateId, editableGateId], 15);
+
+    const nextDesign = useEditor.getState().track.design;
+    expect(nextDesign.shapeById[lockedGateId]).toMatchObject({
+      rotation: 10,
+    });
+    expect(nextDesign.shapeById[editableGateId]).toMatchObject({
+      rotation: 35,
+    });
+    expectDesignUpdatedAt("2026-04-13T10:06:26.000Z");
+    expectPastStatesCount(1);
+  });
+
   it("undoes and redoes a real design change through the temporal store", () => {
     const state = useEditor.getState();
     const gateId = state.addShape(gateDraft({ width: 2.2, height: 1.9 }));
@@ -178,6 +216,36 @@ describe("editor store history", () => {
       width: 3,
       height: 2,
     });
+  });
+
+  it("resizes only editable shapes in a mixed locked selection", () => {
+    const state = useEditor.getState();
+    const lockedGateId = state.addShape(
+      gateDraft({ locked: true, width: 2, height: 2 })
+    );
+    const editableGateId = state.addShape(
+      gateDraft({ x: 12, y: 9, width: 2.5, height: 1.5 })
+    );
+
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:06:29.000Z");
+
+    state.updateShapes([lockedGateId, editableGateId], {
+      width: 3,
+      height: 2,
+    });
+
+    const nextDesign = useEditor.getState().track.design;
+    expect(nextDesign.shapeById[lockedGateId]).toMatchObject({
+      width: 2,
+      height: 2,
+    });
+    expect(nextDesign.shapeById[editableGateId]).toMatchObject({
+      width: 3,
+      height: 2,
+    });
+    expectDesignUpdatedAt("2026-04-13T10:06:29.000Z");
+    expectPastStatesCount(1);
   });
 
   it("sanitizeHistoryState clears transient session and ui state after history steps", () => {
@@ -1129,6 +1197,10 @@ describe("editor store history", () => {
       x: 3,
       y: 1,
     });
+    expect(useEditor.getState().track.design.updatedAt).toBe(
+      "2026-04-13T10:12:10.000Z"
+    );
+    expectPastStatesCount(1);
 
     expect(useEditor.getState().track.design.shapeOrder).toEqual([
       firstId,
@@ -1147,6 +1219,82 @@ describe("editor store history", () => {
       thirdId,
       firstId,
     ]);
+  });
+
+  it("keeps nudge and rotation transform changes undoable and redoable", () => {
+    const state = useEditor.getState();
+    const gateId = state.addShape(gateDraft({ x: 1, y: 2, rotation: 5 }));
+
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:12:12.000Z");
+    state.nudgeShapes([gateId], 2, -1);
+    setEditorTestTime("2026-04-13T10:12:13.000Z");
+    state.rotateShapes([gateId], 30);
+
+    expect(useEditor.getState().track.design.shapeById[gateId]).toMatchObject({
+      x: 3,
+      y: 1,
+      rotation: 35,
+    });
+    expectDesignUpdatedAt("2026-04-13T10:12:13.000Z");
+    expectPastStatesCount(2);
+
+    runHistoryStep(useEditor.temporal.getState().undo);
+    expect(useEditor.getState().track.design.shapeById[gateId]).toMatchObject({
+      x: 3,
+      y: 1,
+      rotation: 5,
+    });
+
+    runHistoryStep(useEditor.temporal.getState().undo);
+    expect(useEditor.getState().track.design.shapeById[gateId]).toMatchObject({
+      x: 1,
+      y: 2,
+      rotation: 5,
+    });
+
+    runHistoryStep(useEditor.temporal.getState().redo);
+    expect(useEditor.getState().track.design.shapeById[gateId]).toMatchObject({
+      x: 3,
+      y: 1,
+      rotation: 5,
+    });
+
+    runHistoryStep(useEditor.temporal.getState().redo);
+    expect(useEditor.getState().track.design.shapeById[gateId]).toMatchObject({
+      x: 3,
+      y: 1,
+      rotation: 35,
+    });
+  });
+
+  it("keeps grouped selection nudges as one undoable transform", () => {
+    const state = useEditor.getState();
+    const firstId = state.addShape(gateDraft({ x: 5, y: 6 }));
+    const secondId = state.addShape(flagDraft({ x: 7, y: 8 }));
+    const groupId = state.groupSelection([firstId, secondId]);
+
+    expect(groupId).toBeTruthy();
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:12:14.000Z");
+
+    state.nudgeShapes(useEditor.getState().session.selection, 2, -1);
+
+    let nextDesign = useEditor.getState().track.design;
+    expect(nextDesign.shapeById[firstId]).toMatchObject({ x: 7, y: 5 });
+    expect(nextDesign.shapeById[secondId]).toMatchObject({ x: 9, y: 7 });
+    expectDesignUpdatedAt("2026-04-13T10:12:14.000Z");
+    expectPastStatesCount(1);
+
+    runHistoryStep(useEditor.temporal.getState().undo);
+    nextDesign = useEditor.getState().track.design;
+    expect(nextDesign.shapeById[firstId]).toMatchObject({ x: 5, y: 6 });
+    expect(nextDesign.shapeById[secondId]).toMatchObject({ x: 7, y: 8 });
+
+    runHistoryStep(useEditor.temporal.getState().redo);
+    nextDesign = useEditor.getState().track.design;
+    expect(nextDesign.shapeById[firstId]).toMatchObject({ x: 7, y: 5 });
+    expect(nextDesign.shapeById[secondId]).toMatchObject({ x: 9, y: 7 });
   });
 
   it("reorderShapes moves a shape before another", () => {

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -667,6 +667,11 @@ describe("editor store history", () => {
       "polyline"
     );
 
+    state.setSegmentSelection({
+      shapeId: joinedId!,
+      segmentIndex: 0,
+      point: { x: 1, y: 0 },
+    });
     expect(state.closePolyline(joinedId!)).toBe(true);
     expect(
       useEditor.getState().track.design.shapeById[joinedId!]
@@ -674,6 +679,7 @@ describe("editor store history", () => {
       kind: "polyline",
       closed: true,
     });
+    expect(useEditor.getState().ui.segmentSelection).toBeNull();
   });
 
   it("does not join or close locked polylines", () => {
@@ -743,6 +749,68 @@ describe("editor store history", () => {
     expect(
       useEditor.getState().track.design.shapeById[secondId]
     ).toBeUndefined();
+  });
+
+  it("clears stale route edit selections after structural route edits", () => {
+    const state = useEditor.getState();
+    const routeId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 },
+          { x: 4, y: 0, z: 0 },
+        ],
+      })
+    );
+
+    state.setVertexSelection({ shapeId: routeId, idx: 1 });
+    state.removePolylinePoint(routeId, 1);
+    expect(useEditor.getState().ui.vertexSelection).toBeNull();
+
+    state.setSegmentSelection({
+      shapeId: routeId,
+      segmentIndex: 0,
+      point: { x: 1, y: 0 },
+    });
+    state.appendPolylinePoint(routeId, { x: 6, y: 0, z: 0 });
+    expect(useEditor.getState().ui.segmentSelection).toBeNull();
+
+    state.setVertexSelection({ shapeId: routeId, idx: 1 });
+    state.reversePolylinePoints(routeId);
+    expect(useEditor.getState().ui.vertexSelection).toBeNull();
+  });
+
+  it("clears stale route edit selections when joining routes", () => {
+    const state = useEditor.getState();
+    const firstId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 },
+        ],
+      })
+    );
+    const secondId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 2, y: 0, z: 0 },
+          { x: 4, y: 1, z: 0 },
+        ],
+      })
+    );
+
+    state.setSegmentSelection({
+      shapeId: firstId,
+      segmentIndex: 0,
+      point: { x: 1, y: 0 },
+    });
+
+    const joinedId = state.joinPolylines([firstId, secondId]);
+
+    expect(joinedId).toBeTruthy();
+    expect(useEditor.getState().session.selection).toEqual([joinedId]);
+    expect(useEditor.getState().ui.segmentSelection).toBeNull();
+    expect(useEditor.getState().ui.vertexSelection).toBeNull();
   });
 
   it("keeps route waypoint insertion undoable and clears stale segment selection", () => {

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -780,6 +780,30 @@ describe("editor store history", () => {
     expect(useEditor.getState().ui.vertexSelection).toBeNull();
   });
 
+  it("does not insert route waypoints outside valid bounds or create history", () => {
+    const state = useEditor.getState();
+    const routeId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 4, y: 0, z: 0 },
+        ],
+      })
+    );
+
+    const beforeUpdatedAt = clearHistoryAndCaptureUpdatedAt();
+
+    state.insertPolylinePoint(routeId, -1, { x: 1, y: 1, z: 0 });
+    state.insertPolylinePoint(routeId, 3, { x: 1, y: 1, z: 0 });
+
+    const route = useEditor.getState().track.design.shapeById[routeId];
+    expect(route?.kind === "polyline" ? route.points : []).toEqual([
+      { x: 0, y: 0, z: 0 },
+      { x: 4, y: 0, z: 0 },
+    ]);
+    expectNoDesignHistoryChange(beforeUpdatedAt);
+  });
+
   it("clears stale route edit selections when joining routes", () => {
     const state = useEditor.getState();
     const firstId = state.addShape(
@@ -811,6 +835,129 @@ describe("editor store history", () => {
     expect(useEditor.getState().session.selection).toEqual([joinedId]);
     expect(useEditor.getState().ui.segmentSelection).toBeNull();
     expect(useEditor.getState().ui.vertexSelection).toBeNull();
+  });
+
+  it("keeps route reverse undoable and redoable", () => {
+    const state = useEditor.getState();
+    const routeId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 1 },
+          { x: 4, y: 0, z: 2 },
+        ],
+      })
+    );
+
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:11:10.000Z");
+    state.reversePolylinePoints(routeId);
+
+    let route = useEditor.getState().track.design.shapeById[routeId];
+    expect(route?.kind === "polyline" ? route.points : []).toEqual([
+      { x: 4, y: 0, z: 2 },
+      { x: 2, y: 0, z: 1 },
+      { x: 0, y: 0, z: 0 },
+    ]);
+    expectDesignUpdatedAt("2026-04-13T10:11:10.000Z");
+    expectPastStatesCount(1);
+
+    runHistoryStep(useEditor.temporal.getState().undo);
+    route = useEditor.getState().track.design.shapeById[routeId];
+    expect(route?.kind === "polyline" ? route.points : []).toEqual([
+      { x: 0, y: 0, z: 0 },
+      { x: 2, y: 0, z: 1 },
+      { x: 4, y: 0, z: 2 },
+    ]);
+
+    runHistoryStep(useEditor.temporal.getState().redo);
+    route = useEditor.getState().track.design.shapeById[routeId];
+    expect(route?.kind === "polyline" ? route.points : []).toEqual([
+      { x: 4, y: 0, z: 2 },
+      { x: 2, y: 0, z: 1 },
+      { x: 0, y: 0, z: 0 },
+    ]);
+  });
+
+  it("keeps route close undoable and redoable", () => {
+    const state = useEditor.getState();
+    const routeId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 },
+          { x: 4, y: 0, z: 0 },
+        ],
+      })
+    );
+
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:11:11.000Z");
+    expect(state.closePolyline(routeId)).toBe(true);
+
+    let route = useEditor.getState().track.design.shapeById[routeId];
+    expect(route).toMatchObject({ kind: "polyline", closed: true });
+    expectDesignUpdatedAt("2026-04-13T10:11:11.000Z");
+    expectPastStatesCount(1);
+
+    runHistoryStep(useEditor.temporal.getState().undo);
+    route = useEditor.getState().track.design.shapeById[routeId];
+    expect(route?.kind === "polyline" ? route.closed : null).toBeFalsy();
+
+    runHistoryStep(useEditor.temporal.getState().redo);
+    route = useEditor.getState().track.design.shapeById[routeId];
+    expect(route).toMatchObject({ kind: "polyline", closed: true });
+  });
+
+  it("keeps route join undoable and redoable", () => {
+    const state = useEditor.getState();
+    const firstId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 0, y: 0, z: 0 },
+          { x: 2, y: 0, z: 0 },
+        ],
+      })
+    );
+    const secondId = state.addShape(
+      polylineDraft({
+        points: [
+          { x: 2, y: 0, z: 0 },
+          { x: 4, y: 1, z: 0 },
+        ],
+      })
+    );
+
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:11:12.000Z");
+    const joinedId = state.joinPolylines([firstId, secondId]);
+
+    expect(joinedId).toBeTruthy();
+    expect(useEditor.getState().track.design.shapeById[firstId]).toBeUndefined();
+    expect(
+      useEditor.getState().track.design.shapeById[secondId]
+    ).toBeUndefined();
+    expect(useEditor.getState().track.design.shapeById[joinedId!]?.kind).toBe(
+      "polyline"
+    );
+    expectDesignUpdatedAt("2026-04-13T10:11:12.000Z");
+    expectPastStatesCount(1);
+
+    runHistoryStep(useEditor.temporal.getState().undo);
+    expect(useEditor.getState().track.design.shapeById[firstId]).toBeTruthy();
+    expect(useEditor.getState().track.design.shapeById[secondId]).toBeTruthy();
+    expect(
+      useEditor.getState().track.design.shapeById[joinedId!]
+    ).toBeUndefined();
+
+    runHistoryStep(useEditor.temporal.getState().redo);
+    expect(useEditor.getState().track.design.shapeById[firstId]).toBeUndefined();
+    expect(
+      useEditor.getState().track.design.shapeById[secondId]
+    ).toBeUndefined();
+    expect(useEditor.getState().track.design.shapeById[joinedId!]?.kind).toBe(
+      "polyline"
+    );
   });
 
   it("keeps route waypoint insertion undoable and clears stale segment selection", () => {


### PR DESCRIPTION
## Summary

- complete the editor reliability polish roadmap slice across locked actions, route editing, transform/snapping, mobile ergonomics, recovery/failure states, and large-layout stability
- improve mobile tools layout/copy, failure-state recovery guidance, map-reference tile bounds, and large-layout coverage
- mark the editor reliability polish work complete in the roadmap