### PR TITLE
perf: Smooth mobile Studio drawers

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -131,6 +131,7 @@ Focus:
 
 - Improve editor recovery and failure states so autosave, import, export, share, account sync, and runtime errors explain what happened and what the user can do next
 - Run a mobile editor ergonomics pass across Project Manager, inspector drawers, path builder, multi-select, map reference controls, and app/menu actions
+- Keep the shipped Studio mobile drawer smoothness pass covered: dedicated-handle dragging, contained momentum scrolling, lighter animated overlays, and stable inspector callbacks without changing the existing mobile workflow model
 - Harden selection and transform behavior around locked objects, grouped selections, route waypoint editing, snapping, rotation, resize handles, and undo/redo
 - Improve export and share confidence by clarifying what each output includes, what is intentionally excluded, and which limitations matter for race-day use
 - Stress-test larger layouts and dense projects with map references, 3D preview, PDF/export, and longer routes, then make targeted performance or debounce fixes

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -47,6 +47,9 @@ The next TrackDraw priority is generated flightpath validation first, translatio
   - [ ] 3D transform gizmo and edit mode toolbar
         Draft PVA: [3D Transform Controls PVA](../pva/3d-transform-controls-pva.md). Prototype selected-item move and rotate controls with orbit-friendly camera behavior only where the interaction is predictable across 2D and 3D. Do not add dimension handles until move/rotate are accepted.
 
+- [x] Mobile Studio drawer smoothness pass (`No account required`)
+      Reduced intermittent drawer stutter without changing the mobile workflow: Studio bottom drawers now keep drag work on a dedicated handle, contain momentum scrolling inside the drawer, avoid animating a full-screen backdrop blur, and keep expensive inspector callbacks stable. Added regression coverage for the specialized mobile drawer shell while leaving the shared drawer UI primitive stock.
+
 - [ ] Path editing UX (`No account required`)
       Make drawing and adjusting a path feel more natural, especially for curved layouts where the current waypoint model forces extra points to avoid sharp corners.
   - [ ] Per-waypoint curve strength (`Research`)

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -3,7 +3,6 @@
 import * as React from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 import {
-  DrawerContent,
   DrawerDescription,
   DrawerHeader,
   DrawerTitle,
@@ -20,8 +19,10 @@ interface MobileDrawerProps {
   footerContent?: React.ReactNode;
   nested?: boolean;
   repositionInputs?: boolean;
+  handleOnly?: boolean;
   bodyClassName?: string;
   contentClassName?: string;
+  overlayClassName?: string;
 }
 
 interface MobileDrawerHeaderProps {
@@ -70,30 +71,47 @@ export function MobileDrawer({
   footerContent,
   nested = false,
   repositionInputs = false,
+  handleOnly = true,
   bodyClassName,
   contentClassName,
+  overlayClassName,
 }: MobileDrawerProps) {
   const content = (
-    <DrawerContent
-      className={cn(
-        "border-border/50 bg-card max-h-[85dvh] gap-0 overflow-hidden rounded-t-[1.35rem] border shadow-[0_-16px_36px_rgba(0,0,0,0.14)] lg:hidden",
-        contentClassName
-      )}
-    >
-      <MobileDrawerHeader title={title} subtitle={subtitle} />
-      {pinnedContent}
-      <div
-        className={cn("flex-1 overflow-y-auto px-4 pt-3 pb-6", bodyClassName)}
+    <DrawerPrimitive.Portal>
+      <DrawerPrimitive.Overlay
+        data-slot="mobile-drawer-overlay"
+        className={cn(
+          "data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 z-50 bg-black/20",
+          overlayClassName
+        )}
+      />
+      <DrawerPrimitive.Content
+        data-slot="mobile-drawer-content"
+        className={cn(
+          "group/drawer-content border-border/50 bg-card fixed inset-x-0 bottom-0 z-50 flex h-auto max-h-[85dvh] flex-col gap-0 overflow-hidden rounded-t-[1.35rem] border text-sm shadow-[0_-16px_36px_rgba(0,0,0,0.14)] lg:hidden",
+          contentClassName
+        )}
       >
-        {children}
-      </div>
-      {footerContent}
-    </DrawerContent>
+        <DrawerPrimitive.Handle className="mx-auto mt-3 h-1 w-25 shrink-0 self-center rounded-full bg-black/14 dark:bg-white/72" />
+        <MobileDrawerHeader title={title} subtitle={subtitle} />
+        {pinnedContent}
+        <div
+          className={cn(
+            "min-h-0 flex-1 touch-pan-y overflow-y-auto overscroll-y-contain px-4 pt-3 pb-6 [-webkit-overflow-scrolling:touch]",
+            bodyClassName
+          )}
+        >
+          {children}
+        </div>
+        {footerContent}
+      </DrawerPrimitive.Content>
+    </DrawerPrimitive.Portal>
   );
 
   const drawerProps = {
     direction: "bottom" as const,
     modal: true,
+    handleOnly,
     onOpenChange,
     open,
     repositionInputs,

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -479,6 +479,23 @@ export default function EditorShell({
     [handleTabChange, shapeById]
   );
 
+  const closeMobileInspector = useCallback(() => {
+    setMobileInspectorOpen(false);
+  }, []);
+
+  const handleResumeMobileSelectedPath = useCallback(
+    (shapeId?: string) => {
+      const targetId =
+        shapeId ?? (selection.length === 1 ? selection[0] : undefined);
+      const shape = targetId ? shapeById[targetId] : null;
+      if (!shape || shape.kind !== "polyline" || shape.locked) return;
+
+      setMobilePathBuilderPinnedOpen(true);
+      handleResumeSelectedPath(shape.id);
+    },
+    [handleResumeSelectedPath, selection, shapeById]
+  );
+
   const openPresetPicker = useCallback(() => {
     setPresetPickerOpen(true);
   }, [setPresetPickerOpen]);
@@ -702,7 +719,7 @@ export default function EditorShell({
             selectedGroupName={selectedGroupName}
             saveStatusLabel={saveStatusLabel}
             tab={tab}
-            onCloseInspector={() => setMobileInspectorOpen(false)}
+            onCloseInspector={closeMobileInspector}
             onFitView={() => canvasRef.current?.fitToWindow()}
             onCancelPath={() => {
               canvasRef.current?.cancelDraftPath();
@@ -719,13 +736,7 @@ export default function EditorShell({
               setMobileMultiSelectEnabled(false);
               setMobileInspectorOpen(true);
             }}
-            onResumeSelectedPath={() => {
-              const selectedShape =
-                selection.length === 1 ? shapeById[selection[0]] : null;
-              if (!selectedShape || selectedShape.kind !== "polyline") return;
-              setMobilePathBuilderPinnedOpen(true);
-              canvasRef.current?.resumePolylineEditing(selectedShape.id);
-            }}
+            onResumeSelectedPath={handleResumeMobileSelectedPath}
             onOpenReadOnlyMenu={() => setReadOnlyMenuOpen(true)}
             onOpenTools={() => {
               setMobileInspectorOpen(false);

--- a/src/components/editor/MobileAppMenu.tsx
+++ b/src/components/editor/MobileAppMenu.tsx
@@ -216,7 +216,7 @@ export default function MobileAppMenu({
               headerClassName="px-4 pt-3 pb-3"
             />
 
-            <div className="flex-1 overflow-y-auto px-3 py-3">
+            <div className="min-h-0 flex-1 touch-pan-y overflow-y-auto overscroll-y-contain px-3 py-3 [-webkit-overflow-scrolling:touch]">
               <div className="border-border/60 bg-card rounded-2xl border px-2 py-2">
                 {user ? (
                   <button

--- a/src/components/editor/mobile/EditorMobilePanels.tsx
+++ b/src/components/editor/mobile/EditorMobilePanels.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import {
@@ -93,7 +93,7 @@ interface EditorMobilePanelsProps {
   onOpenTools: () => void;
   onOpenView: () => void;
   onRotateSelection: (delta: number) => void;
-  onResumeSelectedPath: () => void;
+  onResumeSelectedPath: (shapeId?: string) => void;
   onSetMobileRulersEnabled: (enabled: boolean) => void;
   onSetMobileGizmoEnabled: (enabled: boolean) => void;
   onSetMobileObstacleNumbersEnabled: (enabled: boolean) => void;
@@ -209,7 +209,7 @@ function MobileQuickActionsOverlay({
           ) : canResumePathEditing ? (
             <button
               type="button"
-              onClick={onResumeSelectedPath}
+              onClick={() => onResumeSelectedPath?.()}
               disabled={selectionHasLockedShapes}
               className="flex min-h-14 min-w-0 flex-col items-center justify-center gap-1 rounded-[0.95rem] px-2 py-2 text-[11px] font-medium text-white/72 transition-colors hover:bg-white/10 hover:text-white disabled:text-white/35"
             >
@@ -467,6 +467,14 @@ export function EditorMobilePanels({
     onOpenView();
   };
 
+  const resumeSelectedPathFromInspector = useCallback(
+    (shapeId: string) => {
+      onCloseInspector();
+      onResumeSelectedPath(shapeId);
+    },
+    [onCloseInspector, onResumeSelectedPath]
+  );
+
   useEffect(() => {
     const mediaQuery = window.matchMedia(
       "(max-width: 1023px) and (orientation: landscape)"
@@ -722,10 +730,7 @@ export function EditorMobilePanels({
         >
           <Inspector
             mobileInline
-            onResumeSelectedPath={() => {
-              onCloseInspector();
-              onResumeSelectedPath();
-            }}
+            onResumeSelectedPath={resumeSelectedPathFromInspector}
           />
         </MobileDrawer>
       )}

--- a/tests/components/MobileDrawer.test.tsx
+++ b/tests/components/MobileDrawer.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MobileDrawer } from "@/components/MobileDrawer";
+
+vi.mock("vaul", async () => {
+  const React = await import("react");
+
+  const Root = ({
+    children,
+    handleOnly,
+  }: {
+    children: React.ReactNode;
+    handleOnly?: boolean;
+  }) => (
+    <div data-testid="drawer-root" data-handle-only={String(handleOnly)}>
+      {children}
+    </div>
+  );
+  const Primitive = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+  >(({ children, ...props }, ref) => (
+    <div ref={ref} {...props}>
+      {children}
+    </div>
+  ));
+  Primitive.displayName = "DrawerPrimitive";
+  const Handle = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement>
+  >(({ children, ...props }, ref) => (
+    <div ref={ref} data-vaul-handle="" {...props}>
+      {children}
+    </div>
+  ));
+  Handle.displayName = "DrawerHandle";
+
+  return {
+    Drawer: {
+      Content: Primitive,
+      Description: Primitive,
+      Handle,
+      NestedRoot: Root,
+      Overlay: Primitive,
+      Portal: Primitive,
+      Root,
+      Title: Primitive,
+    },
+  };
+});
+
+describe("MobileDrawer", () => {
+  afterEach(cleanup);
+
+  it("keeps drag work on the handle and contains mobile scrolling", () => {
+    render(
+      <MobileDrawer
+        open
+        onOpenChange={vi.fn()}
+        title="Inspector"
+        subtitle="Selected item"
+      >
+        Drawer body
+      </MobileDrawer>
+    );
+
+    expect(screen.getByTestId("drawer-root").dataset.handleOnly).toBe("true");
+
+    const overlay = document.querySelector(
+      '[data-slot="mobile-drawer-overlay"]'
+    );
+    expect(overlay?.className).toContain("bg-black/20");
+    expect(overlay?.className).not.toContain("backdrop-blur");
+
+    const content = document.querySelector(
+      '[data-slot="mobile-drawer-content"]'
+    );
+    expect(content?.className).toContain("group/drawer-content");
+    const handle = content?.querySelector("[data-vaul-handle]");
+    expect(handle).toBeTruthy();
+    expect(handle?.className).toContain("self-center");
+
+    const body = screen.getByText("Drawer body");
+    expect(body.className).toContain("touch-pan-y");
+    expect(body.className).toContain("overscroll-y-contain");
+    expect(body.className).toContain("overflow-y-auto");
+  });
+});


### PR DESCRIPTION
## Summary

- smooth Studio bottom drawers with handle-only dragging and contained momentum scrolling
- reduce animation overhead with a lighter drawer overlay while keeping the shared drawer primitive stock
- stabilize inspector callbacks and add regression coverage for the specialized mobile drawer
- mark the mobile drawer smoothness roadmap item as completed

## Why

Mobile Studio drawers could intermittently stutter during dragging and scrolling. The drawer-specific behavior now avoids competing gestures and unnecessary full-screen blur work without changing the existing mobile workflow.

## Validation

- `npm run lint`
- `npm run test`
- `npm run type`
- `npm run build`
