### PR TITLE
feat: Add track preflight and streamline inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog is intentionally concise. GitHub Releases and Release Drafter can
 
 ## [Unreleased]
 
+### Track preflight and a leaner inspector
+
+The Layout inspector now brings route, timing, numbering, and configured inventory checks together in one advisory Preflight summary. Issues open the related obstacle or Race Line, while sharing and export remain available. Repeated status cards and project details have been reduced, route analysis appears only where it is relevant, and the mobile inspector keeps inactive timing and duplicate quick actions out of the way.
+
 ### Locale-aware visual exports and integrations
 
 PNG and SVG exports now use the selected language for footer dates and untitled-track copy. Public gallery dates and API Docs language metadata also follow all four supported languages, including Simplified Chinese.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -28,6 +28,8 @@ After v1.14.0, the next product focus should stay deliberately narrow:
 2. Translation follow-up: run a bounded Crowdin Free pilot, retain Weblate as the self-hosted fallback, and keep locale catalogs out of the Worker bundle.
 3. Focused 3D item controls: add direct 3D move/rotate controls only where they are predictable across desktop, mobile, undo/redo, and lock state.
 
+Track Preflight and a leaner inspector hierarchy should follow as one focused usability slice once generated-route warning behavior is trustworthy enough to reuse. Preflight should consolidate existing signals rather than introduce another validation system or a broad race-day mode.
+
 Race-day workflow depth, account lifecycle depth, custom banner textures, share version history, gallery collections, billing, and community features should stay behind those priorities unless a concrete support issue or release risk forces them forward.
 
 Lower-priority follow-up such as share version history, gallery collections, Velocidrone export stabilization, AR, and build mode should stay parked until there is clearer need.
@@ -148,6 +150,50 @@ Maintenance focus:
 - Keep import/export, autosave, share publish/read, read-only viewing, account sync, and mobile editor flows covered when touching nearby code
 - Add regression tests when a fix affects selection, transforms, route editing, export generation, project recovery, sharing, or larger layouts
 - Treat future reliability work as targeted support-driven slices rather than a broad redesign track
+
+#### Track Preflight And Inspector Focus (`No account required`)
+
+Bring existing route, numbering, timing, and inventory signals into one compact layout-review summary while reducing repeated inspector chrome.
+
+Why:
+
+- Route warnings, obstacle numbering, overlay preparation, and inventory buildability already expose useful signals, but users currently have to discover them in separate inspector and integration surfaces
+- Project, Layout, and Selection views repeat context, status metadata, and route analysis, which makes the inspector feel heavier than the underlying tasks require
+- A shared summary can make the final design-to-handoff review clearer without creating a separate race-day product or changing local-first editing
+
+First slice:
+
+- Add a pure preflight report that composes existing route-numbering, route-warning, timing/overlay, and inventory reports into stable issue categories and target references
+- Show a compact summary at the top of the Layout inspector with `Incomplete`, `Review`, or `Ready` states and expandable issue groups
+- Let actionable issues select the relevant track item or Race Line and direct waypoint-based warnings back to route review
+- Treat timing and inventory as opt-in checks: an untouched timing setup or all-zero default inventory must not make every ordinary design look incomplete
+- Keep preflight advisory. Do not block sharing or export, and define `Ready` as no known active-check issues rather than a claim that a track is safe or race-ready
+- Use the summary to replace repeated Layout lead pills and status cards instead of adding another large inspector section
+
+Current shipped foundation:
+
+- A pure preflight report composes route numbering, route-review warnings, timing readiness, and configured inventory shortages without introducing new thresholds
+- The Layout inspector shows an advisory `Incomplete`, `Review`, or `Ready` summary; actionable issues select the related obstacle or Race Line
+- Route generation remains available as a focused action while its former status cards are consolidated into Preflight
+- Project and Layout leads no longer repeat nearby values, render density is under Advanced, and the item list avoids nested card chrome and hides filters for small layouts
+- Elevation analysis is limited to Layout and selected Race Line contexts, inactive mobile timing is collapsed, and generic mobile selection actions are no longer duplicated inside the drawer
+- Inspector numeric fields inherit accessible labels, common actions have visible focus, tabs support arrow-key navigation, and item selection/removal use separate controls
+
+Inspector focus:
+
+- Show elevation analysis only in route-relevant contexts instead of as a permanent footer across Project, Layout, single-selection, and multi-selection views
+- Remove repeated lead metadata where the same title, position, buildability, or numbering state appears again immediately below
+- Make disclosure task-driven: keep common fields prominent, collapse inactive timing and advanced placement details on mobile, and move render density behind advanced settings
+- Flatten the placed-items list so search and filters appear when useful without wrapping the list in additional card-like chrome
+- Fix inspector field labeling, visible focus, and keyboard tab behavior as part of the cleanup rather than treating accessibility as a separate polish pass
+- Preserve automatic Selection context, locked/read-only behavior, undo/redo boundaries, mobile touch targets, and the existing Project/Layout/Selection model during the first slice
+
+Important boundary:
+
+- Reuse existing validators and thresholds; do not duplicate route-analysis logic in React inspector components
+- Keep generated-route warnings in the generation workflow until real-layout validation and threshold tuning are complete
+- Exclude out-of-field geometry checks, per-format export runtime readiness, and gallery/share metadata readiness from the first slice because they do not yet share the same domain semantics
+- Do not expand this slice into simulation, AR, build mode, new persistence, or a broad inspector redesign
 
 #### Production Observability and Operational Resilience
 
@@ -342,6 +388,7 @@ Feature tracks:
 
 - Collapsible inspector workspace: continue refining the shipped desktop collapse rail only if real usage shows friction around selection context or repeated resizing
 - Persistent sidebar density: keep local-only collapse preferences for editor chrome where that improves repeated editing
+- Inspector hierarchy cleanup: follow the Track Preflight slice above so repeated summaries, route analysis, disclosure defaults, and accessibility fundamentals are improved as one coherent pass rather than separate cosmetic changes
 
 Important boundary:
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -22,12 +22,21 @@ Labels used below:
 
 ## Current Priority
 
-The next TrackDraw priority is generated flightpath validation first, translation management tooling second, and focused 3D item controls third. Selective race-day workflow depth can follow once those are stable. Keep larger account, community, billing, and platform expansion behind those unless a specific support or release risk forces it forward.
+The next TrackDraw priority is generated flightpath validation first, translation management tooling second, and focused 3D item controls third. Track Preflight and a leaner inspector hierarchy can follow as one focused usability slice once generated-route warning behavior is trustworthy enough to reuse. Keep larger account, community, billing, and platform expansion behind those unless a specific support or release risk forces it forward.
 
 ## Follow-up
 
 - [ ] Generated flightpath validation follow-up (`Research`, `No account required`)
       Validate real layouts and tune warnings, route anchor heights, and unclear sequence feedback before treating generated routes as more than a first-pass drafting aid. Research document: `docs/research/generated-flightpath-assistance.md`.
+
+- [x] Track Preflight and inspector focus (`No account required`)
+      Bring existing route, numbering, timing, and inventory signals into one compact advisory summary at the top of the Layout inspector. Use `Incomplete`, `Review`, and `Ready` without a score or safety claim, make issues jump to the relevant item or route context, and keep sharing and export non-blocking.
+  - [x] Pure preflight report
+        Compose the existing route-numbering, route-warning, timing/overlay, and inventory reports into stable issue categories and target references. Treat timing and inventory as opt-in checks, and keep generated-route, bounds, export-runtime, and share-metadata validation outside the first slice.
+  - [x] Lean inspector hierarchy
+        Replace repeated lead pills and status cards with the preflight summary, show elevation analysis only in route-relevant contexts, collapse inactive timing and advanced placement details on mobile, flatten the placed-items list, and move render density behind advanced settings.
+  - [x] Inspector accessibility fundamentals
+        Give inspector fields programmatic labels, restore visible focus, and make the Project/Layout/Selection tabs follow the expected keyboard pattern while preserving automatic Selection context and mobile touch behavior.
 
 - [ ] Production observability and scheduled-maintenance hardening
       Establish a privacy-safe production baseline across route families and background work without adding duplicate release validation. Use deliberate Workers log/trace sampling, actionable thresholds, and a practical notification path for 5xx responses, exceptions, `exceededCpu`, D1/R2 failures, authentication email failures, and repeated scheduled-task failures.

--- a/lang/de/inspector.json
+++ b/lang/de/inspector.json
@@ -4,6 +4,45 @@
     "layout": "Layout",
     "selection": "Auswahl"
   },
+  "preflight": {
+    "title": "Vorprüfung",
+    "status": {
+      "incomplete": {
+        "title": "Unvollständig",
+        "description": "Füge Streckenelemente hinzu, um die Prüfung zu starten."
+      },
+      "review": {
+        "title": "Prüfen",
+        "description": "{count, plural, one {1 bekannter Punkt benötigt Aufmerksamkeit.} other {{count} bekannte Punkte benötigen Aufmerksamkeit.}}"
+      },
+      "ready": {
+        "title": "Bereit",
+        "description": "Keine bekannten Probleme in den aktiven Prüfungen."
+      }
+    },
+    "categories": {
+      "route": "Route",
+      "timing": "Zeitnahme",
+      "inventory": "Inventar"
+    },
+    "checkInactive": "aus",
+    "openIssue": "Öffnen",
+    "emptyDetails": "Die Vorprüfung startet, sobald die Strecke Elemente enthält.",
+    "noIssues": "Die aktiven Prüfungen haben keine bekannten Probleme.",
+    "issues": {
+      "missingRoute": "Füge eine Race Line für die platzierten Streckenhindernisse hinzu.",
+      "noRouteMatches": "Die Streckenhindernisse liegen nicht nah genug an der Race Line.",
+      "offRoute": "{name} liegt außerhalb der Toleranz der Race Line.",
+      "timingMissingRoute": "Die Zeitnahme benötigt genau eine nutzbare Race Line.",
+      "multipleRoutes": "Die Zeitnahme hat mehrere nutzbare Race Lines gefunden.",
+      "missingStartFinish": "Füge eine Start/Ziel-Zeitmarkierung hinzu.",
+      "duplicateStartFinish": "Behalte nur eine Start/Ziel-Zeitmarkierung.",
+      "missingSplitId": "Einer Split-Zeitmarkierung fehlt die ID.",
+      "duplicateTimingId": "IDs von Zeitmarkierungen müssen eindeutig sein.",
+      "timingPointOffRoute": "Eine Zeitmarkierung liegt zu weit von der Race Line entfernt.",
+      "inventoryShortage": "{kind}: {count} fehlt im Inventar."
+    }
+  },
   "emptyState": {
     "title": "Keine Auswahl",
     "body": "Wähle ein oder mehrere Elemente auf dem Canvas aus, um hier Objekteigenschaften zu bearbeiten."
@@ -144,7 +183,8 @@
     "sections": {
       "routeNumbering": "Routennummerierung",
       "inventory": "Inventar",
-      "field": "Feld"
+      "field": "Feld",
+      "advanced": "Erweitert"
     },
     "field": {
       "unitsLabel": "Einheiten",

--- a/lang/en/inspector.json
+++ b/lang/en/inspector.json
@@ -4,6 +4,45 @@
     "layout": "Layout",
     "selection": "Selection"
   },
+  "preflight": {
+    "title": "Preflight",
+    "status": {
+      "incomplete": {
+        "title": "Incomplete",
+        "description": "Add track items to start the layout review."
+      },
+      "review": {
+        "title": "Review",
+        "description": "{count, plural, one {1 known item needs attention.} other {{count} known items need attention.}}"
+      },
+      "ready": {
+        "title": "Ready",
+        "description": "No known issues in the active checks."
+      }
+    },
+    "categories": {
+      "route": "Route",
+      "timing": "Timing",
+      "inventory": "Inventory"
+    },
+    "checkInactive": "off",
+    "openIssue": "Open",
+    "emptyDetails": "Preflight starts when the layout contains track items.",
+    "noIssues": "The active checks have no known issues.",
+    "issues": {
+      "missingRoute": "Add a Race Line for the placed route obstacles.",
+      "noRouteMatches": "The route obstacles do not sit close enough to the Race Line.",
+      "offRoute": "{name} is outside the Race Line tolerance.",
+      "timingMissingRoute": "Timing needs one usable Race Line.",
+      "multipleRoutes": "Timing found multiple usable Race Lines.",
+      "missingStartFinish": "Add one start/finish timing marker.",
+      "duplicateStartFinish": "Keep only one start/finish timing marker.",
+      "missingSplitId": "A split timing marker is missing its ID.",
+      "duplicateTimingId": "Timing marker IDs must be unique.",
+      "timingPointOffRoute": "A timing marker sits too far from the Race Line.",
+      "inventoryShortage": "{kind}: {count} missing from inventory."
+    }
+  },
   "emptyState": {
     "title": "No selection",
     "body": "Select one or more items on the canvas to edit object properties here."
@@ -144,7 +183,8 @@
     "sections": {
       "routeNumbering": "Route numbering",
       "inventory": "Inventory",
-      "field": "Field"
+      "field": "Field",
+      "advanced": "Advanced"
     },
     "field": {
       "unitsLabel": "Units",

--- a/lang/nl/inspector.json
+++ b/lang/nl/inspector.json
@@ -4,6 +4,45 @@
     "layout": "Indeling",
     "selection": "Selectie"
   },
+  "preflight": {
+    "title": "Preflight",
+    "status": {
+      "incomplete": {
+        "title": "Onvolledig",
+        "description": "Voeg trackitems toe om de indeling te controleren."
+      },
+      "review": {
+        "title": "Controleren",
+        "description": "{count, plural, one {1 bekend aandachtspunt.} other {{count} bekende aandachtspunten.}}"
+      },
+      "ready": {
+        "title": "Gereed",
+        "description": "Geen bekende problemen in de actieve controles."
+      }
+    },
+    "categories": {
+      "route": "Route",
+      "timing": "Timing",
+      "inventory": "Inventaris"
+    },
+    "checkInactive": "uit",
+    "openIssue": "Open",
+    "emptyDetails": "Preflight start zodra de indeling trackitems bevat.",
+    "noIssues": "De actieve controles hebben geen bekende problemen.",
+    "issues": {
+      "missingRoute": "Voeg een race line toe voor de geplaatste route-obstakels.",
+      "noRouteMatches": "De route-obstakels liggen niet dicht genoeg bij de race line.",
+      "offRoute": "{name} ligt buiten de tolerantie van de race line.",
+      "timingMissingRoute": "Timing heeft één bruikbare race line nodig.",
+      "multipleRoutes": "Timing heeft meerdere bruikbare race lines gevonden.",
+      "missingStartFinish": "Voeg één start/finish-timingmarkering toe.",
+      "duplicateStartFinish": "Behoud slechts één start/finish-timingmarkering.",
+      "missingSplitId": "Een split-timingmarkering mist een ID.",
+      "duplicateTimingId": "Timingmarkering-ID's moeten uniek zijn.",
+      "timingPointOffRoute": "Een timingmarkering ligt te ver van de race line.",
+      "inventoryShortage": "{kind}: {count} ontbreekt in de inventaris."
+    }
+  },
   "emptyState": {
     "title": "Geen selectie",
     "body": "Selecteer een of meer items op het canvas om hun eigenschappen te bewerken."
@@ -144,7 +183,8 @@
     "sections": {
       "routeNumbering": "Routenummering",
       "inventory": "Inventaris",
-      "field": "Veld"
+      "field": "Veld",
+      "advanced": "Geavanceerd"
     },
     "field": {
       "unitsLabel": "Eenheden",

--- a/lang/zh/inspector.json
+++ b/lang/zh/inspector.json
@@ -4,6 +4,41 @@
     "layout": "布局",
     "selection": "选择"
   },
+  "preflight": {
+    "title": "预检",
+    "status": {
+      "incomplete": {
+        "title": "未完成",
+        "description": "添加赛道元素后即可开始布局检查。"
+      },
+      "review": {
+        "title": "需要检查",
+        "description": "有 {count} 个已知项目需要处理。"
+      },
+      "ready": {
+        "title": "就绪",
+        "description": "当前启用的检查中没有已知问题。"
+      }
+    },
+    "categories": { "route": "路线", "timing": "计时", "inventory": "库存" },
+    "checkInactive": "关闭",
+    "openIssue": "打开",
+    "emptyDetails": "布局包含赛道元素后，预检才会开始。",
+    "noIssues": "当前启用的检查没有已知问题。",
+    "issues": {
+      "missingRoute": "请为已放置的路线障碍添加比赛线路。",
+      "noRouteMatches": "路线障碍距离比赛线路过远。",
+      "offRoute": "{name} 超出了比赛线路容差。",
+      "timingMissingRoute": "计时需要一条可用的比赛线路。",
+      "multipleRoutes": "计时发现了多条可用的比赛线路。",
+      "missingStartFinish": "请添加一个起终点计时标记。",
+      "duplicateStartFinish": "只能保留一个起终点计时标记。",
+      "missingSplitId": "分段计时标记缺少 ID。",
+      "duplicateTimingId": "计时标记 ID 必须唯一。",
+      "timingPointOffRoute": "计时标记距离比赛线路过远。",
+      "inventoryShortage": "{kind}：库存缺少 {count} 个。"
+    }
+  },
   "emptyState": {
     "title": "当前未选择内容",
     "body": "在画布上选择一个或多个项目后，就能在这里编辑它们的属性。"
@@ -144,7 +179,8 @@
     "sections": {
       "routeNumbering": "路径编号",
       "inventory": "库存",
-      "field": "场地"
+      "field": "场地",
+      "advanced": "高级"
     },
     "field": {
       "unitsLabel": "单位",

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,7 @@ const nextConfig: NextConfig = {
 };
 
 if (process.env.NODE_ENV === "development" && !process.env.VERCEL) {
-  initOpenNextCloudflareForDev();
+  initOpenNextCloudflareForDev({ environment: "dev" });
 }
 
 export default withNextIntl(nextConfig);

--- a/src/components/editor/mobile/EditorMobilePanels.tsx
+++ b/src/components/editor/mobile/EditorMobilePanels.tsx
@@ -719,11 +719,6 @@ export function EditorMobilePanels({
             if (!open) onCloseInspector();
           }}
           title={t("inspector.title")}
-          subtitle={
-            selectedCount === 0
-              ? t("inspector.subtitles.empty")
-              : t("inspector.subtitles.selected")
-          }
           contentClassName="h-[82dvh] max-h-[92dvh] min-h-[72dvh] overscroll-contain"
           bodyClassName="bg-card min-h-0 touch-pan-y overscroll-y-contain [-webkit-overflow-scrolling:touch] p-0"
           repositionInputs

--- a/src/components/inspector/Inspector.tsx
+++ b/src/components/inspector/Inspector.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { memo, useCallback, useState, type ReactNode } from "react";
+import {
+  memo,
+  useCallback,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 import { motion } from "framer-motion";
 import {
   MultiInspectorView,
@@ -27,6 +34,8 @@ export interface InspectorProps {
   onResumeSelectedPath?: (shapeId: string) => void;
   mobileInline?: boolean;
 }
+
+type InspectorPanel = "project" | "layout" | "selection";
 
 function Inspector({
   headerAction,
@@ -75,7 +84,7 @@ function Inspector({
   );
   const count = selectedShapes.length;
   const [panelState, setPanelState] = useState<{
-    panel: "project" | "layout" | "selection" | null;
+    panel: InspectorPanel | null;
     selection: string[];
   }>(() => ({ panel: null, selection }));
   const panelOverride =
@@ -85,7 +94,7 @@ function Inspector({
         ? "selection"
         : null;
   const setPanelOverride = useCallback(
-    (panel: "project" | "layout" | "selection") => {
+    (panel: InspectorPanel) => {
       setPanelState({ panel, selection });
     },
     [selection]
@@ -129,6 +138,49 @@ function Inspector({
   const activeTabIndicatorLayoutId = mobileInline
     ? "inspector-active-tab-mobile"
     : "inspector-active-tab-desktop";
+  const tabRefs = useRef<Record<InspectorPanel, HTMLButtonElement | null>>({
+    project: null,
+    layout: null,
+    selection: null,
+  });
+  const tabItems: Array<{ id: InspectorPanel; label: string }> = [
+    { id: "project", label: tCommon("labels.project") },
+    { id: "layout", label: t("tabs.layout") },
+    { id: "selection", label: t("tabs.selection") },
+  ];
+  const handleTabKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    currentPanel: InspectorPanel
+  ) => {
+    if (
+      event.key !== "ArrowLeft" &&
+      event.key !== "ArrowRight" &&
+      event.key !== "Home" &&
+      event.key !== "End"
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    const enabledPanels = tabItems
+      .map((item) => item.id)
+      .filter((item) => item !== "selection" || !selectionDisabled);
+    const currentIndex = enabledPanels.indexOf(currentPanel);
+    const nextPanel =
+      event.key === "Home"
+        ? enabledPanels[0]
+        : event.key === "End"
+          ? enabledPanels.at(-1)
+          : event.key === "ArrowRight"
+            ? enabledPanels[(currentIndex + 1) % enabledPanels.length]
+            : enabledPanels[
+                (currentIndex - 1 + enabledPanels.length) % enabledPanels.length
+              ];
+
+    if (!nextPanel) return;
+    setPanelOverride(nextPanel);
+    tabRefs.current[nextPanel]?.focus();
+  };
 
   let selectionView = (
     <div className="flex h-full items-center justify-center px-6 text-center">
@@ -207,22 +259,25 @@ function Inspector({
             aria-label={t("tabs.ariaLabel")}
             className="flex min-w-0 items-center gap-5"
           >
-            {[
-              { id: "project" as const, label: tCommon("labels.project") },
-              { id: "layout" as const, label: t("tabs.layout") },
-              { id: "selection" as const, label: t("tabs.selection") },
-            ].map((item) => (
+            {tabItems.map((item) => (
               <button
                 key={item.id}
+                ref={(node) => {
+                  tabRefs.current[item.id] = node;
+                }}
                 type="button"
                 role="tab"
                 aria-selected={panel === item.id}
-                aria-controls={`inspector-panel-${item.id}`}
+                aria-controls={
+                  panel === item.id ? `inspector-panel-${item.id}` : undefined
+                }
                 id={`inspector-tab-${item.id}`}
+                tabIndex={panel === item.id ? 0 : -1}
                 disabled={item.id === "selection" && selectionDisabled}
                 onClick={() => setPanelOverride(item.id)}
+                onKeyDown={(event) => handleTabKeyDown(event, item.id)}
                 className={cn(
-                  "group relative -mb-px min-h-11 px-1 py-2.5 text-sm font-semibold transition-colors",
+                  "group focus-visible:ring-ring/40 relative -mb-px min-h-11 rounded-sm px-1 py-2.5 text-sm font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
                   panel === item.id
                     ? "text-foreground"
                     : "text-muted-foreground hover:text-foreground active:text-foreground",

--- a/src/components/inspector/PreflightSummary.tsx
+++ b/src/components/inspector/PreflightSummary.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -103,7 +103,10 @@ export function PreflightSummary({
   const t = useTranslations("inspector");
   const tShapes = useTranslations("shapes") as unknown as Translate;
   const [open, setOpen] = useState(false);
-  const shapesById = new Map(shapes.map((shape) => [shape.id, shape]));
+  const shapesById = useMemo(
+    () => new Map(shapes.map((shape) => [shape.id, shape])),
+    [shapes]
+  );
   const issueCount = report.issues.length;
   const title = t(`preflight.status.${report.status}.title`);
   const description =

--- a/src/components/inspector/PreflightSummary.tsx
+++ b/src/components/inspector/PreflightSummary.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import { useState } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  CircleDashed,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+import { getShapeKindLabel, type Translate } from "@/lib/track/items/registry";
+import type {
+  TrackPreflightIssue,
+  TrackPreflightReport,
+} from "@/lib/track/preflight";
+import type { Shape } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+function getRouteWarningLabel(
+  issue: Extract<TrackPreflightIssue, { type: "route-warning" }>,
+  t: ReturnType<typeof useTranslations<"inspector">>
+) {
+  switch (issue.warningKind) {
+    case "stub":
+      return t("elevationChart.warnings.stub.shortLabel");
+    case "steep":
+      return t("elevationChart.warnings.steep.shortLabel");
+    case "hairpin":
+      return t("elevationChart.warnings.hairpin.shortLabel");
+    case "close-points":
+      return t("elevationChart.warnings.close-points.shortLabel");
+    case "spacing-shift":
+      return t("elevationChart.warnings.spacing-shift.shortLabel");
+    case "rhythm-break":
+      return t("elevationChart.warnings.rhythm-break.shortLabel");
+  }
+}
+
+function getTimingIssueLabel(
+  issue: Extract<TrackPreflightIssue, { type: "timing" }>,
+  t: ReturnType<typeof useTranslations<"inspector">>
+) {
+  switch (issue.timingIssueType) {
+    case "duplicate-start-finish":
+      return t("preflight.issues.duplicateStartFinish");
+    case "duplicate-timing-id":
+      return t("preflight.issues.duplicateTimingId");
+    case "missing-route":
+      return t("preflight.issues.timingMissingRoute");
+    case "missing-split-id":
+      return t("preflight.issues.missingSplitId");
+    case "missing-start-finish":
+      return t("preflight.issues.missingStartFinish");
+    case "multiple-routes":
+      return t("preflight.issues.multipleRoutes");
+    case "timing-point-off-route":
+      return t("preflight.issues.timingPointOffRoute");
+  }
+}
+
+function getIssueLabel(
+  issue: TrackPreflightIssue,
+  shapesById: Map<string, Shape>,
+  t: ReturnType<typeof useTranslations<"inspector">>,
+  tShapes: Translate
+) {
+  if (issue.type === "route-warning") {
+    return getRouteWarningLabel(issue, t);
+  }
+  if (issue.type === "timing") {
+    return getTimingIssueLabel(issue, t);
+  }
+  if (issue.type === "inventory-shortage") {
+    return t("preflight.issues.inventoryShortage", {
+      count: issue.missing,
+      kind: getShapeKindLabel(issue.inventoryKind, tShapes),
+    });
+  }
+  if (issue.type === "missing-route") {
+    return t("preflight.issues.missingRoute");
+  }
+  if (issue.type === "no-route-matches") {
+    return t("preflight.issues.noRouteMatches");
+  }
+
+  const shape = issue.shapeIds?.[0] ? shapesById.get(issue.shapeIds[0]) : null;
+  return t("preflight.issues.offRoute", {
+    name:
+      shape?.name?.trim() ||
+      (shape ? getShapeKindLabel(shape.kind, tShapes) : t("tabs.selection")),
+  });
+}
+
+export function PreflightSummary({
+  report,
+  shapes,
+  setSelection,
+}: {
+  report: TrackPreflightReport;
+  shapes: Shape[];
+  setSelection: (ids: string[]) => void;
+}) {
+  const t = useTranslations("inspector");
+  const tShapes = useTranslations("shapes") as unknown as Translate;
+  const [open, setOpen] = useState(false);
+  const shapesById = new Map(shapes.map((shape) => [shape.id, shape]));
+  const issueCount = report.issues.length;
+  const title = t(`preflight.status.${report.status}.title`);
+  const description =
+    report.status === "review"
+      ? t("preflight.status.review.description", { count: issueCount })
+      : t(`preflight.status.${report.status}.description`);
+  const statusClasses =
+    report.status === "review"
+      ? "border-amber-500/25 bg-amber-500/8"
+      : report.status === "ready"
+        ? "border-emerald-500/20 bg-emerald-500/8"
+        : "border-border/45 bg-muted/25";
+
+  const handleIssueClick = (issue: TrackPreflightIssue) => {
+    const ids = issue.shapeIds?.length
+      ? issue.shapeIds
+      : issue.routeId
+        ? [issue.routeId]
+        : [];
+    if (ids.length > 0) setSelection(ids);
+  };
+
+  return (
+    <section aria-labelledby="track-preflight-title" className="space-y-2">
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls="track-preflight-details"
+        onClick={() => setOpen((current) => !current)}
+        className={cn(
+          "focus-visible:ring-ring/40 flex w-full items-start gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
+          statusClasses
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            "mt-0.5 inline-flex size-6 shrink-0 items-center justify-center rounded-md",
+            report.status === "review"
+              ? "bg-amber-500/12 text-amber-600"
+              : report.status === "ready"
+                ? "bg-emerald-500/12 text-emerald-600"
+                : "bg-muted text-muted-foreground"
+          )}
+        >
+          {report.status === "review" ? (
+            <AlertTriangle className="size-3.5" />
+          ) : report.status === "ready" ? (
+            <CheckCircle2 className="size-3.5" />
+          ) : (
+            <CircleDashed className="size-3.5" />
+          )}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-2">
+            <span
+              id="track-preflight-title"
+              className="text-foreground text-xs font-semibold"
+            >
+              {title}
+            </span>
+            <span className="text-muted-foreground/65 text-[10px] font-medium tracking-[0.08em] uppercase">
+              {t("preflight.title")}
+            </span>
+          </span>
+          <span className="text-muted-foreground/78 mt-0.5 block text-[11px] leading-snug">
+            {description}
+          </span>
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={cn(
+            "text-muted-foreground mt-1 size-4 shrink-0 transition-transform",
+            open && "rotate-180"
+          )}
+        />
+      </button>
+
+      <div
+        id="track-preflight-details"
+        hidden={!open}
+        className="border-border/35 overflow-hidden rounded-lg border"
+      >
+        <div className="border-border/30 bg-muted/20 flex flex-wrap gap-x-3 gap-y-1 border-b px-3 py-2">
+          {report.checks.map((check) => (
+            <span
+              key={check.category}
+              className="text-muted-foreground text-[10px] font-medium"
+            >
+              {t(`preflight.categories.${check.category}`)} ·{" "}
+              {check.active ? check.issueCount : t("preflight.checkInactive")}
+            </span>
+          ))}
+        </div>
+        {report.issues.length > 0 ? (
+          <div className="divide-border/25 divide-y">
+            {report.issues.map((issue) => {
+              const actionable = Boolean(
+                issue.shapeIds?.length || issue.routeId
+              );
+              return (
+                <button
+                  key={issue.id}
+                  type="button"
+                  disabled={!actionable}
+                  onClick={() => handleIssueClick(issue)}
+                  className="hover:bg-muted/30 focus-visible:bg-muted/30 focus-visible:ring-ring/40 flex min-h-10 w-full items-center gap-2 px-3 py-2 text-left text-[11px] transition-colors focus-visible:ring-2 focus-visible:outline-hidden disabled:cursor-default disabled:hover:bg-transparent"
+                >
+                  <AlertTriangle
+                    aria-hidden="true"
+                    className="size-3.5 shrink-0 text-amber-600"
+                  />
+                  <span className="min-w-0 flex-1">
+                    {getIssueLabel(issue, shapesById, t, tShapes)}
+                  </span>
+                  {actionable ? (
+                    <span className="text-muted-foreground/60 text-[10px]">
+                      {t("preflight.openIssue")}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-muted-foreground px-3 py-3 text-[11px]">
+            {report.status === "incomplete"
+              ? t("preflight.emptyDetails")
+              : t("preflight.noIssues")}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/inspector/shared.tsx
+++ b/src/components/inspector/shared.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useId, useState } from "react";
+import { createContext, useContext, useEffect, useId, useState } from "react";
 import type { ReactNode } from "react";
 import { useHistorySession } from "@/hooks/account/useHistorySession";
 import { cn } from "@/lib/utils";
@@ -17,6 +17,8 @@ export const fmt = (value: number | null | undefined) =>
   Number(
     (typeof value === "number" && Number.isFinite(value) ? value : 0).toFixed(2)
   );
+
+const RowLabelContext = createContext<string | undefined>(undefined);
 
 export function useInspectorInputBatch() {
   const { beginInteraction, endInteraction, pauseHistory, resumeHistory } =
@@ -73,12 +75,21 @@ export function Row({
   label: string;
   children: ReactNode;
 }) {
+  const labelId = useId();
+
   return (
     <div className="flex min-h-9 items-center gap-3 py-1 lg:min-h-8 lg:py-0.5">
-      <span className="text-muted-foreground/85 w-19.5 shrink-0 text-[11px] tracking-[0.02em] lg:w-22">
+      <span
+        id={labelId}
+        className="text-muted-foreground/85 w-19.5 shrink-0 text-[11px] tracking-[0.02em] lg:w-22"
+      >
         {label}
       </span>
-      <div className="min-w-0 flex-1">{children}</div>
+      <RowLabelContext.Provider value={label}>
+        <div aria-labelledby={labelId} className="min-w-0 flex-1">
+          {children}
+        </div>
+      </RowLabelContext.Provider>
     </div>
   );
 }
@@ -153,14 +164,17 @@ export function Num({
   step = 0.1,
   min,
   max,
+  ariaLabel,
 }: {
   value: number;
   onChange: (value: number) => void;
   step?: number;
   min?: number;
   max?: number;
+  ariaLabel?: string;
 }) {
   const { startBatch, finishBatch } = useInspectorInputBatch();
+  const rowLabel = useContext(RowLabelContext);
 
   return (
     <Input
@@ -168,6 +182,7 @@ export function Num({
       step={step}
       min={min}
       max={max}
+      aria-label={ariaLabel ?? rowLabel}
       value={value}
       onFocus={startBatch}
       onBlur={finishBatch}
@@ -177,7 +192,7 @@ export function Num({
         }
       }}
       onChange={(event) => onChange(+event.target.value)}
-      className="bg-background border-border/50 focus-visible:border-border/80 h-8 rounded-md px-2.5 font-mono text-[11px] shadow-none focus-visible:ring-0 lg:h-7 lg:px-2"
+      className="bg-background border-border/50 focus-visible:border-ring focus-visible:ring-ring/35 h-8 rounded-md px-2.5 font-mono text-[11px] shadow-none focus-visible:ring-2 lg:h-7 lg:px-2"
     />
   );
 }
@@ -188,14 +203,17 @@ export function MeasurementNum({
   onChange,
   minMeters,
   maxMeters,
+  ariaLabel,
 }: {
   valueMeters: number;
   unitSystem: MeasurementUnitSystem;
   onChange: (valueMeters: number) => void;
   minMeters?: number;
   maxMeters?: number;
+  ariaLabel?: string;
 }) {
   const { startBatch, finishBatch } = useInspectorInputBatch();
+  const rowLabel = useContext(RowLabelContext);
   const [draft, setDraft] = useState<string | null>(null);
   const displayValue =
     draft ?? formatMeasurementInputValue(valueMeters, unitSystem);
@@ -222,6 +240,7 @@ export function MeasurementNum({
     <Input
       type="text"
       inputMode="decimal"
+      aria-label={ariaLabel ?? rowLabel}
       value={displayValue}
       onFocus={() => {
         setDraft(displayValue);
@@ -237,7 +256,7 @@ export function MeasurementNum({
         }
       }}
       onChange={(event) => setDraft(event.target.value)}
-      className="bg-background border-border/50 focus-visible:border-border/80 h-8 rounded-md px-2.5 font-mono text-[11px] shadow-none focus-visible:ring-0 lg:h-7 lg:px-2"
+      className="bg-background border-border/50 focus-visible:border-ring focus-visible:ring-ring/35 h-8 rounded-md px-2.5 font-mono text-[11px] shadow-none focus-visible:ring-2 lg:h-7 lg:px-2"
     />
   );
 }
@@ -261,7 +280,7 @@ export function IconBtn({
       onClick={onClick}
       title={title}
       aria-label={title}
-      className={`inline-flex h-8 cursor-pointer items-center justify-center gap-1.5 rounded-md border px-2.5 text-[11px] font-medium transition-colors lg:h-7 lg:px-2 ${
+      className={`focus-visible:ring-ring/40 inline-flex h-8 cursor-pointer items-center justify-center gap-1.5 rounded-md border px-2.5 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:outline-hidden lg:h-7 lg:px-2 ${
         danger
           ? "border-red-500/20 bg-red-500/6 text-red-500 hover:bg-red-500/12"
           : "border-border/50 bg-background text-foreground/82 hover:bg-muted/35"

--- a/src/components/inspector/views/list-panel.tsx
+++ b/src/components/inspector/views/list-panel.tsx
@@ -147,9 +147,9 @@ function ItemRow({
 }) {
   const dragControls = useDragControls();
   const rowClassName =
-    "group/item hover:bg-brand-primary/8 focus-visible:ring-brand-primary/20 relative grid w-full grid-cols-[32px_minmax(0,1fr)_48px_28px] items-center gap-3 px-3 py-2 text-left transition-colors focus-visible:ring-2 focus-visible:outline-hidden";
+    "group/item hover:bg-brand-primary/8 relative grid w-full grid-cols-[minmax(0,1fr)_40px] items-stretch text-left transition-colors";
 
-  const content = (
+  const selectionContent = (
     <>
       <span className="bg-brand-primary absolute top-1.5 bottom-1.5 left-0 w-0.5 rounded-r-full opacity-0 transition-opacity group-hover/item:opacity-100" />
       <div className="flex min-w-0 items-center">
@@ -196,14 +196,26 @@ function ItemRow({
           –
         </span>
       )}
-      <div className="flex items-center justify-end opacity-100 transition-opacity lg:opacity-0 lg:group-hover/item:opacity-100">
+    </>
+  );
+
+  const rowContent = (
+    <>
+      <button
+        type="button"
+        onClick={() => setSelection([shape.id])}
+        className="focus-visible:ring-brand-primary/20 grid min-w-0 grid-cols-[32px_minmax(0,1fr)_48px] items-center gap-3 px-3 py-2 text-left focus-visible:ring-2 focus-visible:outline-hidden"
+      >
+        {selectionContent}
+      </button>
+      <div className="flex items-center justify-center opacity-100 transition-opacity lg:opacity-0 lg:group-focus-within/item:opacity-100 lg:group-hover/item:opacity-100">
         <button
           type="button"
           title={removeItemTitle}
+          aria-label={removeItemTitle}
           disabled={shape.locked}
-          className="text-muted-foreground/55 hover:bg-brand-primary/10 hover:text-brand-primary flex size-5 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-35"
-          onClick={(event) => {
-            event.stopPropagation();
+          className="text-muted-foreground/55 hover:bg-brand-primary/10 hover:text-brand-primary focus-visible:ring-brand-primary/30 flex size-7 items-center justify-center rounded-md transition-colors focus-visible:ring-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-35"
+          onClick={() => {
             if (shape.locked) return;
             removeShapes([shape.id]);
             setHoveredShapeId(null);
@@ -223,40 +235,22 @@ function ItemRow({
         dragListener={false}
         dragControls={dragControls}
         onDragEnd={() => onDragEnd(shape.id)}
-        role="button"
-        tabIndex={0}
-        onClick={() => setSelection([shape.id])}
         className={rowClassName}
         onMouseEnter={() => setHoveredShapeId(shape.id)}
         onMouseLeave={() => setHoveredShapeId(null)}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            setSelection([shape.id]);
-          }
-        }}
       >
-        {content}
+        {rowContent}
       </Reorder.Item>
     );
   }
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={() => setSelection([shape.id])}
       className={rowClassName}
       onMouseEnter={() => setHoveredShapeId(shape.id)}
       onMouseLeave={() => setHoveredShapeId(null)}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          setSelection([shape.id]);
-        }
-      }}
     >
-      {content}
+      {rowContent}
     </div>
   );
 }
@@ -352,6 +346,7 @@ export function ItemOverviewList({
   }, [listShapes, viewFilter, normalizedQuery, tShapes]);
 
   const isDraggable = filteredShapes.length === listShapes.length;
+  const showFilters = listShapes.length > 8 || query.length > 0;
   const routeStatusOff = t("listPanel.routeStatus.off");
   const removeItemTitle = t("actions.removeItem");
 
@@ -368,59 +363,60 @@ export function ItemOverviewList({
       <div
         className={cn("space-y-2.5", grow && "flex min-h-0 flex-1 flex-col")}
       >
-        <div className="flex shrink-0 items-center gap-2">
-          <Input
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder={t("listPanel.filterPlaceholder")}
-            className="bg-background border-border/40 focus-visible:border-border/80 focus-visible:ring-ring/20 h-8 rounded-md px-2.5 text-[11px] shadow-none focus-visible:ring-1 lg:h-7 lg:px-2"
-          />
-          <MetaPill>
-            {filteredShapes.length}/{listShapes.length}
-          </MetaPill>
-        </div>
+        {showFilters ? (
+          <>
+            <div className="flex shrink-0 items-center gap-2">
+              <Input
+                aria-label={t("listPanel.filterPlaceholder")}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={t("listPanel.filterPlaceholder")}
+                className="bg-background border-border/40 focus-visible:border-border/80 focus-visible:ring-ring/20 h-8 rounded-md px-2.5 text-[11px] shadow-none focus-visible:ring-1 lg:h-7 lg:px-2"
+              />
+              <MetaPill>
+                {filteredShapes.length}/{listShapes.length}
+              </MetaPill>
+            </div>
 
-        <div className="flex shrink-0 items-center gap-1">
-          {VIEW_FILTERS.map(({ value, label }) => {
-            const count =
-              value === "obstacles" ? obstacleCount : listShapes.length;
-            return (
-              <button
-                key={value}
-                type="button"
-                onClick={() => setViewFilter(value)}
-                className={cn(
-                  "flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors",
-                  viewFilter === value
-                    ? "bg-brand-primary/12 text-brand-primary"
-                    : "text-muted-foreground/65 hover:text-foreground/80 hover:bg-muted/40"
-                )}
-              >
-                {label}
-                <span
-                  className={cn(
-                    "rounded px-1 font-mono text-[10px]",
-                    viewFilter === value
-                      ? "bg-brand-primary/15 text-brand-primary"
-                      : "bg-muted/60 text-muted-foreground/55"
-                  )}
-                >
-                  {count}
-                </span>
-              </button>
-            );
-          })}
-        </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {VIEW_FILTERS.map(({ value, label }) => {
+                const count =
+                  value === "obstacles" ? obstacleCount : listShapes.length;
+                return (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setViewFilter(value)}
+                    className={cn(
+                      "focus-visible:ring-ring/40 flex items-center gap-1.5 rounded-md px-2 py-1 text-[11px] font-medium transition-colors focus-visible:ring-2 focus-visible:outline-hidden",
+                      viewFilter === value
+                        ? "bg-brand-primary/12 text-brand-primary"
+                        : "text-muted-foreground/65 hover:text-foreground/80 hover:bg-muted/40"
+                    )}
+                  >
+                    {label}
+                    <span
+                      className={cn(
+                        "rounded px-1 font-mono text-[10px]",
+                        viewFilter === value
+                          ? "bg-brand-primary/15 text-brand-primary"
+                          : "bg-muted/60 text-muted-foreground/55"
+                      )}
+                    >
+                      {count}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </>
+        ) : null}
 
-        <ListPanel
-          title={t("listPanel.placedItemsTitle")}
-          subtitle={t("listPanel.placedItemsSubtitle")}
-          grow={grow}
-          meta={
-            <span className="text-muted-foreground/65 text-[11px]">
-              {listShapes.length}
-            </span>
-          }
+        <div
+          className={cn(
+            "border-border/25 overflow-hidden border-y",
+            grow && "flex min-h-0 flex-1 flex-col"
+          )}
         >
           <div className="border-border/15 grid shrink-0 grid-cols-[32px_minmax(0,1fr)_48px_28px] items-center gap-3 border-b px-3 py-1.5">
             <span className="text-muted-foreground/55 text-[10px] font-medium tracking-[0.08em] uppercase">
@@ -503,7 +499,7 @@ export function ItemOverviewList({
               </div>
             )}
           </div>
-        </ListPanel>
+        </div>
       </div>
     </Section>
   );

--- a/src/components/inspector/views/list-panel.tsx
+++ b/src/components/inspector/views/list-panel.tsx
@@ -91,6 +91,14 @@ function getShapeDisplayName(shape: Shape, t: Translate): string {
 
 type ViewFilter = "all" | "obstacles";
 
+export function shouldShowItemFilters(
+  itemCount: number,
+  query: string,
+  viewFilter: ViewFilter
+) {
+  return itemCount > 8 || query.length > 0 || viewFilter !== "all";
+}
+
 export function getListableTrackItems(shapes: Shape[]): Shape[] {
   return shapes.filter((shape) => shape.kind !== "polyline");
 }
@@ -346,7 +354,11 @@ export function ItemOverviewList({
   }, [listShapes, viewFilter, normalizedQuery, tShapes]);
 
   const isDraggable = filteredShapes.length === listShapes.length;
-  const showFilters = listShapes.length > 8 || query.length > 0;
+  const showFilters = shouldShowItemFilters(
+    listShapes.length,
+    query,
+    viewFilter
+  );
   const routeStatusOff = t("listPanel.routeStatus.off");
   const removeItemTitle = t("actions.removeItem");
 

--- a/src/components/inspector/views/multi-selection.tsx
+++ b/src/components/inspector/views/multi-selection.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { type Dispatch, type SetStateAction } from "react";
-import ElevationChart from "@/components/inspector/ElevationChart";
 import { Input } from "@/components/ui/input";
 import { getShapeKindLabel, type Translate } from "@/lib/track/items/registry";
 import {
@@ -35,12 +34,7 @@ import {
   Section,
   useInspectorInputBatch,
 } from "@/components/inspector/shared";
-import {
-  InspectorFooterDesktop,
-  InspectorFooterMobile,
-  InspectorLead,
-  InspectorScrollBody,
-} from "./layout";
+import { InspectorLead, InspectorScrollBody } from "./layout";
 import { useTranslations } from "next-intl";
 
 export interface MultiInspectorViewProps {
@@ -348,14 +342,8 @@ export function MultiInspectorView({
               </Row>
             </Section>
           )}
-          <InspectorFooterMobile>
-            <ElevationChart />
-          </InspectorFooterMobile>
         </div>
       </InspectorScrollBody>
-      <InspectorFooterDesktop>
-        <ElevationChart className="lg:mx-0 lg:border-t-0 lg:px-3" />
-      </InspectorFooterDesktop>
     </div>
   );
 }

--- a/src/components/inspector/views/project-layout.tsx
+++ b/src/components/inspector/views/project-layout.tsx
@@ -1,18 +1,10 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import {
-  AlertTriangle,
-  CheckCircle2,
-  Eye,
-  EyeOff,
-  MapPinned,
-  Route,
-  Sparkles,
-  Trash2,
-} from "lucide-react";
+import { Eye, EyeOff, MapPinned, Sparkles, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import ElevationChart from "@/components/inspector/ElevationChart";
+import { PreflightSummary } from "@/components/inspector/PreflightSummary";
 import { MeasurementUnitToggle } from "@/components/MeasurementUnitToggle";
 import { MapReferenceDialog } from "@/components/map-reference/MapReferenceDialog";
 import { Input } from "@/components/ui/input";
@@ -24,6 +16,7 @@ import {
   normalizeInventoryProfile,
 } from "@/lib/planning/inventory";
 import { getObstacleNumberingReport } from "@/lib/track/obstacleNumbering";
+import { getTrackPreflightReport } from "@/lib/track/preflight";
 import {
   generateRaceLineDraft,
   isGeneratedRaceLine,
@@ -46,11 +39,9 @@ import {
   useInspectorInputBatch,
 } from "@/components/inspector/shared";
 import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
-import { formatFieldSize, formatMeasurement } from "@/lib/track/units";
 import {
   InspectorFooterDesktop,
   InspectorFooterMobile,
-  InspectorLead,
   InspectorScrollBody,
   useIsDesktopInspector,
 } from "./layout";
@@ -60,12 +51,6 @@ import {
   ItemOverviewList,
 } from "./list-panel";
 import { useTranslations } from "next-intl";
-
-function getShapeDisplayName(shape: Shape, index: number, t: Translate) {
-  return (
-    shape.name?.trim() || `${getShapeKindLabel(shape.kind, t)} ${index + 1}`
-  );
-}
 
 function MapReferenceSection({
   design,
@@ -100,6 +85,7 @@ function MapReferenceSection({
               <div className="flex min-w-0 items-center gap-2">
                 <input
                   type="range"
+                  aria-label={t("layout.mapReference.fields.opacity")}
                   min={0.05}
                   max={1}
                   step={0.05}
@@ -261,62 +247,13 @@ function RouteNumberingOverview({
   setSelection: (ids: string[]) => void;
 }) {
   const t = useTranslations("inspector");
-  const tShapes = useTranslations("shapes") as unknown as Translate;
   const report = useMemo(() => getObstacleNumberingReport(design), [design]);
-  const shapeOrder = useMemo(
-    () => new Map(shapes.map((shape, index) => [shape.id, index] as const)),
-    [shapes]
-  );
-  const issueNames = report.issues.slice(0, 3).map((issue) => {
-    const shape = shapes[shapeOrder.get(issue.shapeId) ?? -1];
-    return shape
-      ? getShapeDisplayName(shape, shapeOrder.get(shape.id) ?? 0, tShapes)
-      : issue.shapeId;
-  });
-  const extraIssueCount = Math.max(0, report.unmappedObstacleCount - 3);
-  const isClear =
-    report.status === "ready" ||
-    report.status === "empty" ||
-    report.status === "no-numbered-obstacles";
-  const hasExistingRaceLine = Boolean(report.primaryPolylineId);
   const generatedRaceLine = shapes.find(isGeneratedRaceLine) ?? null;
   const hasGeneratedRaceLine = Boolean(generatedRaceLine);
   const hasWarnings =
     report.status === "partial" ||
     report.status === "no-route-matches" ||
     report.status === "missing-route";
-  const statusLabel =
-    report.status === "ready"
-      ? t("routeNumbering.status.ready")
-      : report.status === "partial"
-        ? t("routeNumbering.status.partial")
-        : report.status === "no-route-matches"
-          ? t("routeNumbering.status.noRouteMatches")
-          : report.status === "missing-route"
-            ? t("routeNumbering.status.missingRoute")
-            : report.status === "no-numbered-obstacles"
-              ? t("routeNumbering.status.noNumberedObstacles")
-              : t("routeNumbering.status.empty");
-  const message =
-    report.status === "ready"
-      ? t("routeNumbering.messages.ready", {
-          count: report.mappedObstacleCount,
-        })
-      : report.status === "partial"
-        ? t("routeNumbering.messages.partial", {
-            mapped: report.mappedObstacleCount,
-            total: report.totalNumberedObstacleCount,
-          })
-        : report.status === "no-route-matches"
-          ? t("routeNumbering.messages.noRouteMatches", {
-              count: report.totalNumberedObstacleCount,
-            })
-          : report.status === "missing-route"
-            ? t("routeNumbering.messages.missingRoute")
-            : report.status === "no-numbered-obstacles"
-              ? t("routeNumbering.messages.noNumberedObstacles")
-              : t("routeNumbering.messages.empty");
-
   const canGenerate =
     report.status === "missing-route" ||
     report.status === "ready" ||
@@ -345,119 +282,27 @@ function RouteNumberingOverview({
     );
   }
 
+  if (!canGenerate) return null;
+
   return (
     <Section title={t("layout.sections.routeNumbering")}>
-      <div className="space-y-3">
-        <div
-          className={cn(
-            "rounded-md border px-2.5 py-2",
-            hasWarnings
-              ? "border-amber-500/25 bg-amber-500/8"
-              : isClear
-                ? "border-emerald-500/20 bg-emerald-500/8"
-                : "border-border/40 bg-muted/25"
-          )}
-        >
-          <div className="flex items-start gap-2">
-            <span
-              className={cn(
-                "mt-0.5 inline-flex size-5 shrink-0 items-center justify-center rounded-sm",
-                hasWarnings
-                  ? "bg-amber-500/12 text-amber-600"
-                  : isClear
-                    ? "bg-emerald-500/12 text-emerald-600"
-                    : "bg-muted text-muted-foreground"
-              )}
-              aria-hidden="true"
-            >
-              {hasWarnings ? (
-                <AlertTriangle className="size-3" />
-              ) : isClear ? (
-                <CheckCircle2 className="size-3" />
-              ) : (
-                <Route className="size-3" />
-              )}
-            </span>
-            <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
-                <p
-                  className={cn(
-                    "text-[12px] font-semibold",
-                    hasWarnings
-                      ? "text-amber-600"
-                      : isClear
-                        ? "text-emerald-600"
-                        : "text-foreground"
-                  )}
-                >
-                  {statusLabel}
-                </p>
-                {hasExistingRaceLine ? (
-                  <span className="border-border/45 bg-background/65 text-muted-foreground inline-flex items-center rounded-sm border px-1.5 py-px text-[10px] font-medium">
-                    {t("routeNumbering.meta.raceLine")}
-                  </span>
-                ) : null}
-                {message ? (
-                  <span className="text-muted-foreground/80 text-[11px] leading-snug">
-                    {message}
-                  </span>
-                ) : null}
-              </div>
-              {issueNames.length > 0 ? (
-                <p className="mt-1 text-[10px] leading-snug text-amber-600/85">
-                  {t("routeNumbering.issues.offRoutePrefix", {
-                    names: issueNames.join(", "),
-                  })}
-                  {extraIssueCount > 0
-                    ? t("routeNumbering.issues.moreSuffix", {
-                        count: extraIssueCount,
-                      })
-                    : ""}
-                </p>
-              ) : null}
-            </div>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-2">
-          <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
-            <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
-              {t("routeNumbering.meta.numbered")}
-            </p>
-            <p className="text-foreground text-[12px] font-semibold">
-              {report.mappedObstacleCount}/{report.totalNumberedObstacleCount}
-            </p>
-          </div>
-          <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
-            <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
-              {t("routeNumbering.meta.issues")}
-            </p>
-            <p className="text-foreground text-[12px] font-semibold">
-              {report.issueCount}
-            </p>
-          </div>
-        </div>
-
-        {canGenerate ? (
-          <button
-            type="button"
-            onClick={handleGenerateRaceLine}
-            className={cn(
-              "inline-flex h-11 w-full items-center justify-center gap-1.5 rounded-lg border px-3 text-xs font-medium transition-colors lg:h-8 lg:text-[11px]",
-              hasWarnings
-                ? "border-amber-500/25 bg-amber-500/10 text-amber-700 hover:bg-amber-500/16 dark:text-amber-400"
-                : "border-emerald-500/25 bg-emerald-500/8 text-emerald-700 hover:bg-emerald-500/14 dark:text-emerald-400"
-            )}
-          >
-            <Sparkles className="size-4 lg:size-3" />
-            <span>
-              {hasGeneratedRaceLine
-                ? t("routeNumbering.generate.regenerateButton")
-                : t("routeNumbering.generate.button")}
-            </span>
-          </button>
-        ) : null}
-      </div>
+      <button
+        type="button"
+        onClick={handleGenerateRaceLine}
+        className={cn(
+          "focus-visible:ring-ring/40 inline-flex h-11 w-full items-center justify-center gap-1.5 rounded-lg border px-3 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-hidden lg:h-8 lg:text-[11px]",
+          hasWarnings
+            ? "border-amber-500/25 bg-amber-500/10 text-amber-700 hover:bg-amber-500/16 dark:text-amber-400"
+            : "border-emerald-500/25 bg-emerald-500/8 text-emerald-700 hover:bg-emerald-500/14 dark:text-emerald-400"
+        )}
+      >
+        <Sparkles className="size-4 lg:size-3" />
+        <span>
+          {hasGeneratedRaceLine
+            ? t("routeNumbering.generate.regenerateButton")
+            : t("routeNumbering.generate.button")}
+        </span>
+      </button>
     </Section>
   );
 }
@@ -507,16 +352,14 @@ export function ProjectLayoutInspectorView({
   const fieldUnitLabel = unitSystem === "imperial" ? "ft" : "m";
   const isDesktop = useIsDesktopInspector();
   const inventory = normalizeInventoryProfile(design.inventory);
+  const inventoryActive = inventoryKinds.some((kind) => inventory[kind] > 0);
   const inventoryComparison = getInventoryComparison(design, tShapes);
-  const totalMissing = inventoryComparison.reduce(
-    (sum, item) => sum + item.missing,
-    0
-  );
-  const kindsMissing = inventoryComparison.filter(
-    (item) => item.missing > 0
-  ).length;
   const obstacleNumberingReport = useMemo(
     () => getObstacleNumberingReport(design),
+    [design]
+  );
+  const preflightReport = useMemo(
+    () => getTrackPreflightReport(design),
     [design]
   );
   const trackItemShapes = useMemo(
@@ -539,34 +382,6 @@ export function ProjectLayoutInspectorView({
   const inventoryContent = (
     <Section title={t("layout.sections.inventory")}>
       <div className="space-y-3">
-        <div className="grid grid-cols-3 gap-2">
-          <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
-            <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
-              {tCommon("labels.status")}
-            </p>
-            <p className="text-foreground text-[12px] font-semibold">
-              {totalMissing === 0
-                ? t("layout.inventory.status.buildable")
-                : t("layout.inventory.status.short")}
-            </p>
-          </div>
-          <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
-            <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
-              {t("layout.inventory.labels.missing")}
-            </p>
-            <p className="text-foreground text-[12px] font-semibold">
-              {totalMissing}
-            </p>
-          </div>
-          <div className="border-border/40 bg-muted/25 rounded-md border px-2.5 py-2">
-            <p className="text-muted-foreground/70 text-[9px] tracking-[0.12em] uppercase">
-              {t("layout.inventory.labels.types")}
-            </p>
-            <p className="text-foreground text-[12px] font-semibold">
-              {kindsMissing}
-            </p>
-          </div>
-        </div>
         <p className="text-muted-foreground/70 text-[11px] leading-relaxed">
           {t("layout.inventory.description")}
         </p>
@@ -575,7 +390,7 @@ export function ProjectLayoutInspectorView({
             const comparison = inventoryComparison.find(
               (item) => item.kind === kind
             );
-            const missing = comparison?.missing ?? 0;
+            const missing = inventoryActive ? (comparison?.missing ?? 0) : 0;
             return (
               <Row key={kind} label={getShapeKindLabel(kind, tShapes)}>
                 <div className="flex min-w-0 items-center gap-2">
@@ -596,12 +411,16 @@ export function ProjectLayoutInspectorView({
                     className={
                       missing > 0
                         ? "shrink-0 rounded-md border border-amber-500/25 bg-amber-500/10 px-2 py-1 font-mono text-[10px] font-medium text-amber-500"
-                        : "shrink-0 rounded-md border border-emerald-500/20 bg-emerald-500/8 px-2 py-1 font-mono text-[10px] font-medium text-emerald-500"
+                        : inventoryActive
+                          ? "shrink-0 rounded-md border border-emerald-500/20 bg-emerald-500/8 px-2 py-1 font-mono text-[10px] font-medium text-emerald-500"
+                          : "border-border/35 bg-muted/25 text-muted-foreground/55 shrink-0 rounded-md border px-2 py-1 font-mono text-[10px] font-medium"
                     }
                   >
                     {missing > 0
                       ? `-${missing}`
-                      : t("layout.inventory.stockOk")}
+                      : inventoryActive
+                        ? t("layout.inventory.stockOk")
+                        : "—"}
                   </span>
                 </div>
               </Row>
@@ -614,24 +433,12 @@ export function ProjectLayoutInspectorView({
 
   const projectContent = (
     <>
-      <InspectorLead
-        title={design.title.trim() || t("layout.project.titlePlaceholder")}
-        subtitle={t("layout.project.subtitle")}
-        meta={[
-          t("layout.meta.itemsCount", { count: shapes.length }),
-          formatFieldSize(design.field.width, design.field.height, unitSystem),
-          t("layout.meta.grid", {
-            grid: formatMeasurement(design.field.gridStep, unitSystem, {
-              precision: 1,
-            }),
-          }),
-        ]}
-      />
       <div>
         <p className="text-muted-foreground/70 mb-1.5 text-[11px] font-medium tracking-[0.08em] uppercase">
           {tCommon("labels.title")}
         </p>
         <Input
+          aria-label={tCommon("labels.title")}
           value={design.title}
           onFocus={startBatch}
           onBlur={finishBatch}
@@ -642,7 +449,7 @@ export function ProjectLayoutInspectorView({
           }}
           onChange={(event) => updateDesignMeta({ title: event.target.value })}
           placeholder={t("layout.project.titlePlaceholder")}
-          className="bg-muted/40 border-border/40 focus-visible:border-border/80 focus-visible:ring-ring/20 h-8 rounded-md px-2.5 text-sm shadow-none focus-visible:ring-1 lg:h-7 lg:px-2 lg:text-[11px]"
+          className="bg-muted/40 border-border/40 focus-visible:border-border/80 focus-visible:ring-ring/20 h-11 rounded-lg px-3 text-base shadow-none focus-visible:ring-1 lg:h-9 lg:rounded-md lg:px-2.5 lg:text-sm"
         />
       </div>
       <Section title={t("layout.sections.field")}>
@@ -673,6 +480,8 @@ export function ProjectLayoutInspectorView({
             minMeters={0.5}
           />
         </Row>
+      </Section>
+      <Section title={t("layout.sections.advanced")} defaultOpen={false}>
         <Row label={t("layout.field.renderScaleLabel")}>
           <div
             className="flex min-w-0 items-center gap-2"
@@ -701,26 +510,10 @@ export function ProjectLayoutInspectorView({
 
   const layoutContent = (
     <>
-      <InspectorLead
-        title={t("layout.overview.title")}
-        subtitle={t("layout.overview.subtitle")}
-        meta={[
-          t("layout.meta.itemsCount", { count: trackItemShapes.length }),
-          totalMissing === 0
-            ? t("layout.meta.buildable")
-            : t("layout.meta.shortItems", { count: totalMissing }),
-          kindsMissing > 0
-            ? t("layout.meta.typesShort", { count: kindsMissing })
-            : t("layout.meta.stockCovered"),
-          obstacleNumberingReport.status === "ready"
-            ? t("layout.meta.numbered", {
-                count: obstacleNumberingReport.mappedObstacleCount,
-              })
-            : obstacleNumberingReport.status === "no-numbered-obstacles" ||
-                obstacleNumberingReport.status === "empty"
-              ? t("layout.meta.numberingIdle")
-              : t("layout.meta.numberingNeedsReview"),
-        ]}
+      <PreflightSummary
+        report={preflightReport}
+        shapes={shapes}
+        setSelection={setSelection}
       />
       <div className="space-y-4">
         <MapReferenceSection
@@ -770,9 +563,11 @@ export function ProjectLayoutInspectorView({
             {panel === "project" ? projectContent : layoutContent}
           </div>
         </InspectorScrollBody>
-        <InspectorFooterDesktop>
-          <ElevationChart className="lg:mx-0 lg:border-t-0 lg:px-3" />
-        </InspectorFooterDesktop>
+        {panel === "layout" ? (
+          <InspectorFooterDesktop>
+            <ElevationChart className="lg:mx-0 lg:border-t-0 lg:px-3" />
+          </InspectorFooterDesktop>
+        ) : null}
       </div>
     );
   }
@@ -782,9 +577,11 @@ export function ProjectLayoutInspectorView({
       <InspectorScrollBody mobileInline={mobileInline}>
         <div className="space-y-5 px-4 py-4 pb-[max(env(safe-area-inset-bottom),1rem)]">
           {panel === "project" ? projectContent : layoutContent}
-          <InspectorFooterMobile>
-            <ElevationChart />
-          </InspectorFooterMobile>
+          {panel === "layout" ? (
+            <InspectorFooterMobile>
+              <ElevationChart />
+            </InspectorFooterMobile>
+          ) : null}
         </div>
       </InspectorScrollBody>
     </div>

--- a/src/components/inspector/views/single-shape.tsx
+++ b/src/components/inspector/views/single-shape.tsx
@@ -197,7 +197,7 @@ export function SingleInspectorView({
     catalogIdentity !== null && catalogEntry?.editable?.color === false;
   const canSetTimingMarker = isTimingMarkerShape(shape);
   const secondarySectionDefaultOpen = !mobileInline;
-  const timingSectionDefaultOpen = !mobileInline || canSetTimingMarker;
+  const timingSectionDefaultOpen = !mobileInline || Boolean(timingMarker);
   const timingRoleOptions: Array<{
     label: string;
     role: TimingRole | "none";
@@ -227,7 +227,6 @@ export function SingleInspectorView({
             })}
             meta={[
               shapeKindLabel,
-              `${fmt(anchorPosition.x)}, ${fmt(anchorPosition.y)}`,
               ...(timingMarker
                 ? [
                     timingMarker.role === "start_finish"
@@ -244,59 +243,63 @@ export function SingleInspectorView({
             ]}
           />
           <div className="space-y-2.5">
-            <div className="grid grid-cols-3 gap-1.5">
-              <button
-                type="button"
-                onClick={() => setShapesLocked([shape.id], !shape.locked)}
-                title={
-                  shape.locked
-                    ? tCommon("actions.unlock")
-                    : tCommon("actions.lock")
-                }
-                aria-label={
-                  shape.locked
-                    ? tCommon("actions.unlock")
-                    : tCommon("actions.lock")
-                }
-                className={`${actionBtnClass} min-w-0`}
-              >
-                {shape.locked ? (
-                  <Lock className="size-3 shrink-0 text-amber-400" />
-                ) : (
-                  <LockOpen className="size-3 shrink-0" />
-                )}
-                <span className="truncate">
-                  {shape.locked
-                    ? t("actions.unlockShort")
-                    : t("actions.lockShort")}
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={() => duplicateShapes([shape.id])}
-                title={tCommon("actions.duplicate")}
-                aria-label={tCommon("actions.duplicate")}
-                disabled={shape.locked}
-                className={`${actionBtnClass} min-w-0`}
-              >
-                <Copy className="size-3 shrink-0" />
-                <span className="truncate">{t("actions.duplicateShort")}</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  removeShapes([shape.id]);
-                  setSelection([]);
-                }}
-                title={tCommon("actions.delete")}
-                aria-label={tCommon("actions.delete")}
-                disabled={shape.locked}
-                className={`${inspectorActionBtnDangerClass} min-w-0`}
-              >
-                <Trash2 className="size-3 shrink-0" />
-                <span className="truncate">{t("actions.deleteShort")}</span>
-              </button>
-            </div>
+            {!mobileInline ? (
+              <div className="grid grid-cols-3 gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => setShapesLocked([shape.id], !shape.locked)}
+                  title={
+                    shape.locked
+                      ? tCommon("actions.unlock")
+                      : tCommon("actions.lock")
+                  }
+                  aria-label={
+                    shape.locked
+                      ? tCommon("actions.unlock")
+                      : tCommon("actions.lock")
+                  }
+                  className={`${actionBtnClass} min-w-0`}
+                >
+                  {shape.locked ? (
+                    <Lock className="size-3 shrink-0 text-amber-400" />
+                  ) : (
+                    <LockOpen className="size-3 shrink-0" />
+                  )}
+                  <span className="truncate">
+                    {shape.locked
+                      ? t("actions.unlockShort")
+                      : t("actions.lockShort")}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => duplicateShapes([shape.id])}
+                  title={tCommon("actions.duplicate")}
+                  aria-label={tCommon("actions.duplicate")}
+                  disabled={shape.locked}
+                  className={`${actionBtnClass} min-w-0`}
+                >
+                  <Copy className="size-3 shrink-0" />
+                  <span className="truncate">
+                    {t("actions.duplicateShort")}
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    removeShapes([shape.id]);
+                    setSelection([]);
+                  }}
+                  title={tCommon("actions.delete")}
+                  aria-label={tCommon("actions.delete")}
+                  disabled={shape.locked}
+                  className={`${inspectorActionBtnDangerClass} min-w-0`}
+                >
+                  <Trash2 className="size-3 shrink-0" />
+                  <span className="truncate">{t("actions.deleteShort")}</span>
+                </button>
+              </div>
+            ) : null}
             {showPathActions ? (
               <div className="grid grid-cols-2 gap-1.5">
                 {onResumeSelectedPath ? (
@@ -458,6 +461,7 @@ export function SingleInspectorView({
           <Section title={t("transform.sectionTitle")}>
             <Row label={tCommon("labels.name")}>
               <Input
+                aria-label={tCommon("labels.name")}
                 value={shape.name ?? ""}
                 onFocus={startBatch}
                 onBlur={finishBatch}
@@ -473,7 +477,7 @@ export function SingleInspectorView({
                 autoComplete="off"
                 autoCorrect="off"
                 spellCheck={false}
-                className="bg-background border-border/50 focus-visible:border-border/80 h-8 rounded-md px-2.5 text-[11px] shadow-none focus-visible:ring-0 lg:h-7 lg:px-2"
+                className="bg-background border-border/50 focus-visible:border-ring focus-visible:ring-ring/35 h-8 rounded-md px-2.5 text-[11px] shadow-none focus-visible:ring-2 lg:h-7 lg:px-2"
               />
             </Row>
             <Row label={t("transform.positionLabel")}>
@@ -483,6 +487,7 @@ export function SingleInspectorView({
                     X ({unitLabel})
                   </span>
                   <MeasurementNum
+                    ariaLabel={`X (${unitLabel})`}
                     valueMeters={fmt(anchorPosition.x)}
                     unitSystem={unitSystem}
                     onChange={(value) => updateShape(shape.id, { x: value })}
@@ -493,6 +498,7 @@ export function SingleInspectorView({
                     Y ({unitLabel})
                   </span>
                   <MeasurementNum
+                    ariaLabel={`Y (${unitLabel})`}
                     valueMeters={fmt(anchorPosition.y)}
                     unitSystem={unitSystem}
                     onChange={(value) => updateShape(shape.id, { y: value })}
@@ -663,9 +669,11 @@ export function SingleInspectorView({
           )}
         </div>
       </InspectorScrollBody>
-      <InspectorFooterDesktop>
-        <ElevationChart className="lg:mx-0 lg:border-t-0 lg:px-3" />
-      </InspectorFooterDesktop>
+      {shape.kind === "polyline" ? (
+        <InspectorFooterDesktop>
+          <ElevationChart className="lg:mx-0 lg:border-t-0 lg:px-3" />
+        </InspectorFooterDesktop>
+      ) : null}
     </div>
   );
 }

--- a/src/lib/inspector/single/view-model.ts
+++ b/src/lib/inspector/single/view-model.ts
@@ -3,13 +3,13 @@ import { getShapeGroupId, getShapeGroupName } from "@/lib/track/shape-groups";
 import type { Shape } from "@/lib/types";
 
 export const inspectorActionBtnClass =
-  "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-border/45 bg-background/80 px-2.5 text-[11px] font-medium text-foreground/82 transition-colors hover:bg-muted/35 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8";
+  "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-border/45 bg-background/80 px-2.5 text-[11px] font-medium text-foreground/82 transition-colors hover:bg-muted/35 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8";
 
 export const inspectorActionBtnPrimaryClass =
-  "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-primary/25 bg-primary/8 px-2.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/12 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8";
+  "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-primary/25 bg-primary/8 px-2.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/12 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8";
 
 export const inspectorActionBtnDangerClass =
-  "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-red-500/20 bg-red-500/6 px-2.5 text-[11px] font-medium text-red-500 transition-colors hover:bg-red-500/12 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8";
+  "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-red-500/20 bg-red-500/6 px-2.5 text-[11px] font-medium text-red-500 transition-colors hover:bg-red-500/12 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8";
 
 function finiteOrZero(value: unknown) {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
@@ -41,9 +41,9 @@ export function getSingleInspectorViewModel(shape: Shape, t: Translate) {
 
   return {
     actionBtnClass:
-      "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-border/45 bg-background/80 px-2.5 text-[11px] font-medium text-foreground/82 transition-colors hover:bg-muted/35 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8",
+      "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-border/45 bg-background/80 px-2.5 text-[11px] font-medium text-foreground/82 transition-colors hover:bg-muted/35 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8",
     actionBtnPrimaryClass:
-      "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-primary/25 bg-primary/8 px-2.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/12 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8",
+      "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-primary/25 bg-primary/8 px-2.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/12 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8",
     anchorPosition: getShapeAnchorPosition(shape),
     defaultColor: shape.color ?? "#3b82f6",
     groupId,

--- a/src/lib/inspector/single/view-model.ts
+++ b/src/lib/inspector/single/view-model.ts
@@ -40,10 +40,8 @@ export function getSingleInspectorViewModel(shape: Shape, t: Translate) {
   const shapeKindLabel = getShapeKindLabel(shape.kind, t);
 
   return {
-    actionBtnClass:
-      "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-border/45 bg-background/80 px-2.5 text-[11px] font-medium text-foreground/82 transition-colors hover:bg-muted/35 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8",
-    actionBtnPrimaryClass:
-      "inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-primary/25 bg-primary/8 px-2.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/12 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-not-allowed disabled:opacity-40 lg:h-8",
+    actionBtnClass: inspectorActionBtnClass,
+    actionBtnPrimaryClass: inspectorActionBtnPrimaryClass,
     anchorPosition: getShapeAnchorPosition(shape),
     defaultColor: shape.color ?? "#3b82f6",
     groupId,

--- a/src/lib/track/preflight.ts
+++ b/src/lib/track/preflight.ts
@@ -1,0 +1,215 @@
+import {
+  getRequiredInventoryCounts,
+  inventoryKinds,
+  normalizeInventoryProfile,
+} from "@/lib/planning/inventory";
+import { getDesignShapes } from "@/lib/track/design";
+import { getObstacleNumberingReport } from "@/lib/track/obstacleNumbering";
+import { isNumberedTrackObstacle } from "@/lib/track/items/registry";
+import {
+  getOverlayPrepReport,
+  type OverlayPrepIssueType,
+} from "@/lib/track/overlay-prep";
+import {
+  getPolylineRouteWarnings,
+  type RouteWarningKind,
+} from "@/lib/track/polyline-derived";
+import { getDesignTimingMarkers } from "@/lib/track/timing";
+import type {
+  InventoryShapeKind,
+  PolylineShape,
+  TrackDesign,
+} from "@/lib/types";
+
+export type TrackPreflightCategory = "route" | "timing" | "inventory";
+export type TrackPreflightStatus = "incomplete" | "review" | "ready";
+
+export type TrackPreflightIssue =
+  | {
+      category: "route";
+      id: string;
+      routeId?: string;
+      shapeIds?: string[];
+      type: "missing-route" | "no-route-matches" | "off-route";
+    }
+  | {
+      category: "route";
+      id: string;
+      routeId: string;
+      shapeIds?: string[];
+      type: "route-warning";
+      warningKind: Exclude<RouteWarningKind, "flat">;
+      waypointIndex?: number;
+    }
+  | {
+      category: "timing";
+      id: string;
+      routeId?: string;
+      shapeIds?: string[];
+      timingIssueType: OverlayPrepIssueType;
+      type: "timing";
+    }
+  | {
+      category: "inventory";
+      id: string;
+      inventoryKind: InventoryShapeKind;
+      missing: number;
+      routeId?: string;
+      shapeIds: string[];
+      type: "inventory-shortage";
+    };
+
+export interface TrackPreflightCheck {
+  active: boolean;
+  category: TrackPreflightCategory;
+  issueCount: number;
+}
+
+export interface TrackPreflightReport {
+  checks: TrackPreflightCheck[];
+  issues: TrackPreflightIssue[];
+  status: TrackPreflightStatus;
+}
+
+function getRouteIssues(design: TrackDesign): TrackPreflightIssue[] {
+  const shapes = getDesignShapes(design);
+  const routes = shapes.filter(
+    (shape): shape is PolylineShape => shape.kind === "polyline"
+  );
+  const numbering = getObstacleNumberingReport(design);
+  const issues: TrackPreflightIssue[] = [];
+
+  if (
+    numbering.status === "missing-route" &&
+    numbering.totalNumberedObstacleCount > 0 &&
+    routes.length === 0
+  ) {
+    issues.push({
+      category: "route",
+      id: "route:missing",
+      shapeIds: shapes.filter(isNumberedTrackObstacle).map((shape) => shape.id),
+      type: "missing-route",
+    });
+  } else if (numbering.status === "no-route-matches") {
+    issues.push({
+      category: "route",
+      id: "route:no-matches",
+      routeId: numbering.primaryPolylineId ?? undefined,
+      shapeIds: numbering.issues.map((issue) => issue.shapeId),
+      type: "no-route-matches",
+    });
+  } else if (numbering.status === "partial") {
+    for (const issue of numbering.issues) {
+      issues.push({
+        category: "route",
+        id: `route:off-route:${issue.shapeId}`,
+        routeId: numbering.primaryPolylineId ?? undefined,
+        shapeIds: [issue.shapeId],
+        type: "off-route",
+      });
+    }
+  }
+
+  for (const route of routes) {
+    for (const [index, warning] of getPolylineRouteWarnings(route).entries()) {
+      if (warning.kind === "flat") continue;
+      issues.push({
+        category: "route",
+        id: `route:warning:${route.id}:${warning.kind}:${warning.waypointIndex ?? index}`,
+        routeId: route.id,
+        type: "route-warning",
+        warningKind: warning.kind,
+        waypointIndex: warning.waypointIndex,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function getTimingIssues(design: TrackDesign): TrackPreflightIssue[] {
+  if (getDesignTimingMarkers(design).length === 0) return [];
+
+  return getOverlayPrepReport(design).issues.map((issue, index) => ({
+    category: "timing" as const,
+    id: `timing:${issue.type}:${issue.shapeId ?? issue.timingId ?? index}`,
+    routeId: issue.routeId,
+    shapeIds: issue.shapeIds ?? (issue.shapeId ? [issue.shapeId] : undefined),
+    timingIssueType: issue.type,
+    type: "timing" as const,
+  }));
+}
+
+function getInventoryIssues(design: TrackDesign): TrackPreflightIssue[] {
+  const available = normalizeInventoryProfile(design.inventory);
+  const inventoryActive = inventoryKinds.some((kind) => available[kind] > 0);
+  if (!inventoryActive) return [];
+
+  const shapes = getDesignShapes(design);
+  const required = getRequiredInventoryCounts(shapes);
+
+  return inventoryKinds.flatMap((kind) => {
+    const missing = Math.max(0, required[kind] - available[kind]);
+    if (missing === 0) return [];
+
+    return [
+      {
+        category: "inventory" as const,
+        id: `inventory:${kind}`,
+        inventoryKind: kind,
+        missing,
+        shapeIds: shapes
+          .filter((shape) => shape.kind === kind)
+          .map((shape) => shape.id),
+        type: "inventory-shortage" as const,
+      },
+    ];
+  });
+}
+
+export function getTrackPreflightReport(
+  design: TrackDesign
+): TrackPreflightReport {
+  const shapes = getDesignShapes(design);
+  if (shapes.length === 0) {
+    return {
+      checks: [
+        { active: false, category: "route", issueCount: 0 },
+        { active: false, category: "timing", issueCount: 0 },
+        { active: false, category: "inventory", issueCount: 0 },
+      ],
+      issues: [],
+      status: "incomplete",
+    };
+  }
+
+  const routeIssues = getRouteIssues(design);
+  const timingActive = getDesignTimingMarkers(design).length > 0;
+  const timingIssues = getTimingIssues(design);
+  const inventory = normalizeInventoryProfile(design.inventory);
+  const inventoryActive = inventoryKinds.some((kind) => inventory[kind] > 0);
+  const inventoryIssues = getInventoryIssues(design);
+  const issues = [...routeIssues, ...timingIssues, ...inventoryIssues];
+
+  return {
+    checks: [
+      {
+        active: true,
+        category: "route",
+        issueCount: routeIssues.length,
+      },
+      {
+        active: timingActive,
+        category: "timing",
+        issueCount: timingIssues.length,
+      },
+      {
+        active: inventoryActive,
+        category: "inventory",
+        issueCount: inventoryIssues.length,
+      },
+    ],
+    issues,
+    status: issues.length > 0 ? "review" : "ready",
+  };
+}

--- a/src/lib/track/preflight.ts
+++ b/src/lib/track/preflight.ts
@@ -81,8 +81,7 @@ function getRouteIssues(design: TrackDesign): TrackPreflightIssue[] {
 
   if (
     numbering.status === "missing-route" &&
-    numbering.totalNumberedObstacleCount > 0 &&
-    routes.length === 0
+    numbering.totalNumberedObstacleCount > 0
   ) {
     issues.push({
       category: "route",

--- a/src/store/editor-hints.ts
+++ b/src/store/editor-hints.ts
@@ -17,26 +17,32 @@ type EditorHintsState = {
   resetGuidedHints: () => void;
 };
 
-// Access localStorage lazily so the reference is re-evaluated on each call.
-// This ensures test mocks installed after module load are picked up correctly.
+// Access window.localStorage lazily so server evaluation stays storage-free and
+// test/browser storage installed after module load is picked up correctly.
 const safeLocalStorageBackend = {
   getItem: (name: string): string | null => {
+    if (typeof window === "undefined") return null;
+
     try {
-      return localStorage.getItem(name);
+      return window.localStorage.getItem(name);
     } catch {
       return null;
     }
   },
   setItem: (name: string, value: string) => {
+    if (typeof window === "undefined") return;
+
     try {
-      localStorage.setItem(name, value);
+      window.localStorage.setItem(name, value);
     } catch {
       /* storage unavailable */
     }
   },
   removeItem: (name: string) => {
+    if (typeof window === "undefined") return;
+
     try {
-      localStorage.removeItem(name);
+      window.localStorage.removeItem(name);
     } catch {
       /* storage unavailable */
     }

--- a/src/store/locale.ts
+++ b/src/store/locale.ts
@@ -31,8 +31,10 @@ function normalizeLocale(locale: unknown): SupportedLocale {
 
 const localeStorageBackend = {
   getItem: (name: string): string | null => {
+    if (typeof window === "undefined") return null;
+
     try {
-      const raw = localStorage.getItem(name);
+      const raw = window.localStorage.getItem(name);
       if (!raw) return null;
 
       const parsed: unknown = JSON.parse(raw);
@@ -56,15 +58,19 @@ const localeStorageBackend = {
     }
   },
   setItem: (name: string, value: string) => {
+    if (typeof window === "undefined") return;
+
     try {
-      localStorage.setItem(name, value);
+      window.localStorage.setItem(name, value);
     } catch {
       /* storage unavailable */
     }
   },
   removeItem: (name: string) => {
+    if (typeof window === "undefined") return;
+
     try {
-      localStorage.removeItem(name);
+      window.localStorage.removeItem(name);
     } catch {
       /* storage unavailable */
     }

--- a/src/store/measurement-unit.ts
+++ b/src/store/measurement-unit.ts
@@ -20,22 +20,28 @@ function getBrowserDefault(): MeasurementUnitSystem {
 
 const safeLocalStorageBackend = {
   getItem: (name: string): string | null => {
+    if (typeof window === "undefined") return null;
+
     try {
-      return localStorage.getItem(name);
+      return window.localStorage.getItem(name);
     } catch {
       return null;
     }
   },
   setItem: (name: string, value: string) => {
+    if (typeof window === "undefined") return;
+
     try {
-      localStorage.setItem(name, value);
+      window.localStorage.setItem(name, value);
     } catch {
       /* storage unavailable */
     }
   },
   removeItem: (name: string) => {
+    if (typeof window === "undefined") return;
+
     try {
-      localStorage.removeItem(name);
+      window.localStorage.removeItem(name);
     } catch {
       /* storage unavailable */
     }

--- a/tests/components/inspector/Inspector.test.tsx
+++ b/tests/components/inspector/Inspector.test.tsx
@@ -62,4 +62,23 @@ describe("Inspector tab switching", () => {
         .getAttribute("aria-selected")
     ).toBe("true");
   });
+
+  it("moves between available tabs with arrow keys", () => {
+    const gateId = useEditor.getState().addShape(gateDraft());
+    act(() => {
+      useEditor.getState().setSelection([gateId]);
+    });
+    render(<Inspector mobileInline />);
+
+    const layoutTab = screen.getByRole("tab", { name: "Layout" });
+    const selectionTab = screen.getByRole("tab", { name: "Selection" });
+
+    selectionTab.focus();
+    fireEvent.keyDown(selectionTab, { key: "ArrowLeft" });
+
+    expect(layoutTab.getAttribute("aria-selected")).toBe("true");
+    expect(document.activeElement).toBe(layoutTab);
+    expect(layoutTab.tabIndex).toBe(0);
+    expect(selectionTab.tabIndex).toBe(-1);
+  });
 });

--- a/tests/components/inspector/RouteNumberingOverview.test.tsx
+++ b/tests/components/inspector/RouteNumberingOverview.test.tsx
@@ -115,6 +115,24 @@ describe("RouteNumberingOverview generate race line action", () => {
     expect(mocks.toastError).not.toHaveBeenCalled();
   });
 
+  it("opens preflight issues and selects their related track items", async () => {
+    const user = userEvent.setup();
+    const gates = [gate("gate-1", 0, 0), gate("gate-2", 10, 0)];
+    const design = designWithGates(gates);
+    const setSelection = vi.fn();
+
+    renderProjectLayoutInspector(design, gates, { setSelection });
+
+    await user.click(screen.getByRole("button", { name: /Review Preflight/ }));
+    await user.click(
+      screen.getByRole("button", {
+        name: /Add a Race Line for the placed route obstacles/,
+      })
+    );
+
+    expect(setSelection).toHaveBeenCalledWith(["gate-1", "gate-2"]);
+  });
+
   it("still generates a race line but surfaces a warning when only one obstacle is placed", async () => {
     const user = userEvent.setup();
     const gates = [gate("gate-1", 0, 0)];

--- a/tests/components/inspector/SingleInspectorView.test.tsx
+++ b/tests/components/inspector/SingleInspectorView.test.tsx
@@ -105,7 +105,7 @@ describe("SingleInspectorView race timing controls", () => {
     expect(screen.queryByRole("button", { name: "Split" })).toBeNull();
   });
 
-  it("keeps mobile secondary sections collapsed while transform and race timing stay open", () => {
+  it("keeps inactive mobile secondary sections collapsed while transform stays open", () => {
     renderSingleInspector(gate, { mobileInline: true });
 
     expect(
@@ -119,13 +119,11 @@ describe("SingleInspectorView race timing controls", () => {
         .getByRole("button", { name: "Transform" })
         .getAttribute("aria-expanded")
     ).toBe("true");
-    // Race timing stays open on mobile for any shape that supports it,
-    // so clearing the role mid-interaction does not collapse the section.
     expect(
       screen
         .getByRole("button", { name: "Race timing" })
         .getAttribute("aria-expanded")
-    ).toBe("true");
+    ).toBe("false");
   });
 
   it("keeps grouped shape details collapsed on mobile", () => {
@@ -170,7 +168,7 @@ describe("SingleInspectorView race timing controls", () => {
     ).toBe("true");
   });
 
-  it("keeps race timing section open on mobile after clearing the timing role", async () => {
+  it("collapses race timing on mobile after clearing the timing role", async () => {
     const shapeWithMarker: GateShape = {
       ...gate,
       meta: { timing: { role: "start_finish" } },
@@ -205,12 +203,11 @@ describe("SingleInspectorView race timing controls", () => {
     // Simulate the store updating after the user sets role to "Off"
     rerender(<SingleInspectorView {...props} shape={gate} />);
 
-    // The section must stay open — closing mid-interaction was the bug
     expect(
       screen
         .getByRole("button", { name: "Race timing" })
         .getAttribute("aria-expanded")
-    ).toBe("true");
+    ).toBe("false");
   });
 
   it("explains locked shape interaction limits", () => {

--- a/tests/components/inspector/list-panel.test.tsx
+++ b/tests/components/inspector/list-panel.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   computeReorderBeforeId,
   getListableTrackItems,
+  shouldShowItemFilters,
 } from "@/components/inspector/views/list-panel";
 import type { Shape } from "@/lib/types";
 
@@ -48,5 +49,15 @@ describe("getListableTrackItems", () => {
     const flag = { id: "flag-1", kind: "flag" } as Shape;
 
     expect(getListableTrackItems([gate, route, flag])).toEqual([gate, flag]);
+  });
+});
+
+describe("shouldShowItemFilters", () => {
+  it("keeps controls visible while an item filter is active", () => {
+    expect(shouldShowItemFilters(4, "", "obstacles")).toBe(true);
+  });
+
+  it("hides inactive controls for a short unfiltered list", () => {
+    expect(shouldShowItemFilters(4, "", "all")).toBe(false);
   });
 });

--- a/tests/lib/track/preflight.test.ts
+++ b/tests/lib/track/preflight.test.ts
@@ -83,6 +83,20 @@ describe("getTrackPreflightReport", () => {
     );
   });
 
+  it("reports a missing route when only a one-point polyline draft exists", () => {
+    const report = getTrackPreflightReport(
+      withShapes([gate("gate-1", 5), route([{ x: 5, y: 5 }])])
+    );
+
+    expect(report.status).toBe("review");
+    expect(report.issues).toContainEqual(
+      expect.objectContaining({
+        category: "route",
+        type: "missing-route",
+      })
+    );
+  });
+
   it("only activates timing checks after a timing marker is configured", () => {
     const withoutTiming = getTrackPreflightReport(
       withShapes([gate("gate-1", 5)])

--- a/tests/lib/track/preflight.test.ts
+++ b/tests/lib/track/preflight.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { createDefaultDesign } from "@/lib/track/design";
+import { getTrackPreflightReport } from "@/lib/track/preflight";
+import type { Shape, TrackDesign } from "@/lib/types";
+
+function withShapes(shapes: Shape[]): TrackDesign {
+  const design = createDefaultDesign();
+  return {
+    ...design,
+    shapeOrder: shapes.map((shape) => shape.id),
+    shapeById: Object.fromEntries(
+      shapes.map((shape) => [shape.id, shape] as const)
+    ),
+  };
+}
+
+const gate = (id: string, x: number, meta?: Record<string, unknown>) =>
+  ({
+    id,
+    kind: "gate",
+    x,
+    y: 5,
+    rotation: 0,
+    width: 2,
+    height: 2,
+    meta,
+  }) satisfies Shape;
+
+const route = (points: Array<{ x: number; y: number; z?: number }>) =>
+  ({
+    id: "route-1",
+    kind: "polyline",
+    x: 0,
+    y: 0,
+    rotation: 0,
+    points,
+  }) satisfies Shape;
+
+describe("getTrackPreflightReport", () => {
+  it("marks an empty design incomplete without activating checks", () => {
+    const report = getTrackPreflightReport(createDefaultDesign());
+
+    expect(report.status).toBe("incomplete");
+    expect(report.issues).toEqual([]);
+    expect(report.checks.every((check) => !check.active)).toBe(true);
+  });
+
+  it("marks a routed layout ready while ignoring flat elevation", () => {
+    const report = getTrackPreflightReport(
+      withShapes([
+        gate("gate-1", 5),
+        gate("gate-2", 15),
+        route([
+          { x: 0, y: 5 },
+          { x: 20, y: 5 },
+        ]),
+      ])
+    );
+
+    expect(report.status).toBe("ready");
+    expect(report.issues).toEqual([]);
+  });
+
+  it("reports off-route obstacles as actionable route issues", () => {
+    const report = getTrackPreflightReport(
+      withShapes([
+        gate("gate-1", 5),
+        { ...gate("gate-2", 15), y: 20 },
+        route([
+          { x: 0, y: 5 },
+          { x: 20, y: 5 },
+        ]),
+      ])
+    );
+
+    expect(report.status).toBe("review");
+    expect(report.issues).toContainEqual(
+      expect.objectContaining({
+        category: "route",
+        shapeIds: ["gate-2"],
+        type: "off-route",
+      })
+    );
+  });
+
+  it("only activates timing checks after a timing marker is configured", () => {
+    const withoutTiming = getTrackPreflightReport(
+      withShapes([gate("gate-1", 5)])
+    );
+    const withTiming = getTrackPreflightReport(
+      withShapes([gate("gate-1", 5, { timing: { role: "start_finish" } })])
+    );
+
+    expect(
+      withoutTiming.checks.find((check) => check.category === "timing")?.active
+    ).toBe(false);
+    expect(
+      withTiming.checks.find((check) => check.category === "timing")?.active
+    ).toBe(true);
+    expect(withTiming.issues.some((issue) => issue.category === "timing")).toBe(
+      true
+    );
+  });
+
+  it("only activates inventory checks for a configured profile", () => {
+    const base = withShapes([gate("gate-1", 5), gate("gate-2", 15)]);
+    const inactive = getTrackPreflightReport(base);
+    const active = getTrackPreflightReport({
+      ...base,
+      inventory: { ...base.inventory, gate: 1 },
+    });
+
+    expect(
+      inactive.checks.find((check) => check.category === "inventory")?.active
+    ).toBe(false);
+    expect(active.issues).toContainEqual(
+      expect.objectContaining({
+        inventoryKind: "gate",
+        missing: 1,
+        type: "inventory-shortage",
+      })
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- Add an advisory Track Preflight report that composes existing route, numbering, timing, and configured inventory signals.
- Show actionable `Incomplete`, `Review`, and `Ready` states in the Layout inspector without blocking share or export.
- Reduce repeated inspector metadata and status cards, make route analysis contextual, simplify mobile disclosure/actions, and improve field labels, focus, tabs, and item-list semantics.
- Enlarge the project-title field so it reads as a primary project control.
- Align `next dev` with Wrangler's `dev` environment and keep persisted client stores from touching Node's experimental `localStorage` global.

## Why

Useful layout-review signals existed across separate surfaces, while the inspector repeated status and context information. This combines those signals without introducing a second validation system or a safety score.

The local product-event failure was caused by `next dev` using Wrangler's default local binding while `npm run migrate:local` migrated the `dev` binding.

## Validation

- `npm run lint`
- `npm run type`
- `npm run i18n:check`
- `npm run test` — 158 files, 856 tests
- `npm run build`
