### PR TITLE
feat: Invite community translators

### DIFF
--- a/lang/de-DE/landing.json
+++ b/lang/de-DE/landing.json
@@ -214,15 +214,22 @@
     "communityTitle": "Community",
     "github": "GitHub",
     "dutchDroneSquad": "Dutch Drone Squad",
+    "translate": "Beim Übersetzen helfen",
     "facebook": "Facebook",
     "instagram": "Instagram",
     "reportIssue": "Problem melden",
     "supportTitle": "Support",
     "githubSponsors": "GitHub Sponsors",
     "kofi": "Ko-fi",
-    "copyright": "© {year} Dutch Drone Squad. Open-Source-Projekt.",
+    "copyright": "© {year} <organization>Dutch Drone Squad</organization>. Open-Source-Projekt.",
     "madeWithPre": "Gemacht mit",
     "madeWithPost": "für die FPV-Community"
+  },
+  "translationCta": {
+    "eyebrow": "Übersetzungen aus der Community",
+    "title": "Hilf mit, TrackDraw in weiteren Sprachen anzubieten",
+    "description": "Du sprichst eine weitere Sprache? Mach bei Crowdin mit und hilf mehr FPV-Clubs und Rennorganisatoren, TrackDraw zu nutzen.",
+    "action": "Auf Crowdin übersetzen"
   },
   "gallery": {
     "pageTitle": "FPV Drone Race Track Galerie",

--- a/lang/en-US/landing.json
+++ b/lang/en-US/landing.json
@@ -214,15 +214,22 @@
     "communityTitle": "Community",
     "github": "GitHub",
     "dutchDroneSquad": "Dutch Drone Squad",
+    "translate": "Help translate",
     "facebook": "Facebook",
     "instagram": "Instagram",
     "reportIssue": "Report an issue",
     "supportTitle": "Support",
     "githubSponsors": "GitHub Sponsors",
     "kofi": "Ko-fi",
-    "copyright": "© {year} Dutch Drone Squad. Open source project.",
+    "copyright": "© {year} <organization>Dutch Drone Squad</organization>. Open source project.",
     "madeWithPre": "Made with",
     "madeWithPost": "for the FPV community"
+  },
+  "translationCta": {
+    "eyebrow": "Community translations",
+    "title": "Help make TrackDraw available in more languages",
+    "description": "Know another language? Join the translation project on Crowdin and help more FPV clubs and race organizers use TrackDraw.",
+    "action": "Translate on Crowdin"
   },
   "gallery": {
     "pageTitle": "FPV Drone Race Track Gallery",

--- a/lang/nl-NL/landing.json
+++ b/lang/nl-NL/landing.json
@@ -214,15 +214,22 @@
     "communityTitle": "Community",
     "github": "GitHub",
     "dutchDroneSquad": "Dutch Drone Squad",
+    "translate": "Help met vertalen",
     "facebook": "Facebook",
     "instagram": "Instagram",
     "reportIssue": "Probleem melden",
     "supportTitle": "Ondersteuning",
     "githubSponsors": "GitHub Sponsors",
     "kofi": "Ko-fi",
-    "copyright": "© {year} Dutch Drone Squad. Open source project.",
+    "copyright": "© {year} <organization>Dutch Drone Squad</organization>. Open source project.",
     "madeWithPre": "Gemaakt met",
     "madeWithPost": "voor de FPV-community"
+  },
+  "translationCta": {
+    "eyebrow": "Vertalen met de community",
+    "title": "Help TrackDraw beschikbaar te maken in meer talen",
+    "description": "Spreek je een andere taal? Doe mee via Crowdin en help meer FPV-clubs en raceorganisatoren TrackDraw te gebruiken.",
+    "action": "Vertalen via Crowdin"
   },
   "gallery": {
     "pageTitle": "FPV Drone Race Track Galerij",

--- a/lang/zh-CN/landing.json
+++ b/lang/zh-CN/landing.json
@@ -214,15 +214,22 @@
     "communityTitle": "社区",
     "github": "GitHub",
     "dutchDroneSquad": "Dutch Drone Squad",
+    "translate": "协助翻译",
     "facebook": "Facebook",
     "instagram": "Instagram",
     "reportIssue": "反馈问题",
     "supportTitle": "支持项目",
     "githubSponsors": "GitHub Sponsors",
     "kofi": "Ko-fi",
-    "copyright": "© {year} Dutch Drone Squad。开源项目。",
+    "copyright": "© {year} <organization>Dutch Drone Squad</organization>。开源项目。",
     "madeWithPre": "用",
     "madeWithPost": "为 FPV 社区打造"
+  },
+  "translationCta": {
+    "eyebrow": "社区翻译",
+    "title": "帮助 TrackDraw 支持更多语言",
+    "description": "你熟悉其他语言吗？欢迎加入 Crowdin 翻译项目，帮助更多 FPV 俱乐部和赛事组织者使用 TrackDraw。",
+    "action": "前往 Crowdin 翻译"
   },
   "gallery": {
     "pageTitle": "FPV 穿越机竞速赛道图库",

--- a/src/components/landing/Footer.tsx
+++ b/src/components/landing/Footer.tsx
@@ -6,8 +6,8 @@ import {
   Bug,
   Coffee,
   FileText,
-  Flag,
   Heart,
+  Languages,
   Pencil,
   ScrollText,
   ShieldCheck,
@@ -173,13 +173,13 @@ export function Footer() {
                 </li>
                 <li>
                   <a
-                    href="https://dutchdronesquad.nl"
+                    href="https://crowdin.com/project/trackdraw"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-muted-foreground hover:text-foreground flex items-center gap-2 transition-colors"
                   >
-                    <Flag className="size-4 shrink-0" />
-                    {t("footer.dutchDroneSquad")}
+                    <Languages className="size-4 shrink-0" />
+                    {t("footer.translate")}
                   </a>
                 </li>
                 <li>
@@ -241,7 +241,21 @@ export function Footer() {
 
         {/* Bottom bar */}
         <div className="border-border text-muted-foreground flex flex-col items-center justify-between gap-3 border-t pt-6 text-sm sm:flex-row">
-          <p>{t("footer.copyright", { year: new Date().getFullYear() })}</p>
+          <p>
+            {t.rich("footer.copyright", {
+              year: new Date().getFullYear(),
+              organization: (chunks) => (
+                <a
+                  href="https://dutchdronesquad.nl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:text-foreground underline-offset-4 transition-colors hover:underline"
+                >
+                  {chunks}
+                </a>
+              ),
+            })}
+          </p>
           <p className="flex items-center gap-1.5">
             {t("footer.madeWithPre")}{" "}
             <Heart className="size-3.5 shrink-0 fill-current text-red-500" />{" "}

--- a/src/components/landing/HomePage.tsx
+++ b/src/components/landing/HomePage.tsx
@@ -27,6 +27,7 @@ import {
   Route,
   Share2,
   FileText,
+  Languages,
 } from "lucide-react";
 import { Screenshot } from "@/components/landing/Screenshot";
 import { FaqAccordion } from "@/components/landing/FaqAccordion";
@@ -555,6 +556,34 @@ export default function Home() {
               </h2>
             </Reveal>
             <FaqAccordion items={faq} />
+          </div>
+        </section>
+
+        <section className="border-border/40 border-t">
+          <div className="mx-auto flex w-full max-w-6xl flex-col items-start gap-6 px-6 py-12 sm:flex-row sm:items-center sm:justify-between sm:py-14">
+            <Reveal className="max-w-2xl">
+              <div className="text-brand-primary mb-3 flex items-center gap-2 text-sm font-medium">
+                <Languages className="size-4" />
+                {t("translationCta.eyebrow")}
+              </div>
+              <h2 className="text-2xl font-semibold tracking-tight">
+                {t("translationCta.title")}
+              </h2>
+              <p className="text-muted-foreground mt-3 text-sm leading-7 sm:text-base">
+                {t("translationCta.description")}
+              </p>
+            </Reveal>
+            <Reveal>
+              <a
+                href="https://crowdin.com/project/trackdraw"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-brand-primary text-primary-foreground hover:bg-brand-primary/90 inline-flex shrink-0 items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-semibold transition-colors"
+              >
+                {t("translationCta.action")}
+                <ArrowRight className="size-4" />
+              </a>
+            </Reveal>
           </div>
         </section>
       </main>


### PR DESCRIPTION
## Summary

- add a compact landing-page call to help translate TrackDraw on Crowdin
- replace the footer organization entry with a Crowdin translation link
- link Dutch Drone Squad from the copyright line
- add localized CTA copy for English, Dutch, German, and Simplified Chinese

## Validation

- `npm run i18n:check`
- `npm run lint`
- `npm run type`
- `npm run test`
- `npm run build`