### PR TITLE
feat: Paginate dashboard data tables

### DIFF
--- a/lang/de/common.json
+++ b/lang/de/common.json
@@ -38,7 +38,11 @@
     "filterPlaceholder": "{title} filtern...",
     "noResults": "Keine Ergebnisse gefunden.",
     "selectedCount": "{count} ausgewählt",
-    "clearFilters": "Filter löschen"
+    "clearFilters": "Filter löschen",
+    "rowsPerPage": "Zeilen pro Seite",
+    "page": "Seite {current} von {total}",
+    "previousPage": "Vorherige Seite",
+    "nextPage": "Nächste Seite"
   },
   "measurementUnit": {
     "metric": "Metrisch",

--- a/lang/en/common.json
+++ b/lang/en/common.json
@@ -38,7 +38,11 @@
     "filterPlaceholder": "Filter {title}...",
     "noResults": "No results found.",
     "selectedCount": "{count} selected",
-    "clearFilters": "Clear filters"
+    "clearFilters": "Clear filters",
+    "rowsPerPage": "Rows per page",
+    "page": "Page {current} of {total}",
+    "previousPage": "Previous page",
+    "nextPage": "Next page"
   },
   "measurementUnit": {
     "metric": "Metric",

--- a/lang/nl/common.json
+++ b/lang/nl/common.json
@@ -38,7 +38,11 @@
     "filterPlaceholder": "Filter {title}...",
     "noResults": "Geen resultaten gevonden.",
     "selectedCount": "{count} geselecteerd",
-    "clearFilters": "Filters wissen"
+    "clearFilters": "Filters wissen",
+    "rowsPerPage": "Rijen per pagina",
+    "page": "Pagina {current} van {total}",
+    "previousPage": "Vorige pagina",
+    "nextPage": "Volgende pagina"
   },
   "measurementUnit": {
     "metric": "Metrisch",

--- a/src/app/dashboard/api-keys/columns.tsx
+++ b/src/app/dashboard/api-keys/columns.tsx
@@ -115,6 +115,9 @@ export function getApiKeysColumns({
     {
       id: "status",
       accessorFn: (row) => getApiKeyStatus(row),
+      filterFn: (row, columnId, filterValue: ApiKeyStatus[]) =>
+        filterValue.length === 0 ||
+        filterValue.includes(row.getValue<ApiKeyStatus>(columnId)),
       header: t("table.status"),
       meta: { className: "w-28" },
       cell: ({ row }) => {

--- a/src/app/dashboard/audit/columns.tsx
+++ b/src/app/dashboard/audit/columns.tsx
@@ -293,6 +293,9 @@ export function getAuditColumns({
     {
       id: "event",
       accessorFn: (row) => getEventTitle(row.eventType, t),
+      filterFn: (row, _columnId, filterValue: string[]) =>
+        filterValue.length === 0 ||
+        filterValue.includes(row.original.eventType),
       meta: { className: "w-[34%]" },
       header: ({ column }) => (
         <Button
@@ -359,6 +362,9 @@ export function getAuditColumns({
     {
       id: "actor",
       accessorFn: (row) => getUserLabel(row.actor, unknownUserLabel),
+      filterFn: (row, _columnId, filterValue: string[]) =>
+        filterValue.length === 0 ||
+        filterValue.includes(getActorFilterValue(row.original)),
       meta: { className: "w-[20%]" },
       header: ({ column }) => (
         <Button
@@ -491,6 +497,13 @@ export function getAuditColumns({
           {formatDateTime(row.original.createdAt)}
         </span>
       ),
+    },
+    {
+      id: "eventCategory",
+      accessorFn: (row) => getEventCategory(row.eventType),
+      filterFn: (row, columnId, filterValue: AuditEventCategory[]) =>
+        filterValue.length === 0 ||
+        filterValue.includes(row.getValue<AuditEventCategory>(columnId)),
     },
   ];
 }

--- a/src/app/dashboard/gallery/columns.tsx
+++ b/src/app/dashboard/gallery/columns.tsx
@@ -325,6 +325,9 @@ export function getGalleryColumns({
     },
     {
       accessorKey: "galleryState",
+      filterFn: (row, columnId, filterValue: GalleryState[]) =>
+        filterValue.length === 0 ||
+        filterValue.includes(row.getValue<GalleryState>(columnId)),
       header: t("table.state"),
       meta: { className: "w-28" },
       cell: ({ row }) => (
@@ -337,6 +340,9 @@ export function getGalleryColumns({
       id: "shareLifecycle",
       header: t("table.share"),
       accessorFn: (row) => getShareLifecycleState(row),
+      filterFn: (row, columnId, filterValue: string[]) =>
+        filterValue.length === 0 ||
+        filterValue.includes(row.getValue<string>(columnId)),
       meta: { className: "w-56" },
       cell: ({ row }) => {
         const lifecycleState = getShareLifecycleState(row.original);

--- a/src/app/dashboard/shares/columns.tsx
+++ b/src/app/dashboard/shares/columns.tsx
@@ -195,6 +195,11 @@ export function getSharesColumns({
     {
       id: "owner",
       accessorFn: (row) => getOwnerLabel(row, t),
+      filterFn: (row, _columnId, filterValue: string[]) =>
+        filterValue.length === 0 ||
+        filterValue.includes(
+          row.original.ownerUserId ? "account" : "anonymous"
+        ),
       header: tCommon("labels.owner"),
       meta: { className: "w-[20%] min-w-44" },
       cell: ({ row }) => (
@@ -211,6 +216,9 @@ export function getSharesColumns({
     {
       id: "type",
       accessorFn: (row) => row.shareType,
+      filterFn: (row, columnId, filterValue: string[]) =>
+        filterValue.length === 0 ||
+        filterValue.includes(row.getValue<string>(columnId)),
       header: t("table.type"),
       meta: { className: "w-28" },
       cell: ({ row }) => (
@@ -224,6 +232,9 @@ export function getSharesColumns({
     {
       id: "status",
       accessorFn: (row) => getLifecycleState(row),
+      filterFn: (row, columnId, filterValue: string[]) =>
+        filterValue.length === 0 ||
+        filterValue.includes(row.getValue<string>(columnId)),
       header: t("table.status"),
       meta: { className: "w-64 min-w-64" },
       cell: ({ row }) => {

--- a/src/app/dashboard/users/columns.tsx
+++ b/src/app/dashboard/users/columns.tsx
@@ -109,6 +109,9 @@ export function getUsersColumns({
     },
     {
       accessorKey: "role",
+      filterFn: (row, columnId, filterValue: AccountRole[]) =>
+        filterValue.length === 0 ||
+        filterValue.includes(row.getValue<AccountRole>(columnId)),
       header: t("table.role"),
       meta: { className: "w-32" },
       cell: ({ row }) => (

--- a/src/components/dashboard/ApiKeysManager.tsx
+++ b/src/components/dashboard/ApiKeysManager.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
   getFilteredRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   type SortingState,
   useReactTable,
@@ -79,13 +82,26 @@ export default function DashboardApiKeysManager({
   const [selectedStatuses, setSelectedStatuses] = useState<ApiKeyStatus[]>([]);
   const [inspectKey, setInspectKey] = useState<AdminApiKey | null>(null);
 
-  const columns = getApiKeysColumns({ t: t as unknown as Translate });
+  const columns = useMemo(
+    () => getApiKeysColumns({ t: t as unknown as Translate }),
+    [t]
+  );
+  const columnFilters = useMemo(
+    () =>
+      selectedStatuses.length > 0
+        ? [{ id: "status", value: selectedStatuses }]
+        : [],
+    [selectedStatuses]
+  );
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: initialKeys,
     columns,
-    state: { globalFilter, sorting },
+    state: { globalFilter, sorting, columnFilters },
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: 10 },
+    },
     onGlobalFilterChange: setGlobalFilter,
     onSortingChange: setSorting,
     globalFilterFn: (row, _columnId, filterValue: string) => {
@@ -100,20 +116,18 @@ export default function DashboardApiKeysManager({
     },
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+    getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
 
-  const allRows = table.getRowModel().rows;
-  const filteredRows = allRows.filter((row) =>
-    selectedStatuses.length === 0
-      ? true
-      : selectedStatuses.includes(getApiKeyStatus(row.original))
-  );
+  const filteredRowCount = table.getFilteredRowModel().rows.length;
+  const statusCounts = table.getColumn("status")?.getFacetedUniqueValues();
   const statusFilterOptions = statusFilterValues.map((value) => ({
     value,
     label: t(`statusValues.${value}`),
-    count: allRows.filter((row) => getApiKeyStatus(row.original) === value)
-      .length,
+    count: statusCounts?.get(value) ?? 0,
   }));
 
   const emptyMessage =
@@ -138,20 +152,22 @@ export default function DashboardApiKeysManager({
 
       <DataTable
         table={table}
-        rows={filteredRows}
         columnsLength={columns.length}
         emptyMessage={emptyMessage}
         minWidthClassName="min-w-[860px]"
         emptyClassName="py-8"
         onRowClick={(row) => setInspectKey(row.original)}
+        pagination={{
+          summary: (
+            <p className="text-muted-foreground text-xs">
+              {t("status.showing", {
+                filtered: filteredRowCount,
+                total: initialKeys.length,
+              })}
+            </p>
+          ),
+        }}
       />
-
-      <p className="text-muted-foreground text-xs">
-        {t("status.showing", {
-          filtered: filteredRows.length,
-          total: initialKeys.length,
-        })}
-      </p>
 
       <Sheet
         open={inspectKey !== null}

--- a/src/components/dashboard/GalleryManager.tsx
+++ b/src/components/dashboard/GalleryManager.tsx
@@ -2,11 +2,13 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   getCoreRowModel,
+  getFacetedRowModel,
   getFilteredRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   type SortingState,
   useReactTable,
@@ -190,57 +192,58 @@ export default function DashboardGalleryManager({
 
   const canManageGallery = galleryManagerRoles.includes(currentUserRole);
 
-  const updateEntry = async (
-    shareToken: string,
-    action: GalleryUpdateAction
-  ) => {
-    if (!canManageGallery) {
-      toast.error(t("restrictions.manage"));
-      return;
-    }
-
-    setPendingShareToken(shareToken);
-
-    try {
-      const response = await fetch(
-        `/api/dashboard/gallery/${encodeURIComponent(shareToken)}`,
-        {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ action }),
-        }
-      );
-
-      const payload = (await response.json()) as
-        { ok: true; entry: StoredGalleryEntry } | { ok: false; error?: string };
-
-      if (!response.ok || !payload.ok) {
-        throw new Error(
-          payload.ok
-            ? t("messages.updateFailed")
-            : (payload.error ?? t("messages.updateFailed"))
-        );
+  const updateEntry = useCallback(
+    async (shareToken: string, action: GalleryUpdateAction) => {
+      if (!canManageGallery) {
+        toast.error(t("restrictions.manage"));
+        return;
       }
 
-      setEntries((previous) =>
-        previous.map((entry) =>
-          entry.shareToken === payload.entry.shareToken
-            ? { ...entry, ...payload.entry }
-            : entry
-        )
-      );
+      setPendingShareToken(shareToken);
 
-      toast.success(t("messages.updateSuccess", { action }));
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : t("messages.updateFailed")
-      );
-    } finally {
-      setPendingShareToken(null);
-    }
-  };
+      try {
+        const response = await fetch(
+          `/api/dashboard/gallery/${encodeURIComponent(shareToken)}`,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ action }),
+          }
+        );
+
+        const payload = (await response.json()) as
+          | { ok: true; entry: StoredGalleryEntry }
+          | { ok: false; error?: string };
+
+        if (!response.ok || !payload.ok) {
+          throw new Error(
+            payload.ok
+              ? t("messages.updateFailed")
+              : (payload.error ?? t("messages.updateFailed"))
+          );
+        }
+
+        setEntries((previous) =>
+          previous.map((entry) =>
+            entry.shareToken === payload.entry.shareToken
+              ? { ...entry, ...payload.entry }
+              : entry
+          )
+        );
+
+        toast.success(t("messages.updateSuccess", { action }));
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : t("messages.updateFailed")
+        );
+      } finally {
+        setPendingShareToken(null);
+      }
+    },
+    [canManageGallery, t]
+  );
 
   const deleteEntry = async (shareToken: string) => {
     if (!canManageGallery) {
@@ -303,20 +306,39 @@ export default function DashboardGalleryManager({
     }
   };
 
-  const columns = getGalleryColumns({
-    t: t as unknown as Translate,
-    tCommon: tCommon as unknown as Translate,
-    pendingShareToken,
-    canManageGallery,
-    onUpdateEntry: (shareToken, action) => void updateEntry(shareToken, action),
-    onDeleteCandidate: setDeleteCandidate,
-  });
+  const columns = useMemo(
+    () =>
+      getGalleryColumns({
+        t: t as unknown as Translate,
+        tCommon: tCommon as unknown as Translate,
+        pendingShareToken,
+        canManageGallery,
+        onUpdateEntry: (shareToken, action) =>
+          void updateEntry(shareToken, action),
+        onDeleteCandidate: setDeleteCandidate,
+      }),
+    [canManageGallery, pendingShareToken, t, tCommon, updateEntry]
+  );
+  const columnFilters = useMemo(
+    () => [
+      ...(selectedGalleryStates.length > 0
+        ? [{ id: "galleryState", value: selectedGalleryStates }]
+        : []),
+      ...(selectedShareLifecycles.length > 0
+        ? [{ id: "shareLifecycle", value: selectedShareLifecycles }]
+        : []),
+    ],
+    [selectedGalleryStates, selectedShareLifecycles]
+  );
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: entries,
     columns,
-    state: { globalFilter, sorting },
+    state: { globalFilter, sorting, columnFilters },
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: 10 },
+    },
     onGlobalFilterChange: setGlobalFilter,
     onSortingChange: setSorting,
     globalFilterFn: (row, _columnId, filterValue: string) => {
@@ -330,30 +352,16 @@ export default function DashboardGalleryManager({
     },
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
 
-  const rowsForCurrentSearch = table.getRowModel().rows;
-  const stateFilteredRows = rowsForCurrentSearch.filter((row) =>
-    selectedGalleryStates.length === 0
-      ? true
-      : selectedGalleryStates.includes(row.original.galleryState)
-  );
-  const filteredRows = stateFilteredRows.filter((row) =>
-    selectedShareLifecycles.length === 0
-      ? true
-      : selectedShareLifecycles.includes(getShareLifecycleState(row.original))
-  );
-  const stateFacetRows = rowsForCurrentSearch.filter((row) =>
-    selectedShareLifecycles.length === 0
-      ? true
-      : selectedShareLifecycles.includes(getShareLifecycleState(row.original))
-  );
-  const shareFacetRows = rowsForCurrentSearch.filter((row) =>
-    selectedGalleryStates.length === 0
-      ? true
-      : selectedGalleryStates.includes(row.original.galleryState)
-  );
+  const filteredRowCount = table.getFilteredRowModel().rows.length;
+  const stateFacetRows =
+    table.getColumn("galleryState")?.getFacetedRowModel().rows ?? [];
+  const shareFacetRows =
+    table.getColumn("shareLifecycle")?.getFacetedRowModel().rows ?? [];
   const stateFilterOptions = stateFilterValues.map((value) => ({
     value,
     label: t(`stateValues.${value}`),
@@ -402,7 +410,6 @@ export default function DashboardGalleryManager({
 
       <DataTable
         table={table}
-        rows={filteredRows}
         columnsLength={columns.length}
         emptyMessage={emptyMessage}
         minWidthClassName="min-w-[920px]"
@@ -411,14 +418,17 @@ export default function DashboardGalleryManager({
         getRowAriaLabel={(row) =>
           t("aria.row", { title: row.original.galleryTitle })
         }
+        pagination={{
+          summary: (
+            <p className="text-muted-foreground text-xs">
+              {t("status.showing", {
+                filtered: filteredRowCount,
+                total: entries.length,
+              })}
+            </p>
+          ),
+        }}
       />
-
-      <p className="text-muted-foreground text-xs">
-        {t("status.showing", {
-          filtered: filteredRows.length,
-          total: entries.length,
-        })}
-      </p>
 
       <Dialog
         open={inspectCandidate !== null}

--- a/src/components/dashboard/SharesManager.tsx
+++ b/src/components/dashboard/SharesManager.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   getCoreRowModel,
+  getFacetedRowModel,
   getFilteredRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   type SortingState,
   useReactTable,
@@ -175,33 +177,57 @@ export default function DashboardSharesManager({
     }
   };
 
-  const copyShareLink = async (token: string) => {
-    const href = `${window.location.origin}/share/${token}`;
+  const copyShareLink = useCallback(
+    async (token: string) => {
+      const href = `${window.location.origin}/share/${token}`;
 
-    try {
-      await window.navigator.clipboard.writeText(href);
-      toast.success(t("messages.copyLinkSuccess"));
-    } catch {
-      toast.error(t("messages.copyLinkFailed"));
-    }
-  };
+      try {
+        await window.navigator.clipboard.writeText(href);
+        toast.success(t("messages.copyLinkSuccess"));
+      } catch {
+        toast.error(t("messages.copyLinkFailed"));
+      }
+    },
+    [t]
+  );
 
-  const columns = getSharesColumns({
-    t: t as unknown as Translate,
-    tCommon: tCommon as unknown as Translate,
-    pendingToken,
-    canManageShares,
-    canPurgeShares,
-    onCopyLink: (token) => void copyShareLink(token),
-    onRevokeCandidate: setRevokeCandidate,
-    onPurgeCandidate: setPurgeCandidate,
-  });
+  const columns = useMemo(
+    () =>
+      getSharesColumns({
+        t: t as unknown as Translate,
+        tCommon: tCommon as unknown as Translate,
+        pendingToken,
+        canManageShares,
+        canPurgeShares,
+        onCopyLink: (token) => void copyShareLink(token),
+        onRevokeCandidate: setRevokeCandidate,
+        onPurgeCandidate: setPurgeCandidate,
+      }),
+    [canManageShares, canPurgeShares, copyShareLink, pendingToken, t, tCommon]
+  );
+  const columnFilters = useMemo(
+    () => [
+      ...(selectedLifecycles.length > 0
+        ? [{ id: "status", value: selectedLifecycles }]
+        : []),
+      ...(selectedTypes.length > 0
+        ? [{ id: "type", value: selectedTypes }]
+        : []),
+      ...(selectedOwners.length > 0
+        ? [{ id: "owner", value: selectedOwners }]
+        : []),
+    ],
+    [selectedLifecycles, selectedOwners, selectedTypes]
+  );
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: shares,
     columns,
-    state: { globalFilter, sorting },
+    state: { globalFilter, sorting, columnFilters },
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: 10 },
+    },
     onGlobalFilterChange: setGlobalFilter,
     onSortingChange: setSorting,
     globalFilterFn: (row, _columnId, filterValue: string) => {
@@ -217,36 +243,18 @@ export default function DashboardSharesManager({
     },
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
 
-  const rowsForCurrentSearch = table.getRowModel().rows;
-  const matchesLifecycleFilter = (share: DashboardShare) =>
-    selectedLifecycles.length === 0 ||
-    selectedLifecycles.includes(getLifecycleState(share));
-  const matchesTypeFilter = (share: DashboardShare) =>
-    selectedTypes.length === 0 || selectedTypes.includes(share.shareType);
-  const matchesOwnerFilter = (share: DashboardShare) =>
-    selectedOwners.length === 0 ||
-    selectedOwners.includes(getOwnerFilterValue(share));
-
-  const filteredRows = rowsForCurrentSearch.filter(
-    (row) =>
-      matchesLifecycleFilter(row.original) &&
-      matchesTypeFilter(row.original) &&
-      matchesOwnerFilter(row.original)
-  );
-  const lifecycleFacetRows = rowsForCurrentSearch.filter(
-    (row) => matchesTypeFilter(row.original) && matchesOwnerFilter(row.original)
-  );
-  const typeFacetRows = rowsForCurrentSearch.filter(
-    (row) =>
-      matchesLifecycleFilter(row.original) && matchesOwnerFilter(row.original)
-  );
-  const ownerFacetRows = rowsForCurrentSearch.filter(
-    (row) =>
-      matchesLifecycleFilter(row.original) && matchesTypeFilter(row.original)
-  );
+  const filteredRowCount = table.getFilteredRowModel().rows.length;
+  const lifecycleFacetRows =
+    table.getColumn("status")?.getFacetedRowModel().rows ?? [];
+  const typeFacetRows =
+    table.getColumn("type")?.getFacetedRowModel().rows ?? [];
+  const ownerFacetRows =
+    table.getColumn("owner")?.getFacetedRowModel().rows ?? [];
   const lifecycleFilterOptions = lifecycleFilterValues.map((value) => ({
     value,
     label: t(`statusValues.${value}`),
@@ -309,20 +317,22 @@ export default function DashboardSharesManager({
 
       <DataTable
         table={table}
-        rows={filteredRows}
         columnsLength={columns.length}
         emptyMessage={emptyMessage}
         minWidthClassName="min-w-[920px]"
         emptyClassName="py-8"
         getRowAriaLabel={(row) => t("aria.row", { title: row.original.title })}
+        pagination={{
+          summary: (
+            <p className="text-muted-foreground text-xs">
+              {t("status.showing", {
+                filtered: filteredRowCount,
+                total: shares.length,
+              })}
+            </p>
+          ),
+        }}
       />
-
-      <p className="text-muted-foreground text-xs">
-        {t("status.showing", {
-          filtered: filteredRows.length,
-          total: shares.length,
-        })}
-      </p>
 
       <Dialog
         open={revokeCandidate !== null}

--- a/src/components/dashboard/UsersManager.tsx
+++ b/src/components/dashboard/UsersManager.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   getCoreRowModel,
+  getFacetedRowModel,
+  getFacetedUniqueValues,
   getFilteredRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   type SortingState,
   useReactTable,
@@ -402,16 +405,32 @@ export default function DashboardUsersManager({
     }
   };
 
-  const columns = getUsersColumns({
-    t: t as unknown as Translate,
-    currentUserId,
-  });
+  const columns = useMemo(
+    () =>
+      getUsersColumns({
+        t: t as unknown as Translate,
+        currentUserId,
+      }),
+    [currentUserId, t]
+  );
+  const columnFilters = useMemo(
+    () =>
+      selectedRoles.length > 0 ? [{ id: "role", value: selectedRoles }] : [],
+    [selectedRoles]
+  );
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: users,
     columns,
-    state: { globalFilter, sorting },
+    state: {
+      globalFilter,
+      sorting,
+      columnFilters,
+    },
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: 10 },
+    },
     onGlobalFilterChange: setGlobalFilter,
     onSortingChange: setSorting,
     globalFilterFn: (row, _columnId, filterValue: string) => {
@@ -424,19 +443,17 @@ export default function DashboardUsersManager({
     },
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getFacetedUniqueValues: getFacetedUniqueValues(),
+    getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
-  const rowsForCurrentSearch = table.getRowModel().rows;
-  const filteredRows = rowsForCurrentSearch.filter((row) =>
-    selectedRoles.length === 0
-      ? true
-      : selectedRoles.includes(row.original.role)
-  );
+  const filteredRowCount = table.getFilteredRowModel().rows.length;
+  const roleCounts = table.getColumn("role")?.getFacetedUniqueValues();
   const roleFilterOptions = accountRoles.map((role) => ({
     label: getAccountRoleLabel(role),
     value: role,
-    count: rowsForCurrentSearch.filter((row) => row.original.role === role)
-      .length,
+    count: roleCounts?.get(role) ?? 0,
   }));
 
   return (
@@ -456,18 +473,20 @@ export default function DashboardUsersManager({
 
       <DataTable
         table={table}
-        rows={filteredRows}
         columnsLength={columns.length}
         emptyMessage={t("empty.default")}
         onRowClick={(row) => setInspectCandidate(row.original)}
+        pagination={{
+          summary: (
+            <p className="text-muted-foreground text-xs">
+              {t("status.showing", {
+                filtered: filteredRowCount,
+                total: users.length,
+              })}
+            </p>
+          ),
+        }}
       />
-
-      <p className="text-muted-foreground text-xs">
-        {t("status.showing", {
-          filtered: filteredRows.length,
-          total: users.length,
-        })}
-      </p>
 
       <Sheet
         open={inspectCandidate !== null}

--- a/src/components/dashboard/tables/AuditEventsTable.tsx
+++ b/src/components/dashboard/tables/AuditEventsTable.tsx
@@ -123,24 +123,27 @@ export default function DashboardAuditEventsTable({
       (row) => getEventCategory(row.original.eventType) === value
     ).length,
   }));
-  const actorFilterOptions = Array.from(
-    new Map(
-      actorFacetRows.map((row) => [
-        getActorFilterValue(row.original),
-        {
-          label: getActorFilterLabel(row.original, unknownUserLabel),
-          value: getActorFilterValue(row.original),
-        },
-      ])
-    ).values()
-  )
-    .sort((a, b) => a.label.localeCompare(b.label))
-    .map((filter) => ({
-      ...filter,
-      count: actorFacetRows.filter(
-        (row) => getActorFilterValue(row.original) === filter.value
-      ).length,
-    }));
+  const actorFiltersByValue = new Map<
+    string,
+    { label: string; value: string; count: number }
+  >();
+  for (const row of actorFacetRows) {
+    const value = getActorFilterValue(row.original);
+    const existingFilter = actorFiltersByValue.get(value);
+    if (existingFilter) {
+      existingFilter.count += 1;
+      continue;
+    }
+
+    actorFiltersByValue.set(value, {
+      label: getActorFilterLabel(row.original, unknownUserLabel),
+      value,
+      count: 1,
+    });
+  }
+  const actorFilterOptions = Array.from(actorFiltersByValue.values()).sort(
+    (a, b) => a.label.localeCompare(b.label)
+  );
 
   const uniqueActorCount = new Set(
     filteredRows.map((row) => row.original.actorUserId).filter(Boolean)

--- a/src/components/dashboard/tables/AuditEventsTable.tsx
+++ b/src/components/dashboard/tables/AuditEventsTable.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   getCoreRowModel,
+  getFacetedRowModel,
   getFilteredRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   type SortingState,
   useReactTable,
@@ -47,13 +49,38 @@ export default function DashboardAuditEventsTable({
     { id: "createdAt", desc: true },
   ]);
 
-  const columns = getAuditColumns({ t, unknownUserLabel });
+  const columns = useMemo(
+    () => getAuditColumns({ t, unknownUserLabel }),
+    [t, unknownUserLabel]
+  );
+  const columnFilters = useMemo(
+    () => [
+      ...(selectedCategories.length > 0
+        ? [{ id: "eventCategory", value: selectedCategories }]
+        : []),
+      ...(selectedEventTypes.length > 0
+        ? [{ id: "event", value: selectedEventTypes }]
+        : []),
+      ...(selectedActors.length > 0
+        ? [{ id: "actor", value: selectedActors }]
+        : []),
+    ],
+    [selectedActors, selectedCategories, selectedEventTypes]
+  );
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: events,
     columns,
-    state: { globalFilter, sorting },
+    state: {
+      globalFilter,
+      sorting,
+      columnFilters,
+      columnVisibility: { eventCategory: false },
+    },
+    initialState: {
+      pagination: { pageIndex: 0, pageSize: 10 },
+    },
     onGlobalFilterChange: setGlobalFilter,
     onSortingChange: setSorting,
     globalFilterFn: (row, _columnId, filterValue: string) =>
@@ -65,33 +92,18 @@ export default function DashboardAuditEventsTable({
       ),
     getCoreRowModel: getCoreRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
+    getFacetedRowModel: getFacetedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });
 
-  const rowsForCurrentSearch = table.getRowModel().rows;
-  const byCategory = (event: DashboardAuditEvent) =>
-    selectedCategories.length === 0 ||
-    selectedCategories.includes(getEventCategory(event.eventType));
-  const byEventType = (event: DashboardAuditEvent) =>
-    selectedEventTypes.length === 0 ||
-    selectedEventTypes.includes(event.eventType);
-  const byActor = (event: DashboardAuditEvent) =>
-    selectedActors.length === 0 ||
-    selectedActors.includes(getActorFilterValue(event));
-
-  const categoryFacetRows = rowsForCurrentSearch
-    .filter((row) => byEventType(row.original))
-    .filter((row) => byActor(row.original));
-  const eventTypeFacetRows = rowsForCurrentSearch
-    .filter((row) => byCategory(row.original))
-    .filter((row) => byActor(row.original));
-  const actorFacetRows = rowsForCurrentSearch
-    .filter((row) => byCategory(row.original))
-    .filter((row) => byEventType(row.original));
-  const filteredRows = rowsForCurrentSearch
-    .filter((row) => byCategory(row.original))
-    .filter((row) => byEventType(row.original))
-    .filter((row) => byActor(row.original));
+  const categoryFacetRows =
+    table.getColumn("eventCategory")?.getFacetedRowModel().rows ?? [];
+  const eventTypeFacetRows =
+    table.getColumn("event")?.getFacetedRowModel().rows ?? [];
+  const actorFacetRows =
+    table.getColumn("actor")?.getFacetedRowModel().rows ?? [];
+  const filteredRows = table.getFilteredRowModel().rows;
 
   const eventTypeFilters = Array.from(
     new Set(events.map((event) => event.eventType))
@@ -113,7 +125,7 @@ export default function DashboardAuditEventsTable({
   }));
   const actorFilterOptions = Array.from(
     new Map(
-      rowsForCurrentSearch.map((row) => [
+      actorFacetRows.map((row) => [
         getActorFilterValue(row.original),
         {
           label: getActorFilterLabel(row.original, unknownUserLabel),
@@ -192,10 +204,10 @@ export default function DashboardAuditEventsTable({
 
       <DataTable
         table={table}
-        rows={filteredRows}
-        columnsLength={columns.length}
+        columnsLength={table.getVisibleLeafColumns().length}
         emptyMessage={t("table.noEvents")}
         minWidthClassName="min-w-[980px]"
+        pagination={{}}
       />
     </div>
   );

--- a/src/components/data-table/DataTable.tsx
+++ b/src/components/data-table/DataTable.tsx
@@ -22,6 +22,7 @@ import {
   dataTableWrapperClassName,
   getDataTableColumnClassName,
 } from "./DataTableLayout";
+import DataTablePagination from "./DataTablePagination";
 
 type DataTableFrameProps = ComponentProps<"div"> & {
   minWidthClassName?: string;
@@ -40,6 +41,10 @@ type DataTableProps<TData> = {
   emptyClassName?: string;
   onRowClick?: (row: Row<TData>) => void;
   getRowAriaLabel?: (row: Row<TData>) => string;
+  pagination?: {
+    summary?: ReactNode;
+    pageSizeOptions?: number[];
+  };
 };
 
 type DataTableEmptyStateProps = ComponentProps<typeof TableCell> & {
@@ -116,76 +121,94 @@ export default function DataTable<TData>({
   emptyClassName,
   onRowClick,
   getRowAriaLabel,
+  pagination,
 }: DataTableProps<TData>) {
   return (
-    <DataTableFrame
-      className={wrapperClassName}
-      minWidthClassName={minWidthClassName}
-      tableClassName={tableClassName}
-    >
-      <TableHeader>
-        {table.getHeaderGroups().map((headerGroup) => (
-          <TableRow key={headerGroup.id}>
-            {headerGroup.headers.map((header) => (
-              <DataTableHeaderCell
-                key={header.id}
-                className={getDataTableColumnClassName(
-                  header.column.columnDef.meta,
-                  "header"
-                )}
-              >
-                {header.isPlaceholder
-                  ? null
-                  : flexRender(
-                      header.column.columnDef.header,
-                      header.getContext()
-                    )}
-              </DataTableHeaderCell>
-            ))}
-          </TableRow>
-        ))}
-      </TableHeader>
-      <TableBody>
-        {rows.length ? (
-          rows.map((row) => (
-            <TableRow
-              key={row.id}
-              onClick={onRowClick ? () => onRowClick(row) : undefined}
-              onKeyDown={
-                onRowClick
-                  ? (e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        onRowClick(row);
-                      }
-                    }
-                  : undefined
-              }
-              tabIndex={onRowClick ? 0 : undefined}
-              className={onRowClick ? "cursor-pointer" : undefined}
-              aria-label={getRowAriaLabel ? getRowAriaLabel(row) : undefined}
-            >
-              {row.getVisibleCells().map((cell) => (
-                <DataTableBodyCell
-                  key={cell.id}
+    <div className="space-y-3">
+      <DataTableFrame
+        className={wrapperClassName}
+        minWidthClassName={minWidthClassName}
+        tableClassName={tableClassName}
+      >
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <DataTableHeaderCell
+                  key={header.id}
                   className={getDataTableColumnClassName(
-                    cell.column.columnDef.meta,
-                    "cell"
+                    header.column.columnDef.meta,
+                    "header"
                   )}
                 >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </DataTableBodyCell>
+                  {header.isPlaceholder
+                    ? null
+                    : flexRender(
+                        header.column.columnDef.header,
+                        header.getContext()
+                      )}
+                </DataTableHeaderCell>
               ))}
             </TableRow>
-          ))
-        ) : (
-          <DataTableEmptyState
-            colSpan={columnsLength}
-            message={emptyMessage}
-            className={emptyClassName}
+          ))}
+        </TableHeader>
+        <TableBody>
+          {rows.length ? (
+            rows.map((row) => (
+              <TableRow
+                key={row.id}
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+                onKeyDown={
+                  onRowClick
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          onRowClick(row);
+                        }
+                      }
+                    : undefined
+                }
+                tabIndex={onRowClick ? 0 : undefined}
+                className={onRowClick ? "cursor-pointer" : undefined}
+                aria-label={getRowAriaLabel ? getRowAriaLabel(row) : undefined}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <DataTableBodyCell
+                    key={cell.id}
+                    className={getDataTableColumnClassName(
+                      cell.column.columnDef.meta,
+                      "cell"
+                    )}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </DataTableBodyCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <DataTableEmptyState
+              colSpan={columnsLength}
+              message={emptyMessage}
+              className={emptyClassName}
+            />
+          )}
+        </TableBody>
+      </DataTableFrame>
+
+      {pagination ? (
+        <div
+          className={cn(
+            "flex flex-col gap-3 sm:flex-row sm:items-center",
+            pagination.summary ? "sm:justify-between" : "sm:justify-end"
+          )}
+        >
+          {pagination.summary}
+          <DataTablePagination
+            table={table}
+            pageSizeOptions={pagination.pageSizeOptions}
           />
-        )}
-      </TableBody>
-    </DataTableFrame>
+        </div>
+      ) : null}
+    </div>
   );
 }

--- a/src/components/data-table/DataTablePagination.tsx
+++ b/src/components/data-table/DataTablePagination.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { Table } from "@tanstack/react-table";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+type DataTablePaginationProps<TData> = {
+  table: Table<TData>;
+  pageSizeOptions?: number[];
+};
+
+export default function DataTablePagination<TData>({
+  table,
+  pageSizeOptions = [10, 25, 50],
+}: DataTablePaginationProps<TData>) {
+  const t = useTranslations("common.dataTable");
+  const pageCount = Math.max(table.getPageCount(), 1);
+  const pageIndex = Math.min(
+    table.getState().pagination.pageIndex,
+    pageCount - 1
+  );
+
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-3">
+      <div className="flex items-center gap-2">
+        <span className="text-muted-foreground text-xs">
+          {t("rowsPerPage")}
+        </span>
+        <Select
+          value={`${table.getState().pagination.pageSize}`}
+          onValueChange={(value) => table.setPageSize(Number(value))}
+        >
+          <SelectTrigger
+            className="h-8 w-18 text-xs"
+            aria-label={t("rowsPerPage")}
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent align="end">
+            {pageSizeOptions.map((pageSize) => (
+              <SelectItem key={pageSize} value={`${pageSize}`}>
+                {pageSize}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <span className="min-w-24 text-center text-xs tabular-nums">
+        {t("page", { current: pageIndex + 1, total: pageCount })}
+      </span>
+
+      <div className="flex items-center gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="size-8"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+          aria-label={t("previousPage")}
+        >
+          <ChevronLeft />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="size-8"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+          aria-label={t("nextPage")}
+        >
+          <ChevronRight />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/data-table/DataTablePagination.tsx
+++ b/src/components/data-table/DataTablePagination.tsx
@@ -39,7 +39,7 @@ export default function DataTablePagination<TData>({
           onValueChange={(value) => table.setPageSize(Number(value))}
         >
           <SelectTrigger
-            className="h-8 w-18 text-xs"
+            className="h-8 w-20 text-xs"
             aria-label={t("rowsPerPage")}
           >
             <SelectValue />

--- a/tests/components/dashboard/ApiKeysManager.test.tsx
+++ b/tests/components/dashboard/ApiKeysManager.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import DashboardApiKeysManager from "@/components/dashboard/ApiKeysManager";
+import type { AdminApiKey } from "@/lib/server/api-keys";
+
+function createApiKey(index: number): AdminApiKey {
+  return {
+    id: `key-${index}`,
+    name: `API key ${index}`,
+    start: `td_${index}`,
+    prefix: "td_",
+    enabled: true,
+    requestCount: index,
+    remaining: null,
+    lastRequest: null,
+    expiresAt: null,
+    createdAt: "2026-07-01T10:00:00.000Z",
+    updatedAt: "2026-07-01T10:00:00.000Z",
+    rateLimitEnabled: false,
+    rateLimitMax: null,
+    rateLimitTimeWindowMs: null,
+    permissions: null,
+    ownerUserId: `user-${index}`,
+    ownerName: `Owner ${index}`,
+    ownerEmail: `owner-${index}@trackdraw.local`,
+  };
+}
+
+describe("DashboardApiKeysManager", () => {
+  afterEach(cleanup);
+
+  it("paginates API keys", async () => {
+    const user = userEvent.setup();
+    const keys = Array.from({ length: 12 }, (_, index) =>
+      createApiKey(index + 1)
+    );
+
+    render(<DashboardApiKeysManager initialKeys={keys} />);
+
+    expect(screen.getByText("Page 1 of 2")).toBeTruthy();
+    expect(screen.queryByText("API key 11")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(screen.getByText("Page 2 of 2")).toBeTruthy();
+    expect(screen.getByText("API key 11")).toBeTruthy();
+  });
+});

--- a/tests/components/dashboard/AuditEventsTable.test.tsx
+++ b/tests/components/dashboard/AuditEventsTable.test.tsx
@@ -46,4 +46,36 @@ describe("DashboardAuditEventsTable", () => {
     expect(screen.getByText("Page 2 of 2")).toBeTruthy();
     expect(screen.getByText("System Event 2")).toBeTruthy();
   });
+
+  it("counts actor facet options in the filtered row set", async () => {
+    const user = userEvent.setup();
+    const moderatorEvent = {
+      ...createEvent(3),
+      actorUserId: "moderator-1",
+      actor: {
+        id: "moderator-1",
+        name: "Moderator",
+        email: "moderator@trackdraw.local",
+      },
+    };
+
+    render(
+      <DashboardAuditEventsTable
+        events={[createEvent(1), createEvent(2), moderatorEvent]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Actor" }));
+
+    expect(
+      screen.getByRole("button", {
+        name: "Admin (admin@trackdraw.local) 2",
+      })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: "Moderator (moderator@trackdraw.local) 1",
+      })
+    ).toBeTruthy();
+  });
 });

--- a/tests/components/dashboard/AuditEventsTable.test.tsx
+++ b/tests/components/dashboard/AuditEventsTable.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import type { DashboardAuditEvent } from "@/app/dashboard/audit/columns";
+import DashboardAuditEventsTable from "@/components/dashboard/tables/AuditEventsTable";
+
+function createEvent(index: number): DashboardAuditEvent {
+  return {
+    id: `event-${index}`,
+    actorUserId: "admin-1",
+    targetUserId: null,
+    eventType: `system.event.${index}`,
+    entityType: "system",
+    entityId: null,
+    metadata: null,
+    createdAt: `2026-07-${String(index).padStart(2, "0")}T10:00:00.000Z`,
+    actor: {
+      id: "admin-1",
+      name: "Admin",
+      email: "admin@trackdraw.local",
+    },
+    target: null,
+  };
+}
+
+describe("DashboardAuditEventsTable", () => {
+  afterEach(cleanup);
+
+  it("paginates audit events after sorting", async () => {
+    const user = userEvent.setup();
+    const events = Array.from({ length: 12 }, (_, index) =>
+      createEvent(index + 1)
+    );
+
+    render(<DashboardAuditEventsTable events={events} />);
+
+    expect(screen.getByText("Page 1 of 2")).toBeTruthy();
+    expect(screen.queryByText("System Event 2")).toBeNull();
+    expect(screen.getByText("12")).toBeTruthy();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(screen.getByText("Page 2 of 2")).toBeTruthy();
+    expect(screen.getByText("System Event 2")).toBeTruthy();
+  });
+});

--- a/tests/components/dashboard/GalleryManager.test.tsx
+++ b/tests/components/dashboard/GalleryManager.test.tsx
@@ -177,4 +177,29 @@ describe("DashboardGalleryManager", () => {
       method: "DELETE",
     });
   });
+
+  it("paginates gallery entries", async () => {
+    const user = userEvent.setup();
+    const entries = Array.from({ length: 12 }, (_, index) => ({
+      ...entry,
+      id: `entry-${index + 1}`,
+      shareToken: `share-token-${index + 1}`,
+      galleryTitle: `Track ${index + 1}`,
+    }));
+
+    render(
+      <DashboardGalleryManager
+        currentUserRole="moderator"
+        initialEntries={entries}
+      />
+    );
+
+    expect(screen.getByText("Page 1 of 2")).toBeTruthy();
+    expect(screen.queryByText("Track 11")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(screen.getByText("Page 2 of 2")).toBeTruthy();
+    expect(screen.getByText("Track 11")).toBeTruthy();
+  });
 });

--- a/tests/components/dashboard/SharesManager.test.tsx
+++ b/tests/components/dashboard/SharesManager.test.tsx
@@ -282,4 +282,28 @@ describe("DashboardSharesManager", () => {
       ).disabled
     ).toBe(true);
   });
+
+  it("paginates shares", async () => {
+    const user = userEvent.setup();
+    const shares = Array.from({ length: 12 }, (_, index) => ({
+      ...activeShare,
+      token: `share-token-${index + 1}`,
+      title: `Track ${index + 1}`,
+    }));
+
+    render(
+      <DashboardSharesManager
+        currentUserRole="moderator"
+        initialShares={shares}
+      />
+    );
+
+    expect(screen.getByText("Page 1 of 2")).toBeTruthy();
+    expect(screen.queryByText("Track 11")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(screen.getByText("Page 2 of 2")).toBeTruthy();
+    expect(screen.getByText("Track 11")).toBeTruthy();
+  });
 });

--- a/tests/components/dashboard/UsersManager.test.tsx
+++ b/tests/components/dashboard/UsersManager.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it } from "vitest";
+import DashboardUsersManager from "@/components/dashboard/UsersManager";
+import type { AdminUser } from "@/lib/account/admin-users";
+
+function createUser(index: number): AdminUser {
+  return {
+    id: `user-${index}`,
+    name: `User ${index}`,
+    email: `user-${index}@trackdraw.local`,
+    image: null,
+    role: "user",
+    createdAt: `2026-07-${String(index).padStart(2, "0")}T10:00:00.000Z`,
+    updatedAt: `2026-07-${String(index).padStart(2, "0")}T10:00:00.000Z`,
+    lastLoginAt: null,
+    projectCount: 0,
+    bannedAt: null,
+    banReason: null,
+  };
+}
+
+describe("DashboardUsersManager", () => {
+  afterEach(cleanup);
+
+  it("paginates accounts and resets to the first page when searching", async () => {
+    const user = userEvent.setup();
+    const users = Array.from({ length: 12 }, (_, index) =>
+      createUser(index + 1)
+    );
+
+    render(
+      <DashboardUsersManager currentUserId="user-1" initialUsers={users} />
+    );
+
+    expect(screen.getByText("Page 1 of 2")).toBeTruthy();
+    expect(screen.getByText("User 10")).toBeTruthy();
+    expect(screen.queryByText("User 11")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(screen.getByText("Page 2 of 2")).toBeTruthy();
+    expect(screen.getByText("User 11")).toBeTruthy();
+
+    await user.type(
+      screen.getByPlaceholderText("Search by name or email..."),
+      "User 12"
+    );
+
+    expect(screen.getByText("Page 1 of 1")).toBeTruthy();
+    expect(screen.getByText("User 12")).toBeTruthy();
+    expect(screen.queryByText("User 11")).toBeNull();
+  });
+
+  it("applies role filters before paginating", async () => {
+    const user = userEvent.setup();
+    const users = Array.from({ length: 12 }, (_, index) =>
+      createUser(index + 1)
+    );
+    users[11] = { ...users[11], role: "admin" };
+
+    render(
+      <DashboardUsersManager currentUserId="user-1" initialUsers={users} />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Role" }));
+    await user.click(screen.getByRole("button", { name: "Admin 1" }));
+
+    expect(screen.getByText("Page 1 of 1")).toBeTruthy();
+    expect(screen.getByText("User 12")).toBeTruthy();
+    expect(screen.queryByText("User 1")).toBeNull();
+    expect(screen.getByText("Showing 1 of 12 accounts.")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- add pagination to the shared dashboard `DataTable`
- apply consistent 10, 25, and 50 row page sizes across users, gallery, shares, API keys, and audit events
- keep searching, sorting, facet filters, counts, and audit summaries based on the complete filtered result
- add accessible translated pagination controls and focused regression coverage

## Why

Production dashboard datasets are growing beyond a comfortable single-page list. Shared pagination keeps these management views compact and consistent without changing their existing workflows.

## Validation

- `npm run lint`
- `npm run test` — 804 tests passed
- `npm run type`
- `npm run build`
- `npm run i18n:check`