### PR TITLE
feat: Establish Crowdin localization pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The Layout inspector now brings route, timing, numbering, and configured invento
 
 PNG and SVG exports now use the selected language for footer dates and untitled-track copy. Public gallery dates and API Docs language metadata also follow all four supported languages, including Simplified Chinese. Simplified Chinese now uses the standard `zh-CN` locale identifier while existing `zh` preferences continue to work and migrate automatically.
 
+Translation updates can now arrive independently through the Crowdin pilot. Temporarily untranslated messages safely use English instead of blocking a release or showing missing copy.
+
 ## [1.14.0]
 
 ### Simplified Chinese and more complete translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,19 @@ npm run migrate:up:production
 
 `npm run lint` runs Oxlint, including its React Compiler checks.
 
+## Translation Workflow
+
+During the Crowdin pilot, English source copy remains in `lang/en/` and normal feature pull requests. Dutch, German, and Simplified Chinese are maintained in Crowdin and return through localization pull requests; do not edit those target catalogs directly outside a production emergency.
+
+New English keys do not need placeholder copies in every target catalog. Missing target messages safely fall back to English in local server catalogs and generated locale assets. Run these checks when changing product copy:
+
+```bash
+npm run i18n:check
+npm run i18n:scan-hardcoded
+```
+
+The integrity check allows missing target keys but still rejects missing namespace files, stale extra keys, empty target values, and placeholder mismatches. `dashboard` and `legal` remain English-only and are excluded from Crowdin. See [the Crowdin pilot runbook](docs/research/crowdin-pilot.md) for ownership, synchronization, and rollback.
+
 ## Validation
 
 Run these after non-trivial code changes when the environment allows it:

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,9 @@
+preserve_hierarchy: true
+
+files:
+  - source: /lang/en/*.json
+    translation: /lang/%locale%/%original_file_name%
+    ignore:
+      - /lang/en/dashboard.json
+      - /lang/en/legal.json
+    update_option: update_as_unapproved

--- a/docs/deployment/deployment-setup.md
+++ b/docs/deployment/deployment-setup.md
@@ -221,7 +221,9 @@ Gallery previews use the same public media host. For gallery opt-in to upload pr
 
 ### Locale catalog assets
 
-Translation catalogs are generated into `public/locales/` by `npm run i18n:sync-assets`. The directory is ignored by git and is refreshed inside the production build script. Preview and deploy run the OpenNext build step, which calls `npm run build` and therefore uses the same generated assets. Local dev and tests can read directly from `lang/{locale}` and do not need generated assets.
+Translation catalogs are generated into `public/locales/` by `npm run i18n:sync-assets`. The directory is ignored by git and is refreshed before local development and inside the production build script. Preview and deploy run the OpenNext build step, which calls `npm run build` and therefore uses the same generated assets.
+
+During the Crowdin pilot, target catalogs may temporarily omit new English keys. Asset generation recursively merges each target over English, including nested objects and arrays, so missing or empty translations use English until Crowdin returns an approved value. Local server-side catalog reads apply the same fallback before rendering.
 
 OpenNext serves these generated locale JSON files through the existing `ASSETS` binding. Dynamic routes keep only the namespace list and loading logic in Worker code; `en`, `nl`, `de`, and future contributor languages are loaded per namespace from static assets. `StaticLanguageProvider` reads English namespaces from disk during prerender instead of importing catalogs into the shared dynamic root or Worker bundle.
 

--- a/docs/research/crowdin-pilot.md
+++ b/docs/research/crowdin-pilot.md
@@ -1,0 +1,66 @@
+# Crowdin localization pilot
+
+Status: repository foundation ready; external Crowdin project activation and initial import remain operator steps.
+
+Pilot window: 2026-08-10 through 2026-11-10. If the GitHub integration is activated later, move the end date so the evaluation still covers three full months.
+
+## Goal
+
+Use Crowdin as the only editing and review surface for Dutch, German, and Simplified Chinese long enough to judge contributor usability, translation quality, maintenance effort, quota pressure, and pull-request noise. English source copy remains owned by normal TrackDraw feature pull requests.
+
+The pilot stays reversible. Translation JSON remains versioned in Git, production continues to load generated Cloudflare Static Assets, and TrackDraw has no runtime dependency on Crowdin.
+
+## Ownership during the pilot
+
+| Content                                        | Source of truth                                     |
+| ---------------------------------------------- | --------------------------------------------------- |
+| `lang/en/**` product source copy               | GitHub feature pull requests                        |
+| `lang/nl/**`, `lang/de/**`, `lang/zh-CN/**`    | Crowdin                                             |
+| `lang/en/dashboard.json`, `lang/en/legal.json` | GitHub; excluded from Crowdin                       |
+| Production locale assets                       | Generated from the merged Git catalogs during build |
+
+Do not edit target-language JSON directly during the pilot, except for a production emergency that is immediately reconciled back into Crowdin.
+
+## Initial Crowdin setup
+
+1. Create a public, file-based project with English as source and Dutch, German, and Chinese Simplified (`zh-CN`) as targets.
+2. Enable moderated project joining and require 2FA for managers.
+3. Connect `dutchdronesquad/trackdraw` and synchronize only `main` using the repository `crowdin.yml`.
+4. Import existing translations once. Enable source-matching translations because FPV and product terms may intentionally remain English. Approve the imported baseline only after a quick catalog review.
+5. Disable continuous translation import from Git and leave source pushes from Crowdin disabled.
+6. Keep translation export/manual synchronization disabled until `common.json` has completed one verified round trip.
+7. Confirm that Crowdin recognizes nested JSON, ICU plurals, and placeholders before enabling all ten namespaces.
+
+Never commit a Crowdin API token or project credential. The GitHub integration reads `crowdin.yml` without credentials in the repository.
+
+## Normal update cycle
+
+1. A feature pull request changes English source messages and application code.
+2. CI validates English key usage, catalog integrity, and hardcoded-copy rules. Target catalogs may temporarily omit new keys.
+3. After merge, Crowdin pulls the new English source from `main`.
+4. Translators submit changes and a language coordinator approves them.
+5. A maintainer manually triggers the Crowdin translation sync.
+6. Crowdin opens or updates its localization pull request without pushing directly to `main`.
+7. TrackDraw CI rejects stale extra keys, empty values, and placeholder mismatches. Missing target keys remain safe English fallbacks.
+8. A maintainer reviews and merges the localization pull request.
+
+During the pilot, prefer one intentional localization pull request per week or release over hourly repository churn.
+
+## Runtime fallback
+
+Target catalogs are allowed to lag behind English. Server-side development catalogs and generated `public/locales/**` assets recursively merge the target catalog over English. Existing translations win; missing or empty values use English. Arrays such as landing-page bullets and FAQ entries are merged by position.
+
+Extra target keys are ignored at runtime and rejected by CI. Placeholder changes are also rejected so a translated message cannot silently drop required values.
+
+## Evaluation
+
+Review the pilot on 2026-11-10 using:
+
+- number of active translators and languages with a clear reviewer;
+- median time from a merged English string to an approved translation;
+- translation pull-request frequency, conflicts, and maintainer time;
+- placeholder, terminology, and compact-label issues found in review;
+- hosted-word usage and whether the Free or open-source plan remains appropriate;
+- contributor feedback compared with editing JSON through GitHub.
+
+Continue when Crowdin materially lowers contributor friction without disproportionate maintenance or licensing risk. Otherwise stop the integration, export and merge the latest approved translations once, remove `crowdin.yml`, and return target-language ownership to GitHub. Git history and the final export preserve all translation work.

--- a/docs/research/translation-management.md
+++ b/docs/research/translation-management.md
@@ -103,21 +103,16 @@ If a contributor leaves, remove them from platform teams or disable the account.
 - Keep route structure unchanged; translation management must not introduce locale-prefixed URLs.
 - Keep `dashboard` and `legal` English-only. They can remain in the repo for fallback/source use, but they should stay out of contributor translation workflows.
 - Keep all translation changes reviewable as normal pull requests.
-- Preserve CI checks for locale parity, unresolved keys, and intentional hardcoded-copy exceptions.
+- Preserve CI checks for catalog integrity, unresolved English keys, placeholders, and intentional hardcoded-copy exceptions. Missing target keys are allowed only because build and runtime catalogs provide a tested English fallback.
 - Support external contributors without requiring direct repository write access.
 - Add new languages only when there is an owner for terminology review, compact UI labels, and export/PDF/Race Pack copy.
 - Prevent translation growth from making the Cloudflare Worker package grow linearly with every added language.
 
-## Recommended pilot
+## Selected pilot
 
-1. Create a Crowdin Free workspace and verify the displayed hosted-word allowance before import.
-2. Import only the ten translatable English namespaces and the existing `nl`, `de`, and `zh-CN` catalogs.
-3. Prove one namespace end to end, preferably `common`: source update, translator suggestion, language review, export, pull request, and existing locale validation.
-4. Keep GitHub pull requests and CI as the release gate; do not grant the platform a direct push path to `main`.
-5. Apply for Crowdin's open-source license in parallel, with the current and anticipated commercial model disclosed.
-6. Document FPV terminology, compact-label expectations, placeholders/ICU syntax, and the English-only boundary.
-7. Reassess when hosted words approach 45,000–50,000, a sixth target language is planned, or Crowdin permissions/integration are insufficient.
-8. Prototype Weblate only if that reassessment shows a concrete reason to accept self-hosting overhead.
+TrackDraw will run a reversible three-month Crowdin pilot from 2026-08-10 through 2026-11-10, shifting the end date if external activation happens later. Crowdin owns `nl`, `de`, and `zh-CN` editing during the pilot; English remains in GitHub. The repository retains all catalogs and production keeps using generated Static Assets.
+
+The setup, update cycle, evaluation criteria, and rollback are documented in `docs/research/crowdin-pilot.md`. The first external step is a one-namespace `common.json` round trip before enabling all ten namespaces.
 
 ## Risks and decisions
 
@@ -137,4 +132,4 @@ If a contributor leaves, remove them from platform teams or disable the account.
 
 ## Status
 
-Research complete enough to start a bounded pilot; the final platform decision remains open. No external workspace, infrastructure, or sync workflow has been created yet.
+Crowdin is selected for a bounded three-month pilot; the permanent platform decision remains open until the evaluation. Repository fallback and synchronization foundations are in place, while external project activation and the initial catalog import remain operator steps.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -17,7 +17,7 @@ TrackDraw is now strong in these areas:
 - Account-backed REST API with API key management and a live race overlay data endpoint
 - Catalog-backed official MultiGP obstacles including gates, ladders, flags, dive gate, launch gate, and a barrier category for hurdles, banners, fencing, and nets
 - Account-backed user presets where users save and reuse named canvas selections across devices
-- English, Dutch, German, and Simplified Chinese multilingual product experience with explicit language choice, route-scoped message loading, generated locale assets, and CI checks for catalog parity and new hardcoded UI copy
+- English, Dutch, German, and Simplified Chinese multilingual product experience with explicit language choice, route-scoped message loading, generated locale assets, English fallback for temporarily incomplete Crowdin catalogs, and CI checks for catalog integrity and new hardcoded UI copy
 - Protected magic-link account handoff that avoids automatic email scanner sign-ins while keeping the sign-in flow simple
 - Optional generated race-line drafting from ordered obstacles, with warnings for layouts that need manual attention
 - Interactive elevation profile review with waypoint, obstacle, timing, and warning markers linked back to the canvas
@@ -271,7 +271,7 @@ Current shipped foundation:
 - Dashboard and legal surfaces remain English-only
 - English remains the stable fallback baseline, with route-scoped message loading and a centralized i18n catalog policy
 - Locale JSON is generated into OpenNext static assets for production builds so additional languages do not become full static catalog imports in the Cloudflare Worker script
-- Locale parity/unresolved-key validation and hardcoded-copy scanning run in CI so new UI copy is intentionally cataloged or explicitly allowlisted
+- Catalog-integrity/unresolved-key validation and hardcoded-copy scanning run in CI so new UI copy is intentionally cataloged or explicitly allowlisted; missing Crowdin target keys use the tested English fallback
 - PNG/SVG footer dates and untitled-track fallbacks, public-gallery dates, and API Docs titles/document language follow all four supported locales
 
 Maintenance focus:
@@ -292,10 +292,10 @@ Important boundary:
 - Do not block regional measurement support on full i18n; units can ship first as a smaller, lower-risk slice
 - Do not infer units only from language, because English users can prefer Metric and non-English users can work with Imperial venue expectations
 - Do not translate dashboard or legal pages unless that product/legal boundary is deliberately changed later
-- Do not let translation tooling bypass CI locale checks, unresolved-key checks, or source review through pull requests
+- Do not let translation tooling bypass CI catalog-integrity checks, unresolved-key checks, or source review through pull requests
 - Do not accept linear Worker bundle growth as an unavoidable cost of adding languages
 - Do not bundle a Chinese font for the regular UI; keep the additional font scoped and lazy-loaded for document export where browser/system font fallback is unavailable
-- Do not add Chinese-only catalog keys without matching English, Dutch, and German entries; keep locale parity intact and translate those values deliberately instead of using permanent English placeholders
+- Do not add target-only catalog keys without an English source key. Target catalogs may temporarily lag during the pilot, but Crowdin-owned translations should replace English fallbacks deliberately rather than leaving them permanent
 
 #### Track Element Catalog
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -52,13 +52,15 @@ The next TrackDraw priority is generated flightpath validation first, translatio
   - [ ] Hosted versus self-hosted decision
         Run a bounded Crowdin Free pilot first; retain self-hosted Weblate as the fallback. Decide only after validating quota, permissions, repository sync, contributor review, licensing, and ongoing operational cost.
   - [ ] Crowdin Free pilot
-        Confirm the workspace quota, import only the ten translatable namespaces with `nl`/`de`/`zh`, and validate one namespace end to end. Apply separately for the open-source grant without depending on eligibility.
+        Run the reversible pilot through 2026-11-10, shifting the end date if activation happens later. Import only the ten translatable namespaces with `nl`/`de`/`zh-CN`, validate `common.json` end to end first, and apply separately for the open-source grant without depending on eligibility.
+  - [x] Reversible pilot foundation
+        Added repository-owned Crowdin mapping, recursive English fallback for partial target catalogs and generated Static Assets, integrity checks for stale keys, empty values, and placeholders, plus a documented three-month evaluation and rollback path.
   - [x] Worker bundle impact measured
         A fresh dry run measured 2,116.79 KiB gzip. Locale JSON remains in Cloudflare Static Assets rather than the Worker handler, so changing translation platforms would not materially shrink the Worker bundle.
   - [x] Weblate production requirements researched
         If self-hosting becomes necessary, use an ephemeral pilot before a separate production stack with TLS, SMTP, restricted access, persistent storage, off-host backups, restore testing, monitoring, and deliberate upgrades. A permanent ACC environment is not initially required.
   - [ ] Repository sync workflow
-        Prototype source upload and translation pull requests through GitHub Actions while preserving normal code review and existing locale validation checks.
+        Activate the GitHub integration against `main`, import existing translations once, and validate Crowdin's service-branch pull request through normal code review and existing locale integrity checks.
   - [ ] Translator guidance
         Document the language-leader model, suggestion-first contributor flow, FPV terminology, placeholders/ICU syntax, compact UI label expectations, and the `dashboard`/`legal` English-only boundary before inviting broader contributor translation work.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "AGPL-3.0-only",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "npm run i18n:sync-assets && next dev --turbopack",
     "build": "npm run i18n:sync-assets && next build",
     "analyze": "next experimental-analyze",
     "start": "next start",

--- a/scripts/i18n_check.mjs
+++ b/scripts/i18n_check.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 /**
- * Translation completeness audit.
+ * Translation integrity audit.
  *
- * 1. Compares every locale's message files against the `en` baseline and
- *    reports missing/extra keys per namespace.
+ * 1. Compares every locale's message files against the `en` baseline. Missing
+ *    target keys are allowed and use the English runtime fallback; extra keys,
+ *    empty values, and placeholder mismatches remain errors.
  * 2. Scans src/** for `useTranslations("namespace")` bindings and the keys
  *    called through them, flagging any key that doesn't resolve in the `en`
  *    catalog (the same class of bug as a runtime MISSING_MESSAGE error).
@@ -12,10 +13,12 @@
  * Exits non-zero if any issue is found, so it can be wired into CI.
  */
 import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join, relative, extname } from "node:path";
+import { join, relative, extname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const root = fileURLToPath(new URL("..", import.meta.url));
+const root = process.env.TRACKDRAW_I18N_ROOT
+  ? resolve(process.env.TRACKDRAW_I18N_ROOT)
+  : fileURLToPath(new URL("..", import.meta.url));
 const langDir = join(root, "lang");
 const srcDir = join(root, "src");
 const baseLocale = "en";
@@ -47,7 +50,7 @@ function flatten(obj, prefix = "") {
   const out = {};
   for (const [key, value] of Object.entries(obj)) {
     const path = prefix ? `${prefix}.${key}` : key;
-    if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    if (value !== null && typeof value === "object") {
       Object.assign(out, flatten(value, path));
     } else {
       out[path] = value;
@@ -66,9 +69,24 @@ function resolvePath(obj, dottedPath) {
     );
 }
 
-// ── Part 1: locale parity ──────────────────────────────────────────────
+function extractPlaceholders(message) {
+  if (typeof message !== "string") return new Set();
+  return new Set(
+    [...message.matchAll(/\{([A-Za-z][\w]*)\s*(?:,|\})/g)].map(
+      (match) => match[1]
+    )
+  );
+}
 
-function checkLocaleParity() {
+function hasSameValues(left, right) {
+  return (
+    left.size === right.size && [...left].every((value) => right.has(value))
+  );
+}
+
+// ── Part 1: locale integrity ───────────────────────────────────────────
+
+function checkLocaleIntegrity() {
   const locales = listLocales();
   const otherLocales = locales.filter((l) => l !== baseLocale);
   const baseNamespaces = listNamespaces(baseLocale);
@@ -76,6 +94,7 @@ function checkLocaleParity() {
     (namespace) => !englishOnlyNamespaces.has(namespace)
   );
   let problems = 0;
+  let fallbacks = 0;
 
   for (const namespace of localizedBaseNamespaces) {
     const baseMessages = flatten(loadNamespace(baseLocale, namespace));
@@ -87,7 +106,7 @@ function checkLocaleParity() {
         localeMessages = flatten(loadNamespace(locale, namespace));
       } catch {
         console.log(`\n[${locale}] missing namespace file: ${namespace}.json`);
-        problems += baseKeys.size;
+        problems += 1;
         continue;
       }
       const localeKeys = new Set(Object.keys(localeMessages));
@@ -97,12 +116,12 @@ function checkLocaleParity() {
 
       if (missing.length > 0) {
         console.log(
-          `\n[${locale}/${namespace}.json] missing ${missing.length} key(s) present in ${baseLocale}:`
+          `\n[${locale}/${namespace}.json] uses the ${baseLocale} fallback for ${missing.length} missing key(s):`
         );
         for (const key of missing) {
           console.log(`  - ${key}  (en: ${JSON.stringify(baseMessages[key])})`);
         }
-        problems += missing.length;
+        fallbacks += missing.length;
       }
       if (extra.length > 0) {
         console.log(
@@ -112,6 +131,30 @@ function checkLocaleParity() {
           console.log(`  - ${key}`);
         }
         problems += extra.length;
+      }
+
+      for (const key of [...baseKeys].filter((k) => localeKeys.has(k))) {
+        const baseValue = baseMessages[key];
+        const localeValue = localeMessages[key];
+        if (
+          typeof localeValue !== "string" ||
+          localeValue.trim().length === 0
+        ) {
+          console.log(
+            `\n[${locale}/${namespace}.json] ${key} must contain a non-empty translated string.`
+          );
+          problems += 1;
+          continue;
+        }
+
+        const basePlaceholders = extractPlaceholders(baseValue);
+        const localePlaceholders = extractPlaceholders(localeValue);
+        if (!hasSameValues(basePlaceholders, localePlaceholders)) {
+          console.log(
+            `\n[${locale}/${namespace}.json] ${key} has different placeholders (en: ${[...basePlaceholders].join(", ") || "none"}; ${locale}: ${[...localePlaceholders].join(", ") || "none"}).`
+          );
+          problems += 1;
+        }
       }
     }
   }
@@ -130,7 +173,7 @@ function checkLocaleParity() {
     }
   }
 
-  return problems;
+  return { problems, fallbacks };
 }
 
 // ── Part 2: usage scan against en catalog ──────────────────────────────
@@ -253,12 +296,12 @@ function checkUsages() {
   return problems;
 }
 
-const parityProblems = checkLocaleParity();
+const { problems: integrityProblems, fallbacks } = checkLocaleIntegrity();
 const usageProblems = checkUsages();
 
-const total = parityProblems + usageProblems;
+const total = integrityProblems + usageProblems;
 console.log(
-  `\n${total === 0 ? "✓" : "✗"} i18n check: ${parityProblems} locale-parity issue(s), ${usageProblems} unresolved-key usage(s).`
+  `\n${total === 0 ? "✓" : "✗"} i18n check: ${integrityProblems} locale-integrity issue(s), ${fallbacks} English fallback(s), ${usageProblems} unresolved-key usage(s).`
 );
 
 process.exit(total === 0 ? 0 : 1);

--- a/scripts/i18n_hardcoded_scan.mjs
+++ b/scripts/i18n_hardcoded_scan.mjs
@@ -3,8 +3,8 @@
  * Conservative hardcoded UI-copy scan.
  *
  * This complements scripts/i18n_check.mjs. The normal i18n check validates
- * catalog parity and translation-key usage; this scan catches newly introduced
- * literal JSX text and common user-facing string props.
+ * catalog integrity, English fallback safety, and translation-key usage; this
+ * scan catches newly introduced literal JSX text and common user-facing props.
  *
  * Keep this check intentionally narrow and allowlisted. A noisy hardcoded-copy
  * scanner gets ignored quickly, so false positives should be resolved either by

--- a/scripts/i18n_sync_assets.mjs
+++ b/scripts/i18n_sync_assets.mjs
@@ -7,11 +7,14 @@ import {
   readdirSync,
   readFileSync,
   statSync,
+  writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const root = fileURLToPath(new URL("..", import.meta.url));
+const root = process.env.TRACKDRAW_I18N_ROOT
+  ? resolve(process.env.TRACKDRAW_I18N_ROOT)
+  : fileURLToPath(new URL("..", import.meta.url));
 const langDir = join(root, "lang");
 const outDir = join(root, "public", "locales");
 const sourceLocale = "en";
@@ -34,10 +37,45 @@ function listNamespaces(locale) {
     .map((name) => name.replace(/\.json$/, ""));
 }
 
+function isMessageTree(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function mergeMessagesWithFallback(fallback, translation) {
+  if (typeof fallback === "string") {
+    return typeof translation === "string" && translation.trim().length > 0
+      ? translation
+      : fallback;
+  }
+
+  if (Array.isArray(fallback)) {
+    const translatedItems = Array.isArray(translation) ? translation : [];
+    return fallback.map((fallbackValue, index) =>
+      mergeMessagesWithFallback(fallbackValue, translatedItems[index])
+    );
+  }
+
+  if (!isMessageTree(fallback)) return fallback;
+
+  const translatedTree = isMessageTree(translation) ? translation : {};
+  return Object.fromEntries(
+    Object.entries(fallback).map(([key, fallbackValue]) => [
+      key,
+      mergeMessagesWithFallback(fallbackValue, translatedTree[key]),
+    ])
+  );
+}
+
+function loadNamespace(locale, namespace) {
+  return JSON.parse(
+    readFileSync(join(langDir, locale, `${namespace}.json`), "utf8")
+  );
+}
+
 rmSync(outDir, { recursive: true, force: true });
 
 for (const locale of listLocales()) {
-  const namespaces = listNamespaces(locale).filter(
+  const namespaces = listNamespaces(sourceLocale).filter(
     (namespace) =>
       locale === sourceLocale || !englishOnlyNamespaces.has(namespace)
   );
@@ -45,9 +83,23 @@ for (const locale of listLocales()) {
   mkdirSync(localeOutDir, { recursive: true });
 
   for (const namespace of namespaces) {
-    copyFileSync(
-      join(langDir, locale, `${namespace}.json`),
-      join(localeOutDir, `${namespace}.json`)
+    const destination = join(localeOutDir, `${namespace}.json`);
+    if (locale === sourceLocale) {
+      copyFileSync(join(langDir, locale, `${namespace}.json`), destination);
+      continue;
+    }
+
+    const fallbackMessages = loadNamespace(sourceLocale, namespace);
+    let translatedMessages;
+    try {
+      translatedMessages = loadNamespace(locale, namespace);
+    } catch {
+      translatedMessages = undefined;
+    }
+    const mergedMessages = mergeMessagesWithFallback(
+      fallbackMessages,
+      translatedMessages
     );
+    writeFileSync(destination, `${JSON.stringify(mergedMessages, null, 2)}\n`);
   }
 }

--- a/src/i18n/catalogs.ts
+++ b/src/i18n/catalogs.ts
@@ -2,6 +2,7 @@ import "server-only";
 
 import i18nPolicy from "@lang/i18n-policy.json";
 import { defaultLocale, type SupportedLocale } from "@/lib/i18n/locales";
+import { mergeMessagesWithFallback } from "@/lib/i18n/merge-messages";
 
 const catalogNamespaces = [
   "common",
@@ -102,7 +103,17 @@ async function readNamespaceFromSourceFile(
   locale: SupportedLocale,
   namespace: MessageNamespace
 ) {
-  return readJsonFile(["lang", locale, `${namespace}.json`]);
+  const messages = await readJsonFile(["lang", locale, `${namespace}.json`]);
+  if (locale === defaultLocale || messages === undefined) return messages;
+
+  const fallbackMessages = await readJsonFile([
+    "lang",
+    defaultLocale,
+    `${namespace}.json`,
+  ]);
+  return fallbackMessages === undefined
+    ? messages
+    : mergeMessagesWithFallback(fallbackMessages, messages);
 }
 
 async function readNamespaceAsset(

--- a/src/lib/i18n/merge-messages.ts
+++ b/src/lib/i18n/merge-messages.ts
@@ -1,0 +1,33 @@
+type MessageTree = Record<string, unknown>;
+
+function isMessageTree(value: unknown): value is MessageTree {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function mergeMessagesWithFallback(
+  fallback: unknown,
+  translation: unknown
+): unknown {
+  if (typeof fallback === "string") {
+    return typeof translation === "string" && translation.trim().length > 0
+      ? translation
+      : fallback;
+  }
+
+  if (Array.isArray(fallback)) {
+    const translatedItems = Array.isArray(translation) ? translation : [];
+    return fallback.map((fallbackValue, index) =>
+      mergeMessagesWithFallback(fallbackValue, translatedItems[index])
+    );
+  }
+
+  if (!isMessageTree(fallback)) return fallback;
+
+  const translatedTree = isMessageTree(translation) ? translation : {};
+  return Object.fromEntries(
+    Object.entries(fallback).map(([key, fallbackValue]) => [
+      key,
+      mergeMessagesWithFallback(fallbackValue, translatedTree[key]),
+    ])
+  );
+}

--- a/tests/lib/i18n/merge-messages.test.ts
+++ b/tests/lib/i18n/merge-messages.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { mergeMessagesWithFallback } from "@/lib/i18n/merge-messages";
+
+describe("mergeMessagesWithFallback", () => {
+  it("keeps translations and recursively fills missing objects and arrays", () => {
+    expect(
+      mergeMessagesWithFallback(
+        {
+          title: "Source title",
+          nested: { translated: "Source", missing: "Fallback" },
+          bullets: ["One", "Two"],
+        },
+        {
+          title: "Vertaalde titel",
+          nested: { translated: "Vertaald", extra: "Ignored" },
+          bullets: ["Eén"],
+          extra: "Ignored",
+        }
+      )
+    ).toEqual({
+      title: "Vertaalde titel",
+      nested: { translated: "Vertaald", missing: "Fallback" },
+      bullets: ["Eén", "Two"],
+    });
+  });
+
+  it("uses the fallback for empty or structurally invalid translations", () => {
+    expect(mergeMessagesWithFallback("Source", "   ")).toBe("Source");
+    expect(
+      mergeMessagesWithFallback({ label: "Source" }, "invalid structure")
+    ).toEqual({ label: "Source" });
+  });
+});

--- a/tests/scripts/i18n-pilot.test.ts
+++ b/tests/scripts/i18n-pilot.test.ts
@@ -45,7 +45,12 @@ describe("Crowdin pilot catalog scripts", () => {
   });
 
   afterEach(() => {
-    rmSync(fixtureRoot, { recursive: true, force: true });
+    const rootToRemove = fixtureRoot;
+    fixtureRoot = "";
+
+    if (rootToRemove) {
+      rmSync(rootToRemove, { recursive: true, force: true });
+    }
   });
 
   it("generates complete assets by merging target messages over English", () => {

--- a/tests/scripts/i18n-pilot.test.ts
+++ b/tests/scripts/i18n-pilot.test.ts
@@ -1,0 +1,84 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let fixtureRoot = "";
+
+function writeJson(path: string, value: unknown) {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function runScript(name: "i18n_check.mjs" | "i18n_sync_assets.mjs") {
+  return spawnSync(process.execPath, [join(process.cwd(), "scripts", name)], {
+    encoding: "utf8",
+    env: { ...process.env, TRACKDRAW_I18N_ROOT: fixtureRoot },
+  });
+}
+
+describe("Crowdin pilot catalog scripts", () => {
+  beforeEach(() => {
+    fixtureRoot = mkdtempSync(join(tmpdir(), "trackdraw-i18n-pilot-"));
+    mkdirSync(join(fixtureRoot, "lang", "en"), { recursive: true });
+    mkdirSync(join(fixtureRoot, "lang", "nl"), { recursive: true });
+    mkdirSync(join(fixtureRoot, "src"), { recursive: true });
+    writeJson(join(fixtureRoot, "lang", "i18n-policy.json"), {
+      englishOnlyNamespaces: [],
+    });
+    writeJson(join(fixtureRoot, "lang", "en", "common.json"), {
+      nested: { translated: "Source", missing: "Fallback" },
+      bullets: ["One", "Two"],
+      greeting: "Hello {name}",
+    });
+    writeJson(join(fixtureRoot, "lang", "nl", "common.json"), {
+      nested: { translated: "Vertaald" },
+      bullets: ["Eén"],
+      greeting: "Hallo {name}",
+    });
+  });
+
+  afterEach(() => {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it("generates complete assets by merging target messages over English", () => {
+    const result = runScript("i18n_sync_assets.mjs");
+    expect(result.status, result.stderr).toBe(0);
+
+    const generated = JSON.parse(
+      readFileSync(
+        join(fixtureRoot, "public", "locales", "nl", "common.json"),
+        "utf8"
+      )
+    );
+    expect(generated).toEqual({
+      nested: { translated: "Vertaald", missing: "Fallback" },
+      bullets: ["Eén", "Two"],
+      greeting: "Hallo {name}",
+    });
+  });
+
+  it("allows missing target keys while reporting their English fallbacks", () => {
+    const result = runScript("i18n_check.mjs");
+
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(result.stdout).toContain("2 English fallback(s)");
+  });
+
+  it("still rejects placeholder mismatches", () => {
+    writeJson(join(fixtureRoot, "lang", "nl", "common.json"), {
+      greeting: "Hallo",
+    });
+
+    const result = runScript("i18n_check.mjs");
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("greeting has different placeholders");
+  });
+});


### PR DESCRIPTION
## Summary

- add repository-owned Crowdin mapping for the ten translatable namespaces and `nl`, `de`, and `zh-CN` output paths
- allow target catalogs to lag behind English while recursively generating complete server and Static Asset catalogs
- keep stale keys, empty target values, placeholder mismatches, unresolved English keys, and hardcoded UI copy as CI failures
- document the three-month pilot window, ownership, update cycle, evaluation criteria, and complete rollback path

## Why

The Crowdin trial should be a real, reversible localization workflow rather than a hybrid where developers copy English placeholders into every target catalog. English remains owned by feature pull requests, Crowdin owns target-language editing, and temporary gaps safely render English until an approved localization pull request arrives.

All translation JSON remains in Git and production continues to use Cloudflare Static Assets, so the pilot adds no runtime dependency on Crowdin and can be stopped without losing translation work.

## Validation

- `npm run lint`
- `npm run type`
- `npm run test` — 879 tests passed
- `npm run build`
- `npm run i18n:check`
- `npm run i18n:scan-hardcoded`
- focused merge, generated-asset, partial-catalog, placeholder, and client-provider tests — 8 tests passed
- `npx prettier --check` on all changed files
- `git diff --cached --check`
