### PR TITLE
feat: Add trends to project and share metrics

### DIFF
--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -46,11 +46,11 @@
       },
       "activeProjects": {
         "label": "Active projects",
-        "sub": "non-archived"
+        "sub": "+{count} this month"
       },
       "activeShares": {
         "label": "Active shares",
-        "sub": "live share links"
+        "sub": "+{count} this month"
       },
       "gallery": {
         "label": "Public gallery",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -417,7 +417,14 @@ export default async function DashboardPage() {
             <KpiCard
               label={t("kpi.activeProjects.label")}
               value={overviewStats.activeProjects}
-              sub={t("kpi.activeProjects.sub")}
+              sub={t("kpi.activeProjects.sub", {
+                count: overviewStats.newActiveProjectsThisMonth,
+              })}
+              trend={{
+                current: overviewStats.newActiveProjectsThisMonth,
+                previous: overviewStats.newActiveProjectsLastMonth,
+              }}
+              vsPrevMonthLabel={t("kpi.comparison.vsPrevMonth")}
               icon={FolderOpen}
               accent="bg-violet-500"
               iconTone="bg-violet-500/10 text-violet-600 dark:text-violet-400"
@@ -427,7 +434,14 @@ export default async function DashboardPage() {
             <KpiCard
               label={t("kpi.activeShares.label")}
               value={overviewStats.activeShares}
-              sub={t("kpi.activeShares.sub")}
+              sub={t("kpi.activeShares.sub", {
+                count: overviewStats.newActiveSharesThisMonth,
+              })}
+              trend={{
+                current: overviewStats.newActiveSharesThisMonth,
+                previous: overviewStats.newActiveSharesLastMonth,
+              }}
+              vsPrevMonthLabel={t("kpi.comparison.vsPrevMonth")}
               icon={Link2}
               accent="bg-orange-500"
               iconTone="bg-orange-500/10 text-orange-600 dark:text-orange-400"

--- a/src/lib/server/metrics.ts
+++ b/src/lib/server/metrics.ts
@@ -368,8 +368,8 @@ export async function getOverviewStats(): Promise<OverviewStats> {
         .prepare(
           `select
             count(*) as count,
-            sum(case when created_at >= date('now', 'start of month') then 1 else 0 end) as new_this_month,
-            sum(case when created_at >= date('now', 'start of month', '-1 month') and created_at < date('now', 'start of month') then 1 else 0 end) as new_last_month
+            coalesce(sum(case when created_at >= date('now', 'start of month') then 1 else 0 end), 0) as new_this_month,
+            coalesce(sum(case when created_at >= date('now', 'start of month', '-1 month') and created_at < date('now', 'start of month') then 1 else 0 end), 0) as new_last_month
            from projects
            where archived_at is null`
         )
@@ -382,8 +382,8 @@ export async function getOverviewStats(): Promise<OverviewStats> {
         .prepare(
           `select
             count(*) as count,
-            sum(case when created_at >= date('now', 'start of month') then 1 else 0 end) as new_this_month,
-            sum(case when created_at >= date('now', 'start of month', '-1 month') and created_at < date('now', 'start of month') then 1 else 0 end) as new_last_month
+            coalesce(sum(case when created_at >= date('now', 'start of month') then 1 else 0 end), 0) as new_this_month,
+            coalesce(sum(case when created_at >= date('now', 'start of month', '-1 month') and created_at < date('now', 'start of month') then 1 else 0 end), 0) as new_last_month
            from shares
            where revoked_at is null
              and (expires_at is null or expires_at > datetime('now'))

--- a/src/lib/server/metrics.ts
+++ b/src/lib/server/metrics.ts
@@ -339,7 +339,11 @@ export type OverviewStats = {
   newUsersThisMonth: number;
   newUsersLastMonth: number;
   activeProjects: number;
+  newActiveProjectsThisMonth: number;
+  newActiveProjectsLastMonth: number;
   activeShares: number;
+  newActiveSharesThisMonth: number;
+  newActiveSharesLastMonth: number;
   recentUsers: RecentUser[];
 };
 
@@ -362,17 +366,34 @@ export async function getOverviewStats(): Promise<OverviewStats> {
         }>(),
       db
         .prepare(
-          `select count(*) as count from projects where archived_at is null`
+          `select
+            count(*) as count,
+            sum(case when created_at >= date('now', 'start of month') then 1 else 0 end) as new_this_month,
+            sum(case when created_at >= date('now', 'start of month', '-1 month') and created_at < date('now', 'start of month') then 1 else 0 end) as new_last_month
+           from projects
+           where archived_at is null`
         )
-        .first<{ count: number }>(),
+        .first<{
+          count: number;
+          new_this_month: number;
+          new_last_month: number;
+        }>(),
       db
         .prepare(
-          `select count(*) as count from shares
+          `select
+            count(*) as count,
+            sum(case when created_at >= date('now', 'start of month') then 1 else 0 end) as new_this_month,
+            sum(case when created_at >= date('now', 'start of month', '-1 month') and created_at < date('now', 'start of month') then 1 else 0 end) as new_last_month
+           from shares
            where revoked_at is null
              and (expires_at is null or expires_at > datetime('now'))
              and owner_user_id is not null`
         )
-        .first<{ count: number }>(),
+        .first<{
+          count: number;
+          new_this_month: number;
+          new_last_month: number;
+        }>(),
       db
         .prepare(
           `select id, name, email, createdAt from users order by createdAt desc limit 6`
@@ -390,7 +411,11 @@ export async function getOverviewStats(): Promise<OverviewStats> {
     newUsersThisMonth: usersRow?.new_this_month ?? 0,
     newUsersLastMonth: usersRow?.new_last_month ?? 0,
     activeProjects: projectsRow?.count ?? 0,
+    newActiveProjectsThisMonth: projectsRow?.new_this_month ?? 0,
+    newActiveProjectsLastMonth: projectsRow?.new_last_month ?? 0,
     activeShares: sharesRow?.count ?? 0,
+    newActiveSharesThisMonth: sharesRow?.new_this_month ?? 0,
+    newActiveSharesLastMonth: sharesRow?.new_last_month ?? 0,
     recentUsers: recentUsersRows?.results ?? [],
   };
 }

--- a/tests/lib/server/metrics.test.ts
+++ b/tests/lib/server/metrics.test.ts
@@ -77,8 +77,12 @@ describe("dashboard metrics", () => {
       createD1Statement({
         first: { total: 12, new_this_month: 4, new_last_month: 3 },
       }),
-      createD1Statement({ first: { count: 7 } }),
-      createD1Statement({ first: { count: 5 } }),
+      createD1Statement({
+        first: { count: 7, new_this_month: 3, new_last_month: 2 },
+      }),
+      createD1Statement({
+        first: { count: 5, new_this_month: 2, new_last_month: 4 },
+      }),
       createD1AllStatement([
         {
           id: "user-1",
@@ -93,6 +97,10 @@ describe("dashboard metrics", () => {
 
     expect(stats.newUsersThisMonth).toBe(4);
     expect(stats.newUsersLastMonth).toBe(3);
+    expect(stats.newActiveProjectsThisMonth).toBe(3);
+    expect(stats.newActiveProjectsLastMonth).toBe(2);
+    expect(stats.newActiveSharesThisMonth).toBe(2);
+    expect(stats.newActiveSharesLastMonth).toBe(4);
     expect(stats.recentUsers[0]).toMatchObject({
       id: "user-1",
       name: null,
@@ -105,6 +113,12 @@ describe("dashboard metrics", () => {
       "createdAt >= date('now', 'start of month', '-1 month')"
     );
     expect(String(mocks.prepare.mock.calls[0][0])).not.toContain("-30 days");
+    expect(String(mocks.prepare.mock.calls[1][0])).toContain(
+      "created_at >= date('now', 'start of month')"
+    );
+    expect(String(mocks.prepare.mock.calls[2][0])).toContain(
+      "created_at >= date('now', 'start of month', '-1 month')"
+    );
   });
 
   it("separates rolling ranges from calendar-year growth buckets with empty periods filled", async () => {

--- a/tests/lib/server/metrics.test.ts
+++ b/tests/lib/server/metrics.test.ts
@@ -114,7 +114,13 @@ describe("dashboard metrics", () => {
     );
     expect(String(mocks.prepare.mock.calls[0][0])).not.toContain("-30 days");
     expect(String(mocks.prepare.mock.calls[1][0])).toContain(
+      "coalesce(sum(case"
+    );
+    expect(String(mocks.prepare.mock.calls[1][0])).toContain(
       "created_at >= date('now', 'start of month')"
+    );
+    expect(String(mocks.prepare.mock.calls[2][0])).toContain(
+      "coalesce(sum(case"
     );
     expect(String(mocks.prepare.mock.calls[2][0])).toContain(
       "created_at >= date('now', 'start of month', '-1 month')"


### PR DESCRIPTION
## Summary

- add month-over-month trends to the Active projects and Active shares dashboard KPIs
- show how many currently active projects and shares were created this month
- keep project counts limited to non-archived projects and share counts limited to active account-backed links
- extend overview metrics coverage for the new monthly values

## Impact

Dashboard users can now compare project and share growth with the previous calendar month, matching the existing Total users KPI.

## Validation

- `npm run lint`
- `npm run test` — 798 tests passed
- `npm run type`
- `npm run build`
- `npm run i18n:check`