### PR TITLE
fix: Preserve ICU warning context across locales

### DIFF
--- a/lang/de-DE/inspector.json
+++ b/lang/de-DE/inspector.json
@@ -314,35 +314,35 @@
         "fix": "Setze Wegpunkthöhen im Inspector oder in der 3D-Ansicht, wenn die Route steigen oder fallen soll."
       },
       "steep": {
-        "summary": "{count, plural, one {Steile Steigung bei Wegpunkt {first}} other {Steile Steigung an {count} Segmenten}}",
+        "summary": "{count, plural, one {Steile Steigung bei Wegpunkt {first}} other {Steile Steigung an {count} Segmenten, beginnend bei Wegpunkt {first}}}",
         "shortLabel": "Steile Steigung",
         "title": "Steigung ändert sich zu schnell",
         "problem": "Ein Abschnitt steigt oder fällt stark über eine kurze Distanz, wodurch die 3D-Linie abrupt wirken kann.",
         "fix": "Verteile die Höhenänderung über mehr Distanz oder füge einen Zwischenwegpunkt hinzu."
       },
       "hairpin": {
-        "summary": "{count, plural, one {Enge Kurve bei Wegpunkt {first}} other {{count} enge Kurven}}",
+        "summary": "{count, plural, one {Enge Kurve bei Wegpunkt {first}} other {{count} enge Kurven, beginnend bei Wegpunkt {first}}}",
         "shortLabel": "Enge Kurve",
         "title": "Kurve ist sehr eng",
         "problem": "Ein Wegpunkt erzeugt eine scharfe Richtungsumkehr, die bei Geschwindigkeit schwer sauber zu fliegen sein kann.",
         "fix": "Verschiebe den Wegpunkt nach außen oder schaffe vor und nach der Kurve mehr Raum."
       },
       "close-points": {
-        "summary": "{count, plural, one {Nahe Wegpunkte bei {first}} other {{count} eng beieinanderliegende Wegpunkte}}",
+        "summary": "{count, plural, one {Nahe Wegpunkte bei {first}} other {{count} eng beieinanderliegende Wegpunkte bei {first}}}",
         "shortLabel": "Nahe Punkte",
         "title": "Wegpunkte liegen zu nah beieinander",
         "problem": "Zwei Wegpunkte liegen so nah beieinander, dass sie ein winziges Routensegment erzeugen.",
         "fix": "Lösche einen der Punkte oder verschiebe ihn weiter vom Nachbarn weg."
       },
       "spacing-shift": {
-        "summary": "{count, plural, one {Abrupter Abstandswechsel bei Wegpunkt {first}} other {{count} abrupte Abstandswechsel}}",
+        "summary": "{count, plural, one {Abrupter Abstandswechsel bei Wegpunkt {first}} other {{count} abrupte Abstandswechsel, beginnend bei Wegpunkt {first}}}",
         "shortLabel": "Abstandswechsel",
         "title": "Gate-Rhythmus ändert sich abrupt",
         "problem": "Der Abstand vor und nach einem Wegpunkt ändert sich plötzlich, wodurch die Route ungleichmäßig wirken kann.",
         "fix": "Positioniere nahe Wegpunkte neu, damit sich die Abstände schrittweiser ändern."
       },
       "rhythm-break": {
-        "summary": "{count, plural, one {Kurzes Korrektursegment bei Wegpunkt {first}} other {{count} kurze Korrektursegmente}}",
+        "summary": "{count, plural, one {Kurzes Korrektursegment bei Wegpunkt {first}} other {{count} kurze Korrektursegmente, beginnend bei Wegpunkt {first}}}",
         "shortLabel": "Kurze Korrektur",
         "title": "Kurze Korrektur bricht den Flow",
         "problem": "Ein kurzes mittleres Segment unterbricht längere umliegende Abschnitte und kann ein unangenehmes Wackeln erzeugen.",

--- a/lang/en-US/inspector.json
+++ b/lang/en-US/inspector.json
@@ -314,35 +314,35 @@
         "fix": "Set waypoint elevations in the inspector or 3D view if the route should climb or drop."
       },
       "steep": {
-        "summary": "{count, plural, one {Steep grade near waypoint {first}} other {Steep grade at {count} segments}}",
+        "summary": "{count, plural, one {Steep grade near waypoint {first}} other {Steep grade at {count} segments, starting near waypoint {first}}}",
         "shortLabel": "Steep grade",
         "title": "Grade changes too quickly",
         "problem": "One section climbs or drops sharply over a short distance, which can make the 3D line feel abrupt.",
         "fix": "Spread the height change across more distance or add an intermediate waypoint."
       },
       "hairpin": {
-        "summary": "{count, plural, one {Tight turn at waypoint {first}} other {{count} tight turns}}",
+        "summary": "{count, plural, one {Tight turn at waypoint {first}} other {{count} tight turns, starting at waypoint {first}}}",
         "shortLabel": "Tight turn",
         "title": "Turn is very tight",
         "problem": "A waypoint creates a sharp reversal that may be hard to fly cleanly at speed.",
         "fix": "Move the waypoint outward or add more room before and after the turn."
       },
       "close-points": {
-        "summary": "{count, plural, one {Close waypoints near {first}} other {{count} closely spaced waypoints}}",
+        "summary": "{count, plural, one {Close waypoints near {first}} other {{count} closely spaced waypoints near {first}}}",
         "shortLabel": "Close points",
         "title": "Waypoints are too close",
         "problem": "Two waypoints are so close together that they create a tiny route segment.",
         "fix": "Delete one of the points or move it farther away from its neighbor."
       },
       "spacing-shift": {
-        "summary": "{count, plural, one {Abrupt spacing shift near waypoint {first}} other {{count} abrupt spacing shifts}}",
+        "summary": "{count, plural, one {Abrupt spacing shift near waypoint {first}} other {{count} abrupt spacing shifts, starting near waypoint {first}}}",
         "shortLabel": "Spacing shift",
         "title": "Gate rhythm changes abruptly",
         "problem": "The distance before and after a waypoint changes suddenly, which can make the route feel uneven.",
         "fix": "Reposition nearby waypoints so the spacing changes more gradually."
       },
       "rhythm-break": {
-        "summary": "{count, plural, one {Short correction segment near waypoint {first}} other {{count} short correction segments}}",
+        "summary": "{count, plural, one {Short correction segment near waypoint {first}} other {{count} short correction segments, starting near waypoint {first}}}",
         "shortLabel": "Short correction",
         "title": "Short correction breaks the flow",
         "problem": "A short middle segment interrupts longer surrounding sections and can create an awkward wobble.",

--- a/lang/nl-NL/inspector.json
+++ b/lang/nl-NL/inspector.json
@@ -314,35 +314,35 @@
         "fix": "Stel waypoint-hoogtes in via de inspector of 3D-weergave als de route moet klimmen of dalen."
       },
       "steep": {
-        "summary": "{count, plural, one {Steile helling nabij waypoint {first}} other {Steile helling bij {count} segmenten}}",
+        "summary": "{count, plural, one {Steile helling nabij waypoint {first}} other {Steile helling bij {count} segmenten, vanaf waypoint {first}}}",
         "shortLabel": "Steile helling",
         "title": "Helling verandert te snel",
         "problem": "Een sectie klimt of daalt scherp over een korte afstand, wat de 3D-lijn abrupt kan laten aanvoelen.",
         "fix": "Spreid de hoogteverandering over meer afstand of voeg een tussenliggend waypoint toe."
       },
       "hairpin": {
-        "summary": "{count, plural, one {Scherpe bocht bij waypoint {first}} other {{count} scherpe bochten}}",
+        "summary": "{count, plural, one {Scherpe bocht bij waypoint {first}} other {{count} scherpe bochten, vanaf waypoint {first}}}",
         "shortLabel": "Scherpe bocht",
         "title": "Bocht is erg scherp",
         "problem": "Een waypoint creëert een scherpe ombuiging die mogelijk moeilijk schoon te vliegen is op snelheid.",
         "fix": "Verplaats het waypoint naar buiten of voeg meer ruimte toe voor en na de bocht."
       },
       "close-points": {
-        "summary": "{count, plural, one {Waypoints te dicht bij elkaar nabij {first}} other {{count} dicht opeenstaande waypoints}}",
+        "summary": "{count, plural, one {Waypoints te dicht bij elkaar nabij {first}} other {{count} dicht opeenstaande waypoints nabij {first}}}",
         "shortLabel": "Dichte waypoints",
         "title": "Waypoints staan te dicht bij elkaar",
         "problem": "Twee waypoints staan zo dicht bij elkaar dat ze een heel klein routesegment vormen.",
         "fix": "Verwijder een van de waypoints of verplaats het verder van zijn buur."
       },
       "spacing-shift": {
-        "summary": "{count, plural, one {Abrupte afstandswijziging nabij waypoint {first}} other {{count} abrupte afstandswijzigingen}}",
+        "summary": "{count, plural, one {Abrupte afstandswijziging nabij waypoint {first}} other {{count} abrupte afstandswijzigingen, vanaf waypoint {first}}}",
         "shortLabel": "Afstandswijziging",
         "title": "Gate-ritme verandert abrupt",
         "problem": "De afstand voor en na een waypoint verandert plotseling, wat de route ongelijk kan laten aanvoelen.",
         "fix": "Verplaats nabijgelegen waypoints zodat de afstand geleidelijker verandert."
       },
       "rhythm-break": {
-        "summary": "{count, plural, one {Korte correctie nabij waypoint {first}} other {{count} korte correctiesegmenten}}",
+        "summary": "{count, plural, one {Korte correctie nabij waypoint {first}} other {{count} korte correctiesegmenten, vanaf waypoint {first}}}",
         "shortLabel": "Korte correctie",
         "title": "Korte correctie verstoort de flow",
         "problem": "Een kort tussensegment onderbreekt langere omliggende secties en kan een onhandige zwabber veroorzaken.",

--- a/lang/zh-CN/inspector.json
+++ b/lang/zh-CN/inspector.json
@@ -310,35 +310,35 @@
         "fix": "如果这条线路需要爬升或下落，请在检查器或 3D 视图里设置路径点高度。"
       },
       "steep": {
-        "summary": "{count, plural, one {路径点 {first} 附近坡度过大} other {{count} 段坡度过大}}",
+        "summary": "{count, plural, one {路径点 {first} 附近坡度过大} other {从路径点 {first} 附近开始有 {count} 段坡度过大}}",
         "shortLabel": "坡度过大",
         "title": "高度变化过于突然",
         "problem": "有一段线路在很短距离内急升或急降，会让 3D 线路显得很突兀。",
         "fix": "把高度变化拉长，或增加一个中间路径点。"
       },
       "hairpin": {
-        "summary": "{count, plural, one {路径点 {first} 处转向过急} other {{count} 个急转}}",
+        "summary": "{count, plural, one {路径点 {first} 处转向过急} other {从路径点 {first} 开始有 {count} 个急转}}",
         "shortLabel": "急转",
         "title": "转向过于紧凑",
         "problem": "某个路径点形成了近乎折返的急转，高速飞行时可能很难顺畅通过。",
         "fix": "把路径点往外挪，或在转弯前后留出更多空间。"
       },
       "close-points": {
-        "summary": "{count, plural, one {路径点 {first} 附近点距过近} other {{count} 处路径点间距过近}}",
+        "summary": "{count, plural, one {路径点 {first} 附近点距过近} other {路径点 {first} 附近有 {count} 处路径点间距过近}}",
         "shortLabel": "点距过近",
         "title": "路径点之间太近",
         "problem": "两个路径点距离太近，导致中间出现极短的路径段。",
         "fix": "删除其中一个点，或把它移远一些。"
       },
       "spacing-shift": {
-        "summary": "{count, plural, one {路径点 {first} 附近节奏突变} other {{count} 处节奏突变}}",
+        "summary": "{count, plural, one {路径点 {first} 附近节奏突变} other {从路径点 {first} 附近开始有 {count} 处节奏突变}}",
         "shortLabel": "节奏突变",
         "title": "门距节奏变化过猛",
         "problem": "某个路径点前后的距离变化太突然，会让整条线路节奏不均匀。",
         "fix": "调整附近路径点，让间距变化更平滑。"
       },
       "rhythm-break": {
-        "summary": "{count, plural, one {路径点 {first} 附近有短修正段} other {{count} 段短修正}}",
+        "summary": "{count, plural, one {路径点 {first} 附近有短修正段} other {从路径点 {first} 附近开始有 {count} 段短修正}}",
         "shortLabel": "短修正",
         "title": "短修正打断流畅度",
         "problem": "较长线路中夹了一个很短的中间线段，容易产生别扭的小摆动。",


### PR DESCRIPTION
## Summary

- include the first affected waypoint in both ICU plural branches for route warnings
- keep Chinese translations valid when Crowdin removes the unsupported `one` category
- make multi-warning summaries more useful in every supported language

## Why

Simplified Chinese only supports the ICU `other` plural category. Crowdin therefore removes `one` during export. Because `{first}` previously existed only in `one`, the exported locale lost that required placeholder.

## Validation

- `npm run i18n:check`
- `npm run lint`
- `npm run type`
- `npm run build`