### PR TITLE
Improve project save observability

### DIFF
--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -29,6 +29,28 @@ function unauthorizedResponse() {
   );
 }
 
+function invalidProjectPayloadResponse() {
+  return NextResponse.json(
+    { ok: false, error: "Invalid project payload" },
+    { status: 400 }
+  );
+}
+
+function getErrorLogDetails(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+      stack: error.stack,
+    };
+  }
+
+  return {
+    name: "UnknownError",
+    message: String(error),
+  };
+}
+
 export async function GET(request: Request) {
   try {
     const user = await getCurrentUserFromHeaders(request.headers);
@@ -112,11 +134,18 @@ export async function POST(request: Request) {
       );
     }
 
-    const message =
-      error instanceof z.ZodError
-        ? "Invalid project payload"
-        : "Failed to save project";
-    console.error("[TrackDraw] Failed to save project", { error });
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    if (error instanceof z.ZodError || error instanceof SyntaxError) {
+      return invalidProjectPayloadResponse();
+    }
+
+    const errorDetails = getErrorLogDetails(error);
+    console.error(
+      `[TrackDraw] Failed to save project: ${errorDetails.name}: ${errorDetails.message}`,
+      errorDetails
+    );
+    return NextResponse.json(
+      { ok: false, error: "Failed to save project" },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -48,6 +48,7 @@ function getErrorLogDetails(error: unknown) {
   return {
     name: "UnknownError",
     message: String(error),
+    thrown: error,
   };
 }
 

--- a/tests/app/api/projects.route.test.ts
+++ b/tests/app/api/projects.route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultDesign } from "@/lib/track/design";
 import type { StoredProject } from "@/lib/server/projects";
 import {
@@ -75,6 +75,10 @@ describe("projects API route", () => {
     vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(testUser);
   });
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("lists account projects with design version metadata", async () => {
     const project = createStoredProjectFixture({
       updatedAt: "2026-04-20T12:00:00.000Z",
@@ -121,6 +125,27 @@ describe("projects API route", () => {
       forceWrite: undefined,
       baseDesignUpdatedAt: "2026-04-20T10:00:00.000Z",
     });
+  });
+
+  it("returns bad request for invalid project save payloads without logging an error", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const response = await POST(
+      postRequest({
+        title: "Race layout",
+        forceWrite: "yes",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Invalid project payload",
+    });
+    expect(saveProjectForUser).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
   });
 
   it("returns a version conflict without overwriting the account project", async () => {
@@ -172,5 +197,36 @@ describe("projects API route", () => {
         shapeCount: 0,
       },
     });
+  });
+
+  it("logs useful details for unexpected project save failures", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const design = createDefaultDesign();
+    vi.mocked(saveProjectForUser).mockRejectedValue(
+      new Error("D1 insert failed")
+    );
+
+    const response = await POST(
+      postRequest({
+        projectId: "project-1",
+        title: "Race layout",
+        design,
+      })
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Failed to save project",
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[TrackDraw] Failed to save project: Error: D1 insert failed",
+      expect.objectContaining({
+        name: "Error",
+        message: "D1 insert failed",
+      })
+    );
   });
 });

--- a/tests/app/api/projects.route.test.ts
+++ b/tests/app/api/projects.route.test.ts
@@ -69,6 +69,14 @@ function postRequest(body: unknown) {
   return jsonRequest("http://localhost/api/projects", "POST", body);
 }
 
+function malformedJsonPostRequest() {
+  return new Request("http://localhost/api/projects", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{",
+  });
+}
+
 describe("projects API route", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -138,6 +146,22 @@ describe("projects API route", () => {
         forceWrite: "yes",
       })
     );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Invalid project payload",
+    });
+    expect(saveProjectForUser).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("returns bad request for malformed project save JSON without logging an error", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const response = await POST(malformedJsonPostRequest());
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
@@ -226,6 +250,37 @@ describe("projects API route", () => {
       expect.objectContaining({
         name: "Error",
         message: "D1 insert failed",
+      })
+    );
+  });
+
+  it("keeps the raw thrown value when logging unexpected non-error failures", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const design = createDefaultDesign();
+    const thrown = { code: "D1_BUSY", retryable: true };
+    vi.mocked(saveProjectForUser).mockRejectedValue(thrown);
+
+    const response = await POST(
+      postRequest({
+        projectId: "project-1",
+        title: "Race layout",
+        design,
+      })
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      error: "Failed to save project",
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[TrackDraw] Failed to save project: UnknownError: [object Object]",
+      expect.objectContaining({
+        name: "UnknownError",
+        message: "[object Object]",
+        thrown,
       })
     );
   });


### PR DESCRIPTION
## Summary

- Return `400 Invalid project payload` for malformed project-save requests instead of logging them as server errors.
- Include the error name and message in unexpected project-save error logs so Cloudflare Observability shows the actual failure cause.
- Add route tests for invalid payload handling and unexpected save-failure logging.

## Why

Cloudflare currently groups `POST /api/projects` failures under the generic `[TrackDraw] Failed to save project` message. That makes it hard to tell whether the event was a bad client payload or a real backend failure such as a D1 write problem.