### PR TITLE
docs: Define Crowdin AI translation workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,18 @@ Use `README.md` for the product overview and `CONTRIBUTING.md` for setup, comman
 - When fixing lint or type errors, match the exact reported file and symbol before editing.
 - Do not revert unrelated dirty work. Work with existing changes unless the user explicitly asks for a revert.
 
+## Localization And Crowdin
+
+- English product copy in `lang/en-US/**` is the source of truth and belongs in normal feature pull requests.
+- Do not edit `lang/nl-NL/**`, `lang/de-DE/**`, or `lang/zh-CN/**` in a feature pull request, even when you can generate plausible translations. Crowdin owns those target catalogs.
+- Do not copy new English keys into target catalogs as placeholders. Missing target keys intentionally use the tested English runtime fallback.
+- After English reaches `main`, the Crowdin workflow uploads it automatically. Crowdin then supplies initial AI/machine translations; those translations return through the `l10n_crowdin` localization pull request.
+- Human translations and corrections in Crowdin take precedence over generated translations. Do not overwrite them from the repository.
+- Direct target-catalog edits are allowed only in a production emergency or an explicitly requested one-time reconciliation. Reconcile such changes back into Crowdin immediately instead of creating a second source of truth.
+- If a working tree already contains agent-generated target translations, do not silently keep, discard, or regenerate them. Flag them for reconciliation with Crowdin and keep subsequent feature work English-only.
+- A new English key does not require target-key parity, but every translatable namespace file must still exist for every supported target locale.
+- Run `npm run i18n:check` and `npm run i18n:scan-hardcoded` when changing product copy. See `CONTRIBUTING.md` and `docs/research/crowdin-pilot.md` for the synchronization and review workflow.
+
 ## Ownership Map
 
 - `src/app`: route entry points and page-level metadata

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,6 +141,8 @@ npm run migrate:up:production
 
 During the Crowdin pilot, English source copy remains in `lang/en-US/` and normal feature pull requests. Dutch (`lang/nl-NL/`), German (`lang/de-DE/`), and Simplified Chinese (`lang/zh-CN/`) are maintained in Crowdin and return through localization pull requests; do not edit those target catalogs directly outside a production emergency. Generated locale assets use the same regional directory names. Product locale identifiers stored by the frontend remain the shorter `en`, `nl`, `de`, and `zh-CN` values.
 
+This applies to AI-assisted feature work too: coding agents should add or change only the English source messages. Crowdin automatically creates the initial AI/machine translations for newly uploaded source strings. A dedicated translator is not required for every update; a maintainer can release generated translations after Crowdin QA and a lightweight review, and human contributors can improve them later. Keeping generation inside Crowdin preserves its glossary, translation memory, QA history, and human corrections.
+
 New English keys do not need placeholder copies in every target catalog. Missing target messages safely fall back to English in local server catalogs and generated locale assets. Run these checks when changing product copy:
 
 ```bash
@@ -150,7 +152,9 @@ npm run i18n:scan-hardcoded
 
 The integrity check allows missing target keys but still rejects missing namespace files, stale extra keys, empty target values, and placeholder mismatches. `dashboard` and `legal` remain English-only and are excluded from Crowdin. See [the Crowdin pilot runbook](docs/research/crowdin-pilot.md) for ownership, synchronization, and rollback.
 
-The repository-owned `Crowdin` GitHub Action uploads changed English sources after they reach `main`. Maintainers can also run it manually to open or update the translation pull request. It exports only translated target strings, uses the repository-scoped GitHub token, and attributes generated commits to `Crowdin Bot` rather than the maintainer who configured Crowdin.
+The repository-owned `Crowdin` GitHub Action uploads changed English sources after they reach `main`. The Crowdin project should auto-translate newly uploaded, untranslated content without replacing existing human translations, as described in the pilot runbook. Maintainers can run the workflow manually, preferably once per week or before a release, to open or update the translation pull request. It exports only translated target strings, uses the repository-scoped GitHub token, and attributes generated commits to `Crowdin Bot` rather than the maintainer who configured Crowdin.
+
+If target catalogs were edited locally by mistake, do not merge them as an independent translation source. Either discard those target-only edits or perform an explicit one-time import and review in Crowdin, then resume the normal Crowdin-owned flow.
 
 ## Validation
 

--- a/docs/pva/i18n-multilingual-pva.md
+++ b/docs/pva/i18n-multilingual-pva.md
@@ -34,7 +34,7 @@ Approve phase 1 (architecture + editor namespace pilot) if TrackDraw accepts:
 - the editor namespace ships first as the pilot before other surfaces are migrated
 - untranslated strings fall back to the English message, never to a missing-key error
 
-Do not approve automatic machine translation, locale-based URL redirection, or changes to the share/embed routing contract before the editor pilot is stable.
+At this phase gate, automatic machine translation was intentionally deferred until the editor pilot was stable. The later Crowdin pilot now allows machine-assisted target copy inside Crowdin; locale-based URL redirection and changes to the share/embed routing contract remain out of scope.
 
 ## Go / No-Go Criteria
 

--- a/docs/research/crowdin-pilot.md
+++ b/docs/research/crowdin-pilot.md
@@ -1,12 +1,12 @@
 # Crowdin localization pilot
 
-Status: Crowdin project activated and initial repository round trip completed; migration from the user-authorized native integration to the repository-owned GitHub Action remains an operator step.
+Status: Crowdin project activated and initial repository round trip completed; migration from the user-authorized native integration to the repository-owned GitHub Action and enabling automatic translation remain operator steps.
 
 Pilot window: 2026-08-10 through 2026-11-10. If the GitHub integration is activated later, move the end date so the evaluation still covers three full months.
 
 ## Goal
 
-Use Crowdin as the only editing and review surface for Dutch, German, and Simplified Chinese long enough to judge contributor usability, translation quality, maintenance effort, quota pressure, and pull-request noise. English source copy remains owned by normal TrackDraw feature pull requests.
+Use Crowdin as the only generation, editing, and review surface for Dutch, German, and Simplified Chinese long enough to judge machine-assisted quality, contributor usability, maintenance effort, quota pressure, and pull-request noise. English source copy remains owned by normal TrackDraw feature pull requests. Dedicated translators are welcome but are not required for every existing target language: Crowdin AI/machine translation supplies the initial version and humans can improve it later.
 
 The pilot stays reversible. Translation JSON remains versioned in Git, production continues to load generated Cloudflare Static Assets, and TrackDraw has no runtime dependency on Crowdin.
 
@@ -32,6 +32,23 @@ Do not edit target-language JSON directly during the pilot, except for a product
 7. Keep repository translation upload disabled after the one-time import. Crowdin remains the source of truth for target catalogs.
 8. Confirm that Crowdin recognizes nested JSON, ICU plurals, and placeholders before inviting translators.
 9. Pause the native Crowdin GitHub integration by clearing its sync schedule before merging the Action workflow. Keep the connection available for rollback until the first Action-generated pull request succeeds.
+10. Under **Settings > Auto-Translate**, enable automatic translation when new source content is uploaded. Process untranslated strings only, use Crowdin AI or a configured machine-translation engine, and do not replace existing human translations.
+11. Give the automatic translator TrackDraw-specific guidance: concise browser UI copy, an informal but clear product tone, preservation of `TrackDraw`, FPV terminology, ICU placeholders, units, and technical tokens, and no invented product behavior.
+12. Confirm the selected engine and plan cover Dutch, German, and Simplified Chinese. Keep the auto-translation accuracy/queue results available for the maintainer review before export.
+
+Use this as the starting instruction for Crowdin AI and refine it through the glossary rather than adding conflicting instructions per batch:
+
+```text
+Translate concise TrackDraw browser UI copy from en-US into the target language.
+Use natural, clear, informal product language rather than a word-for-word translation.
+Preserve TrackDraw, FPV terms, URLs, file formats, keyboard shortcuts, units,
+technical tokens, HTML/tags, and every ICU placeholder exactly. Prefer the project
+glossary and translation memory. Keep labels compact enough for controls. Do not
+invent features, promises, privacy behavior, or technical meaning. Return only the
+translated message.
+```
+
+Auto-Translate is a Crowdin project setting, not a repository setting. Enabling or changing it is therefore an explicit operator action and cannot be inferred from `crowdin.yml` or the GitHub Action alone.
 
 Never commit a Crowdin API token or project credential. The Action reads both values from GitHub Actions secrets through the environment variable references in `crowdin.yml`.
 
@@ -43,6 +60,17 @@ Keep QA checks enabled, but distinguish runtime-breaking syntax from linguistic 
 - set **Spelling mistakes**, punctuation, capitalization, and length checks to **Warning** so a false positive cannot block an otherwise valid translation;
 - leave untranslated strings untranslated instead of saving the English source as a target translation.
 
+Generated translations are provisional, not disposable. Crowdin QA must pass before export, and a maintainer reviews a small sample plus sensitive or space-constrained strings. A dedicated language coordinator is not required for each synchronization round. When a human later corrects a translation, retain that translation and configure future auto-translation runs to skip it.
+
+Before starting the localization workflow, the maintainer checks:
+
+- no blocking variables, ICU, or tag mismatch remains;
+- every changed placeholder is preserved exactly;
+- all warnings, privacy/security copy, destructive actions, and export instructions added in the batch have been reviewed;
+- at least five other new strings per target language, or all of them when the batch is smaller, read plausibly in context;
+- compact controls do not contain obviously excessive copy;
+- English text is retained only for intentional product or technical terminology.
+
 An `ISSUES FOUND` or `Spellcheck failed` language indicator means at least one suggestion has an unresolved QA finding; it does not mean the complete language import failed. Open the issue count for that language and review a sample before changing project-wide settings. Add legitimate product names, FPV terminology, acronyms, and retained English technical terms to **Settings > QA Checks > Spellcheck Ignore list**. Glossary terms are not added to this ignore list automatically.
 
 ## Normal update cycle
@@ -50,15 +78,28 @@ An `ISSUES FOUND` or `Spellcheck failed` language indicator means at least one s
 1. A feature pull request changes English source messages and application code.
 2. CI validates English key usage, catalog integrity, and hardcoded-copy rules. Target catalogs may temporarily omit new keys.
 3. After merge, the `Crowdin` GitHub Action uploads changed English source files to Crowdin.
-4. Translators submit changes and a language coordinator approves them.
-5. A maintainer manually runs the `Crowdin` workflow when translations are ready. Running it once per week or release is preferred over a schedule during the pilot.
-6. The Action opens or updates `l10n_crowdin` without pushing directly to `main`. The PR and GitHub operation are attributed to `github-actions[bot]`; translation commits use `Crowdin Bot` as their author.
-7. TrackDraw CI rejects stale extra keys, empty values, and placeholder mismatches. Missing target keys remain safe English fallbacks.
-8. A maintainer reviews and merges the localization pull request.
+4. Crowdin automatically translates newly uploaded, untranslated strings. Translation memory and existing human translations remain preferred and are not replaced.
+5. Human contributors can suggest or approve improvements when available, but their absence does not block the existing languages.
+6. A maintainer checks the auto-translation queue, blocking QA findings, placeholders, and a representative sample. Pay extra attention to compact controls, warnings, export copy, and FPV terminology.
+7. A maintainer manually runs the `Crowdin` workflow when the batch is ready. Running it once per week or release is preferred over a schedule during the pilot.
+8. The Action opens or updates `l10n_crowdin` without pushing directly to `main`. The PR and GitHub operation are attributed to `github-actions[bot]`; translation commits use `Crowdin Bot` as their author.
+9. TrackDraw CI rejects stale extra keys, empty values, and placeholder mismatches. Missing target keys remain safe English fallbacks.
+10. A maintainer reviews and merges the localization pull request. Machine-generated wording can ship after this lightweight review and be corrected later through Crowdin.
 
 During the pilot, prefer one intentional localization pull request per week or release over hourly repository churn.
 
 The Action exports with `skip_untranslated_strings` enabled. Crowdin therefore omits untranslated target keys instead of copying English ICU source messages into target catalogs. TrackDraw's tested runtime fallback supplies English until a real translation is available. The Action's commit message deliberately does not contain `[ci skip]`, so localization pull requests remain subject to the normal repository checks. GitHub may require a maintainer to approve workflows initiated by `github-actions[bot]`.
+
+## Agent-generated target translations
+
+Coding agents must keep normal feature work English-only, even if they can translate all supported languages. Generating target copy directly in Git bypasses Crowdin's glossary, translation memory, QA state, and later human corrections.
+
+If a branch already contains useful agent-generated target translations, choose one of these paths before merge:
+
+1. Remove the target-only edits and let Crowdin auto-translate the merged English source; or
+2. Treat the edits as a deliberate one-time baseline import, review them, import them into Crowdin, confirm the resulting Crowdin export, and only then merge the Crowdin-generated localization PR.
+
+Do not permanently enable repository translation upload and do not merge the same target changes independently through a feature PR. After reconciliation, Crowdin resumes ownership of all target catalogs.
 
 ## Native integration cutover
 
@@ -80,7 +121,7 @@ Extra target keys are ignored at runtime and rejected by CI. Placeholder changes
 
 Review the pilot on 2026-11-10 using:
 
-- number of active translators and languages with a clear reviewer;
+- machine-translation coverage, active human contributors when available, and the amount of maintainer review required;
 - median time from a merged English string to an approved translation;
 - translation pull-request frequency, conflicts, and maintainer time;
 - placeholder, terminology, and compact-label issues found in review;

--- a/docs/research/translation-management.md
+++ b/docs/research/translation-management.md
@@ -73,7 +73,7 @@ Keep that architecture. Do not use Crowdin's runtime CDN merely to remove reposi
 
 This access model applies regardless of platform:
 
-- Start with a private Crowdin project/pilot while the workflow is being proven.
+- For the current Crowdin pilot, use the public, file-based project defined in the pilot runbook. If a future platform evaluation needs a private proof, keep it temporary and update the runbook before changing contributor access.
 - Use language-scoped permissions and suggestion/review roles where the selected plan supports them.
 - Do not allow direct pushes from contributors to GitHub or `main`.
 - Do not give normal translators platform API tokens, GitHub tokens, repository access, source-string edit permissions, or project administration rights.

--- a/docs/research/translation-management.md
+++ b/docs/research/translation-management.md
@@ -77,7 +77,8 @@ This access model applies regardless of platform:
 - Use language-scoped permissions and suggestion/review roles where the selected plan supports them.
 - Do not allow direct pushes from contributors to GitHub or `main`.
 - Do not give normal translators platform API tokens, GitHub tokens, repository access, source-string edit permissions, or project administration rights.
-- Assign a language leader for every supported non-English language. This person owns terminology consistency, reviews contributor suggestions, and decides when a translation is ready to ship.
+- Existing target languages may use Crowdin AI/machine translation as their maintained baseline when no regular translator is available. A maintainer owns release sampling and blocking QA; human contributors can improve the baseline later.
+- Assign a language leader when a language has recurring human contributors or needs sustained terminology review. Do not make that role a prerequisite for every synchronization round of an existing language.
 - Add contributors to language-scoped teams, for example a Chinese translator team limited to `zh-CN` and translatable components only.
 - Start new contributors with suggestion-only access where possible. They can propose translations without directly changing the accepted translation state.
 - Promote contributors to limited Translate access only after trust is established and the language leader has review capacity.
@@ -88,9 +89,9 @@ This access model applies regardless of platform:
 Practical contribution flow:
 
 1. Contributor asks to help with a language.
-2. Maintainer confirms there is a language leader for that language and sends a platform invite.
+2. Maintainer confirms the language scope and available review path, then sends a platform invite.
 3. Contributor suggests strings in the translation platform.
-4. Language leader handles terminology, failing checks, contributor feedback, and approvals.
+4. A language leader, when assigned, handles terminology and contributor feedback; otherwise a maintainer handles blocking QA and release sampling.
 5. Automation pulls accepted changes into a normal translation PR.
 6. The PR runs locale validation, unresolved-key checks, hardcoded-copy checks, and any relevant UI/export tests before merge.
 
@@ -105,12 +106,12 @@ If a contributor leaves, remove them from platform teams or disable the account.
 - Keep all translation changes reviewable as normal pull requests.
 - Preserve CI checks for catalog integrity, unresolved English keys, placeholders, and intentional hardcoded-copy exceptions. Missing target keys are allowed only because build and runtime catalogs provide a tested English fallback.
 - Support external contributors without requiring direct repository write access.
-- Add new languages only when there is an owner for terminology review, compact UI labels, and export/PDF/Race Pack copy.
+- Add new languages only when there is either an owner for terminology review or an explicit decision to support a machine-maintained baseline with maintainer sampling, especially for compact UI labels and export/PDF/Race Pack copy.
 - Prevent translation growth from making the Cloudflare Worker package grow linearly with every added language.
 
 ## Selected pilot
 
-TrackDraw will run a reversible three-month Crowdin pilot from 2026-08-10 through 2026-11-10, shifting the end date if external activation happens later. Crowdin owns `nl`, `de`, and `zh-CN` editing during the pilot; English remains in GitHub. The repository retains all catalogs and production keeps using generated Static Assets.
+TrackDraw will run a reversible three-month Crowdin pilot from 2026-08-10 through 2026-11-10, shifting the end date if external activation happens later. Crowdin owns `nl`, `de`, and `zh-CN` generation and editing during the pilot; English remains in GitHub. Crowdin AI/machine translation supplies the initial target copy when regular translators are unavailable, with maintainer QA and sampling before the localization pull request is merged. The repository retains all catalogs and production keeps using generated Static Assets.
 
 The setup, update cycle, evaluation criteria, and rollback are documented in `docs/research/crowdin-pilot.md`. The initial repository round trip exposed two integration concerns: native synchronization attributed commits to the authorizing maintainer and exported untranslated ICU messages as English target text. The repository-owned GitHub Action avoids personal commit attribution and skips untranslated target strings so the existing runtime fallback remains responsible for temporary English copy.
 


### PR DESCRIPTION
## Summary

- make English-only feature catalog ownership explicit for contributors and AI agents
- document Crowdin AI/MT auto-translation, maintainer sampling, and human-correction precedence
- add an operator prompt, release checklist, and one-time reconciliation path for locally generated target translations

## Why

TrackDraw does not currently have regular translators for every supported language. This keeps machine-assisted translation centralized in Crowdin without making dedicated language coordinators a release prerequisite or creating a second source of truth in feature branches.

## Validation

- `npx prettier --check AGENTS.md CONTRIBUTING.md docs/research/crowdin-pilot.md docs/research/translation-management.md docs/pva/i18n-multilingual-pva.md`
- `npm run i18n:check`
- `npm run i18n:scan-hardcoded`
- `git diff --check`