### PR TITLE
fix: localize starter layouts and catalog entries

### DIFF
--- a/lang/de/editor.json
+++ b/lang/de/editor.json
@@ -231,19 +231,19 @@
       "label": "Starter-Layouts",
       "layouts": {
         "open-practice": {
-          "name": "Open practice",
-          "title": "Open Practice Layout",
-          "description": "Open flow with a start area and room to build your own lap."
+          "name": "Offenes Training",
+          "title": "Layout für offenes Training",
+          "description": "Offener Streckenverlauf mit einem Startbereich und Platz, um deine eigene Runde zu gestalten."
         },
         "compact-race-start": {
-          "name": "Compact race start",
-          "title": "Compact Race Start",
-          "description": "Tight opening with an immediate gate line and early turn."
+          "name": "Kompakter Rennstart",
+          "title": "Kompakter Rennstart",
+          "description": "Enger Auftakt mit direkt folgender Gate-Linie und einer frühen Kurve."
         },
         "technical-ladder-line": {
-          "name": "Technical ladder line",
-          "title": "Technical Ladder Line",
-          "description": "First gate, two ladders, and a follow-up gate for quick rhythm."
+          "name": "Technische Ladder-Linie",
+          "title": "Technische Ladder-Linie",
+          "description": "Erstes Gate, zwei Ladders und ein anschließendes Gate für einen schnellen Rhythmus."
         }
       }
     },

--- a/lang/de/shapes.json
+++ b/lang/de/shapes.json
@@ -48,99 +48,99 @@
   "catalogEntries": {
     "trackdraw-generic-gate": {
       "name": "TrackDraw Gate",
-      "size": "2 x 2 m"
+      "size": "2 × 2 m"
     },
     "multigp-standard-gate-5x5": {
       "name": "MultiGP Standard Gate 5x5",
-      "size": "5 ft x 5 ft"
+      "size": "5 ft × 5 ft"
     },
     "multigp-championship-gate-7x6": {
       "name": "MultiGP Championship Gate 7x6",
-      "size": "7 ft x 6 ft"
+      "size": "7 ft × 6 ft"
     },
     "trackdraw-generic-tower": {
       "name": "TrackDraw Tower",
-      "size": "2 x 2 m, elevated"
+      "size": "2 × 2 m, erhöht"
     },
     "multigp-tower-5x5": {
       "name": "MultiGP Tower 5x5",
-      "size": "5 ft x 5 ft, elevated 5 ft"
+      "size": "5 ft × 5 ft, um 5 ft erhöht"
     },
     "multigp-tower-7x6": {
       "name": "MultiGP Tower 7x6",
-      "size": "7 ft x 6 ft, elevated 6 ft"
+      "size": "7 ft × 6 ft, um 6 ft erhöht"
     },
     "multigp-double-gate-tower-5x5": {
       "name": "MultiGP Double Gate Tower 5x5",
-      "size": "5 ft wide, 2 x 5 ft openings"
+      "size": "5 ft breit, 2 Öffnungen à 5 ft"
     },
     "multigp-double-gate-tower-7x6": {
       "name": "MultiGP Double Gate Tower 7x6",
-      "size": "7 ft wide, 2 x 6 ft openings"
+      "size": "7 ft breit, 2 Öffnungen à 6 ft"
     },
     "trackdraw-generic-flag": {
-      "name": "TrackDraw Flag",
-      "size": "0.25 m radius, 3.5 m pole"
+      "name": "TrackDraw Flagge",
+      "size": "0,25 m Radius, 3,5 m hoher Mast"
     },
     "multigp-corner-flag": {
       "name": "MultiGP Corner Flag",
       "size": "10 ft"
     },
     "trackdraw-generic-cone": {
-      "name": "TrackDraw Cone",
-      "size": "0.2 m radius"
+      "name": "TrackDraw Kegel",
+      "size": "0,2 m Radius"
     },
     "trackdraw-generic-label": {
       "name": "TrackDraw Label",
-      "size": "Text label"
+      "size": "Textbeschriftung"
     },
     "trackdraw-generic-start-finish": {
-      "name": "TrackDraw Start / Finish",
-      "size": "3 m wide"
+      "name": "TrackDraw Start / Ziel",
+      "size": "3 m breit"
     },
     "trackdraw-generic-ladder": {
       "name": "TrackDraw Ladder",
-      "size": "2 x 6 m, 3 rungs"
+      "size": "2 × 6 m, 3 Sprossen"
     },
     "multigp-standard-ladder-5x5": {
       "name": "MultiGP Standard Ladder 5x5",
-      "size": "5 ft wide, 3 × 5 ft sections"
+      "size": "5 ft breit, 3 Abschnitte à 5 ft"
     },
     "multigp-championship-ladder-7x6": {
       "name": "MultiGP Championship Ladder 7x6",
-      "size": "7 ft wide, 3 × 6 ft openings"
+      "size": "7 ft breit, 3 Öffnungen à 6 ft"
     },
     "multigp-topless-ladder-7x6": {
       "name": "MultiGP Topless Ladder 7x6",
-      "size": "7 ft wide, 3 x 6 ft topless"
+      "size": "7 ft breit, 3 × 6 ft ohne oberen Querholm"
     },
     "trackdraw-generic-dive-gate": {
       "name": "TrackDraw Dive Gate",
-      "size": "2.8 m square"
+      "size": "2,8 m quadratisch"
     },
     "multigp-dive-gate-7x6": {
       "name": "MultiGP Dive Gate 7x6",
-      "size": "7 ft x 6 ft"
+      "size": "7 ft × 6 ft"
     },
     "multigp-launch-gate-7x6": {
       "name": "MultiGP Launch Gate 7x6",
-      "size": "7 ft x 6 ft"
+      "size": "7 ft × 6 ft"
     },
     "trackdraw-generic-banner": {
       "name": "TrackDraw Banner",
       "size": "3 × 2 m"
     },
     "trackdraw-generic-fence": {
-      "name": "TrackDraw Fence",
-      "size": "3 × 1.2 m"
+      "name": "TrackDraw Zaun",
+      "size": "3 × 1,2 m"
     },
     "trackdraw-generic-net": {
-      "name": "TrackDraw Net",
+      "name": "TrackDraw Netz",
       "size": "3 × 2 m"
     },
     "multigp-hurdle": {
       "name": "MultiGP Hurdle",
-      "size": "10 ft wide, 5 ft tall"
+      "size": "10 ft breit, 5 ft hoch"
     }
   }
 }

--- a/lang/nl/editor.json
+++ b/lang/nl/editor.json
@@ -231,19 +231,19 @@
       "label": "Startlayouts",
       "layouts": {
         "open-practice": {
-          "name": "Open practice",
-          "title": "Open Practice Layout",
-          "description": "Open flow with a start area and room to build your own lap."
+          "name": "Vrije training",
+          "title": "Layout voor vrije training",
+          "description": "Open baanindeling met een startgebied en ruimte om je eigen ronde te ontwerpen."
         },
         "compact-race-start": {
-          "name": "Compact race start",
-          "title": "Compact Race Start",
-          "description": "Tight opening with an immediate gate line and early turn."
+          "name": "Compacte racestart",
+          "title": "Compacte racestart",
+          "description": "Krappe opening met direct een lijn van gates en een vroege bocht."
         },
         "technical-ladder-line": {
-          "name": "Technical ladder line",
-          "title": "Technical Ladder Line",
-          "description": "First gate, two ladders, and a follow-up gate for quick rhythm."
+          "name": "Technische ladderlijn",
+          "title": "Technische ladderlijn",
+          "description": "Eerste gate, twee ladders en een opvolgende gate voor een snel ritme."
         }
       }
     },

--- a/lang/nl/shapes.json
+++ b/lang/nl/shapes.json
@@ -48,91 +48,91 @@
   "catalogEntries": {
     "trackdraw-generic-gate": {
       "name": "TrackDraw Gate",
-      "size": "2 x 2 m"
+      "size": "2 × 2 m"
     },
     "multigp-standard-gate-5x5": {
       "name": "MultiGP Standard Gate 5x5",
-      "size": "5 ft x 5 ft"
+      "size": "5 ft × 5 ft"
     },
     "multigp-championship-gate-7x6": {
       "name": "MultiGP Championship Gate 7x6",
-      "size": "7 ft x 6 ft"
+      "size": "7 ft × 6 ft"
     },
     "trackdraw-generic-tower": {
       "name": "TrackDraw Tower",
-      "size": "2 x 2 m, elevated"
+      "size": "2 × 2 m, verhoogd"
     },
     "multigp-tower-5x5": {
       "name": "MultiGP Tower 5x5",
-      "size": "5 ft x 5 ft, elevated 5 ft"
+      "size": "5 ft × 5 ft, 5 ft verhoogd"
     },
     "multigp-tower-7x6": {
       "name": "MultiGP Tower 7x6",
-      "size": "7 ft x 6 ft, elevated 6 ft"
+      "size": "7 ft × 6 ft, 6 ft verhoogd"
     },
     "multigp-double-gate-tower-5x5": {
       "name": "MultiGP Double Gate Tower 5x5",
-      "size": "5 ft wide, 2 x 5 ft openings"
+      "size": "5 ft breed, 2 openingen van 5 ft"
     },
     "multigp-double-gate-tower-7x6": {
       "name": "MultiGP Double Gate Tower 7x6",
-      "size": "7 ft wide, 2 x 6 ft openings"
+      "size": "7 ft breed, 2 openingen van 6 ft"
     },
     "trackdraw-generic-flag": {
-      "name": "TrackDraw Flag",
-      "size": "0.25 m radius, 3.5 m pole"
+      "name": "TrackDraw Vlag",
+      "size": "0,25 m straal, paal van 3,5 m"
     },
     "multigp-corner-flag": {
       "name": "MultiGP Corner Flag",
       "size": "10 ft"
     },
     "trackdraw-generic-cone": {
-      "name": "TrackDraw Cone",
-      "size": "0.2 m radius"
+      "name": "TrackDraw Pion",
+      "size": "0,2 m straal"
     },
     "trackdraw-generic-label": {
       "name": "TrackDraw Label",
-      "size": "Text label"
+      "size": "Tekstlabel"
     },
     "trackdraw-generic-start-finish": {
       "name": "TrackDraw Start / Finish",
-      "size": "3 m wide"
+      "size": "3 m breed"
     },
     "trackdraw-generic-ladder": {
       "name": "TrackDraw Ladder",
-      "size": "2 x 6 m, 3 rungs"
+      "size": "2 × 6 m, 3 sporten"
     },
     "multigp-standard-ladder-5x5": {
       "name": "MultiGP Standard Ladder 5x5",
-      "size": "5 ft wide, 3 × 5 ft sections"
+      "size": "5 ft breed, 3 secties van 5 ft"
     },
     "multigp-championship-ladder-7x6": {
       "name": "MultiGP Championship Ladder 7x6",
-      "size": "7 ft wide, 3 × 6 ft openings"
+      "size": "7 ft breed, 3 openingen van 6 ft"
     },
     "multigp-topless-ladder-7x6": {
       "name": "MultiGP Topless Ladder 7x6",
-      "size": "7 ft wide, 3 x 6 ft topless"
+      "size": "7 ft breed, 3 × 6 ft zonder bovenbalk"
     },
     "trackdraw-generic-dive-gate": {
       "name": "TrackDraw Dive Gate",
-      "size": "2.8 m square"
+      "size": "2,8 m vierkant"
     },
     "multigp-dive-gate-7x6": {
       "name": "MultiGP Dive Gate 7x6",
-      "size": "7 ft x 6 ft"
+      "size": "7 ft × 6 ft"
     },
     "multigp-launch-gate-7x6": {
       "name": "MultiGP Launch Gate 7x6",
-      "size": "7 ft x 6 ft"
+      "size": "7 ft × 6 ft"
     },
     "trackdraw-generic-banner": {
       "name": "TrackDraw Banner",
       "size": "3 × 2 m"
     },
     "trackdraw-generic-fence": {
-      "name": "TrackDraw Fence",
-      "size": "3 × 1.2 m"
+      "name": "TrackDraw Hek",
+      "size": "3 × 1,2 m"
     },
     "trackdraw-generic-net": {
       "name": "TrackDraw Net",
@@ -140,7 +140,7 @@
     },
     "multigp-hurdle": {
       "name": "MultiGP Hurdle",
-      "size": "10 ft wide, 5 ft tall"
+      "size": "10 ft breed, 5 ft hoog"
     }
   }
 }

--- a/tests/i18n/ClientLanguageProvider.test.tsx
+++ b/tests/i18n/ClientLanguageProvider.test.tsx
@@ -81,10 +81,10 @@ describe("ClientLanguageProvider", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Taal")).toBeTruthy();
+      expect(document.documentElement.lang).toBe("nl");
     });
 
     expect(fetchMock).toHaveBeenCalledWith("/locales/nl/common.json");
-    expect(document.documentElement.lang).toBe("nl");
   });
 
   it("keeps English-only namespaces while loading translated assets", async () => {


### PR DESCRIPTION
## Summary

- translate the German and Dutch starter-layout names, titles, and descriptions introduced in #606
- localize catalog size descriptions and generic TrackDraw item names
- preserve official MultiGP product names while normalizing localized measurements

## Why

This follows up on the unresolved review feedback from #606. English source copy had been copied into the German and Dutch message catalogs, so those users still saw untranslated starter presets and catalog metadata.

## Impact

German and Dutch users now get localized starter presets and clearer catalog dimensions without changing catalog IDs or editor behavior.

## Validation

- `npm run i18n:check`
- `npm run test -- tests/lib/planning/starter-layouts.test.ts tests/lib/track/elements/catalog.test.ts` (18 tests)
- targeted Prettier check for the changed locale files
- `git diff --check`