### PR TITLE
feat: Improve admin dashboard controls

### DIFF
--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -657,7 +657,8 @@
       "expiredOn": "Expired {date}",
       "expiresOn": "Expires {date}",
       "noExpiry": "No expiry",
-      "expectedCleanup": "Expected cleanup {date}"
+      "expectedCleanup": "Expected cleanup {date}",
+      "statusWithCleanup": "{status}. {cleanup}"
     },
     "revokeDialog": {
       "title": "Revoke share?",

--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -589,7 +589,8 @@
     "filters": {
       "searchPlaceholder": "Search title, owner or token...",
       "status": "Status",
-      "type": "Type"
+      "type": "Type",
+      "owner": "Owner"
     },
     "statusValues": {
       "active": "Active",
@@ -599,6 +600,10 @@
     "typeValues": {
       "published": "Published",
       "temporary": "Temporary"
+    },
+    "ownerValues": {
+      "anonymous": "Anonymous",
+      "account": "Account owner"
     },
     "galleryValues": {
       "unlisted": "Private"
@@ -643,11 +648,16 @@
     "status": {
       "showing": "Showing {filtered} of {total} shares."
     },
+    "retention": {
+      "title": "Automatic cleanup is active",
+      "description": "A background job runs daily at 03:17 UTC. It permanently deletes shares revoked for more than 30 days and temporary shares expired for more than 30 days."
+    },
     "lifecycle": {
       "revokedOn": "Revoked {date}",
       "expiredOn": "Expired {date}",
       "expiresOn": "Expires {date}",
-      "noExpiry": "No expiry"
+      "noExpiry": "No expiry",
+      "expectedCleanup": "Expected cleanup {date}"
     },
     "revokeDialog": {
       "title": "Revoke share?",

--- a/src/app/dashboard/shares/columns.tsx
+++ b/src/app/dashboard/shares/columns.tsx
@@ -34,6 +34,10 @@ export type Translate = (
   values?: Record<string, unknown>
 ) => string;
 
+const SHARE_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const SHARE_CLEANUP_UTC_HOUR = 3;
+const SHARE_CLEANUP_UTC_MINUTE = 17;
+
 export function getOwnerLabel(share: DashboardShare, t: Translate) {
   if (!share.ownerUserId) return t("owner.anonymous");
   return (
@@ -83,6 +87,35 @@ function formatDate(value: string | null) {
   } catch {
     return value;
   }
+}
+
+function formatCleanupDate(value: Date) {
+  return new Intl.DateTimeFormat("en-GB", {
+    dateStyle: "medium",
+    timeZone: "UTC",
+  }).format(value);
+}
+
+function getExpectedCleanupDate(share: DashboardShare) {
+  const anchor = share.revokedAt
+    ? share.revokedAt
+    : share.shareType === "temporary"
+      ? share.expiresAt
+      : null;
+  if (!anchor) return null;
+
+  const anchorTime = new Date(anchor).getTime();
+  if (!Number.isFinite(anchorTime)) return null;
+
+  const eligibleAt = anchorTime + SHARE_RETENTION_MS;
+  const cleanupAt = new Date(eligibleAt);
+  cleanupAt.setUTCHours(SHARE_CLEANUP_UTC_HOUR, SHARE_CLEANUP_UTC_MINUTE, 0, 0);
+
+  if (cleanupAt.getTime() < eligibleAt) {
+    cleanupAt.setUTCDate(cleanupAt.getUTCDate() + 1);
+  }
+
+  return formatCleanupDate(cleanupAt);
 }
 
 function getLifecycleDetail(share: DashboardShare, t: Translate) {
@@ -156,9 +189,6 @@ export function getSharesColumns({
       cell: ({ row }) => (
         <div className="min-w-0">
           <p className="truncate text-sm font-medium">{row.original.title}</p>
-          <p className="text-muted-foreground truncate text-xs">
-            {row.original.token}
-          </p>
         </div>
       ),
     },
@@ -195,14 +225,39 @@ export function getSharesColumns({
       id: "status",
       accessorFn: (row) => getLifecycleState(row),
       header: t("table.status"),
-      meta: { className: "w-56" },
+      meta: { className: "w-64 min-w-64" },
       cell: ({ row }) => {
         const state = getLifecycleState(row.original);
+        const expectedCleanupDate = getExpectedCleanupDate(row.original);
+        const expectedCleanupLabel = expectedCleanupDate
+          ? t("lifecycle.expectedCleanup", { date: expectedCleanupDate })
+          : null;
         return (
-          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
-            <Badge variant={getLifecycleVariant(state)} className="shrink-0">
-              {t(`statusValues.${state}`)}
-            </Badge>
+          <div className="flex min-w-0 items-center gap-2">
+            {expectedCleanupLabel ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant={getLifecycleVariant(state)}
+                    tabIndex={0}
+                    aria-label={expectedCleanupLabel}
+                    className="focus-visible:ring-ring/40 shrink-0 cursor-help rounded-md outline-none focus-visible:ring-2"
+                  >
+                    {t(`statusValues.${state}`)}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={6}>
+                  {expectedCleanupLabel}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <Badge
+                variant={getLifecycleVariant(state)}
+                className="shrink-0"
+              >
+                {t(`statusValues.${state}`)}
+              </Badge>
+            )}
             <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs">
               {getLifecycleDetail(row.original, t)}
             </span>

--- a/src/app/dashboard/shares/columns.tsx
+++ b/src/app/dashboard/shares/columns.tsx
@@ -251,10 +251,7 @@ export function getSharesColumns({
                 </TooltipContent>
               </Tooltip>
             ) : (
-              <Badge
-                variant={getLifecycleVariant(state)}
-                className="shrink-0"
-              >
+              <Badge variant={getLifecycleVariant(state)} className="shrink-0">
                 {t(`statusValues.${state}`)}
               </Badge>
             )}

--- a/src/app/dashboard/shares/columns.tsx
+++ b/src/app/dashboard/shares/columns.tsx
@@ -228,10 +228,17 @@ export function getSharesColumns({
       meta: { className: "w-64 min-w-64" },
       cell: ({ row }) => {
         const state = getLifecycleState(row.original);
+        const lifecycleLabel = t(`statusValues.${state}`);
         const expectedCleanupDate = getExpectedCleanupDate(row.original);
         const expectedCleanupLabel = expectedCleanupDate
           ? t("lifecycle.expectedCleanup", { date: expectedCleanupDate })
           : null;
+        const accessibleLifecycleLabel = expectedCleanupLabel
+          ? t("lifecycle.statusWithCleanup", {
+              status: lifecycleLabel,
+              cleanup: expectedCleanupLabel,
+            })
+          : lifecycleLabel;
         return (
           <div className="flex min-w-0 items-center gap-2">
             {expectedCleanupLabel ? (
@@ -240,10 +247,10 @@ export function getSharesColumns({
                   <Badge
                     variant={getLifecycleVariant(state)}
                     tabIndex={0}
-                    aria-label={expectedCleanupLabel}
+                    aria-label={accessibleLifecycleLabel}
                     className="focus-visible:ring-ring/40 shrink-0 cursor-help rounded-md outline-none focus-visible:ring-2"
                   >
-                    {t(`statusValues.${state}`)}
+                    {lifecycleLabel}
                   </Badge>
                 </TooltipTrigger>
                 <TooltipContent side="top" sideOffset={6}>
@@ -252,7 +259,7 @@ export function getSharesColumns({
               </Tooltip>
             ) : (
               <Badge variant={getLifecycleVariant(state)} className="shrink-0">
-                {t(`statusValues.${state}`)}
+                {lifecycleLabel}
               </Badge>
             )}
             <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs">

--- a/src/components/dashboard/MetricsCharts.tsx
+++ b/src/components/dashboard/MetricsCharts.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { forwardRef, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { CalendarIcon } from "lucide-react";
 import type { DateRange } from "react-day-picker";
@@ -24,7 +24,7 @@ import {
   ChartTooltip,
   type ChartConfig,
 } from "@/components/ui/chart";
-import { Button } from "@/components/ui/button";
+import { Button, type ButtonProps } from "@/components/ui/button";
 import { MetricsRangeCalendar } from "@/components/dashboard/MetricsRangeCalendar";
 import {
   Drawer,
@@ -49,6 +49,7 @@ import {
   type GrowthTimeline,
 } from "@/lib/metrics-growth";
 import type { AdminMetrics, GrowthByRange } from "@/lib/server/metrics";
+import { cn } from "@/lib/utils";
 
 // --- User population donut with center label ---
 
@@ -498,22 +499,30 @@ function getGrowthRangeLabel(
   return t(`ranges.${range}`);
 }
 
-function RangePickerTrigger({
-  label,
-  onClick,
-}: {
+type RangePickerTriggerProps = Omit<
+  ButtonProps,
+  "children" | "size" | "variant"
+> & {
   label: string;
-  onClick?: () => void;
-}) {
+};
+
+const RangePickerTrigger = forwardRef<
+  HTMLButtonElement,
+  RangePickerTriggerProps
+>(({ label, className, ...triggerProps }, ref) => {
   const t = useTranslations("dashboard.metrics.userGrowth");
 
   return (
     <Button
+      ref={ref}
       type="button"
       variant="ghost"
       size="sm"
-      onClick={onClick}
-      className="border-input bg-background hover:bg-accent hover:text-accent-foreground data-[state=open]:bg-accent h-9 w-auto max-w-[9.5rem] justify-start gap-2 rounded-lg border px-2.5 text-left font-normal shadow-xs sm:w-56 sm:max-w-none"
+      className={cn(
+        "border-input bg-background hover:bg-muted hover:text-foreground data-[state=open]:bg-muted h-9 w-auto max-w-[9.5rem] justify-start gap-2 rounded-lg border px-2.5 text-left font-normal shadow-xs sm:w-56 sm:max-w-none",
+        className
+      )}
+      {...triggerProps}
     >
       <CalendarIcon className="text-muted-foreground size-4 shrink-0" />
       <span className="min-w-0 flex-1">
@@ -524,7 +533,8 @@ function RangePickerTrigger({
       </span>
     </Button>
   );
-}
+});
+RangePickerTrigger.displayName = "RangePickerTrigger";
 
 function RangePickerContent({
   activeRange,

--- a/src/components/dashboard/SharesManager.tsx
+++ b/src/components/dashboard/SharesManager.tsx
@@ -9,7 +9,7 @@ import {
   type SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import { Loader2 } from "lucide-react";
+import { Clock3, Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import {
   getLifecycleState,
@@ -40,6 +40,7 @@ type DashboardSharesManagerProps = {
 };
 
 type ShareTypeFilterValue = "published" | "temporary";
+type ShareOwnerFilterValue = "anonymous" | "account";
 
 const sharesManagerRoles: AccountRole[] = ["moderator", "admin"];
 const purgeManagerRoles: AccountRole[] = ["admin"];
@@ -49,6 +50,11 @@ const lifecycleFilterValues: ShareLifecycleState[] = [
   "revoked",
 ];
 const typeFilterValues: ShareTypeFilterValue[] = ["published", "temporary"];
+const ownerFilterValues: ShareOwnerFilterValue[] = ["anonymous", "account"];
+
+function getOwnerFilterValue(share: DashboardShare): ShareOwnerFilterValue {
+  return share.ownerUserId ? "account" : "anonymous";
+}
 
 export default function DashboardSharesManager({
   currentUserRole,
@@ -64,6 +70,9 @@ export default function DashboardSharesManager({
     ShareLifecycleState[]
   >([]);
   const [selectedTypes, setSelectedTypes] = useState<ShareTypeFilterValue[]>(
+    []
+  );
+  const [selectedOwners, setSelectedOwners] = useState<ShareOwnerFilterValue[]>(
     []
   );
   const [revokeCandidate, setRevokeCandidate] = useState<DashboardShare | null>(
@@ -212,25 +221,31 @@ export default function DashboardSharesManager({
   });
 
   const rowsForCurrentSearch = table.getRowModel().rows;
-  const lifecycleFilteredRows = rowsForCurrentSearch.filter((row) =>
-    selectedLifecycles.length === 0
-      ? true
-      : selectedLifecycles.includes(getLifecycleState(row.original))
+  const matchesLifecycleFilter = (share: DashboardShare) =>
+    selectedLifecycles.length === 0 ||
+    selectedLifecycles.includes(getLifecycleState(share));
+  const matchesTypeFilter = (share: DashboardShare) =>
+    selectedTypes.length === 0 || selectedTypes.includes(share.shareType);
+  const matchesOwnerFilter = (share: DashboardShare) =>
+    selectedOwners.length === 0 ||
+    selectedOwners.includes(getOwnerFilterValue(share));
+
+  const filteredRows = rowsForCurrentSearch.filter(
+    (row) =>
+      matchesLifecycleFilter(row.original) &&
+      matchesTypeFilter(row.original) &&
+      matchesOwnerFilter(row.original)
   );
-  const filteredRows = lifecycleFilteredRows.filter((row) =>
-    selectedTypes.length === 0
-      ? true
-      : selectedTypes.includes(row.original.shareType)
+  const lifecycleFacetRows = rowsForCurrentSearch.filter(
+    (row) => matchesTypeFilter(row.original) && matchesOwnerFilter(row.original)
   );
-  const lifecycleFacetRows = rowsForCurrentSearch.filter((row) =>
-    selectedTypes.length === 0
-      ? true
-      : selectedTypes.includes(row.original.shareType)
+  const typeFacetRows = rowsForCurrentSearch.filter(
+    (row) =>
+      matchesLifecycleFilter(row.original) && matchesOwnerFilter(row.original)
   );
-  const typeFacetRows = rowsForCurrentSearch.filter((row) =>
-    selectedLifecycles.length === 0
-      ? true
-      : selectedLifecycles.includes(getLifecycleState(row.original))
+  const ownerFacetRows = rowsForCurrentSearch.filter(
+    (row) =>
+      matchesLifecycleFilter(row.original) && matchesTypeFilter(row.original)
   );
   const lifecycleFilterOptions = lifecycleFilterValues.map((value) => ({
     value,
@@ -245,11 +260,28 @@ export default function DashboardSharesManager({
     count: typeFacetRows.filter((row) => row.original.shareType === value)
       .length,
   }));
+  const ownerFilterOptions = ownerFilterValues.map((value) => ({
+    value,
+    label: t(`ownerValues.${value}`),
+    count: ownerFacetRows.filter(
+      (row) => getOwnerFilterValue(row.original) === value
+    ).length,
+  }));
   const emptyMessage =
     shares.length === 0 ? t("empty.default") : t("empty.filtered");
 
   return (
     <div className="space-y-4">
+      <div className="bg-muted/35 flex items-start gap-3 rounded-lg border px-4 py-3">
+        <Clock3 className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+        <div className="space-y-0.5 text-sm">
+          <p className="font-medium">{t("retention.title")}</p>
+          <p className="text-muted-foreground text-xs leading-relaxed">
+            {t("retention.description")}
+          </p>
+        </div>
+      </div>
+
       <DataTableToolbar
         searchValue={globalFilter}
         onSearchChange={setGlobalFilter}
@@ -266,6 +298,12 @@ export default function DashboardSharesManager({
           selected={selectedTypes}
           options={typeFilterOptions}
           onChange={setSelectedTypes}
+        />
+        <DataTableFacetFilter
+          title={t("filters.owner")}
+          selected={selectedOwners}
+          options={ownerFilterOptions}
+          onChange={setSelectedOwners}
         />
       </DataTableToolbar>
 

--- a/tests/components/dashboard/MetricsCharts.test.tsx
+++ b/tests/components/dashboard/MetricsCharts.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import { UserGrowthCard } from "@/components/dashboard/MetricsCharts";
+import type { GrowthByRange } from "@/lib/server/metrics";
+
+const growthData = {
+  bucket: "month" as const,
+  from: "2026-04-01",
+  to: "2026-07-09",
+  userGrowth: [{ period: "2026-07-01", label: "Jul 2026", users: 2 }],
+  userGrowthCumulative: [
+    { period: "2026-07-01", label: "Jul 2026", users: 12 },
+  ],
+};
+
+const growthByRange: GrowthByRange = {
+  "3m": growthData,
+  "6m": growthData,
+  "12m": growthData,
+  ytd: growthData,
+  previousYear: growthData,
+};
+
+describe("UserGrowthCard", () => {
+  afterEach(cleanup);
+
+  it("opens the desktop range popover from its custom trigger", async () => {
+    const user = userEvent.setup();
+    render(
+      <UserGrowthCard
+        growthByRange={growthByRange}
+        growthTimeline={{
+          dailyGrowth: [{ date: "2026-07-01", users: 2 }],
+          totalUsers: 12,
+          today: "2026-07-09",
+        }}
+      />
+    );
+
+    const desktopTrigger = screen
+      .getAllByRole("button", { name: "Range Last 3 months" })
+      .find((button) => button.getAttribute("aria-haspopup") === "dialog");
+
+    expect(desktopTrigger).toBeTruthy();
+    expect(desktopTrigger?.className).toContain("hover:bg-muted");
+    expect(desktopTrigger?.className).not.toContain("hover:bg-accent");
+
+    await user.click(desktopTrigger!);
+
+    expect(screen.getByText("Presets")).toBeTruthy();
+    expect(desktopTrigger?.getAttribute("aria-expanded")).toBe("true");
+  });
+});

--- a/tests/components/dashboard/SharesManager.test.tsx
+++ b/tests/components/dashboard/SharesManager.test.tsx
@@ -214,9 +214,12 @@ describe("DashboardSharesManager", () => {
       />
     );
 
-    expect(screen.getByLabelText("Expected cleanup 22 May 2026")).toBeTruthy();
-    expect(screen.getByLabelText("Expected cleanup 20 Jun 2026")).toBeTruthy();
-    expect(screen.getAllByLabelText(/^Expected cleanup/)).toHaveLength(2);
+    const revokedCleanup = screen.getByLabelText(
+      /Expected cleanup 22 May 2026$/
+    );
+    expect(revokedCleanup.getAttribute("aria-label")).toMatch(/^Revoked\./);
+    expect(screen.getByLabelText(/Expected cleanup 20 Jun 2026$/)).toBeTruthy();
+    expect(screen.getAllByLabelText(/Expected cleanup/)).toHaveLength(2);
   });
 
   it("revokes active shares with a PATCH request", async () => {

--- a/tests/components/dashboard/SharesManager.test.tsx
+++ b/tests/components/dashboard/SharesManager.test.tsx
@@ -90,6 +90,18 @@ const revokedShare: DashboardShare = {
   galleryState: null,
 };
 
+const anonymousShare: DashboardShare = {
+  ...activeShare,
+  token: "anonymous-token",
+  title: "Anonymous Track",
+  expiresAt: "2026-05-20T10:00:00.000Z",
+  shareType: "temporary",
+  ownerUserId: null,
+  ownerName: null,
+  ownerEmail: null,
+  galleryState: null,
+};
+
 describe("DashboardSharesManager", () => {
   const writeText = vi.fn();
 
@@ -137,6 +149,74 @@ describe("DashboardSharesManager", () => {
     expect(
       screen.getByLabelText("Open share Track One").getAttribute("href")
     ).toBe("/share/share-token");
+  });
+
+  it("keeps share tokens searchable without displaying them in the table", async () => {
+    const user = userEvent.setup();
+    render(
+      <DashboardSharesManager
+        currentUserRole="moderator"
+        initialShares={[activeShare, anonymousShare]}
+      />
+    );
+
+    expect(screen.queryByText("share-token")).toBeNull();
+
+    await user.type(
+      screen.getByPlaceholderText("Search title, owner or token..."),
+      "share-token"
+    );
+
+    expect(screen.getByText("Track One")).toBeTruthy();
+    expect(screen.queryByText("Anonymous Track")).toBeNull();
+  });
+
+  it("filters shares by anonymous ownership", async () => {
+    const user = userEvent.setup();
+    render(
+      <DashboardSharesManager
+        currentUserRole="moderator"
+        initialShares={[activeShare, anonymousShare]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Owner" }));
+    await user.click(screen.getByRole("button", { name: "Anonymous 1" }));
+
+    expect(screen.getByText("Anonymous Track")).toBeTruthy();
+    expect(screen.queryByText("Track One")).toBeNull();
+    expect(screen.getByText("Showing 1 of 2 shares.")).toBeTruthy();
+  });
+
+  it("explains the scheduled share cleanup policy", () => {
+    render(
+      <DashboardSharesManager
+        currentUserRole="moderator"
+        initialShares={[activeShare]}
+      />
+    );
+
+    expect(screen.getByText("Automatic cleanup is active")).toBeTruthy();
+    expect(
+      screen.getByText(/background job runs daily at 03:17 UTC/i)
+    ).toBeTruthy();
+    expect(screen.getByText(/revoked for more than 30 days/i)).toBeTruthy();
+    expect(
+      screen.getByText(/temporary shares expired for more than 30 days/i)
+    ).toBeTruthy();
+  });
+
+  it("shows the expected cleanup date for each retained share", () => {
+    render(
+      <DashboardSharesManager
+        currentUserRole="admin"
+        initialShares={[activeShare, revokedShare, anonymousShare]}
+      />
+    );
+
+    expect(screen.getByLabelText("Expected cleanup 22 May 2026")).toBeTruthy();
+    expect(screen.getByLabelText("Expected cleanup 20 Jun 2026")).toBeTruthy();
+    expect(screen.getAllByLabelText(/^Expected cleanup/)).toHaveLength(2);
   });
 
   it("revokes active shares with a PATCH request", async () => {


### PR DESCRIPTION
## Summary

- add share owner filtering for anonymous and account-backed shares
- explain scheduled share retention and expose expected cleanup dates from lifecycle badges
- simplify share rows while keeping tokens searchable
- restore the desktop user-growth range picker and use a neutral hover/open state

## Why

Share lifecycle and cleanup behavior was difficult for administrators to discover. The desktop metrics picker also used a custom trigger that did not forward the popover props and ref, so only the mobile drawer opened correctly.

## Validation

- `npm run lint`
- `npm run test` — 796 tests
- `npm run type`
- `npm run build`