### PR TITLE
chore: Remove legacy localStorage migration shims

### DIFF
--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -87,8 +87,8 @@ The next TrackDraw priority is export and handoff workflow polish first, editor 
 
 ## Later Product Follow-up
 
-- [ ] Remove legacy localStorage migration shims (`Lower priority`, `No account required`)
-      Two migration shims were added in v1.11.0 to preserve existing user preferences after the Zustand persist migration. Remove them once enough releases have passed that the old keys are no longer realistically present. The shims live in `src/store/measurement-unit.ts` (legacy raw-string format for `trackdraw.measurementUnitSystem`) and `src/store/editor-hints.ts` (legacy `trackdraw-hint-*-dismissed` per-key format). Safe to remove no earlier than v1.13.0.
+- [x] Remove legacy localStorage migration shims (`Lower priority`, `No account required`)
+      Removed the v1.11.0 one-time migration shims for the old raw-string `trackdraw.measurementUnitSystem` value and the old per-key `trackdraw-hint-*-dismissed` hint flags. The active Zustand persist keys remain unchanged.
 
 - [ ] VelociDrone experimental export stabilization (`Lower priority`, `No account required`)
       Keep this parked until there is appetite to validate more real layouts and tighten prefab mapping/orientation edge cases.

--- a/src/store/editor-hints.ts
+++ b/src/store/editor-hints.ts
@@ -17,59 +17,12 @@ type EditorHintsState = {
   resetGuidedHints: () => void;
 };
 
-// Legacy per-key storage used before this store was introduced.
-const LEGACY_KEYS = {
-  gate: "trackdraw-hint-gate-dismissed",
-  path: "trackdraw-hint-path-dismissed",
-  preview: "trackdraw-hint-preview-dismissed",
-  review3d: "trackdraw-hint-review3d-dismissed",
-  postPath: "trackdraw-hint-post-path-dismissed",
-} as const;
-
 // Access localStorage lazily so the reference is re-evaluated on each call.
 // This ensures test mocks installed after module load are picked up correctly.
-// On first load, migrates any persisted values from the legacy per-key format.
-const legacyAwareBackend = {
+const safeLocalStorageBackend = {
   getItem: (name: string): string | null => {
     try {
-      const raw = localStorage.getItem(name);
-      if (raw) {
-        try {
-          const parsed: unknown = JSON.parse(raw);
-          if (parsed && typeof parsed === "object" && "state" in parsed)
-            return raw;
-        } catch {
-          /* malformed JSON, fall through to legacy check */
-        }
-      }
-      // No valid envelope yet — check for legacy per-key values
-      const gateHintDismissed =
-        localStorage.getItem(LEGACY_KEYS.gate) === "true";
-      const desktopPathHintDismissed =
-        localStorage.getItem(LEGACY_KEYS.path) === "true";
-      const desktopPreviewHintDismissed =
-        localStorage.getItem(LEGACY_KEYS.preview) === "true";
-      const review3DHintDismissed =
-        localStorage.getItem(LEGACY_KEYS.review3d) === "true";
-      const postPathNudgeDismissed =
-        localStorage.getItem(LEGACY_KEYS.postPath) === "true";
-      const hasAnyLegacy =
-        gateHintDismissed ||
-        desktopPathHintDismissed ||
-        desktopPreviewHintDismissed ||
-        review3DHintDismissed ||
-        postPathNudgeDismissed;
-      if (!raw && !hasAnyLegacy) return null;
-      return JSON.stringify({
-        state: {
-          gateHintDismissed,
-          desktopPathHintDismissed,
-          desktopPreviewHintDismissed,
-          review3DHintDismissed,
-          postPathNudgeDismissed,
-        },
-        version: 0,
-      });
+      return localStorage.getItem(name);
     } catch {
       return null;
     }
@@ -115,7 +68,7 @@ export const useEditorHintsStore = create<EditorHintsState>()(
     }),
     {
       name: "trackdraw.editorHints",
-      storage: createJSONStorage(() => legacyAwareBackend),
+      storage: createJSONStorage(() => safeLocalStorageBackend),
       partialize: (state) => ({
         gateHintDismissed: state.gateHintDismissed,
         desktopPathHintDismissed: state.desktopPathHintDismissed,

--- a/src/store/measurement-unit.ts
+++ b/src/store/measurement-unit.ts
@@ -5,7 +5,6 @@ import { createJSONStorage, persist } from "zustand/middleware";
 import {
   getMeasurementUnitSystemFromLocales,
   MEASUREMENT_STORAGE_KEY,
-  normalizeMeasurementUnitSystem,
   type MeasurementUnitSystem,
 } from "@/lib/track/units";
 
@@ -19,29 +18,10 @@ function getBrowserDefault(): MeasurementUnitSystem {
   return getMeasurementUnitSystemFromLocales(navigator.languages);
 }
 
-// Handles legacy format: the old hook stored a raw string ("metric" / "imperial")
-// directly in localStorage instead of a Zustand JSON envelope. On first read we
-// migrate transparently so existing user preferences are preserved.
-const legacyAwareBackend = {
+const safeLocalStorageBackend = {
   getItem: (name: string): string | null => {
     try {
-      const raw = localStorage.getItem(name);
-      if (!raw) return null;
-      // Check for a valid Zustand envelope first
-      try {
-        const parsed: unknown = JSON.parse(raw);
-        if (parsed && typeof parsed === "object" && "state" in parsed) {
-          return raw;
-        }
-      } catch {
-        // Not valid JSON — must be a legacy raw string like "metric"/"imperial"
-      }
-      // Legacy raw string — wrap in Zustand envelope
-      const normalized = normalizeMeasurementUnitSystem(raw);
-      return JSON.stringify({
-        state: { unitSystem: normalized ?? getBrowserDefault() },
-        version: 0,
-      });
+      return localStorage.getItem(name);
     } catch {
       return null;
     }
@@ -70,7 +50,7 @@ export const useMeasurementUnitStore = create<MeasurementUnitState>()(
     }),
     {
       name: MEASUREMENT_STORAGE_KEY,
-      storage: createJSONStorage(() => legacyAwareBackend),
+      storage: createJSONStorage(() => safeLocalStorageBackend),
     }
   )
 );

--- a/tests/hooks/useMeasurementUnitSystem.test.tsx
+++ b/tests/hooks/useMeasurementUnitSystem.test.tsx
@@ -42,7 +42,7 @@ describe("useMeasurementUnitSystem", () => {
     expect(result.current.unitSystem).toBe("imperial");
   });
 
-  it("migrates legacy raw-string format on first load", async () => {
+  it("ignores the removed legacy raw-string format on first load", async () => {
     restoreStorage?.();
     restoreStorage = installWindowStorage(
       createMemoryStorage({ "trackdraw.measurementUnitSystem": "imperial" })
@@ -52,6 +52,6 @@ describe("useMeasurementUnitSystem", () => {
       await import("@/store/measurement-unit");
     await useMeasurementUnitStore.persist.rehydrate();
 
-    expect(useMeasurementUnitStore.getState().unitSystem).toBe("imperial");
+    expect(useMeasurementUnitStore.getState().unitSystem).toBe("metric");
   });
 });


### PR DESCRIPTION
## Summary

Remove the legacy one-time localStorage migration paths that were kept after the v1.11.0 Zustand persist migration.

## Changes

- Replace the measurement-unit legacy-aware backend with a simple safe localStorage backend.
- Remove the old per-key editor hint migration lookup.
- Update the measurement unit hook test to assert the removed raw-string format is ignored.
- Mark the roadmap item complete.

## Impact

Current Zustand persist keys and storage envelopes stay unchanged. Very old raw-string measurement-unit values and old `trackdraw-hint-*-dismissed` flags are no longer imported.