### PR TITLE
Fix magic link handoff and legal i18n

### DIFF
--- a/lang/de/login.json
+++ b/lang/de/login.json
@@ -39,5 +39,24 @@
     "passkeyNotFound": "Dieser Passkey konnte keinem TrackDraw-Konto zugeordnet werden. Versuche einen anderen Passkey oder nutze den Anmeldelink per E-Mail.",
     "passkeyFailed": "Anmeldung mit Passkey fehlgeschlagen.",
     "checkEmail": "Prüfe deine E-Mail auf einen Anmeldelink."
+  },
+  "magicLinkVerify": {
+    "eyebrow": "Sichere Anmeldung",
+    "secureSession": "Geschützte Magic-Link-Übergabe",
+    "needsNewLink": "Neuer Link erforderlich",
+    "autoTitle": "Du wirst angemeldet",
+    "autoDescription": "TrackDraw öffnet deinen Arbeitsbereich mit dem Anmeldelink aus deiner E-Mail.",
+    "title": "TrackDraw öffnen",
+    "description": "Fahre in diesem Browser fort, um die Anmeldung abzuschließen. So bleibt dein einmaliger Link vor automatischen E-Mail-Sicherheitsprüfungen geschützt.",
+    "statusEmail": "E-Mail-Link empfangen",
+    "statusVerify": "Anmeldelink wird geprüft",
+    "statusStudio": "Arbeitsbereich wird geöffnet",
+    "continue": "Weiter zu TrackDraw",
+    "continuing": "Weiter...",
+    "requestNewLink": "Neuen Link anfordern",
+    "backToLogin": "Zurück zur Anmeldung",
+    "invalidTitle": "Dieser Anmeldelink ist unvollständig",
+    "invalidDescription": "Fordere einen neuen Anmeldelink an und öffne die neueste TrackDraw-E-Mail.",
+    "failed": "Dieser Anmeldelink konnte nicht verwendet werden. Fordere einen neuen Link an und versuche es erneut."
   }
 }

--- a/lang/en/login.json
+++ b/lang/en/login.json
@@ -39,5 +39,24 @@
     "passkeyNotFound": "We couldn't match that passkey to your TrackDraw account. Try another passkey or use your email sign-in link.",
     "passkeyFailed": "Failed to sign in with passkey.",
     "checkEmail": "Check your email for a sign-in link."
+  },
+  "magicLinkVerify": {
+    "eyebrow": "Secure sign-in",
+    "secureSession": "Protected magic-link handoff",
+    "needsNewLink": "Fresh link needed",
+    "autoTitle": "Signing you in",
+    "autoDescription": "TrackDraw is opening your workspace with the sign-in link from your email.",
+    "title": "Open TrackDraw",
+    "description": "Continue from this browser to finish signing in. This protects your one-time link from automatic email security checks.",
+    "statusEmail": "Email link received",
+    "statusVerify": "Verifying your sign-in link",
+    "statusStudio": "Opening your workspace",
+    "continue": "Continue to TrackDraw",
+    "continuing": "Continuing...",
+    "requestNewLink": "Request a new link",
+    "backToLogin": "Back to login",
+    "invalidTitle": "This sign-in link is incomplete",
+    "invalidDescription": "Request a new sign-in link and open it from the latest TrackDraw email.",
+    "failed": "This sign-in link could not be used. Request a new link and try again."
   }
 }

--- a/lang/nl/login.json
+++ b/lang/nl/login.json
@@ -39,5 +39,24 @@
     "passkeyNotFound": "We konden die passkey niet koppelen aan je TrackDraw-account. Probeer een andere passkey of gebruik je e-mailinloglink.",
     "passkeyFailed": "Inloggen met passkey mislukt.",
     "checkEmail": "Controleer je e-mail voor een inloglink."
+  },
+  "magicLinkVerify": {
+    "eyebrow": "Veilig inloggen",
+    "secureSession": "Beschermde magic-link overdracht",
+    "needsNewLink": "Nieuwe link nodig",
+    "autoTitle": "Je wordt ingelogd",
+    "autoDescription": "TrackDraw opent je werkruimte met de inloglink uit je e-mail.",
+    "title": "Open TrackDraw",
+    "description": "Ga verder vanuit deze browser om het inloggen af te ronden. Zo blijft je eenmalige link beschermd tegen automatische e-mailcontroles.",
+    "statusEmail": "E-maillink ontvangen",
+    "statusVerify": "Je inloglink controleren",
+    "statusStudio": "Je werkruimte openen",
+    "continue": "Verder naar TrackDraw",
+    "continuing": "Doorgaan...",
+    "requestNewLink": "Nieuwe link aanvragen",
+    "backToLogin": "Terug naar inloggen",
+    "invalidTitle": "Deze inloglink is niet compleet",
+    "invalidDescription": "Vraag een nieuwe inloglink aan en open de nieuwste TrackDraw-mail.",
+    "failed": "Deze inloglink kon niet worden gebruikt. Vraag een nieuwe link aan en probeer het opnieuw."
   }
 }

--- a/scripts/i18n_hardcoded_allowlist.json
+++ b/scripts/i18n_hardcoded_allowlist.json
@@ -18,6 +18,15 @@
     "note": "Brand-only alt text is intentionally stable unless the image needs descriptive alt copy."
   },
   {
+    "file": "src/app/login/magic-link/MagicLinkConfirm.tsx",
+    "kind": "JSX prop alt",
+    "text": "TrackDraw",
+    "count": 2,
+    "group": "intentional-brand-alt",
+    "priority": "exception",
+    "note": "Brand-only alt text is intentionally stable unless the image needs descriptive alt copy."
+  },
+  {
     "file": "src/app/share/[token]/not-found.tsx",
     "kind": "JSX prop alt",
     "text": "TrackDraw",

--- a/src/app/login/magic-link/MagicLinkConfirm.tsx
+++ b/src/app/login/magic-link/MagicLinkConfirm.tsx
@@ -103,15 +103,16 @@ export function MagicLinkConfirm() {
   }, [canAutoVerify, handleContinue, verifyOptions]);
 
   const readyToVerify = Boolean(verifyOptions);
+  const isVerifying = pending || canAutoVerify;
   const showContinueButton = readyToVerify && !canAutoVerify;
   const title = !readyToVerify
     ? t("magicLinkVerify.invalidTitle")
-    : pending || canAutoVerify
+    : isVerifying
       ? t("magicLinkVerify.autoTitle")
       : t("magicLinkVerify.title");
   const description = !readyToVerify
     ? t("magicLinkVerify.invalidDescription")
-    : pending || canAutoVerify
+    : isVerifying
       ? t("magicLinkVerify.autoDescription")
       : t("magicLinkVerify.description");
   const statusItems = [
@@ -121,7 +122,7 @@ export function MagicLinkConfirm() {
     },
     {
       label: t("magicLinkVerify.statusVerify"),
-      state: readyToVerify ? "active" : "idle",
+      state: isVerifying ? "active" : "idle",
     },
     {
       label: t("magicLinkVerify.statusStudio"),
@@ -176,8 +177,10 @@ export function MagicLinkConfirm() {
             <div className="border-border/55 bg-muted/18 border-b px-6 py-5 sm:px-8">
               <div className="flex items-center gap-3">
                 <div className="bg-background text-foreground border-border/60 flex size-10 items-center justify-center rounded-2xl border">
-                  {readyToVerify ? (
+                  {isVerifying ? (
                     <Loader2 className="size-4 animate-spin" />
+                  ) : readyToVerify ? (
+                    <MailCheck className="size-4" />
                   ) : (
                     <AlertTriangle className="size-4" />
                   )}

--- a/src/app/login/magic-link/MagicLinkConfirm.tsx
+++ b/src/app/login/magic-link/MagicLinkConfirm.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Check,
+  Loader2,
+  MailCheck,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  authClient,
+  canAutoVerifyMagicLink,
+  clearMagicLinkRequestMarker,
+  type MagicLinkVerifyOptions,
+} from "@/lib/auth-client";
+
+function getVerifyOptions(
+  searchParams: URLSearchParams
+): MagicLinkVerifyOptions | null {
+  const token = searchParams.get("token")?.trim();
+  if (!token) return null;
+
+  return {
+    token,
+    callbackURL: searchParams.get("callbackURL") ?? undefined,
+    newUserCallbackURL: searchParams.get("newUserCallbackURL") ?? undefined,
+    errorCallbackURL: searchParams.get("errorCallbackURL") ?? undefined,
+  };
+}
+
+function getSafeRedirectPath(value: string | undefined) {
+  if (typeof window === "undefined" || !value) {
+    return "/studio";
+  }
+
+  try {
+    const url = new URL(value, window.location.origin);
+    if (url.origin !== window.location.origin) {
+      return "/studio";
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return "/studio";
+  }
+}
+
+export function MagicLinkConfirm() {
+  const t = useTranslations("login");
+  const searchParams = useSearchParams();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const autoVerifyAttempted = useRef(false);
+  const verifyOptions = useMemo(
+    () => getVerifyOptions(searchParams),
+    [searchParams]
+  );
+  const canAutoVerify = useMemo(
+    () => canAutoVerifyMagicLink(verifyOptions?.callbackURL ?? null),
+    [verifyOptions?.callbackURL]
+  );
+
+  const handleContinue = useCallback(async () => {
+    if (!verifyOptions || pending) return;
+
+    setPending(true);
+    setError(null);
+
+    try {
+      const response = await authClient.magicLink.verify(verifyOptions);
+      if (response?.error) {
+        throw new Error(
+          response.error.message || response.error.code || "INVALID_TOKEN"
+        );
+      }
+
+      clearMagicLinkRequestMarker();
+      window.location.href = getSafeRedirectPath(verifyOptions.callbackURL);
+    } catch (verifyError) {
+      void verifyError;
+      setError(t("magicLinkVerify.failed"));
+      setPending(false);
+    }
+  }, [pending, t, verifyOptions]);
+
+  useEffect(() => {
+    if (!verifyOptions || !canAutoVerify || autoVerifyAttempted.current) {
+      return;
+    }
+
+    autoVerifyAttempted.current = true;
+    const timeout = window.setTimeout(() => {
+      void handleContinue();
+    }, 450);
+
+    return () => window.clearTimeout(timeout);
+  }, [canAutoVerify, handleContinue, verifyOptions]);
+
+  const readyToVerify = Boolean(verifyOptions);
+  const showContinueButton = readyToVerify && !canAutoVerify;
+  const title = !readyToVerify
+    ? t("magicLinkVerify.invalidTitle")
+    : pending || canAutoVerify
+      ? t("magicLinkVerify.autoTitle")
+      : t("magicLinkVerify.title");
+  const description = !readyToVerify
+    ? t("magicLinkVerify.invalidDescription")
+    : pending || canAutoVerify
+      ? t("magicLinkVerify.autoDescription")
+      : t("magicLinkVerify.description");
+  const statusItems = [
+    {
+      label: t("magicLinkVerify.statusEmail"),
+      state: "done",
+    },
+    {
+      label: t("magicLinkVerify.statusVerify"),
+      state: readyToVerify ? "active" : "idle",
+    },
+    {
+      label: t("magicLinkVerify.statusStudio"),
+      state: "idle",
+    },
+  ] as const;
+
+  return (
+    <main className="bg-background text-foreground relative min-h-screen overflow-hidden">
+      <div className="bg-brand-primary/10 absolute top-16 left-1/2 hidden h-72 w-72 -translate-x-[135%] rounded-full blur-3xl sm:block" />
+      <div className="bg-brand-secondary/10 absolute right-0 bottom-10 hidden h-80 w-80 translate-x-1/4 rounded-full blur-3xl sm:block" />
+
+      <div className="relative mx-auto flex min-h-screen w-full max-w-4xl flex-col px-6 py-6 sm:px-8 lg:px-10">
+        <header className="flex items-center justify-between">
+          <Link
+            href="/"
+            className="flex items-center rounded-sm opacity-90 transition-opacity hover:opacity-100"
+            aria-label={t("goHome")}
+          >
+            <span className="relative block h-8 w-36 sm:h-9 sm:w-40">
+              <Image
+                src="/assets/brand/trackdraw-logo-mono-lightbg.svg"
+                alt="TrackDraw"
+                fill
+                priority
+                unoptimized
+                className="object-contain dark:hidden"
+                draggable={false}
+              />
+              <Image
+                src="/assets/brand/trackdraw-logo-mono-darkbg.svg"
+                alt="TrackDraw"
+                fill
+                priority
+                unoptimized
+                className="hidden object-contain dark:block"
+                draggable={false}
+              />
+            </span>
+          </Link>
+
+          <Link
+            href="/login"
+            className="text-muted-foreground hover:text-foreground text-sm transition-colors"
+          >
+            {t("magicLinkVerify.backToLogin")}
+          </Link>
+        </header>
+
+        <div className="flex flex-1 items-center justify-center py-10">
+          <section className="border-border/70 bg-card/94 w-full max-w-lg overflow-hidden rounded-3xl border shadow-[0_24px_80px_rgba(15,23,42,0.10)] backdrop-blur-xl sm:rounded-[1.75rem]">
+            <div className="border-border/55 bg-muted/18 border-b px-6 py-5 sm:px-8">
+              <div className="flex items-center gap-3">
+                <div className="bg-background text-foreground border-border/60 flex size-10 items-center justify-center rounded-2xl border">
+                  {readyToVerify ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <AlertTriangle className="size-4" />
+                  )}
+                </div>
+                <div className="min-w-0">
+                  <p className="text-muted-foreground text-[11px] font-semibold tracking-[0.18em] uppercase">
+                    {t("magicLinkVerify.eyebrow")}
+                  </p>
+                  <p className="text-sm font-medium">
+                    {readyToVerify
+                      ? t("magicLinkVerify.secureSession")
+                      : t("magicLinkVerify.needsNewLink")}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-6 sm:p-8">
+              <div className="space-y-2">
+                <h1 className="text-2xl font-semibold tracking-tight sm:text-[1.7rem]">
+                  {title}
+                </h1>
+                <p className="text-muted-foreground text-sm leading-relaxed">
+                  {description}
+                </p>
+              </div>
+
+              <div className="border-border/60 bg-background/55 mt-6 rounded-2xl border px-4 py-4">
+                <div className="space-y-3">
+                  {statusItems.map((item, index) => (
+                    <div key={item.label} className="flex items-center gap-3">
+                      <span
+                        className={
+                          item.state === "done"
+                            ? "bg-brand-primary flex size-7 shrink-0 items-center justify-center rounded-full text-white"
+                            : item.state === "active"
+                              ? "border-brand-primary/45 text-brand-primary bg-brand-primary/8 flex size-7 shrink-0 items-center justify-center rounded-full border"
+                              : "border-border bg-muted/40 text-muted-foreground flex size-7 shrink-0 items-center justify-center rounded-full border"
+                        }
+                      >
+                        {item.state === "done" ? (
+                          <Check className="size-3.5" />
+                        ) : item.state === "active" ? (
+                          <Loader2 className="size-3.5 animate-spin" />
+                        ) : (
+                          <span className="text-[11px] font-semibold">
+                            {index + 1}
+                          </span>
+                        )}
+                      </span>
+                      <span
+                        className={
+                          item.state === "idle"
+                            ? "text-muted-foreground text-sm"
+                            : "text-foreground text-sm font-medium"
+                        }
+                      >
+                        {item.label}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {error ? (
+                <div
+                  role="alert"
+                  className="mt-5 rounded-xl border border-rose-500/20 bg-rose-500/8 px-3.5 py-3 text-sm text-rose-600 dark:text-rose-300"
+                >
+                  {error}
+                </div>
+              ) : null}
+
+              <div className="mt-7 space-y-3">
+                {showContinueButton ? (
+                  <Button
+                    type="button"
+                    className="h-11 w-full"
+                    disabled={pending}
+                    aria-busy={pending}
+                    onClick={handleContinue}
+                  >
+                    <ArrowRight className="size-4" />
+                    {pending
+                      ? t("magicLinkVerify.continuing")
+                      : t("magicLinkVerify.continue")}
+                  </Button>
+                ) : null}
+
+                <Button
+                  type="button"
+                  variant={readyToVerify ? "ghost" : "outline"}
+                  className="h-11 w-full"
+                  asChild
+                >
+                  <Link href="/login">
+                    <MailCheck className="size-4" />
+                    {t("magicLinkVerify.requestNewLink")}
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/login/magic-link/page.tsx
+++ b/src/app/login/magic-link/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { getTranslations } from "next-intl/server";
+import { MagicLinkConfirm } from "./MagicLinkConfirm";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("login.magicLinkVerify");
+
+  return {
+    title: t("title"),
+    robots: {
+      index: false,
+      follow: false,
+    },
+  };
+}
+
+export default function MagicLinkPage() {
+  return (
+    <Suspense>
+      <MagicLinkConfirm />
+    </Suspense>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -14,7 +14,11 @@ import {
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { authClient, isDevAuthShimEnabled } from "@/lib/auth-client";
+import {
+  authClient,
+  isDevAuthShimEnabled,
+  markMagicLinkRequested,
+} from "@/lib/auth-client";
 
 function getLoginCallbackURL() {
   if (typeof window === "undefined") {
@@ -81,6 +85,7 @@ export default function LoginPage() {
         newUserCallbackURL: callbackURL,
       });
 
+      markMagicLinkRequested(callbackURL);
       toast.success(t("signIn.checkEmail"));
       setEmailSent(true);
     } catch (authError) {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { Footer } from "@/components/landing/Footer";
 import { PublicSiteHeader } from "@/components/landing/PublicSiteHeader";
+import LanguageProvider from "@/i18n/LanguageProvider";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("legal");
@@ -71,78 +72,80 @@ export default async function PrivacyPage() {
   ];
 
   return (
-    <div className="bg-background text-foreground min-h-screen">
-      <PublicSiteHeader currentPage="legal" />
+    <LanguageProvider namespaces={["common", "landing"]}>
+      <div className="bg-background text-foreground min-h-screen">
+        <PublicSiteHeader currentPage="legal" />
 
-      <main>
-        <section className="border-border/40 border-b">
-          <div className="mx-auto w-full max-w-4xl px-6 py-14 sm:py-20">
-            <p className="text-brand-primary text-[11px] font-semibold tracking-[0.2em] uppercase">
-              {t("privacy.breadcrumbLegal")}
-            </p>
-            <h1 className="mt-4 text-4xl leading-tight font-semibold tracking-normal sm:text-5xl">
-              {t("privacy.pageTitle")}
-            </h1>
-            <p className="text-muted-foreground mt-5 max-w-2xl text-sm leading-7">
-              {t("privacy.effectiveDate")}
-            </p>
-          </div>
-        </section>
-
-        <section>
-          <div className="mx-auto w-full max-w-4xl px-6 py-12 sm:py-16">
-            <div className="space-y-10">
-              {sections.map((section) => (
-                <section key={section.title}>
-                  <h2 className="text-xl font-semibold tracking-normal">
-                    {section.title}
-                  </h2>
-                  <div className="text-muted-foreground mt-3 space-y-3 text-sm leading-7">
-                    {section.body.map((item, i) =>
-                      typeof item === "string" ? (
-                        <p key={i}>{item}</p>
-                      ) : (
-                        <div key={i} className="space-y-2">
-                          <p>{item.intro}</p>
-                          <ul className="list-disc space-y-1.5 pl-5">
-                            {item.list.map((li) => (
-                              <li key={li}>{li}</li>
-                            ))}
-                          </ul>
-                        </div>
-                      )
-                    )}
-                  </div>
-                </section>
-              ))}
-
-              <section className="border-border/50 bg-muted/18 rounded-2xl border p-6">
-                <h2 className="text-xl font-semibold tracking-normal">
-                  {t("privacy.s10Title")}
-                </h2>
-                <p className="text-muted-foreground mt-3 text-sm leading-7">
-                  {t("privacy.s10Body")}
-                </p>
-              </section>
-
-              <p className="text-muted-foreground text-sm leading-7">
-                {t.rich("privacy.seeTerms", {
-                  link: (chunks) => (
-                    <Link
-                      href="/terms"
-                      className="text-brand-primary hover:text-brand-primary/85 font-medium transition-colors"
-                    >
-                      {chunks}
-                    </Link>
-                  ),
-                })}
+        <main>
+          <section className="border-border/40 border-b">
+            <div className="mx-auto w-full max-w-4xl px-6 py-14 sm:py-20">
+              <p className="text-brand-primary text-[11px] font-semibold tracking-[0.2em] uppercase">
+                {t("privacy.breadcrumbLegal")}
+              </p>
+              <h1 className="mt-4 text-4xl leading-tight font-semibold tracking-normal sm:text-5xl">
+                {t("privacy.pageTitle")}
+              </h1>
+              <p className="text-muted-foreground mt-5 max-w-2xl text-sm leading-7">
+                {t("privacy.effectiveDate")}
               </p>
             </div>
-          </div>
-        </section>
-      </main>
+          </section>
 
-      <Footer />
-    </div>
+          <section>
+            <div className="mx-auto w-full max-w-4xl px-6 py-12 sm:py-16">
+              <div className="space-y-10">
+                {sections.map((section) => (
+                  <section key={section.title}>
+                    <h2 className="text-xl font-semibold tracking-normal">
+                      {section.title}
+                    </h2>
+                    <div className="text-muted-foreground mt-3 space-y-3 text-sm leading-7">
+                      {section.body.map((item, i) =>
+                        typeof item === "string" ? (
+                          <p key={i}>{item}</p>
+                        ) : (
+                          <div key={i} className="space-y-2">
+                            <p>{item.intro}</p>
+                            <ul className="list-disc space-y-1.5 pl-5">
+                              {item.list.map((li) => (
+                                <li key={li}>{li}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )
+                      )}
+                    </div>
+                  </section>
+                ))}
+
+                <section className="border-border/50 bg-muted/18 rounded-2xl border p-6">
+                  <h2 className="text-xl font-semibold tracking-normal">
+                    {t("privacy.s10Title")}
+                  </h2>
+                  <p className="text-muted-foreground mt-3 text-sm leading-7">
+                    {t("privacy.s10Body")}
+                  </p>
+                </section>
+
+                <p className="text-muted-foreground text-sm leading-7">
+                  {t.rich("privacy.seeTerms", {
+                    link: (chunks) => (
+                      <Link
+                        href="/terms"
+                        className="text-brand-primary hover:text-brand-primary/85 font-medium transition-colors"
+                      >
+                        {chunks}
+                      </Link>
+                    ),
+                  })}
+                </p>
+              </div>
+            </div>
+          </section>
+        </main>
+
+        <Footer />
+      </div>
+    </LanguageProvider>
   );
 }

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { getTranslations } from "next-intl/server";
 import { Footer } from "@/components/landing/Footer";
 import { PublicSiteHeader } from "@/components/landing/PublicSiteHeader";
+import LanguageProvider from "@/i18n/LanguageProvider";
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("legal");
@@ -58,67 +59,69 @@ export default async function TermsPage() {
   ];
 
   return (
-    <div className="bg-background text-foreground min-h-screen">
-      <PublicSiteHeader currentPage="legal" />
+    <LanguageProvider namespaces={["common", "landing"]}>
+      <div className="bg-background text-foreground min-h-screen">
+        <PublicSiteHeader currentPage="legal" />
 
-      <main>
-        <section className="border-border/40 border-b">
-          <div className="mx-auto w-full max-w-4xl px-6 py-14 sm:py-20">
-            <p className="text-brand-primary text-[11px] font-semibold tracking-[0.2em] uppercase">
-              {t("terms.breadcrumbLegal")}
-            </p>
-            <h1 className="mt-4 text-4xl leading-tight font-semibold tracking-normal sm:text-5xl">
-              {t("terms.pageTitle")}
-            </h1>
-            <p className="text-muted-foreground mt-5 max-w-2xl text-sm leading-7">
-              {t("terms.effectiveDate")}
-            </p>
-          </div>
-        </section>
-
-        <section>
-          <div className="mx-auto w-full max-w-4xl px-6 py-12 sm:py-16">
-            <div className="space-y-10">
-              {sections.map((section) => (
-                <section key={section.title}>
-                  <h2 className="text-xl font-semibold tracking-normal">
-                    {section.title}
-                  </h2>
-                  <div className="text-muted-foreground mt-3 space-y-3 text-sm leading-7">
-                    {section.body.map((paragraph, i) => (
-                      <p key={i}>{paragraph}</p>
-                    ))}
-                  </div>
-                </section>
-              ))}
-
-              <section className="border-border/50 bg-muted/18 rounded-2xl border p-6">
-                <h2 className="text-xl font-semibold tracking-normal">
-                  {t("terms.s10Title")}
-                </h2>
-                <p className="text-muted-foreground mt-3 text-sm leading-7">
-                  {t("terms.s10Body")}
-                </p>
-              </section>
-
-              <p className="text-muted-foreground text-sm leading-7">
-                {t.rich("terms.seePrivacy", {
-                  link: (chunks) => (
-                    <Link
-                      href="/privacy"
-                      className="text-brand-primary hover:text-brand-primary/85 font-medium transition-colors"
-                    >
-                      {chunks}
-                    </Link>
-                  ),
-                })}
+        <main>
+          <section className="border-border/40 border-b">
+            <div className="mx-auto w-full max-w-4xl px-6 py-14 sm:py-20">
+              <p className="text-brand-primary text-[11px] font-semibold tracking-[0.2em] uppercase">
+                {t("terms.breadcrumbLegal")}
+              </p>
+              <h1 className="mt-4 text-4xl leading-tight font-semibold tracking-normal sm:text-5xl">
+                {t("terms.pageTitle")}
+              </h1>
+              <p className="text-muted-foreground mt-5 max-w-2xl text-sm leading-7">
+                {t("terms.effectiveDate")}
               </p>
             </div>
-          </div>
-        </section>
-      </main>
+          </section>
 
-      <Footer />
-    </div>
+          <section>
+            <div className="mx-auto w-full max-w-4xl px-6 py-12 sm:py-16">
+              <div className="space-y-10">
+                {sections.map((section) => (
+                  <section key={section.title}>
+                    <h2 className="text-xl font-semibold tracking-normal">
+                      {section.title}
+                    </h2>
+                    <div className="text-muted-foreground mt-3 space-y-3 text-sm leading-7">
+                      {section.body.map((paragraph, i) => (
+                        <p key={i}>{paragraph}</p>
+                      ))}
+                    </div>
+                  </section>
+                ))}
+
+                <section className="border-border/50 bg-muted/18 rounded-2xl border p-6">
+                  <h2 className="text-xl font-semibold tracking-normal">
+                    {t("terms.s10Title")}
+                  </h2>
+                  <p className="text-muted-foreground mt-3 text-sm leading-7">
+                    {t("terms.s10Body")}
+                  </p>
+                </section>
+
+                <p className="text-muted-foreground text-sm leading-7">
+                  {t.rich("terms.seePrivacy", {
+                    link: (chunks) => (
+                      <Link
+                        href="/privacy"
+                        className="text-brand-primary hover:text-brand-primary/85 font-medium transition-colors"
+                      >
+                        {chunks}
+                      </Link>
+                    ),
+                  })}
+                </p>
+              </div>
+            </div>
+          </section>
+        </main>
+
+        <Footer />
+      </div>
+    </LanguageProvider>
   );
 }

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -34,6 +34,13 @@ type MagicLinkSignInOptions = {
   newUserCallbackURL?: string;
 };
 
+export type MagicLinkVerifyOptions = {
+  token: string;
+  callbackURL?: string;
+  newUserCallbackURL?: string;
+  errorCallbackURL?: string;
+};
+
 type SignOutOptions = {
   fetchOptions?: {
     onSuccess?: () => void;
@@ -43,6 +50,8 @@ type SignOutOptions = {
 const DEV_AUTH_SESSION_KEY = "trackdraw-dev-auth-session";
 const DEV_AUTH_PROFILES_KEY = "trackdraw-dev-auth-profiles";
 const DEV_AUTH_ROLE_KEY = "trackdraw-dev-auth-role";
+const MAGIC_LINK_REQUEST_KEY = "trackdraw-magic-link-request";
+const MAGIC_LINK_REQUEST_TTL_MS = 15 * 60 * 1000;
 const DEV_AUTH_EVENT = "trackdraw-dev-auth-change";
 let devSessionCache: AuthSessionData | null = null;
 let devSessionCacheLoaded = false;
@@ -109,6 +118,87 @@ function readDevAuthRole() {
 
 function normalizeEmail(email: string) {
   return email.trim().toLowerCase();
+}
+
+function readMagicLinkRequestMarker(now = Date.now()) {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const rawValue = window.localStorage.getItem(MAGIC_LINK_REQUEST_KEY);
+    if (!rawValue) return null;
+
+    const parsedValue = JSON.parse(rawValue) as {
+      requestedAt?: unknown;
+      callbackURL?: unknown;
+    };
+    const requestedAt =
+      typeof parsedValue.requestedAt === "number"
+        ? parsedValue.requestedAt
+        : null;
+
+    if (!requestedAt || now - requestedAt > MAGIC_LINK_REQUEST_TTL_MS) {
+      window.localStorage.removeItem(MAGIC_LINK_REQUEST_KEY);
+      return null;
+    }
+
+    return {
+      requestedAt,
+      callbackURL:
+        typeof parsedValue.callbackURL === "string"
+          ? parsedValue.callbackURL
+          : null,
+    };
+  } catch {
+    window.localStorage.removeItem(MAGIC_LINK_REQUEST_KEY);
+    return null;
+  }
+}
+
+export function markMagicLinkRequested(callbackURL: string) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(
+    MAGIC_LINK_REQUEST_KEY,
+    JSON.stringify({
+      requestedAt: Date.now(),
+      callbackURL,
+    })
+  );
+}
+
+export function clearMagicLinkRequestMarker() {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.removeItem(MAGIC_LINK_REQUEST_KEY);
+}
+
+export function canAutoVerifyMagicLink(callbackURL: string | null) {
+  const marker = readMagicLinkRequestMarker();
+  if (!marker) return false;
+
+  return (
+    !callbackURL || !marker.callbackURL || marker.callbackURL === callbackURL
+  );
+}
+
+function normalizeMagicLinkSignInOptions(options: MagicLinkSignInOptions) {
+  if (
+    options.callbackURL &&
+    options.newUserCallbackURL &&
+    options.callbackURL === options.newUserCallbackURL
+  ) {
+    const normalizedOptions = { ...options };
+    delete normalizedOptions.newUserCallbackURL;
+    return normalizedOptions;
+  }
+
+  return options;
 }
 
 function readDevAuthProfiles(): Record<string, DevAuthProfileRecord> {
@@ -365,7 +455,9 @@ export const authClient = {
         return;
       }
 
-      return betterAuthClient.signIn.magicLink(options);
+      return betterAuthClient.signIn.magicLink(
+        normalizeMagicLinkSignInOptions(options)
+      );
     },
     async passkey() {
       if (isDevAuthShimEnabled()) {
@@ -390,6 +482,34 @@ export const authClient = {
       };
 
       return clientWithPasskey.signIn.passkey();
+    },
+  },
+  magicLink: {
+    async verify(options: MagicLinkVerifyOptions) {
+      if (isDevAuthShimEnabled()) {
+        if (typeof window !== "undefined") {
+          window.location.href = options.callbackURL ?? "/studio";
+        }
+        return;
+      }
+
+      const clientWithMagicLink =
+        betterAuthClient as typeof betterAuthClient & {
+          magicLink: {
+            verify: (input: {
+              query: Pick<MagicLinkVerifyOptions, "token">;
+            }) => Promise<{
+              data: unknown;
+              error: { message?: string; code?: string } | null;
+            }>;
+          };
+        };
+
+      return clientWithMagicLink.magicLink.verify({
+        query: {
+          token: options.token,
+        },
+      });
     },
   },
   async preloadPasskeyAutoFill() {

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -104,6 +104,14 @@ const betterAuthClient = createAuthClient({
   plugins: [magicLinkClient(), passkeyClient()],
 });
 
+function removeLocalStorageItem(key: string) {
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Storage may be blocked in private or hardened browser contexts.
+  }
+}
+
 export function isDevAuthShimEnabled() {
   return process.env.NODE_ENV === "development";
 }
@@ -139,7 +147,7 @@ function readMagicLinkRequestMarker(now = Date.now()) {
         : null;
 
     if (!requestedAt || now - requestedAt > MAGIC_LINK_REQUEST_TTL_MS) {
-      window.localStorage.removeItem(MAGIC_LINK_REQUEST_KEY);
+      removeLocalStorageItem(MAGIC_LINK_REQUEST_KEY);
       return null;
     }
 
@@ -151,7 +159,7 @@ function readMagicLinkRequestMarker(now = Date.now()) {
           : null,
     };
   } catch {
-    window.localStorage.removeItem(MAGIC_LINK_REQUEST_KEY);
+    removeLocalStorageItem(MAGIC_LINK_REQUEST_KEY);
     return null;
   }
 }
@@ -161,13 +169,17 @@ export function markMagicLinkRequested(callbackURL: string) {
     return;
   }
 
-  window.localStorage.setItem(
-    MAGIC_LINK_REQUEST_KEY,
-    JSON.stringify({
-      requestedAt: Date.now(),
-      callbackURL,
-    })
-  );
+  try {
+    window.localStorage.setItem(
+      MAGIC_LINK_REQUEST_KEY,
+      JSON.stringify({
+        requestedAt: Date.now(),
+        callbackURL,
+      })
+    );
+  } catch {
+    // Magic-link sign-in should still work when browser storage is unavailable.
+  }
 }
 
 export function clearMagicLinkRequestMarker() {
@@ -175,7 +187,7 @@ export function clearMagicLinkRequestMarker() {
     return;
   }
 
-  window.localStorage.removeItem(MAGIC_LINK_REQUEST_KEY);
+  removeLocalStorageItem(MAGIC_LINK_REQUEST_KEY);
 }
 
 export function canAutoVerifyMagicLink(callbackURL: string | null) {

--- a/src/lib/server/auth-email.ts
+++ b/src/lib/server/auth-email.ts
@@ -224,7 +224,16 @@ function buildEmailShell({
   `.trim();
 }
 
+export function buildMagicLinkConfirmationUrl(url: string) {
+  const verifyUrl = new URL(url);
+  const confirmationUrl = new URL("/login/magic-link", verifyUrl.origin);
+  confirmationUrl.search = verifyUrl.search;
+  return confirmationUrl.toString();
+}
+
 export function buildMagicLinkEmail(url: string): AuthEmailContent {
+  const confirmationUrl = buildMagicLinkConfirmationUrl(url);
+
   return {
     subject: "Your TrackDraw sign-in link",
     htmlBody: buildEmailShell({
@@ -233,12 +242,12 @@ export function buildMagicLinkEmail(url: string): AuthEmailContent {
       intro:
         "Use the button below to sign in and reopen your TrackDraw projects. This link expires in 10 minutes.",
       actionLabel: "Open TrackDraw",
-      url,
+      url: confirmationUrl,
       note: "This sign-in link is intended for you only. If you did not request it, you can safely ignore this email.",
     }),
     textBody:
       `Sign in to TrackDraw\n\n` +
-      `Open this one-time sign-in link within 10 minutes:\n${url}\n\n` +
+      `Open this one-time sign-in link within 10 minutes:\n${confirmationUrl}\n\n` +
       `If you did not request this email, you can ignore it.`,
   };
 }

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -217,7 +217,7 @@ export async function getAuth() {
         },
         sendMagicLink: async ({ email: recipient, url, token }) => {
           const [
-            { buildMagicLinkEmail },
+            { buildMagicLinkConfirmationUrl, buildMagicLinkEmail },
             { isPlunkConfigured, sendPlunkMail },
           ] = await Promise.all([loadAuthEmailModule(), loadPlunkModule()]);
 
@@ -242,8 +242,9 @@ export async function getAuth() {
           }
 
           if (isLocalAuthDeliveryFallbackAllowed()) {
+            const confirmationUrl = buildMagicLinkConfirmationUrl(url);
             console.info(
-              `[TrackDraw auth] Magic link for ${recipient}: ${url} (token: ${token})`
+              `[TrackDraw auth] Magic link for ${recipient}: ${confirmationUrl} (token: ${token})`
             );
             return;
           }

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -215,7 +215,7 @@ export async function getAuth() {
           window: 900,
           max: 3,
         },
-        sendMagicLink: async ({ email: recipient, url, token }) => {
+        sendMagicLink: async ({ email: recipient, url }) => {
           const [
             { buildMagicLinkConfirmationUrl, buildMagicLinkEmail },
             { isPlunkConfigured, sendPlunkMail },
@@ -244,7 +244,7 @@ export async function getAuth() {
           if (isLocalAuthDeliveryFallbackAllowed()) {
             const confirmationUrl = buildMagicLinkConfirmationUrl(url);
             console.info(
-              `[TrackDraw auth] Magic link for ${recipient}: ${confirmationUrl} (token: ${token})`
+              `[TrackDraw auth] Magic link for ${recipient}: ${confirmationUrl}`
             );
             return;
           }

--- a/tests/lib/auth-client.test.ts
+++ b/tests/lib/auth-client.test.ts
@@ -9,6 +9,7 @@ const signOutMock = vi.fn();
 const deleteUserMock = vi.fn();
 const updateUserMock = vi.fn();
 const magicLinkMock = vi.fn();
+const magicLinkVerifyMock = vi.fn();
 const passkeySignInMock = vi.fn();
 let restoreStorage: (() => void) | null = null;
 
@@ -29,6 +30,9 @@ vi.mock("better-auth/react", () => ({
     signIn: {
       magicLink: magicLinkMock,
       passkey: passkeySignInMock,
+    },
+    magicLink: {
+      verify: magicLinkVerifyMock,
     },
   })),
 }));
@@ -55,6 +59,7 @@ describe("authClient session resolution", () => {
 
     signOutMock.mockResolvedValue(undefined);
     deleteUserMock.mockResolvedValue(undefined);
+    magicLinkVerifyMock.mockResolvedValue({ data: {}, error: null });
 
     vi.stubGlobal(
       "fetch",
@@ -200,6 +205,74 @@ describe("authClient session resolution", () => {
       callbackURL: "/studio",
     });
     expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("omits duplicate new-user callback URLs from magic-link sign-in", async () => {
+    const { authClient } = await import("@/lib/auth-client");
+
+    await authClient.signIn.magicLink({
+      email: "pilot@trackdraw.local",
+      callbackURL: "/studio/2/project-1",
+      newUserCallbackURL: "/studio/2/project-1",
+    });
+
+    expect(magicLinkMock).toHaveBeenCalledWith({
+      email: "pilot@trackdraw.local",
+      callbackURL: "/studio/2/project-1",
+    });
+  });
+
+  it("keeps distinct new-user callback URLs for magic-link sign-in", async () => {
+    const { authClient } = await import("@/lib/auth-client");
+
+    await authClient.signIn.magicLink({
+      email: "pilot@trackdraw.local",
+      callbackURL: "/studio",
+      newUserCallbackURL: "/studio/2/project-1",
+    });
+
+    expect(magicLinkMock).toHaveBeenCalledWith({
+      email: "pilot@trackdraw.local",
+      callbackURL: "/studio",
+      newUserCallbackURL: "/studio/2/project-1",
+    });
+  });
+
+  it("tracks recent magic-link requests for same-browser handoff", async () => {
+    const {
+      canAutoVerifyMagicLink,
+      clearMagicLinkRequestMarker,
+      markMagicLinkRequested,
+    } = await import("@/lib/auth-client");
+
+    expect(canAutoVerifyMagicLink("/studio")).toBe(false);
+
+    markMagicLinkRequested("/studio");
+
+    expect(canAutoVerifyMagicLink("/studio")).toBe(true);
+    expect(canAutoVerifyMagicLink(null)).toBe(true);
+    expect(canAutoVerifyMagicLink("/gallery")).toBe(false);
+
+    clearMagicLinkRequestMarker();
+
+    expect(canAutoVerifyMagicLink("/studio")).toBe(false);
+  });
+
+  it("verifies magic links through Better Auth without forwarding redirect URLs", async () => {
+    const { authClient } = await import("@/lib/auth-client");
+
+    await authClient.magicLink.verify({
+      token: "token-1",
+      callbackURL: "/studio/2/project-1",
+      newUserCallbackURL: "/welcome",
+      errorCallbackURL: "/login",
+    });
+
+    expect(magicLinkVerifyMock).toHaveBeenCalledWith({
+      query: {
+        token: "token-1",
+      },
+    });
   });
 
   it("trims profile names before updating the Better Auth user", async () => {

--- a/tests/lib/auth-client.test.ts
+++ b/tests/lib/auth-client.test.ts
@@ -2,7 +2,11 @@
 
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createMemoryStorage, installWindowStorage } from "../helpers/storage";
+import {
+  createMemoryStorage,
+  createThrowingStorage,
+  installWindowStorage,
+} from "../helpers/storage";
 
 const useSessionMock = vi.fn();
 const signOutMock = vi.fn();
@@ -256,6 +260,20 @@ describe("authClient session resolution", () => {
     clearMagicLinkRequestMarker();
 
     expect(canAutoVerifyMagicLink("/studio")).toBe(false);
+  });
+
+  it("keeps magic-link sign-in usable when browser storage is unavailable", async () => {
+    restoreStorage?.();
+    restoreStorage = installWindowStorage(createThrowingStorage());
+    const {
+      canAutoVerifyMagicLink,
+      clearMagicLinkRequestMarker,
+      markMagicLinkRequested,
+    } = await import("@/lib/auth-client");
+
+    expect(() => markMagicLinkRequested("/studio")).not.toThrow();
+    expect(canAutoVerifyMagicLink("/studio")).toBe(false);
+    expect(() => clearMagicLinkRequestMarker()).not.toThrow();
   });
 
   it("verifies magic links through Better Auth without forwarding redirect URLs", async () => {

--- a/tests/lib/server/auth-email.test.ts
+++ b/tests/lib/server/auth-email.test.ts
@@ -5,6 +5,7 @@ vi.mock("server-only", () => ({}));
 import {
   buildChangeEmailConfirmationEmail,
   buildEmailVerificationEmail,
+  buildMagicLinkConfirmationUrl,
   buildMagicLinkEmail,
   getAuthEmailPreviewContent,
 } from "@/lib/server/auth-email";
@@ -26,7 +27,24 @@ describe("auth email templates", () => {
       "https://preview.trackdraw.app/assets/brand/trackdraw-logo-color-darkbg@2x.png"
     );
     expect(email.htmlBody).toContain("Open TrackDraw");
+    expect(email.htmlBody).toContain(
+      "https://preview.trackdraw.app/login/magic-link?token=abc"
+    );
+    expect(email.htmlBody).not.toContain("/api/auth/magic-link/verify");
     expect(email.textBody).toContain("Open this one-time sign-in link");
+    expect(email.textBody).toContain(
+      "https://preview.trackdraw.app/login/magic-link?token=abc"
+    );
+  });
+
+  it("rewrites magic-link verification URLs to the confirmation page", () => {
+    expect(
+      buildMagicLinkConfirmationUrl(
+        "https://trackdraw.app/api/auth/magic-link/verify?token=abc&callbackURL=%2Fstudio%2F2%2Fproject-1"
+      )
+    ).toBe(
+      "https://trackdraw.app/login/magic-link?token=abc&callbackURL=%2Fstudio%2F2%2Fproject-1"
+    );
   });
 
   it("keeps the Outlook layout on tables without wrapping the full email card in VML", () => {


### PR DESCRIPTION
## Summary

- route magic-link emails through a TrackDraw handoff page before consuming the Better Auth token
- add same-browser auto handoff with a fallback continue action for scanner-risk contexts
- normalize duplicate magic-link callback parameters and verify tokens via the Better Auth client API
- load landing messages on legal pages so the public header/footer do not throw missing-message errors

## Why

163.com/NetEase appears to scan magic-link URLs before the user clicks them. Because Better Auth magic-link tokens are single-use, a scanner opening the raw verify URL can consume the token and leave the real user with `INVALID_TOKEN`. The handoff keeps the raw consume endpoint out of the email and only verifies after a real browser handoff or user action.

The legal page change fixes Cloudflare observability errors for `MISSING_MESSAGE: landing (en)` on `/privacy` and the same risk on `/terms`.