### PR TITLE
fix: Prune stale pending map tile requests

### DIFF
--- a/src/components/canvas/renderers/map-reference-layer.tsx
+++ b/src/components/canvas/renderers/map-reference-layer.tsx
@@ -28,9 +28,15 @@ export function MapReferenceLayer({
   const pendingTileUrlsRef = useRef(new Set<string>());
 
   useEffect(() => {
+    const tileUrls = new Set(tiles.map(getMapReferenceTileUrl));
+    for (const pendingUrl of pendingTileUrlsRef.current) {
+      if (!tileUrls.has(pendingUrl)) {
+        pendingTileUrlsRef.current.delete(pendingUrl);
+      }
+    }
+
     if (!mapReference?.visible) return;
 
-    const tileUrls = new Set(tiles.map(getMapReferenceTileUrl));
     let mounted = true;
     const missingTiles = tiles.filter((tile) => {
       const url = getMapReferenceTileUrl(tile);

--- a/src/components/canvas/renderers/map-reference-layer.tsx
+++ b/src/components/canvas/renderers/map-reference-layer.tsx
@@ -28,14 +28,14 @@ export function MapReferenceLayer({
   const pendingTileUrlsRef = useRef(new Set<string>());
 
   useEffect(() => {
+    if (!mapReference?.visible) return;
+
     const tileUrls = new Set(tiles.map(getMapReferenceTileUrl));
     for (const pendingUrl of pendingTileUrlsRef.current) {
       if (!tileUrls.has(pendingUrl)) {
         pendingTileUrlsRef.current.delete(pendingUrl);
       }
     }
-
-    if (!mapReference?.visible) return;
 
     let mounted = true;
     const missingTiles = tiles.filter((tile) => {

--- a/tests/components/canvas/MapReferenceLayer.test.tsx
+++ b/tests/components/canvas/MapReferenceLayer.test.tsx
@@ -77,4 +77,55 @@ describe("MapReferenceLayer", () => {
 
     expect(imageInstances).toHaveLength(expectedTileCount);
   });
+
+  it("prunes stale pending tile requests when coverage changes", () => {
+    const shiftedReference: MapReference = {
+      ...mapReference,
+      centerLat: 48.8566,
+      centerLng: 2.3522,
+    };
+    const expectedTileCount = getFieldMapTileCoverage({
+      field,
+      mapReference,
+    }).length;
+    const shiftedTileCount = getFieldMapTileCoverage({
+      field,
+      mapReference: shiftedReference,
+    }).length;
+
+    const { rerender } = render(
+      <MapReferenceLayer
+        field={field}
+        heightPx={800}
+        mapReference={mapReference}
+        widthPx={1200}
+      />
+    );
+
+    expect(imageInstances).toHaveLength(expectedTileCount);
+
+    rerender(
+      <MapReferenceLayer
+        field={field}
+        heightPx={800}
+        mapReference={shiftedReference}
+        widthPx={1200}
+      />
+    );
+
+    expect(imageInstances).toHaveLength(expectedTileCount + shiftedTileCount);
+
+    rerender(
+      <MapReferenceLayer
+        field={field}
+        heightPx={800}
+        mapReference={mapReference}
+        widthPx={1200}
+      />
+    );
+
+    expect(imageInstances).toHaveLength(
+      expectedTileCount + shiftedTileCount + expectedTileCount
+    );
+  });
 });

--- a/tests/components/canvas/MapReferenceLayer.test.tsx
+++ b/tests/components/canvas/MapReferenceLayer.test.tsx
@@ -128,4 +128,45 @@ describe("MapReferenceLayer", () => {
       expectedTileCount + shiftedTileCount + expectedTileCount
     );
   });
+
+  it("preserves pending tile requests while the map reference is hidden", () => {
+    const hiddenReference: MapReference = {
+      ...mapReference,
+      visible: false,
+    };
+    const expectedTileCount = getFieldMapTileCoverage({
+      field,
+      mapReference,
+    }).length;
+
+    const { rerender } = render(
+      <MapReferenceLayer
+        field={field}
+        heightPx={800}
+        mapReference={mapReference}
+        widthPx={1200}
+      />
+    );
+
+    expect(imageInstances).toHaveLength(expectedTileCount);
+
+    rerender(
+      <MapReferenceLayer
+        field={field}
+        heightPx={800}
+        mapReference={hiddenReference}
+        widthPx={1200}
+      />
+    );
+    rerender(
+      <MapReferenceLayer
+        field={field}
+        heightPx={800}
+        mapReference={mapReference}
+        widthPx={1200}
+      />
+    );
+
+    expect(imageInstances).toHaveLength(expectedTileCount);
+  });
 });


### PR DESCRIPTION
## Summary

Follow-up for review feedback on #569. The map reference layer now prunes pending tile URLs that are no longer part of the current tile coverage before computing missing tiles.

## Changes

- Keep `pendingTileUrlsRef` scoped to the current `tileUrls` set.
- Allow tiles that left coverage and later re-entered coverage to be requested again if an old request never settled.
- Add regression coverage for changing map tile coverage while requests remain pending.