### PR TITLE
fix: Separate shares from gallery entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog is intentionally concise. GitHub Releases and Release Drafter can
 
 ## [Unreleased]
 
+### Clearer gallery membership
+
+Ordinary share links are now kept separate from gallery entries. Gallery dashboards and metrics count only listed, featured, or moderated tracks, while removing a track from the gallery continues to leave its share link available.
+
 ## [1.14.0]
 
 ### Simplified Chinese and more complete translations

--- a/docs/deployment/deployment-setup.md
+++ b/docs/deployment/deployment-setup.md
@@ -257,6 +257,8 @@ npm run migrate:up:production
 
 Migration `0012_product_events.sql` adds the product analytics event store used by the admin metrics dashboard. Apply it before deploying code that records product events or queries activation, usage, and retention metrics.
 
+Migration `0013_cleanup_unlisted_gallery_entries.sql` removes legacy gallery rows that were created automatically for ordinary account shares. It leaves the underlying shares and any gallery rows with preview media untouched.
+
 ## Validation flow
 
 Typical local workflow:

--- a/lang/en/dashboard.json
+++ b/lang/en/dashboard.json
@@ -54,7 +54,7 @@
       },
       "gallery": {
         "label": "Public gallery",
-        "sub": "{featured} featured · {unlisted} private"
+        "sub": "{featured} featured · {hidden} hidden"
       },
       "comparison": {
         "vsPrevMonth": "vs prev month"
@@ -611,10 +611,6 @@
       "state": "State",
       "share": "Share"
     },
-    "stateValues": {
-      "unlisted": "Unlisted (regular shares)",
-      "unlistedBadge": "Unlisted"
-    },
     "shareValues": {
       "active": "Active",
       "expired": "Expired",
@@ -759,9 +755,6 @@
     "ownerValues": {
       "anonymous": "Anonymous",
       "account": "Account owner"
-    },
-    "galleryValues": {
-      "unlisted": "Private"
     },
     "table": {
       "track": "Track",

--- a/migrations/0013_cleanup_unlisted_gallery_entries.sql
+++ b/migrations/0013_cleanup_unlisted_gallery_entries.sql
@@ -1,0 +1,7 @@
+-- Account shares used to create an unlisted gallery row automatically.
+-- Rows without gallery media or a publication timestamp are ordinary shares,
+-- not gallery items, and can be removed without affecting the share itself.
+DELETE FROM gallery_entries
+WHERE gallery_state = 'unlisted'
+  AND gallery_published_at IS NULL
+  AND gallery_preview_image IS NULL;

--- a/src/app/api/shares/[token]/route.ts
+++ b/src/app/api/shares/[token]/route.ts
@@ -151,16 +151,9 @@ export async function PATCH(request: Request, context: ShareTokenRouteContext) {
     }
 
     const body = updateGalleryStateSchema.parse(await request.json());
-    const entry = await getOrCreateGalleryEntryForShare(authorized.share);
+    const existingEntry = await getGalleryEntryByShareToken(authorized.token);
 
-    if (!entry) {
-      return NextResponse.json(
-        { ok: false, error: "Gallery entry unavailable for this share" },
-        { status: 400 }
-      );
-    }
-
-    if (entry.galleryState === "hidden") {
+    if (existingEntry?.galleryState === "hidden") {
       return NextResponse.json(
         {
           ok: false,
@@ -179,6 +172,17 @@ export async function PATCH(request: Request, context: ShareTokenRouteContext) {
             error:
               "Set a display name on your account before listing in the gallery",
           },
+          { status: 400 }
+        );
+      }
+
+      const entry =
+        existingEntry ??
+        (await getOrCreateGalleryEntryForShare(authorized.share));
+
+      if (!entry) {
+        return NextResponse.json(
+          { ok: false, error: "Gallery entry unavailable for this share" },
           { status: 400 }
         );
       }
@@ -206,8 +210,8 @@ export async function PATCH(request: Request, context: ShareTokenRouteContext) {
       await moveGalleryEntryToListed(authorized.token);
     } else if (body.action === "update") {
       if (
-        entry.galleryState !== "listed" &&
-        entry.galleryState !== "featured"
+        existingEntry?.galleryState !== "listed" &&
+        existingEntry?.galleryState !== "featured"
       ) {
         return NextResponse.json(
           {
@@ -223,7 +227,7 @@ export async function PATCH(request: Request, context: ShareTokenRouteContext) {
         title: body.title,
         description: body.description,
       });
-    } else {
+    } else if (existingEntry) {
       await deleteGalleryEntry(authorized.token);
     }
 

--- a/src/app/dashboard/gallery/columns.tsx
+++ b/src/app/dashboard/gallery/columns.tsx
@@ -63,10 +63,7 @@ export function getStateVariant(
   return "outline";
 }
 
-export function getStateLabel(
-  state: GalleryState,
-  tCommon: Translate
-) {
+export function getStateLabel(state: GalleryState, tCommon: Translate) {
   switch (state) {
     case "listed":
       return tCommon("status.listed");

--- a/src/app/dashboard/gallery/columns.tsx
+++ b/src/app/dashboard/gallery/columns.tsx
@@ -65,7 +65,6 @@ export function getStateVariant(
 
 export function getStateLabel(
   state: GalleryState,
-  t: Translate,
   tCommon: Translate
 ) {
   switch (state) {
@@ -76,7 +75,7 @@ export function getStateLabel(
     case "hidden":
       return tCommon("status.hidden");
     default:
-      return t("stateValues.unlistedBadge");
+      return tCommon("status.pending");
   }
 }
 
@@ -332,7 +331,7 @@ export function getGalleryColumns({
       meta: { className: "w-28" },
       cell: ({ row }) => (
         <Badge variant={getStateVariant(row.original.galleryState)}>
-          {getStateLabel(row.original.galleryState, t, tCommon)}
+          {getStateLabel(row.original.galleryState, tCommon)}
         </Badge>
       ),
     },

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -453,7 +453,7 @@ export default async function DashboardPage() {
               value={galleryStats.public}
               sub={t("kpi.gallery.sub", {
                 featured: galleryStats.featured,
-                unlisted: galleryStats.unlisted,
+                hidden: galleryStats.hidden,
               })}
               icon={ImageIcon}
               accent="bg-sky-500"

--- a/src/app/dashboard/shares/columns.tsx
+++ b/src/app/dashboard/shares/columns.tsx
@@ -25,7 +25,6 @@ import {
   TooltipTrigger,
 } from "@/components/AppTooltip";
 import { dataTableSortButtonClassName } from "@/components/data-table/DataTableLayout";
-import type { GalleryState } from "@/lib/server/gallery";
 import type { DashboardShare } from "@/lib/server/shares";
 
 export type ShareLifecycleState = "active" | "expired" | "revoked";
@@ -61,7 +60,7 @@ function getLifecycleVariant(
 }
 
 function getGalleryStateVariant(
-  state: GalleryState
+  state: NonNullable<DashboardShare["galleryState"]>
 ): "default" | "muted" | "outline" {
   if (state === "featured") return "default";
   if (state === "hidden") return "muted";
@@ -69,11 +68,9 @@ function getGalleryStateVariant(
 }
 
 function getGalleryStateLabel(
-  state: GalleryState,
-  t: Translate,
+  state: NonNullable<DashboardShare["galleryState"]>,
   tCommon: Translate
 ) {
-  if (state === "unlisted") return t("galleryValues.unlisted");
   return tCommon(`status.${state}`);
 }
 
@@ -288,7 +285,7 @@ export function getSharesColumns({
       cell: ({ row }) =>
         row.original.galleryState ? (
           <Badge variant={getGalleryStateVariant(row.original.galleryState)}>
-            {getGalleryStateLabel(row.original.galleryState, t, tCommon)}
+            {getGalleryStateLabel(row.original.galleryState, tCommon)}
           </Badge>
         ) : (
           <span className="text-muted-foreground text-xs">

--- a/src/components/dashboard/GalleryManager.tsx
+++ b/src/components/dashboard/GalleryManager.tsx
@@ -71,11 +71,7 @@ type DashboardGalleryManagerProps = {
 type ShareLifecycleState = "active" | "expired" | "revoked";
 
 const galleryManagerRoles: AccountRole[] = ["moderator", "admin"];
-const stateFilterValues: GalleryState[] = [
-  "listed",
-  "featured",
-  "hidden",
-];
+const stateFilterValues: GalleryState[] = ["listed", "featured", "hidden"];
 const shareFilterValues: ShareLifecycleState[] = [
   "active",
   "expired",
@@ -365,10 +361,7 @@ export default function DashboardGalleryManager({
     table.getColumn("shareLifecycle")?.getFacetedRowModel().rows ?? [];
   const stateFilterOptions = stateFilterValues.map((value) => ({
     value,
-    label: getStateLabel(
-      value,
-      tCommon as unknown as Translate
-    ),
+    label: getStateLabel(value, tCommon as unknown as Translate),
     count: stateFacetRows.filter((row) => row.original.galleryState === value)
       .length,
   }));

--- a/src/components/dashboard/GalleryManager.tsx
+++ b/src/components/dashboard/GalleryManager.tsx
@@ -75,7 +75,6 @@ const stateFilterValues: GalleryState[] = [
   "listed",
   "featured",
   "hidden",
-  "unlisted",
 ];
 const shareFilterValues: ShareLifecycleState[] = [
   "active",
@@ -366,7 +365,10 @@ export default function DashboardGalleryManager({
     table.getColumn("shareLifecycle")?.getFacetedRowModel().rows ?? [];
   const stateFilterOptions = stateFilterValues.map((value) => ({
     value,
-    label: t(`stateValues.${value}`),
+    label: getStateLabel(
+      value,
+      tCommon as unknown as Translate
+    ),
     count: stateFacetRows.filter((row) => row.original.galleryState === value)
       .length,
   }));
@@ -457,7 +459,6 @@ export default function DashboardGalleryManager({
                     >
                       {getStateLabel(
                         inspectCandidate.galleryState,
-                        t as unknown as Translate,
                         tCommon as unknown as Translate
                       )}
                     </Badge>

--- a/src/components/dialogs/ShareDialog.tsx
+++ b/src/components/dialogs/ShareDialog.tsx
@@ -55,14 +55,14 @@ const GalleryPreviewRenderer = dynamic(
   { ssr: false }
 );
 
-type GalleryState = "unlisted" | "listed" | "featured" | "hidden";
+type GalleryState = "listed" | "featured" | "hidden";
 
 type ActiveShare = {
   url: string;
   shareToken: string;
   shareType: "temporary" | "published";
   expiresInDays: 7 | 30 | 90 | null;
-  galleryState: GalleryState;
+  galleryState: GalleryState | null;
   galleryTitle: string;
   galleryDescription: string;
 };
@@ -88,9 +88,11 @@ function inferExpiryDays(expiresAt: string | null): 7 | 30 | 90 | null {
   return days <= 7 ? 7 : days <= 30 ? 30 : 90;
 }
 
-function parseGalleryState(raw: string | null | undefined): GalleryState {
+function parseGalleryState(
+  raw: string | null | undefined
+): GalleryState | null {
   if (raw === "listed" || raw === "featured" || raw === "hidden") return raw;
-  return "unlisted";
+  return null;
 }
 
 type AnonShare = {
@@ -363,7 +365,7 @@ export default function ShareDialog({
               shareToken: stored.shareToken,
               shareType: "temporary",
               expiresInDays: stored.expiresInDays,
-              galleryState: "unlisted",
+              galleryState: null,
               galleryTitle: "",
               galleryDescription: "",
             });
@@ -439,7 +441,7 @@ export default function ShareDialog({
         shareToken: data.share.token,
         shareType: data.share.shareType,
         expiresInDays: expiry,
-        galleryState: "unlisted",
+        galleryState: null,
         galleryTitle: design.title.trim(),
         galleryDescription: design.description?.trim() ?? "",
       };

--- a/src/components/editor/useAccountProjectSync.ts
+++ b/src/components/editor/useAccountProjectSync.ts
@@ -33,7 +33,7 @@ export type AccountShareItem = {
   expiresAt: string | null;
   projectId: string | null;
   shareType: "temporary" | "published";
-  galleryState: "unlisted" | "listed" | "featured" | "hidden" | null;
+  galleryState: "listed" | "featured" | "hidden" | null;
   galleryTitle: string | null;
   galleryDescription: string | null;
 };

--- a/src/lib/server/gallery.ts
+++ b/src/lib/server/gallery.ts
@@ -120,7 +120,6 @@ export type GalleryOverviewStats = {
   listed: number;
   featured: number;
   hidden: number;
-  unlisted: number;
 };
 
 export function isPublicGalleryState(
@@ -240,7 +239,7 @@ export async function listGalleryEntriesForDashboard(options?: {
   let bindings: (string | number)[];
 
   if (state === "all") {
-    whereClause = "1 = 1";
+    whereClause = "g.gallery_state <> 'unlisted'";
     bindings = [];
   } else if (state === "public") {
     whereClause = "g.gallery_state in ('featured', 'listed')";
@@ -307,6 +306,7 @@ export const getGalleryOverviewStats = cache(
         `
         select gallery_state, count(*) as count
         from gallery_entries
+        where gallery_state <> 'unlisted'
         group by gallery_state
       `
       )
@@ -318,11 +318,11 @@ export const getGalleryOverviewStats = cache(
       listed: 0,
       featured: 0,
       hidden: 0,
-      unlisted: 0,
     };
 
     for (const row of result.results) {
       const state = parseGalleryState(row.gallery_state);
+      if (state === "unlisted") continue;
       const count = Number(row.count ?? 0);
 
       stats[state] += count;
@@ -434,25 +434,6 @@ export async function createUnlistedGalleryEntry(params: {
     .first<GalleryEntryRow>();
 
   return row ? mapGalleryEntryRow(row) : null;
-}
-
-export async function moveGalleryEntryToUnlisted(shareToken: string) {
-  const db = await getDatabase();
-  const now = new Date().toISOString();
-
-  await db
-    .prepare(
-      `
-        update gallery_entries
-        set
-          gallery_state = 'unlisted',
-          moderation_hidden_at = null,
-          updated_at = ?
-        where share_token = ?
-      `
-    )
-    .bind(now, shareToken)
-    .run();
 }
 
 export async function deleteGalleryEntry(shareToken: string) {

--- a/src/lib/server/metrics.ts
+++ b/src/lib/server/metrics.ts
@@ -334,6 +334,7 @@ export async function getAdminMetrics(): Promise<AdminMetrics> {
           sum(case when gallery_state = 'hidden' then 1 else 0 end) as hidden,
           sum(case when gallery_preview_image is null or trim(gallery_preview_image) = '' then 1 else 0 end) as missing_preview
         from gallery_entries
+        where gallery_state <> 'unlisted'
       `
       )
       .first<{
@@ -468,7 +469,10 @@ export async function getProductInsights(): Promise<ProductInsights> {
               select 1 from shares s where s.owner_user_id = u.id
             ) then 1 else 0 end) as created_share,
             sum(case when exists (
-              select 1 from gallery_entries g where g.owner_user_id = u.id
+              select 1
+              from gallery_entries g
+              where g.owner_user_id = u.id
+                and g.gallery_state <> 'unlisted'
             ) then 1 else 0 end) as published_to_gallery
           from users u
         `

--- a/src/lib/server/metrics.ts
+++ b/src/lib/server/metrics.ts
@@ -329,10 +329,10 @@ export async function getAdminMetrics(): Promise<AdminMetrics> {
         `
         select
           count(*) as total,
-          sum(case when gallery_state = 'listed' then 1 else 0 end) as listed,
-          sum(case when gallery_state = 'featured' then 1 else 0 end) as featured,
-          sum(case when gallery_state = 'hidden' then 1 else 0 end) as hidden,
-          sum(case when gallery_preview_image is null or trim(gallery_preview_image) = '' then 1 else 0 end) as missing_preview
+          coalesce(sum(case when gallery_state = 'listed' then 1 else 0 end), 0) as listed,
+          coalesce(sum(case when gallery_state = 'featured' then 1 else 0 end), 0) as featured,
+          coalesce(sum(case when gallery_state = 'hidden' then 1 else 0 end), 0) as hidden,
+          coalesce(sum(case when gallery_preview_image is null or trim(gallery_preview_image) = '' then 1 else 0 end), 0) as missing_preview
         from gallery_entries
         where gallery_state <> 'unlisted'
       `

--- a/src/lib/server/shares.ts
+++ b/src/lib/server/shares.ts
@@ -124,6 +124,12 @@ function parseShareType(value: string | null): ShareType {
   return value === "published" ? "published" : "temporary";
 }
 
+function parseGalleryMembershipState(value: string | null) {
+  if (!value) return null;
+  const state = parseGalleryState(value);
+  return state === "unlisted" ? null : state;
+}
+
 function mapShareRow(row: ShareRow): StoredShare {
   const rawDesign =
     typeof row.design_json === "string"
@@ -152,6 +158,8 @@ function mapShareRow(row: ShareRow): StoredShare {
 }
 
 function mapUserShareRow(row: UserShareRow): UserShare {
+  const galleryState = parseGalleryMembershipState(row.gallery_state);
+
   return {
     token: row.token,
     title: row.title ?? "Untitled track",
@@ -160,9 +168,9 @@ function mapUserShareRow(row: UserShareRow): UserShare {
     expiresAt: row.expires_at,
     projectId: row.project_id,
     shareType: parseShareType(row.share_type),
-    galleryState: parseGalleryState(row.gallery_state),
-    galleryTitle: row.gallery_title,
-    galleryDescription: row.gallery_description,
+    galleryState,
+    galleryTitle: galleryState ? row.gallery_title : null,
+    galleryDescription: galleryState ? row.gallery_description : null,
   };
 }
 
@@ -223,7 +231,7 @@ export type UserShare = {
   expiresAt: string | null;
   projectId: string | null;
   shareType: ShareType;
-  galleryState: "unlisted" | "listed" | "featured" | "hidden" | null;
+  galleryState: "listed" | "featured" | "hidden" | null;
   galleryTitle: string | null;
   galleryDescription: string | null;
 };
@@ -377,7 +385,7 @@ export type DashboardShare = {
   ownerUserId: string | null;
   ownerName: string | null;
   ownerEmail: string | null;
-  galleryState: GalleryState | null;
+  galleryState: Exclude<GalleryState, "unlisted"> | null;
 };
 
 function mapDashboardShareRow(row: DashboardShareRow): DashboardShare {
@@ -391,9 +399,7 @@ function mapDashboardShareRow(row: DashboardShareRow): DashboardShare {
     ownerUserId: row.owner_user_id,
     ownerName: row.owner_name,
     ownerEmail: row.owner_email,
-    galleryState: row.gallery_state
-      ? parseGalleryState(row.gallery_state)
-      : null,
+    galleryState: parseGalleryMembershipState(row.gallery_state),
   };
 }
 
@@ -541,7 +547,6 @@ export async function createShare(
         shareType: "published",
       };
 
-      await getOrCreateGalleryEntryForShare(share);
       return share;
     }
   }
@@ -614,15 +619,6 @@ export async function createShare(
         projectId,
         shareType,
       };
-
-      if (ownerUserId) {
-        await createUnlistedGalleryEntry({
-          shareToken: token,
-          ownerUserId,
-          title,
-          description,
-        });
-      }
 
       return share;
     } catch (error) {

--- a/tests/app/api/shares.gallery.route.test.ts
+++ b/tests/app/api/shares.gallery.route.test.ts
@@ -92,12 +92,14 @@ describe("owner share gallery API route", () => {
     vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(testUser);
     vi.mocked(isResourceOwner).mockReturnValue(true);
     vi.mocked(getOrCreateGalleryEntryForShare).mockResolvedValue(entry);
-    vi.mocked(getGalleryEntryByShareToken).mockResolvedValue({
-      ...entry,
-      galleryState: "listed",
-      galleryTitle: "Public title",
-      galleryDescription: "Public description",
-    });
+    vi.mocked(getGalleryEntryByShareToken)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({
+        ...entry,
+        galleryState: "listed",
+        galleryTitle: "Public title",
+        galleryDescription: "Public description",
+      });
   });
 
   it("lists an owned active share and uploads the generated preview", async () => {
@@ -141,6 +143,7 @@ describe("owner share gallery API route", () => {
       previewImage: "gallery/previews/entry-1.webp",
     });
     expect(moveGalleryEntryToListed).toHaveBeenCalledWith(share.token);
+    expect(getOrCreateGalleryEntryForShare).toHaveBeenCalledWith(share);
   });
 
   it("blocks share revocation before ownership checks when the request is not trusted", async () => {
@@ -196,10 +199,12 @@ describe("owner share gallery API route", () => {
   });
 
   it("blocks owners from changing a hidden gallery entry", async () => {
-    vi.mocked(getOrCreateGalleryEntryForShare).mockResolvedValue({
-      ...entry,
-      galleryState: "hidden",
-    });
+    vi.mocked(getGalleryEntryByShareToken)
+      .mockReset()
+      .mockResolvedValue({
+        ...entry,
+        galleryState: "hidden",
+      });
 
     const response = (await PATCH(
       patchRequest({
@@ -217,6 +222,7 @@ describe("owner share gallery API route", () => {
         "This track is hidden from the gallery and cannot be changed by the owner",
     });
     expect(moveGalleryEntryToListed).not.toHaveBeenCalled();
+    expect(getOrCreateGalleryEntryForShare).not.toHaveBeenCalled();
   });
 
   it("requires an account display name before listing in the gallery", async () => {
@@ -241,13 +247,16 @@ describe("owner share gallery API route", () => {
     });
     expect(updateGalleryEntryMetadata).not.toHaveBeenCalled();
     expect(moveGalleryEntryToListed).not.toHaveBeenCalled();
+    expect(getOrCreateGalleryEntryForShare).not.toHaveBeenCalled();
   });
 
   it("updates metadata only for listed or featured entries", async () => {
-    vi.mocked(getOrCreateGalleryEntryForShare).mockResolvedValue({
-      ...entry,
-      galleryState: "listed",
-    });
+    vi.mocked(getGalleryEntryByShareToken)
+      .mockReset()
+      .mockResolvedValue({
+        ...entry,
+        galleryState: "listed",
+      });
 
     const response = (await PATCH(
       patchRequest({
@@ -265,13 +274,16 @@ describe("owner share gallery API route", () => {
       description: "Updated public description",
     });
     expect(moveGalleryEntryToListed).not.toHaveBeenCalled();
+    expect(getOrCreateGalleryEntryForShare).not.toHaveBeenCalled();
   });
 
   it("rejects metadata updates while an entry is still unlisted", async () => {
-    vi.mocked(getOrCreateGalleryEntryForShare).mockResolvedValue({
-      ...entry,
-      galleryState: "unlisted",
-    });
+    vi.mocked(getGalleryEntryByShareToken)
+      .mockReset()
+      .mockResolvedValue({
+        ...entry,
+        galleryState: "unlisted",
+      });
 
     const response = (await PATCH(
       patchRequest({
@@ -288,9 +300,15 @@ describe("owner share gallery API route", () => {
       error: "Only listed gallery items can update their metadata",
     });
     expect(updateGalleryEntryMetadata).not.toHaveBeenCalled();
+    expect(getOrCreateGalleryEntryForShare).not.toHaveBeenCalled();
   });
 
   it("removes a gallery entry without revoking the share", async () => {
+    vi.mocked(getGalleryEntryByShareToken)
+      .mockReset()
+      .mockResolvedValueOnce(entry)
+      .mockResolvedValueOnce(null);
+
     const response = (await PATCH(
       patchRequest({ action: "unlist" }),
       context()
@@ -298,5 +316,6 @@ describe("owner share gallery API route", () => {
 
     expect(response.status).toBe(200);
     expect(deleteGalleryEntry).toHaveBeenCalledWith(share.token);
+    expect(getOrCreateGalleryEntryForShare).not.toHaveBeenCalled();
   });
 });

--- a/tests/app/api/shares.route.test.ts
+++ b/tests/app/api/shares.route.test.ts
@@ -176,7 +176,7 @@ describe("shares API route", () => {
       expiresAt: null,
       projectId: "project-1",
       shareType: "published",
-      galleryState: "unlisted",
+      galleryState: null,
       galleryTitle: null,
       galleryDescription: null,
     };

--- a/tests/components/dashboard/GalleryManager.test.tsx
+++ b/tests/components/dashboard/GalleryManager.test.tsx
@@ -202,4 +202,21 @@ describe("DashboardGalleryManager", () => {
     expect(screen.getByText("Page 2 of 2")).toBeTruthy();
     expect(screen.getByText("Track 11")).toBeTruthy();
   });
+
+  it("uses translated gallery state labels in the state facet", async () => {
+    const user = userEvent.setup();
+    render(
+      <DashboardGalleryManager
+        currentUserRole="moderator"
+        initialEntries={[entry]}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /State/ }));
+
+    expect(screen.getAllByText("Listed").length).toBeGreaterThan(0);
+    expect(screen.getByText("Featured")).toBeTruthy();
+    expect(screen.getByText("Hidden")).toBeTruthy();
+    expect(screen.queryByText("Unlisted (regular shares)")).toBeNull();
+  });
 });

--- a/tests/components/dialogs/ProjectManagerSharesTab.test.tsx
+++ b/tests/components/dialogs/ProjectManagerSharesTab.test.tsx
@@ -17,7 +17,7 @@ function createShare(
     expiresAt: null,
     projectId: "project-1",
     shareType: "published",
-    galleryState: "unlisted",
+    galleryState: null,
     galleryTitle: null,
     galleryDescription: null,
     ...overrides,

--- a/tests/lib/server/gallery.test.ts
+++ b/tests/lib/server/gallery.test.ts
@@ -32,7 +32,6 @@ import {
   moveGalleryEntryToFeatured,
   moveGalleryEntryToHidden,
   moveGalleryEntryToListed,
-  moveGalleryEntryToUnlisted,
   setGalleryEntryPreviewImage,
   updateGalleryEntryMetadata,
 } from "@/lib/server/gallery";
@@ -120,24 +119,18 @@ describe("gallery server helpers", () => {
     );
   });
 
-  it("updates only gallery state when entries are hidden or unlisted", async () => {
+  it("updates moderation state when entries are hidden", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
     const hiddenStatement = createStatement();
-    const unlistedStatement = createStatement();
-    installStatements([hiddenStatement, unlistedStatement]);
+    installStatements([hiddenStatement]);
 
     await moveGalleryEntryToHidden("share-1");
-    await moveGalleryEntryToUnlisted("share-2");
 
     expect(hiddenStatement.bind).toHaveBeenCalledWith(
       "2026-04-25T12:00:00.000Z",
       "2026-04-25T12:00:00.000Z",
       "share-1"
-    );
-    expect(unlistedStatement.bind).toHaveBeenCalledWith(
-      "2026-04-25T12:00:00.000Z",
-      "share-2"
     );
   });
 
@@ -179,8 +172,8 @@ describe("gallery server helpers", () => {
       listed: 3,
       featured: 2,
       hidden: 1,
-      unlisted: 0,
     });
+    expect(statement.sql).toContain("where gallery_state <> 'unlisted'");
   });
 
   it("returns null from getGalleryEntryByShareToken when no row is found", async () => {
@@ -220,12 +213,12 @@ describe("gallery server helpers", () => {
     });
   });
 
-  it("returns all rows from listGalleryEntriesForDashboard", async () => {
+  it("returns managed gallery rows from listGalleryEntriesForDashboard", async () => {
     const dashboardRow = {
       id: "entry-d",
       share_token: "tok-d",
       owner_user_id: "owner-2",
-      gallery_state: "unlisted",
+      gallery_state: "hidden",
       gallery_title: "Dashboard Track",
       gallery_description: "",
       gallery_preview_image: null,
@@ -248,13 +241,16 @@ describe("gallery server helpers", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
       id: "entry-d",
-      galleryState: "unlisted",
+      galleryState: "hidden",
       ownerName: "Alice",
       ownerEmail: "alice@example.com",
       fieldWidth: 40.5,
       fieldHeight: 20.0,
       shapeCount: 12,
     });
+    expect(mocks.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("g.gallery_state <> 'unlisted'")
+    );
   });
 
   it("listGalleryEntriesForDashboard passes the state filter when provided", async () => {
@@ -265,12 +261,13 @@ describe("gallery server helpers", () => {
     expect(stmt.bind).toHaveBeenCalledWith("listed", 500);
   });
 
-  it("listGalleryEntriesForDashboard queries all states when state='all'", async () => {
+  it("listGalleryEntriesForDashboard excludes staging rows when state='all'", async () => {
     const stmt = createStatement({ all: { results: [] } });
     installStatements([stmt]);
 
     await listGalleryEntriesForDashboard({ state: "all" });
     expect(stmt.bind).toHaveBeenCalledWith(500);
+    expect(stmt.sql).toContain("g.gallery_state <> 'unlisted'");
   });
 
   it("creates an unlisted gallery entry via INSERT RETURNING", async () => {

--- a/tests/lib/server/metrics.test.ts
+++ b/tests/lib/server/metrics.test.ts
@@ -91,6 +91,7 @@ describe("dashboard metrics", () => {
       "or exists (\n          select 1 from apikey"
     );
     const shareTotalsQuery = queryContaining("as total_active");
+    const galleryTotalsQuery = queryContaining("as missing_preview");
     const apiKeysQuery = queryContaining(
       "sum(case when enabled = 1 and (expiresAt is null"
     );
@@ -112,6 +113,7 @@ describe("dashboard metrics", () => {
       "expires_at > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
     );
     expect(shareTotalsQuery).not.toContain("expires_at > datetime('now')");
+    expect(galleryTotalsQuery).toContain("gallery_state <> 'unlisted'");
     expect(apiKeysQuery).toContain(
       "expiresAt > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
     );
@@ -187,6 +189,9 @@ describe("dashboard metrics", () => {
       createdShare: 8,
       publishedToGallery: 3,
     });
+    expect(String(mocks.prepare.mock.calls[0][0])).toContain(
+      "g.gallery_state <> 'unlisted'"
+    );
     expect(insights.contentGrowth).toHaveLength(2);
     expect(insights.usage).toMatchObject({
       totalEvents30d: 33,

--- a/tests/lib/server/metrics.test.ts
+++ b/tests/lib/server/metrics.test.ts
@@ -114,6 +114,7 @@ describe("dashboard metrics", () => {
     );
     expect(shareTotalsQuery).not.toContain("expires_at > datetime('now')");
     expect(galleryTotalsQuery).toContain("gallery_state <> 'unlisted'");
+    expect(galleryTotalsQuery.match(/coalesce\(sum\(/g)).toHaveLength(4);
     expect(apiKeysQuery).toContain(
       "expiresAt > strftime('%Y-%m-%dT%H:%M:%fZ', 'now')"
     );

--- a/tests/lib/server/shares.test.ts
+++ b/tests/lib/server/shares.test.ts
@@ -308,7 +308,7 @@ describe("share server helpers", () => {
     expect(mocks.createUnlistedGalleryEntry).not.toHaveBeenCalled();
   });
 
-  it("creates account shares as published links without expiry", async () => {
+  it("creates account shares without creating gallery entries", async () => {
     const insertStatement = createStatement();
     installStatements([insertStatement]);
 
@@ -324,12 +324,7 @@ describe("share server helpers", () => {
     expect(bindArgs.at(-3)).toBe("user-1");
     expect(bindArgs.at(-2)).toBeNull();
     expect(bindArgs.at(-1)).toBe("published");
-    expect(mocks.createUnlistedGalleryEntry).toHaveBeenCalledWith(
-      expect.objectContaining({
-        shareToken: share.token,
-        ownerUserId: "user-1",
-      })
-    );
+    expect(mocks.createUnlistedGalleryEntry).not.toHaveBeenCalled();
   });
 
   it("updates and reuses the active published share for an account project", async () => {
@@ -340,13 +335,6 @@ describe("share server helpers", () => {
     });
     const updateStatement = createStatement();
     installStatements([selectStatement, updateStatement]);
-    mocks.getGalleryEntryByShareToken.mockResolvedValue({
-      id: "entry-1",
-      shareToken: "existing-token",
-      ownerUserId: "user-1",
-      galleryState: "unlisted",
-    });
-
     const share = await createShare(design, {
       ownerUserId: "user-1",
       projectId: "project-1",
@@ -370,5 +358,38 @@ describe("share server helpers", () => {
     expect(share.shareType).toBe("published");
     expect(share.expiresAt).toBeNull();
     expect(mocks.createUnlistedGalleryEntry).not.toHaveBeenCalled();
+  });
+
+  it("exposes absent and staging gallery rows as no gallery membership", async () => {
+    const row = {
+      token: "tok-user",
+      title: "My share",
+      shape_count: 4,
+      created_at: "2026-04-01T00:00:00.000Z",
+      expires_at: null,
+      project_id: "proj-1",
+      share_type: "published",
+      gallery_state: null,
+      gallery_title: null,
+      gallery_description: null,
+    };
+    const stmt = createD1AllStatement([
+      row,
+      { ...row, token: "tok-staging", gallery_state: "unlisted" },
+    ]);
+    mocks.prepare.mockReturnValue(stmt);
+
+    const result = await getSharesByUserId("user-1");
+
+    expect(
+      result.map((share) => ({
+        galleryState: share.galleryState,
+        galleryTitle: share.galleryTitle,
+        galleryDescription: share.galleryDescription,
+      }))
+    ).toEqual([
+      { galleryState: null, galleryTitle: null, galleryDescription: null },
+      { galleryState: null, galleryTitle: null, galleryDescription: null },
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

- keep ordinary share links separate from gallery membership
- create gallery rows only when an owner explicitly lists a track
- expose absent and internal staging rows as no gallery membership
- exclude staging rows from gallery dashboards, activation data, and health metrics
- clean up legacy empty unlisted rows with D1 migration `0013`

## Why

Account-owned shares previously created an `unlisted` gallery row automatically. That conflated link-only sharing with gallery membership, inflated gallery metrics, and made dashboard filters and statuses ambiguous.

The migration removes only legacy unlisted rows that have never been published and have no preview media. It leaves the underlying share links untouched.

## Validation

- `npm run lint`
- `npm run type`
- `npm run i18n:check`
- `npm run build`
- 67 focused gallery, share, metrics, route, and component tests
- full suite: 833 tests passed; one unrelated UsersManager timing test timed out under concurrent load and passed when rerun in isolation
