### PR TITLE
feat(footer): add Facebook & Instagram links

### DIFF
--- a/lang/de/landing.json
+++ b/lang/de/landing.json
@@ -214,6 +214,8 @@
     "communityTitle": "Community",
     "github": "GitHub",
     "dutchDroneSquad": "Dutch Drone Squad",
+    "facebook": "Facebook",
+    "instagram": "Instagram",
     "reportIssue": "Problem melden",
     "supportTitle": "Support",
     "githubSponsors": "GitHub Sponsors",

--- a/lang/en/landing.json
+++ b/lang/en/landing.json
@@ -214,6 +214,8 @@
     "communityTitle": "Community",
     "github": "GitHub",
     "dutchDroneSquad": "Dutch Drone Squad",
+    "facebook": "Facebook",
+    "instagram": "Instagram",
     "reportIssue": "Report an issue",
     "supportTitle": "Support",
     "githubSponsors": "GitHub Sponsors",

--- a/lang/nl/landing.json
+++ b/lang/nl/landing.json
@@ -214,6 +214,8 @@
     "communityTitle": "Community",
     "github": "GitHub",
     "dutchDroneSquad": "Dutch Drone Squad",
+    "facebook": "Facebook",
+    "instagram": "Instagram",
     "reportIssue": "Probleem melden",
     "supportTitle": "Ondersteuning",
     "githubSponsors": "GitHub Sponsors",

--- a/lang/zh/landing.json
+++ b/lang/zh/landing.json
@@ -214,6 +214,8 @@
     "communityTitle": "社区",
     "github": "GitHub",
     "dutchDroneSquad": "Dutch Drone Squad",
+    "facebook": "Facebook",
+    "instagram": "Instagram",
     "reportIssue": "反馈问题",
     "supportTitle": "支持项目",
     "githubSponsors": "GitHub Sponsors",

--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { Bug, Coffee, FileText, Flag, Heart, ShieldCheck } from "lucide-react";
+import { Bug, Coffee, FileText, Flag, Heart, Pencil, ScrollText, ShieldCheck } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 function GithubIcon({ className }: { className?: string }) {
@@ -14,6 +14,32 @@ function GithubIcon({ className }: { className?: string }) {
       className={className}
     >
       <path d="M12 2C6.477 2 2 6.477 2 12c0 4.418 2.865 8.167 6.839 9.49.5.092.682-.217.682-.482 0-.237-.009-.868-.014-1.703-2.782.604-3.369-1.34-3.369-1.34-.454-1.154-1.11-1.462-1.11-1.462-.908-.62.069-.607.069-.607 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0 1 12 6.836a9.59 9.59 0 0 1 2.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.202 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.163 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
+    </svg>
+  );
+}
+
+function FacebookIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="M24 12.073C24 5.405 18.627 0 12 0S0 5.405 0 12.073C0 18.1 4.388 23.094 10.125 24v-8.437H7.078v-3.49h3.047v-2.66c0-3.025 1.792-4.697 4.533-4.697 1.312 0 2.686.235 2.686.235v2.97h-1.513c-1.491 0-1.956.93-1.956 1.886v2.266h3.328l-.532 3.49h-2.796V24C19.612 23.094 24 18.1 24 12.073z" />
+    </svg>
+  );
+}
+
+function InstagramIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.406-11.845a1.44 1.44 0 1 0 0 2.881 1.44 1.44 0 0 0 0-2.881z" />
     </svg>
   );
 }
@@ -63,8 +89,9 @@ export function Footer() {
                 <li>
                   <Link
                     href="/studio"
-                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
                   >
+                    <Pencil className="size-4 shrink-0" />
                     {t("footer.openStudio")}
                   </Link>
                 </li>
@@ -73,9 +100,21 @@ export function Footer() {
                     href="https://github.com/dutchdronesquad/trackdraw/releases"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
                   >
+                    <ScrollText className="size-4 shrink-0" />
                     {t("footer.releaseNotes")}
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://github.com/dutchdronesquad/trackdraw/issues"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+                  >
+                    <Bug className="size-4 shrink-0" />
+                    {t("footer.reportIssue")}
                   </a>
                 </li>
               </ul>
@@ -136,13 +175,24 @@ export function Footer() {
                 </li>
                 <li>
                   <a
-                    href="https://github.com/dutchdronesquad/trackdraw/issues"
+                    href="https://www.facebook.com/trackdraw"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
                   >
-                    <Bug className="size-4 shrink-0" />
-                    {t("footer.reportIssue")}
+                    <FacebookIcon className="size-4 shrink-0" />
+                    {t("footer.facebook")}
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://www.instagram.com/trackdraw.app/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
+                  >
+                    <InstagramIcon className="size-4 shrink-0" />
+                    {t("footer.instagram")}
                   </a>
                 </li>
               </ul>

--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -2,7 +2,16 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { Bug, Coffee, FileText, Flag, Heart, Pencil, ScrollText, ShieldCheck } from "lucide-react";
+import {
+  Bug,
+  Coffee,
+  FileText,
+  Flag,
+  Heart,
+  Pencil,
+  ScrollText,
+  ShieldCheck,
+} from "lucide-react";
 import { useTranslations } from "next-intl";
 
 function GithubIcon({ className }: { className?: string }) {


### PR DESCRIPTION
## Summary

- Add **Facebook** (`trackdraw`) and **Instagram** (`trackdraw.app`) links with custom SVG icons to the Community section of the footer
- Move **Report an issue** from Community → Product section (better fit alongside Release notes)
- Add icons (`Pencil`, `ScrollText`, `Bug`) to all Product section links for visual consistency
- Add `facebook` and `instagram` i18n keys to all four language files (`en`, `nl`, `de`, `zh`)

## Test plan

- [ ] Footer Community section shows Facebook and Instagram links with correct icons and URLs
- [ ] Footer Product section shows icons on Open Studio, Release notes, and Report an issue
- [ ] Links open in a new tab
- [ ] All four languages render without missing translation keys (`npm run i18n:check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)