### PR TITLE
docs: Highlight community translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ This changelog is intentionally concise. GitHub Releases and Release Drafter can
 
 The Layout inspector now brings route, timing, numbering, and configured inventory checks together in one advisory Preflight summary. Issues open the related obstacle or Race Line, while sharing and export remain available. Repeated status cards and project details have been reduced, route analysis appears only where it is relevant, and the mobile inspector keeps inactive timing and duplicate quick actions out of the way.
 
+### Help translate TrackDraw
+
+TrackDraw's translations are now open to community contributions on [Crowdin](https://crowdin.com/project/trackdraw). Use the new translation link on the homepage to suggest clearer Dutch, German, or Simplified Chinese wording and help make TrackDraw easier to use for more FPV clubs and race organizers.
+
+Translation updates can ship independently from product releases. Text that has not been translated yet safely falls back to English, so contributors can improve the language packs incrementally.
+
 ### Locale-aware visual exports and integrations
 
 PNG and SVG exports now use the selected language for footer dates and untitled-track copy. Public gallery dates and API Docs language metadata also follow all four supported languages, including Simplified Chinese. Simplified Chinese now uses the standard `zh-CN` locale identifier while existing `zh` preferences continue to work and migrate automatically.
-
-Translation updates can now arrive independently through the Crowdin pilot. Temporarily untranslated messages safely use English instead of blocking a release or showing missing copy.
 
 ## [1.14.0]
 


### PR DESCRIPTION
## Summary

- give community translation contributions their own Unreleased changelog entry
- link directly to the public Crowdin project
- keep fallback behavior as supporting context instead of the main message

## Validation

- `npx prettier --check CHANGELOG.md`
- `git diff --check`