### PR TITLE
feat: Isolate scheduled cleanup reporting

### DIFF
--- a/custom-worker.ts
+++ b/custom-worker.ts
@@ -1,9 +1,10 @@
 // @ts-ignore `.open-next/worker.js` is generated at build time
 import { default as handler } from "./.open-next/worker.js";
-import { cleanupExpiredApiKeys } from "./src/lib/server/api-key-retention";
 import { getEarlyWorkerResponse } from "./src/lib/server/request-guards";
-import { cleanupExpiredProductEvents } from "./src/lib/server/product-event-retention";
-import { cleanupExpiredShares } from "./src/lib/server/share-retention";
+import {
+  createScheduledCleanupTasks,
+  runScheduledCleanup,
+} from "./src/lib/server/scheduled-cleanup";
 
 type D1PreparedStatement = {
   bind(...values: unknown[]): D1PreparedStatement;
@@ -37,18 +38,8 @@ const worker = {
     return handler.fetch(request, env, ctx);
   },
 
-  async scheduled(
-    _controller: ScheduledController,
-    env: WorkerEnv,
-    ctx: WorkerExecutionContext
-  ) {
-    ctx.waitUntil(
-      Promise.all([
-        cleanupExpiredShares(env.DB),
-        cleanupExpiredApiKeys(env.DB),
-        cleanupExpiredProductEvents(env.DB),
-      ])
-    );
+  async scheduled(controller: ScheduledController, env: WorkerEnv) {
+    await runScheduledCleanup(controller, createScheduledCleanupTasks(env.DB));
   },
 };
 

--- a/docs/deployment/deployment-setup.md
+++ b/docs/deployment/deployment-setup.md
@@ -303,15 +303,20 @@ The Worker runs a daily cron cleanup and removes:
 - revoked shares
 - shares that have been expired for more than 30 days
 - API keys that have been expired for more than 90 days
+- raw product events that are older than 180 days
+
+The three retention owners run concurrently and settle independently. Each task emits one privacy-safe JSON log with `event: "scheduled_cleanup_task"`, its `task`, `status`, `deleted_rows`, `duration_ms`, `cron`, and `scheduled_at`. Failures additionally include the error name and message, but never a share token, API key, session identifier, email address, or event payload. A final `scheduled_cleanup_summary` log reports the task counts and total deleted rows.
+
+If one task fails, the remaining tasks still finish and report their results. The scheduled handler rejects only after all tasks have settled so Cloudflare records the cron invocation as failed. Retrying the cleanup is safe: every retention query is a threshold-based `DELETE`, and a repeated run with no eligible rows reports success with `deleted_rows: 0`.
 
 The cron schedule is configured in `wrangler.jsonc`. To test the scheduled cleanup locally, run Wrangler with scheduled testing enabled and hit the scheduled route manually.
 
 ```bash
 npx wrangler dev --env dev --test-scheduled
-curl "http://localhost:8787/__scheduled?cron=*+*+*+*+*"
+curl "http://localhost:8787/cdn-cgi/handler/scheduled?cron=17+3+*+*+*&format=json"
 ```
 
-Cloudflare documents `--test-scheduled` and the local `__scheduled` route for scheduled handler testing:
+Cloudflare documents scheduled handler testing and cron triggers here:
 
-- https://developers.cloudflare.com/workers/runtime-apis/scheduled-event/
+- https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/
 - https://developers.cloudflare.com/workers/configuration/cron-triggers/

--- a/docs/deployment/deployment-setup.md
+++ b/docs/deployment/deployment-setup.md
@@ -305,7 +305,7 @@ The Worker runs a daily cron cleanup and removes:
 - API keys that have been expired for more than 90 days
 - raw product events that are older than 180 days
 
-The three retention owners run concurrently and settle independently. Each task emits one privacy-safe JSON log with `event: "scheduled_cleanup_task"`, its `task`, `status`, `deleted_rows`, `duration_ms`, `cron`, and `scheduled_at`. Failures additionally include the error name and message, but never a share token, API key, session identifier, email address, or event payload. A final `scheduled_cleanup_summary` log reports the task counts and total deleted rows.
+The three retention owners run concurrently and settle independently. Each task emits one privacy-safe JSON log with `event: "scheduled_cleanup_task"`, its `task`, `status`, `deleted_rows`, `duration_ms`, `cron`, and `scheduled_at`. Failures additionally include the error name and a single-line, length-limited message, but never a share token, API key, session identifier, email address, or event payload. A final `scheduled_cleanup_summary` log reports the task counts and total deleted rows.
 
 If one task fails, the remaining tasks still finish and report their results. The scheduled handler rejects only after all tasks have settled so Cloudflare records the cron invocation as failed. Retrying the cleanup is safe: every retention query is a threshold-based `DELETE`, and a repeated run with no eligible rows reports success with `deleted_rows: 0`.
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -35,7 +35,7 @@ The next TrackDraw priority is generated flightpath validation first, the remain
         Compare CPU time and `exceededCpu` rates with the pre-deployment baseline after the static public shell reaches production, grouped by route family. OpenNext's safe App Router path still invokes the lightweight routing/cache-interception layer, so invocation count alone is not expected to drop.
   - [ ] Observability baseline and operational thresholds
         Define structured fields, sampling, route-family dashboards or queries, deployment-version correlation, alert thresholds, and notification ownership. Keep tokens, API keys, session data, email addresses, and project payloads out of telemetry.
-  - [ ] Scheduled cleanup isolation and reporting
+  - [x] Scheduled cleanup isolation and reporting
         Ensure share, API-key, and product-event retention tasks complete independently, remain idempotent, emit a structured result per task, and have focused coverage for partial failures so one rejection cannot cut short the other cleanup work.
 
 - [ ] D1 recovery posture (`Research`)

--- a/src/lib/server/scheduled-cleanup.ts
+++ b/src/lib/server/scheduled-cleanup.ts
@@ -25,6 +25,9 @@ type ScheduledCleanupContext = {
 
 type ScheduledCleanupLogger = Pick<Console, "error" | "log">;
 
+const MAX_ERROR_MESSAGE_LENGTH = 200;
+const EMPTY_ERROR_MESSAGE = "Cleanup task failed without an error message";
+
 type ScheduledCleanupTaskSuccess = {
   event: "scheduled_cleanup_task";
   message: "Scheduled cleanup task completed";
@@ -110,9 +113,12 @@ function getDeletedRows(result: unknown) {
 
 function getErrorDetails(error: unknown) {
   if (error instanceof Error) {
+    const normalizedMessage = error.message.replace(/\s+/g, " ").trim();
     return {
       error_name: error.name,
-      error_message: error.message,
+      error_message:
+        normalizedMessage.slice(0, MAX_ERROR_MESSAGE_LENGTH) ||
+        EMPTY_ERROR_MESSAGE,
     };
   }
 

--- a/src/lib/server/scheduled-cleanup.ts
+++ b/src/lib/server/scheduled-cleanup.ts
@@ -1,0 +1,211 @@
+import { cleanupExpiredApiKeys } from "@/lib/server/api-key-retention";
+import { cleanupExpiredProductEvents } from "@/lib/server/product-event-retention";
+import { cleanupExpiredShares } from "@/lib/server/share-retention";
+
+type CleanupPreparedStatement = {
+  bind(...values: unknown[]): CleanupPreparedStatement;
+  run<T = unknown>(): Promise<T>;
+};
+
+type CleanupDatabase = {
+  prepare(query: string): CleanupPreparedStatement;
+};
+
+export type ScheduledCleanupTaskName = "shares" | "api_keys" | "product_events";
+
+export type ScheduledCleanupTask = {
+  name: ScheduledCleanupTaskName;
+  run: () => Promise<unknown>;
+};
+
+type ScheduledCleanupContext = {
+  cron: string;
+  scheduledTime: number;
+};
+
+type ScheduledCleanupLogger = Pick<Console, "error" | "log">;
+
+type ScheduledCleanupTaskSuccess = {
+  event: "scheduled_cleanup_task";
+  message: "Scheduled cleanup task completed";
+  task: ScheduledCleanupTaskName;
+  status: "success";
+  deleted_rows: number | null;
+  duration_ms: number;
+  cron: string;
+  scheduled_at: string;
+};
+
+type ScheduledCleanupTaskFailure = {
+  event: "scheduled_cleanup_task";
+  message: "Scheduled cleanup task failed";
+  task: ScheduledCleanupTaskName;
+  status: "failure";
+  deleted_rows: null;
+  duration_ms: number;
+  cron: string;
+  scheduled_at: string;
+  error_name: string;
+  error_message: string;
+};
+
+export type ScheduledCleanupTaskResult =
+  ScheduledCleanupTaskSuccess | ScheduledCleanupTaskFailure;
+
+export type ScheduledCleanupReport = {
+  event: "scheduled_cleanup_summary";
+  message: "Scheduled cleanup completed";
+  status: "success" | "partial_failure" | "failure";
+  task_count: number;
+  succeeded_tasks: number;
+  failed_tasks: number;
+  deleted_rows: number;
+  cron: string;
+  scheduled_at: string;
+  tasks: ScheduledCleanupTaskResult[];
+};
+
+export class ScheduledCleanupError extends Error {
+  readonly report: ScheduledCleanupReport;
+
+  constructor(report: ScheduledCleanupReport) {
+    super(`${report.failed_tasks} scheduled cleanup task(s) failed`);
+    this.name = "ScheduledCleanupError";
+    this.report = report;
+  }
+}
+
+export function createScheduledCleanupTasks(
+  db: CleanupDatabase
+): ScheduledCleanupTask[] {
+  return [
+    { name: "shares", run: () => cleanupExpiredShares(db) },
+    { name: "api_keys", run: () => cleanupExpiredApiKeys(db) },
+    {
+      name: "product_events",
+      run: () => cleanupExpiredProductEvents(db),
+    },
+  ];
+}
+
+function getScheduledAt(scheduledTime: number) {
+  const date = new Date(scheduledTime);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : "unknown";
+}
+
+function getDeletedRows(result: unknown) {
+  if (typeof result !== "object" || result === null || !("meta" in result)) {
+    return null;
+  }
+
+  const { meta } = result;
+  if (typeof meta !== "object" || meta === null || !("changes" in meta)) {
+    return null;
+  }
+
+  return typeof meta.changes === "number" && Number.isInteger(meta.changes)
+    ? meta.changes
+    : null;
+}
+
+function getErrorDetails(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      error_name: error.name,
+      error_message: error.message,
+    };
+  }
+
+  return {
+    error_name: "UnknownError",
+    error_message: "Cleanup task rejected with a non-Error value",
+  };
+}
+
+export async function runScheduledCleanup(
+  context: ScheduledCleanupContext,
+  tasks: ScheduledCleanupTask[],
+  {
+    logger = console,
+    now = Date.now,
+  }: {
+    logger?: ScheduledCleanupLogger;
+    now?: () => number;
+  } = {}
+) {
+  const scheduledAt = getScheduledAt(context.scheduledTime);
+  const results = await Promise.all(
+    tasks.map(async (task): Promise<ScheduledCleanupTaskResult> => {
+      const startedAt = now();
+
+      try {
+        const result = await task.run();
+        return {
+          event: "scheduled_cleanup_task",
+          message: "Scheduled cleanup task completed",
+          task: task.name,
+          status: "success",
+          deleted_rows: getDeletedRows(result),
+          duration_ms: Math.max(0, now() - startedAt),
+          cron: context.cron,
+          scheduled_at: scheduledAt,
+        };
+      } catch (error) {
+        return {
+          event: "scheduled_cleanup_task",
+          message: "Scheduled cleanup task failed",
+          task: task.name,
+          status: "failure",
+          deleted_rows: null,
+          duration_ms: Math.max(0, now() - startedAt),
+          cron: context.cron,
+          scheduled_at: scheduledAt,
+          ...getErrorDetails(error),
+        };
+      }
+    })
+  );
+
+  for (const result of results) {
+    const serializedResult = JSON.stringify(result);
+    if (result.status === "failure") {
+      logger.error(serializedResult);
+    } else {
+      logger.log(serializedResult);
+    }
+  }
+
+  const failedTasks = results.filter(
+    (result) => result.status === "failure"
+  ).length;
+  const succeededTasks = results.length - failedTasks;
+  const report: ScheduledCleanupReport = {
+    event: "scheduled_cleanup_summary",
+    message: "Scheduled cleanup completed",
+    status:
+      failedTasks === 0
+        ? "success"
+        : succeededTasks === 0
+          ? "failure"
+          : "partial_failure",
+    task_count: results.length,
+    succeeded_tasks: succeededTasks,
+    failed_tasks: failedTasks,
+    deleted_rows: results.reduce(
+      (total, result) => total + (result.deleted_rows ?? 0),
+      0
+    ),
+    cron: context.cron,
+    scheduled_at: scheduledAt,
+    tasks: results,
+  };
+
+  const serializedReport = JSON.stringify(report);
+  if (failedTasks > 0) {
+    logger.error(serializedReport);
+    throw new ScheduledCleanupError(report);
+  }
+
+  logger.log(serializedReport);
+  return report;
+}

--- a/tests/lib/server/scheduled-cleanup.test.ts
+++ b/tests/lib/server/scheduled-cleanup.test.ts
@@ -165,4 +165,41 @@ describe("scheduled cleanup", () => {
       "sensitive rejection value"
     );
   });
+
+  it("normalizes, bounds, and defaults Error messages before logging", async () => {
+    const logger = createLogger();
+    const tasks: ScheduledCleanupTask[] = [
+      {
+        name: "shares",
+        run: vi.fn(async () => {
+          throw new Error(`  D1 cleanup failed\n\t${"x".repeat(250)}  `);
+        }),
+      },
+      {
+        name: "api_keys",
+        run: vi.fn(async () => {
+          throw new Error("  \n\t  ");
+        }),
+      },
+    ];
+
+    await expect(
+      runScheduledCleanup(scheduledContext, tasks, {
+        logger,
+        now: () => 100,
+      })
+    ).rejects.toBeInstanceOf(ScheduledCleanupError);
+
+    const taskLogs = logger.error.mock.calls
+      .map(parseLogCall)
+      .filter((entry) => entry.event === "scheduled_cleanup_task");
+    const normalizedMessage = String(taskLogs[0].error_message);
+    expect(normalizedMessage).toHaveLength(200);
+    expect(normalizedMessage).toMatch(/^D1 cleanup failed x+$/);
+    expect(normalizedMessage).not.toMatch(/[\r\n\t]/);
+    expect(taskLogs[1]).toMatchObject({
+      task: "api_keys",
+      error_message: "Cleanup task failed without an error message",
+    });
+  });
 });

--- a/tests/lib/server/scheduled-cleanup.test.ts
+++ b/tests/lib/server/scheduled-cleanup.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ScheduledCleanupError,
+  createScheduledCleanupTasks,
+  runScheduledCleanup,
+  type ScheduledCleanupTask,
+} from "@/lib/server/scheduled-cleanup";
+
+const scheduledContext = {
+  cron: "17 3 * * *",
+  scheduledTime: Date.UTC(2026, 6, 23, 3, 17),
+};
+
+function createLogger() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function parseLogCall(call: unknown[]) {
+  return JSON.parse(String(call[0])) as Record<string, unknown>;
+}
+
+describe("scheduled cleanup", () => {
+  it("runs every retention task and reports each result when one task fails", async () => {
+    const logger = createLogger();
+    const shares = vi.fn(async () => ({ meta: { changes: 2 } }));
+    const apiKeys = vi.fn(async () => {
+      throw new Error("D1 API key cleanup failed");
+    });
+    const productEvents = vi.fn(async () => ({ meta: { changes: 5 } }));
+    const tasks: ScheduledCleanupTask[] = [
+      { name: "shares", run: shares },
+      { name: "api_keys", run: apiKeys },
+      { name: "product_events", run: productEvents },
+    ];
+
+    const cleanupPromise = runScheduledCleanup(scheduledContext, tasks, {
+      logger,
+      now: () => 100,
+    });
+
+    await expect(cleanupPromise).rejects.toMatchObject({
+      name: "ScheduledCleanupError",
+      report: {
+        status: "partial_failure",
+        task_count: 3,
+        succeeded_tasks: 2,
+        failed_tasks: 1,
+        deleted_rows: 7,
+      },
+    });
+    expect(shares).toHaveBeenCalledOnce();
+    expect(apiKeys).toHaveBeenCalledOnce();
+    expect(productEvents).toHaveBeenCalledOnce();
+
+    const logs = [
+      ...logger.log.mock.calls.map(parseLogCall),
+      ...logger.error.mock.calls.map(parseLogCall),
+    ];
+    expect(
+      logs.filter((entry) => entry.event === "scheduled_cleanup_task")
+    ).toHaveLength(3);
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        event: "scheduled_cleanup_task",
+        task: "api_keys",
+        status: "failure",
+        error_name: "Error",
+        error_message: "D1 API key cleanup failed",
+      })
+    );
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        event: "scheduled_cleanup_summary",
+        status: "partial_failure",
+      })
+    );
+  });
+
+  it("reports a repeated no-op cleanup as a successful idempotent run", async () => {
+    const logger = createLogger();
+    const shares = vi
+      .fn()
+      .mockResolvedValueOnce({ meta: { changes: 3 } })
+      .mockResolvedValueOnce({ meta: { changes: 0 } });
+    const apiKeys = vi.fn(async () => ({ meta: { changes: 0 } }));
+    const productEvents = vi.fn(async () => ({ meta: { changes: 0 } }));
+    const tasks: ScheduledCleanupTask[] = [
+      { name: "shares", run: shares },
+      { name: "api_keys", run: apiKeys },
+      { name: "product_events", run: productEvents },
+    ];
+
+    const firstReport = await runScheduledCleanup(scheduledContext, tasks, {
+      logger,
+      now: () => 100,
+    });
+    const secondReport = await runScheduledCleanup(scheduledContext, tasks, {
+      logger,
+      now: () => 100,
+    });
+
+    expect(firstReport).toMatchObject({
+      status: "success",
+      failed_tasks: 0,
+      deleted_rows: 3,
+    });
+    expect(secondReport).toMatchObject({
+      status: "success",
+      failed_tasks: 0,
+      deleted_rows: 0,
+    });
+    expect(shares).toHaveBeenCalledTimes(2);
+    expect(apiKeys).toHaveBeenCalledTimes(2);
+    expect(productEvents).toHaveBeenCalledTimes(2);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("registers all retention owners in the scheduled task set", async () => {
+    const run = vi.fn(async () => ({ meta: { changes: 0 } }));
+    const statement = {
+      bind: vi.fn(() => statement),
+      run,
+    };
+    const prepare = vi.fn(() => statement);
+
+    const tasks = createScheduledCleanupTasks({ prepare } as Parameters<
+      typeof createScheduledCleanupTasks
+    >[0]);
+
+    expect(tasks.map((task) => task.name)).toEqual([
+      "shares",
+      "api_keys",
+      "product_events",
+    ]);
+    await Promise.all(tasks.map((task) => task.run()));
+    expect(run).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses a privacy-safe fallback for non-Error rejections", async () => {
+    const logger = createLogger();
+    const task: ScheduledCleanupTask = {
+      name: "shares",
+      run: vi.fn(async () => Promise.reject("sensitive rejection value")),
+    };
+
+    await expect(
+      runScheduledCleanup(scheduledContext, [task], {
+        logger,
+        now: () => 100,
+      })
+    ).rejects.toBeInstanceOf(ScheduledCleanupError);
+
+    const errorLogs = logger.error.mock.calls.map(parseLogCall);
+    expect(errorLogs).toContainEqual(
+      expect.objectContaining({
+        event: "scheduled_cleanup_task",
+        error_name: "UnknownError",
+        error_message: "Cleanup task rejected with a non-Error value",
+      })
+    );
+    expect(JSON.stringify(errorLogs)).not.toContain(
+      "sensitive rejection value"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- run share, API-key, and product-event retention tasks independently
- emit privacy-safe structured results per cleanup plus a final summary
- report deleted-row counts, duration, schedule context, and partial failures
- document local scheduled-handler validation and complete the roadmap item

## Why

The scheduled handler previously registered one `Promise.all`. Its first rejection could finish the tracked promise before the remaining cleanup work and results had settled, leaving operators without an independently visible outcome for each retention owner.

The new orchestrator catches each task result, waits for every cleanup, and only then rejects the scheduled invocation when one or more tasks failed. The threshold-based delete operations remain safe to rerun.

## Validation

- `npm run lint`
- `npm run type`
- `npm run test` — 156 files, 838 tests
- `npm run build`
- `npx opennextjs-cloudflare build`
- local Wrangler scheduled smoke test against an isolated, fully migrated D1 database — outcome `ok`, three task results, and one summary
