### PR TITLE
fix: Handle compact session cookie headers

### DIFF
--- a/src/lib/server/auth-session.ts
+++ b/src/lib/server/auth-session.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { getSessionCookie } from "better-auth/cookies";
 import { parseAccountRole, type AccountRole } from "@/lib/account/roles";
 import { getDatabase } from "@/lib/server/db";
 
@@ -21,38 +22,8 @@ type SessionUserRow = {
   bannedAt: string | null;
 };
 
-const SESSION_COOKIE_NAMES = [
-  "__Secure-better-auth.session_token",
-  "better-auth.session_token",
-];
-
 function getAuthSecret() {
   return process.env.BETTER_AUTH_SECRET ?? process.env.AUTH_SECRET ?? null;
-}
-
-function parseCookieHeader(cookieHeader: string | null) {
-  if (!cookieHeader) {
-    return new Map<string, string>();
-  }
-
-  const cookieMap = new Map<string, string>();
-
-  for (const pair of cookieHeader.split("; ")) {
-    const [name, ...valueParts] = pair.split("=");
-    if (!name || valueParts.length === 0) {
-      continue;
-    }
-
-    const rawValue = valueParts.join("=");
-
-    try {
-      cookieMap.set(name, decodeURIComponent(rawValue));
-    } catch {
-      cookieMap.set(name, rawValue);
-    }
-  }
-
-  return cookieMap;
 }
 
 async function importHmacKey(secret: string) {
@@ -110,21 +81,10 @@ async function readSessionTokenFromHeaders(requestHeaders: Headers) {
     return null;
   }
 
-  const cookies = parseCookieHeader(requestHeaders.get("cookie"));
-
-  for (const cookieName of SESSION_COOKIE_NAMES) {
-    const cookieValue = cookies.get(cookieName);
-    if (!cookieValue) {
-      continue;
-    }
-
-    const token = await verifySignedCookieValue(cookieValue, secret);
-    if (token) {
-      return token;
-    }
-  }
-
-  return null;
+  const cookieValue = getSessionCookie(requestHeaders);
+  return cookieValue
+    ? await verifySignedCookieValue(cookieValue, secret)
+    : null;
 }
 
 export async function getCurrentUserFromHeaders(

--- a/tests/lib/server/auth-session.test.ts
+++ b/tests/lib/server/auth-session.test.ts
@@ -95,6 +95,37 @@ describe("auth session resolver", () => {
     });
   });
 
+  it("loads a session when cookie pairs have no whitespace separator", async () => {
+    vi.stubEnv("BETTER_AUTH_SECRET", "test-secret");
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-09T12:00:00.000Z"));
+    const statement = createD1Statement({
+      first: {
+        id: "user-1",
+        email: "pilot@example.com",
+        name: "Race Director",
+        image: null,
+        role: "admin",
+        expiresAt: "2026-06-09T13:00:00.000Z",
+        bannedAt: null,
+      },
+    });
+    installD1Statements(mocks.prepare, [statement]);
+    const sessionCookie = await signedSessionCookie(
+      "session-token",
+      "test-secret"
+    );
+
+    const user = await getCurrentUserFromHeaders(
+      new Headers({
+        cookie: `theme=dark;${sessionCookie}`,
+      })
+    );
+
+    expect(statement.bind).toHaveBeenCalledWith("session-token");
+    expect(user?.id).toBe("user-1");
+  });
+
   it("rejects banned users after loading the session row", async () => {
     vi.stubEnv("BETTER_AUTH_SECRET", "test-secret");
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary

- Use Better Auth’s cookie parser for dashboard session resolution.
- Accept compact multi-cookie headers without whitespace after semicolons.
- Add a regression test for the restored-tab header shape.

## Why

A restored or resumed browser tab can send a valid compact `Cookie` header. The middleware recognized that session cookie, but TrackDraw’s custom dashboard resolver only split cookie pairs on `; ` and returned no user. This incorrectly redirected an authenticated user to `/login` even though a fresh `/dashboard` navigation still worked.

## Impact

Authenticated dashboard sessions remain available when Chrome restores or resumes a suspended tab.

## Validation

- `npm run lint`
- `npm run type`
- `npm run test` — 153 files, 826 tests passed
- `npm run build`