### PR TITLE
fix: Address elevation profile marker feedback

### DIFF
--- a/src/components/inspector/ElevationChart.tsx
+++ b/src/components/inspector/ElevationChart.tsx
@@ -30,6 +30,7 @@ import {
   getShapeTimingMarker,
   getTimingMarkerColor,
   getTimingMarkerTitle,
+  type ShapeTimingMarker,
 } from "@/lib/track/timing";
 import { selectDesignShapes, selectPrimaryPolyline } from "@/store/selectors";
 import { cn } from "@/lib/utils";
@@ -62,7 +63,7 @@ type ChartTimingRouteMarkerCandidate = Omit<
   ChartRouteMarker,
   "ariaLabel" | "type"
 > & {
-  timingTitle: string;
+  marker: ShapeTimingMarker;
   type: "timing";
 };
 
@@ -1044,8 +1045,11 @@ export default function ElevationChart({ className }: { className?: string }) {
   const routeMarkers = useMemo<ChartRouteMarker[]>(() => {
     if (!path) return [];
 
-    const obstacleNumberMap = getObstacleNumberMap(design);
-    let splitIndex = 0;
+    const primaryPolylineId = designShapes.find(
+      (shape): shape is PolylineShape => shape.kind === "polyline"
+    )?.id;
+    const obstacleNumberMap =
+      path.id === primaryPolylineId ? getObstacleNumberMap(design) : null;
     const markerCandidates = designShapes
       .filter((shape) => shape.id !== path.id)
       .flatMap((shape): ChartRouteMarkerCandidate[] => {
@@ -1055,15 +1059,13 @@ export default function ElevationChart({ className }: { className?: string }) {
         if (projection.pathDistance > getRouteMarkerTolerance(shape)) return [];
 
         if (marker) {
-          if (marker.role === "split") splitIndex += 1;
-          const title = getTimingMarkerTitle(marker, splitIndex);
           return [
             {
               color: getTimingMarkerColor(marker),
               d: projection.d,
               id: `timing-${shape.id}`,
+              marker,
               shapeId: shape.id,
-              timingTitle: title,
               type: "timing",
             },
           ];
@@ -1076,13 +1078,14 @@ export default function ElevationChart({ className }: { className?: string }) {
             color: "#64748b",
             d: projection.d,
             id: `obstacle-${shape.id}`,
-            obstacleNumber: obstacleNumberMap.get(shape.id),
+            obstacleNumber: obstacleNumberMap?.get(shape.id),
             shapeId: shape.id,
             type: "obstacle",
           },
         ];
       });
 
+    let splitIndex = 0;
     let fallbackObstacleIndex = 0;
     return markerCandidates
       .sort(
@@ -1090,10 +1093,12 @@ export default function ElevationChart({ className }: { className?: string }) {
       )
       .map((marker) => {
         if (marker.type === "timing") {
-          const { timingTitle, ...routeMarker } = marker;
+          if (marker.marker.role === "split") splitIndex += 1;
+          const title = getTimingMarkerTitle(marker.marker, splitIndex);
+          const { marker: _marker, ...routeMarker } = marker;
           return {
             ...routeMarker,
-            ariaLabel: t("timingMarkerAria", { label: timingTitle }),
+            ariaLabel: t("timingMarkerAria", { label: title }),
           };
         }
 

--- a/src/components/inspector/ElevationChart.tsx
+++ b/src/components/inspector/ElevationChart.tsx
@@ -22,7 +22,10 @@ import {
   type RouteWarning,
   type RouteWarningKind,
 } from "@/lib/track/polyline-derived";
-import { isNumberedObstacle } from "@/lib/track/obstacleNumbering";
+import {
+  getObstacleNumberMap,
+  isNumberedObstacle,
+} from "@/lib/track/obstacleNumbering";
 import {
   getShapeTimingMarker,
   getTimingMarkerColor,
@@ -54,6 +57,25 @@ type ChartRouteMarker = {
   shapeId: string;
   type: "obstacle" | "timing";
 };
+
+type ChartTimingRouteMarkerCandidate = Omit<
+  ChartRouteMarker,
+  "ariaLabel" | "type"
+> & {
+  timingTitle: string;
+  type: "timing";
+};
+
+type ChartObstacleRouteMarkerCandidate = Omit<
+  ChartRouteMarker,
+  "ariaLabel" | "type"
+> & {
+  obstacleNumber?: number;
+  type: "obstacle";
+};
+
+type ChartRouteMarkerCandidate =
+  ChartObstacleRouteMarkerCandidate | ChartTimingRouteMarkerCandidate;
 
 type ChartWarningMarker = {
   d: number;
@@ -485,7 +507,14 @@ function RouteMarkerKey({
   warningMarkers: ChartWarningMarker[];
 }) {
   const t = useTranslations("inspector.elevationChart") as unknown as Translate;
-  const hasTiming = routeMarkers.some((marker) => marker.type === "timing");
+  const timingColors = Array.from(
+    new Set(
+      routeMarkers
+        .filter((marker) => marker.type === "timing")
+        .map((marker) => marker.color)
+    )
+  );
+  const hasTiming = timingColors.length > 0;
   const hasObstacles = routeMarkers.some(
     (marker) => marker.type === "obstacle"
   );
@@ -494,13 +523,21 @@ function RouteMarkerKey({
 
   const items = [
     ...(hasTiming
-      ? [{ color: "#0ea5e9", label: t("timingMarkersLegend") }]
+      ? [
+          {
+            background:
+              timingColors.length === 1
+                ? timingColors[0]
+                : `linear-gradient(90deg, ${timingColors.join(", ")})`,
+            label: t("timingMarkersLegend"),
+          },
+        ]
       : []),
     ...(hasObstacles
-      ? [{ color: "#64748b", label: t("obstacleMarkersLegend") }]
+      ? [{ background: "#64748b", label: t("obstacleMarkersLegend") }]
       : []),
     ...(hasWarnings
-      ? [{ color: "#f59e0b", label: t("warningMarkersLegend") }]
+      ? [{ background: "#f59e0b", label: t("warningMarkersLegend") }]
       : []),
   ];
 
@@ -510,7 +547,7 @@ function RouteMarkerKey({
         <span key={item.label} className="inline-flex items-center gap-1.5">
           <span
             className="size-2 rounded-full"
-            style={{ backgroundColor: item.color }}
+            style={{ background: item.background }}
             aria-hidden="true"
           />
           <span>{item.label}</span>
@@ -879,6 +916,7 @@ export default function ElevationChart({ className }: { className?: string }) {
   const t = useTranslations("inspector.elevationChart") as unknown as Translate;
   const { unitSystem } = useMeasurementUnitSystem();
   const path = useEditor(selectPrimaryPolyline);
+  const design = useEditor((state) => state.track.design);
   const designShapes = useEditor(selectDesignShapes);
   const activeSegmentSelection = useEditor(
     (state) => state.ui.segmentSelection
@@ -1006,28 +1044,26 @@ export default function ElevationChart({ className }: { className?: string }) {
   const routeMarkers = useMemo<ChartRouteMarker[]>(() => {
     if (!path) return [];
 
+    const obstacleNumberMap = getObstacleNumberMap(design);
     let splitIndex = 0;
-    return designShapes
+    const markerCandidates = designShapes
       .filter((shape) => shape.id !== path.id)
-      .flatMap((shape, index): ChartRouteMarker[] => {
+      .flatMap((shape): ChartRouteMarkerCandidate[] => {
         const marker = getShapeTimingMarker(shape);
-        if (marker?.role === "split") splitIndex += 1;
         const projection = projectPointOntoRoute(path, shape);
         if (!projection) return [];
         if (projection.pathDistance > getRouteMarkerTolerance(shape)) return [];
 
         if (marker) {
+          if (marker.role === "split") splitIndex += 1;
           const title = getTimingMarkerTitle(marker, splitIndex);
-          const ariaLabel = t("timingMarkerAria", {
-            label: title,
-          });
           return [
             {
-              ariaLabel,
               color: getTimingMarkerColor(marker),
               d: projection.d,
               id: `timing-${shape.id}`,
               shapeId: shape.id,
+              timingTitle: title,
               type: "timing",
             },
           ];
@@ -1037,19 +1073,40 @@ export default function ElevationChart({ className }: { className?: string }) {
 
         return [
           {
-            ariaLabel: t("obstacleMarkerAria", { index: index + 1 }),
             color: "#64748b",
             d: projection.d,
             id: `obstacle-${shape.id}`,
+            obstacleNumber: obstacleNumberMap.get(shape.id),
             shapeId: shape.id,
             type: "obstacle",
           },
         ];
-      })
+      });
+
+    let fallbackObstacleIndex = 0;
+    return markerCandidates
       .sort(
         (left, right) => left.d - right.d || left.id.localeCompare(right.id)
-      );
-  }, [designShapes, path, t]);
+      )
+      .map((marker) => {
+        if (marker.type === "timing") {
+          const { timingTitle, ...routeMarker } = marker;
+          return {
+            ...routeMarker,
+            ariaLabel: t("timingMarkerAria", { label: timingTitle }),
+          };
+        }
+
+        fallbackObstacleIndex += 1;
+        const { obstacleNumber, ...routeMarker } = marker;
+        return {
+          ...routeMarker,
+          ariaLabel: t("obstacleMarkerAria", {
+            index: obstacleNumber ?? fallbackObstacleIndex,
+          }),
+        };
+      });
+  }, [design, designShapes, path, t]);
 
   const warningMarkers = useMemo<ChartWarningMarker[]>(() => {
     if (!path) return [];

--- a/tests/components/inspector/ElevationChart.test.tsx
+++ b/tests/components/inspector/ElevationChart.test.tsx
@@ -63,6 +63,50 @@ function setupRoute() {
   return { routeId, timingGateId };
 }
 
+function setupRouteWithSplitMarkers() {
+  const state = resetEditorStore();
+  const routeId = state.addShape(
+    polylineDraft({
+      points: [
+        { x: 0, y: 0, z: 0 },
+        { x: 4, y: 0, z: 1 },
+      ],
+    })
+  );
+  state.addShape(
+    gateDraft({
+      x: 50,
+      y: 50,
+      meta: { timing: { role: "split" } },
+    })
+  );
+  const visibleSplitId = state.addShape(
+    gateDraft({
+      x: 4,
+      y: 0,
+      meta: { timing: { role: "split" } },
+    })
+  );
+  state.setSelection([routeId]);
+  return { routeId, visibleSplitId };
+}
+
+function setupRouteWithOffRouteObstacle() {
+  const state = resetEditorStore();
+  const routeId = state.addShape(
+    polylineDraft({
+      points: [
+        { x: 0, y: 0, z: 0 },
+        { x: 4, y: 0, z: 1 },
+      ],
+    })
+  );
+  state.addShape(gateDraft({ x: 50, y: 50 }));
+  const visibleGateId = state.addShape(gateDraft({ x: 4, y: 0 }));
+  state.setSelection([routeId]);
+  return { routeId, visibleGateId };
+}
+
 describe("ElevationChart", () => {
   afterEach(() => {
     cleanup();
@@ -140,6 +184,64 @@ describe("ElevationChart", () => {
     );
 
     expect(useEditor.getState().session.selection).toEqual([timingGateId]);
+  });
+
+  it("numbers visible split timing markers without counting off-route splits", () => {
+    const { visibleSplitId } = setupRouteWithSplitMarkers();
+    renderElevationChart();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open elevation details" })
+    );
+
+    expect(
+      screen.queryByRole("button", {
+        name: "Select timing marker Split 2 in elevation profile",
+      })
+    ).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Select timing marker Split 1 in elevation profile",
+      })
+    );
+
+    expect(useEditor.getState().session.selection).toEqual([visibleSplitId]);
+  });
+
+  it("uses the rendered timing marker color in the marker legend", () => {
+    setupRoute();
+    renderElevationChart();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open elevation details" })
+    );
+
+    const timingLegendDot = screen.getByText("Timing")
+      .previousElementSibling as HTMLElement | null;
+
+    expect(timingLegendDot?.style.background).toBe("#f59e0b");
+  });
+
+  it("labels obstacle markers with route obstacle numbers", () => {
+    const { visibleGateId } = setupRouteWithOffRouteObstacle();
+    renderElevationChart();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open elevation details" })
+    );
+
+    expect(
+      screen.queryByRole("button", {
+        name: "Select obstacle 2 in elevation profile",
+      })
+    ).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Select obstacle 1 in elevation profile",
+      })
+    );
+
+    expect(useEditor.getState().session.selection).toEqual([visibleGateId]);
   });
 
   it("offers warning segment jump actions in the details dialog", () => {

--- a/tests/components/inspector/ElevationChart.test.tsx
+++ b/tests/components/inspector/ElevationChart.test.tsx
@@ -91,6 +91,34 @@ function setupRouteWithSplitMarkers() {
   return { routeId, visibleSplitId };
 }
 
+function setupRouteWithRouteOrderedSplitMarkers() {
+  const state = resetEditorStore();
+  const routeId = state.addShape(
+    polylineDraft({
+      points: [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 1 },
+      ],
+    })
+  );
+  state.addShape(
+    gateDraft({
+      x: 8,
+      y: 0,
+      meta: { timing: { role: "split" } },
+    })
+  );
+  const firstRouteSplitId = state.addShape(
+    gateDraft({
+      x: 2,
+      y: 0,
+      meta: { timing: { role: "split" } },
+    })
+  );
+  state.setSelection([routeId]);
+  return { firstRouteSplitId, routeId };
+}
+
 function setupRouteWithOffRouteObstacle() {
   const state = resetEditorStore();
   const routeId = state.addShape(
@@ -105,6 +133,30 @@ function setupRouteWithOffRouteObstacle() {
   const visibleGateId = state.addShape(gateDraft({ x: 4, y: 0 }));
   state.setSelection([routeId]);
   return { routeId, visibleGateId };
+}
+
+function setupSelectedSecondaryRouteWithReversedObstacleOrder() {
+  const state = resetEditorStore();
+  state.addShape(
+    polylineDraft({
+      points: [
+        { x: 0, y: 0, z: 0 },
+        { x: 10, y: 0, z: 1 },
+      ],
+    })
+  );
+  const secondaryRouteId = state.addShape(
+    polylineDraft({
+      points: [
+        { x: 10, y: 0, z: 1 },
+        { x: 0, y: 0, z: 0 },
+      ],
+    })
+  );
+  const primaryFirstGateId = state.addShape(gateDraft({ x: 2, y: 0 }));
+  const secondaryFirstGateId = state.addShape(gateDraft({ x: 8, y: 0 }));
+  state.setSelection([secondaryRouteId]);
+  return { primaryFirstGateId, secondaryFirstGateId, secondaryRouteId };
 }
 
 describe("ElevationChart", () => {
@@ -208,6 +260,22 @@ describe("ElevationChart", () => {
     expect(useEditor.getState().session.selection).toEqual([visibleSplitId]);
   });
 
+  it("numbers split timing markers in visible route order", () => {
+    const { firstRouteSplitId } = setupRouteWithRouteOrderedSplitMarkers();
+    renderElevationChart();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open elevation details" })
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Select timing marker Split 1 in elevation profile",
+      })
+    );
+
+    expect(useEditor.getState().session.selection).toEqual([firstRouteSplitId]);
+  });
+
   it("uses the rendered timing marker color in the marker legend", () => {
     setupRoute();
     renderElevationChart();
@@ -242,6 +310,28 @@ describe("ElevationChart", () => {
     );
 
     expect(useEditor.getState().session.selection).toEqual([visibleGateId]);
+  });
+
+  it("falls back to selected route order for obstacle labels on non-primary routes", () => {
+    const { primaryFirstGateId, secondaryFirstGateId } =
+      setupSelectedSecondaryRouteWithReversedObstacleOrder();
+    renderElevationChart();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open elevation details" })
+    );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Select obstacle 1 in elevation profile",
+      })
+    );
+
+    expect(useEditor.getState().session.selection).toEqual([
+      secondaryFirstGateId,
+    ]);
+    expect(useEditor.getState().session.selection).not.toEqual([
+      primaryFirstGateId,
+    ]);
   });
 
   it("offers warning segment jump actions in the details dialog", () => {


### PR DESCRIPTION
## Summary
- Count split timing markers only after they pass the route projection/tolerance checks, so visible split labels do not skip numbers.
- Derive the timing legend color from the rendered timing marker colors instead of using a fixed split-blue dot.
- Label obstacle profile markers from the existing route obstacle numbering map, with visible route order as fallback.

## Validation
- `npm run test -- tests/components/inspector/ElevationChart.test.tsx tests/lib/track/polyline-derived.test.ts`
- `npm run type`
- `npm run lint`
- `npm run test`
- `npm run build`
- `npx prettier --check src/components/inspector/ElevationChart.tsx tests/components/inspector/ElevationChart.test.tsx`
- `git diff --check`

Follow-up for review comments on #574.