### PR TITLE
feat: Improve metrics dashboard navigation and planning

### DIFF
--- a/lang/en-US/dashboard.json
+++ b/lang/en-US/dashboard.json
@@ -1,6 +1,7 @@
 {
   "sidebar": {
     "logoAlt": "TrackDraw",
+    "insightsGroup": "Insights",
     "adminGroup": "Admin",
     "nav": {
       "overview": "Overview",
@@ -10,7 +11,7 @@
       "apiKeys": "API Keys",
       "audit": "Audit",
       "metrics": "Metrics",
-      "planDecisions": "Plan decisions",
+      "plansAndLimits": "Plans & limits",
       "emailPreview": "Email Preview",
       "openStudio": "Open Studio",
       "publicSite": "Public Site"
@@ -265,6 +266,7 @@
         "label": "Metrics analysis views",
         "overview": "Overview",
         "acquisition": "Acquisition",
+        "content": "Content",
         "editor": "Editor",
         "exports": "Exports",
         "sharing": "Sharing",
@@ -283,12 +285,6 @@
         "change": "Change",
         "quality": "Quality",
         "window": "Window"
-      },
-      "explore": {
-        "label": "Explore more views:",
-        "acquisition": "Acquisition sources",
-        "content": "Content growth",
-        "retention": "Retention cohorts"
       },
       "metrics": {
         "MTR-001": {
@@ -455,8 +451,8 @@
         "description": "Current inventory and lifecycle issues that may require administration."
       },
       "planning": {
-        "title": "Product and plan decisions",
-        "description": "Account-level resource distribution and the impact of possible plan limits."
+        "title": "Plans and limits",
+        "description": "Account-level resource distribution, possible free-plan limits, and cost coverage."
       }
     },
     "focus": {
@@ -757,8 +753,8 @@
       "limitExplanation": "Proposed free limit: {limit}. Outlined bars represent accounts above this limit.",
       "viewData": "View distribution data",
       "resourceCount": "{resource} per account",
-      "scenarioTitle": "Scenario impact",
-      "scenarioDescription": "Updates as candidate limits and assumptions change.",
+      "scenarioTitle": "Free-plan impact",
+      "scenarioDescription": "See how many existing accounts are close to or above the candidate limits.",
       "accountsNearOrAbove": "Accounts near or above a limit",
       "nearOrAboveDetail": "{pct}% of accounts with content · {near} near · {above} above",
       "monthlyInfrastructureCost": "Monthly infrastructure cost",
@@ -768,15 +764,15 @@
       "costPerActiveCreatorContext": "{cost} per active creator",
       "derivedCostSource": "Derived from {source} and the observed 30-day active-creator count.",
       "missingCostSource": "Add a source before using this estimate in a decision.",
-      "pricingTitle": "Paid plan calculator",
-      "pricingDescription": "Enter one monthly cost and two assumptions.",
+      "pricingTitle": "Cost coverage estimate",
+      "pricingDescription": "Estimate what a future paid plan would need to charge to cover infrastructure costs. This is not a recommended selling price.",
       "paidAdoption": "Paid adoption",
-      "targetMargin": "Target gross margin",
-      "priceFloor": "Cost-based price floor",
-      "pricingContext": "{paid} expected paid creators · {breakEven} break-even",
+      "costBuffer": "Cost buffer",
+      "priceFloor": "Estimated cost-covering price",
+      "pricingContext": "{paid} expected paid creators · {breakEven} base cost per paid account",
       "enterMonthlyCost": "Enter a monthly cost to calculate a price.",
       "perMonthExTax": "per month · excluding tax",
-      "pricingAssumption": "Assumption: one paid account per paying creator and the paid plan recovers all entered infrastructure costs. Tax, payment fees, support, market demand, and willingness to pay are excluded.",
+      "pricingAssumption": "Assumption: one paid account per paying creator. The estimate only covers the entered infrastructure cost plus the optional buffer; tax, payment fees, support, market demand, and willingness to pay are excluded.",
       "behaviorAdvanced": "Advanced assumptions",
       "behaviorAssumption": "Manual directional range; it is not inferred from current usage and is not a forecast.",
       "lower": "Lower bound",
@@ -791,9 +787,9 @@
       "churn": "Churn · unavailable"
     },
     "planningPage": {
-      "metadataTitle": "Metrics plan decisions",
-      "title": "Product and plan decisions",
-      "description": "Explore account-level resource distribution and model possible free-plan limits without changing product behavior.",
+      "metadataTitle": "Plans and limits",
+      "title": "Plans & limits",
+      "description": "Explore fair free-plan limits and estimate what a future paid plan would need to cover TrackDraw's running costs.",
       "observedBaseline": "Observed planning baseline",
       "activeCreators": "active creators",
       "accountsWithContent": "accounts with content",

--- a/src/components/dashboard/AppSidebar.tsx
+++ b/src/components/dashboard/AppSidebar.tsx
@@ -114,6 +114,24 @@ const topNavItems: NavItem[] = [
   },
 ] as const;
 
+const insightsNavItems: NavItem[] = [
+  {
+    key: "metrics",
+    titleKey: "metrics",
+    href: "/dashboard/metrics",
+    icon: BarChart2,
+    activePrefix: "/dashboard/metrics",
+    exact: true,
+  },
+  {
+    key: "metrics-planning",
+    titleKey: "plansAndLimits",
+    href: "/dashboard/metrics/planning",
+    icon: SlidersHorizontal,
+    activePrefix: "/dashboard/metrics/planning",
+  },
+] as const;
+
 const adminNavItems: NavItem[] = [
   {
     key: "users",
@@ -135,21 +153,6 @@ const adminNavItems: NavItem[] = [
     href: "/dashboard/audit",
     icon: Bell,
     activePrefix: "/dashboard/audit",
-  },
-  {
-    key: "metrics",
-    titleKey: "metrics",
-    href: "/dashboard/metrics",
-    icon: BarChart2,
-    activePrefix: "/dashboard/metrics",
-    exact: true,
-  },
-  {
-    key: "metrics-planning",
-    titleKey: "planDecisions",
-    href: "/dashboard/metrics/planning",
-    icon: SlidersHorizontal,
-    activePrefix: "/dashboard/metrics/planning",
   },
   {
     key: "email-preview",
@@ -256,11 +259,15 @@ export default function DashboardAppSidebar({
     return true;
   });
 
-  const filteredAdminItems = adminNavItems.filter((item) => {
-    if (item.key === "users") return visibleModules.includes("users");
+  const filteredInsightsItems = insightsNavItems.filter((item) => {
     if (item.key === "metrics" || item.key === "metrics-planning") {
       return visibleModules.includes("metrics");
     }
+    return true;
+  });
+
+  const filteredAdminItems = adminNavItems.filter((item) => {
+    if (item.key === "users") return visibleModules.includes("users");
     if (item.key === "audit") return visibleModules.includes("audit");
     if (item.key === "api-keys") return visibleModules.includes("api-keys");
     if (item.key === "email-preview") return currentUser.role === "admin";
@@ -305,6 +312,24 @@ export default function DashboardAppSidebar({
             <SidebarGroupContent>
               <SidebarMenu className="gap-1">
                 {filteredTopItems.map((item) => (
+                  <NavMenuItem
+                    key={item.titleKey}
+                    item={item}
+                    currentPath={currentPath}
+                    badge={itemBadges[item.key]}
+                    label={t(`nav.${item.titleKey}`)}
+                  />
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        )}
+        {filteredInsightsItems.length > 0 && (
+          <SidebarGroup>
+            <SidebarGroupLabel>{t("insightsGroup")}</SidebarGroupLabel>
+            <SidebarGroupContent>
+              <SidebarMenu className="gap-1">
+                {filteredInsightsItems.map((item) => (
                   <NavMenuItem
                     key={item.titleKey}
                     item={item}

--- a/src/components/dashboard/MetricsCharts.tsx
+++ b/src/components/dashboard/MetricsCharts.tsx
@@ -49,7 +49,7 @@ import {
   type GrowthTimeline,
 } from "@/lib/metrics-growth";
 import {
-  calculateCostBasedPrice,
+  calculateCostCoverageEstimate,
   calculateCostPerActiveCreator,
   calculateCreatorRange,
   calculatePlanLimitImpact,
@@ -222,6 +222,74 @@ function addCalendarMonths(date: Date, months: number): Date {
   return new Date(date.getFullYear(), date.getMonth() + months, 1);
 }
 
+type UserGrowthTooltipPayload = {
+  color?: string;
+  dataKey?: string | number;
+  value?: number | string;
+};
+
+function UserGrowthTooltip({
+  active,
+  label,
+  newUsersLabel,
+  payload,
+}: {
+  active?: boolean;
+  label?: string | number;
+  newUsersLabel: string;
+  payload?: UserGrowthTooltipPayload[];
+}) {
+  const t = useTranslations("dashboard.metrics.userGrowth");
+  const locale = useLocale();
+
+  if (!active || !payload?.length) return null;
+
+  const valueFor = (key: "totalUsers" | "newUsers") =>
+    payload.find((item) => item.dataKey === key)?.value;
+  const formatValue = (value: number | string | undefined) =>
+    typeof value === "number"
+      ? new Intl.NumberFormat(locale).format(value)
+      : String(value ?? "—");
+  const newUsersValue = valueFor("newUsers");
+  const rows = [
+    {
+      key: "totalUsers" as const,
+      label: t("totalUsers"),
+      value: formatValue(valueFor("totalUsers")),
+    },
+    {
+      key: "newUsers" as const,
+      label: newUsersLabel,
+      value:
+        newUsersValue === undefined ? "—" : `+${formatValue(newUsersValue)}`,
+    },
+  ];
+
+  return (
+    <div className="bg-popover/95 min-w-44 rounded-lg border px-3 py-2.5 text-xs shadow-lg backdrop-blur-sm">
+      <p className="text-foreground mb-2 font-semibold">{label}</p>
+      <div className="space-y-1.5">
+        {rows.map((row) => (
+          <div
+            key={row.key}
+            className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-2"
+          >
+            <span
+              className="size-2 rounded-full"
+              style={{ backgroundColor: `var(--color-${row.key})` }}
+              aria-hidden="true"
+            />
+            <span className="text-muted-foreground">{row.label}</span>
+            <span className="text-foreground pl-3 font-mono font-semibold tabular-nums">
+              {row.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function UserGrowthComboChart({
   growthData,
   newUsersLabel,
@@ -307,6 +375,7 @@ function UserGrowthComboChart({
           />
           <ChartTooltip
             cursor={{ strokeDasharray: "3 3", stroke: "var(--border)" }}
+            content={<UserGrowthTooltip newUsersLabel={newUsersLabel} />}
           />
           <ChartLegend content={<ChartLegendContent />} />
           <Area
@@ -2158,7 +2227,7 @@ function ResourceCard({
               onLimitChange(n);
             }
           }}
-          className="h-9 w-full rounded-md border bg-transparent px-2 text-sm tabular-nums"
+          className="h-11 w-full rounded-md border bg-transparent px-3 text-base tabular-nums md:h-9 md:px-2 md:text-sm"
         />
         <label htmlFor={rangeId} className="sr-only">
           {t("rangeLabel", { resource: title })}
@@ -2171,7 +2240,7 @@ function ResourceCard({
           value={limit}
           aria-describedby={`${resultId} ${descriptionId}`}
           onChange={(e) => onLimitChange(parseInt(e.target.value, 10))}
-          className="accent-foreground h-1.5 w-full cursor-pointer"
+          className="accent-foreground h-11 w-full cursor-pointer md:h-9"
         />
       </div>
 
@@ -2221,7 +2290,7 @@ export function PlanLimitSimulator({
   const [costSource, setCostSource] = useState("");
   const [pricingAssumptions, setPricingAssumptions] = useState({
     paidAdoption: "5",
-    targetMargin: "70",
+    costBuffer: "0",
   });
   const [behaviorRange, setBehaviorRange] = useState({
     lower: "0",
@@ -2255,11 +2324,11 @@ export function PlanLimitSimulator({
     monthlyCost,
     activeCreators
   );
-  const costBasedPrice = calculateCostBasedPrice(
+  const costCoverageEstimate = calculateCostCoverageEstimate(
     monthlyCost,
     activeCreators,
     Number(pricingAssumptions.paidAdoption),
-    Number(pricingAssumptions.targetMargin)
+    Number(pricingAssumptions.costBuffer)
   );
   const creatorRange = calculateCreatorRange(
     activeCreators,
@@ -2389,7 +2458,7 @@ export function PlanLimitSimulator({
                   step="0.01"
                   value={monthlyCostInput}
                   onChange={(event) => setMonthlyCostInput(event.target.value)}
-                  className="h-9 w-full rounded-md border bg-transparent pr-2 pl-6 text-sm tabular-nums"
+                  className="h-11 w-full rounded-md border bg-transparent pr-3 pl-7 text-base tabular-nums sm:h-9 sm:pr-2 sm:pl-6 sm:text-sm"
                 />
               </span>
             </label>
@@ -2400,8 +2469,8 @@ export function PlanLimitSimulator({
                   })
                 : t("enterMonthlyCost")}
             </p>
-            <div className="grid grid-cols-2 gap-2">
-              {(["paidAdoption", "targetMargin"] as const).map((key) => (
+            <div className="grid grid-cols-1 gap-2 min-[360px]:grid-cols-2">
+              {(["paidAdoption", "costBuffer"] as const).map((key) => (
                 <label key={key} className="space-y-1 text-xs">
                   <span className="text-muted-foreground">{t(key)}</span>
                   <span className="relative block">
@@ -2409,7 +2478,7 @@ export function PlanLimitSimulator({
                       type="number"
                       aria-label={t(key)}
                       min={key === "paidAdoption" ? 0.1 : 0}
-                      max={key === "paidAdoption" ? 100 : 99}
+                      max={100}
                       step="0.5"
                       value={pricingAssumptions[key]}
                       onChange={(event) =>
@@ -2418,7 +2487,7 @@ export function PlanLimitSimulator({
                           [key]: event.target.value,
                         }))
                       }
-                      className="h-9 w-full rounded-md border bg-transparent pr-6 pl-2 text-sm tabular-nums"
+                      className="h-11 w-full rounded-md border bg-transparent pr-7 pl-3 text-base tabular-nums sm:h-9 sm:pr-6 sm:pl-2 sm:text-sm"
                     />
                     <span className="text-muted-foreground absolute top-1/2 right-2 -translate-y-1/2">
                       %
@@ -2430,18 +2499,20 @@ export function PlanLimitSimulator({
             <div className="bg-muted/45 rounded-lg p-3">
               <p className="text-muted-foreground text-xs">{t("priceFloor")}</p>
               <p className="mt-0.5 text-2xl font-bold tabular-nums">
-                {costBasedPrice
-                  ? formatCurrency(costBasedPrice.priceFloorPerPaidCreator)
+                {costCoverageEstimate
+                  ? formatCurrency(
+                      costCoverageEstimate.costCoveringPricePerPaidCreator
+                    )
                   : t("notAvailable")}
               </p>
               <p className="text-muted-foreground mt-1 text-xs tabular-nums">
-                {costBasedPrice
+                {costCoverageEstimate
                   ? t("pricingContext", {
                       paid: new Intl.NumberFormat(locale, {
                         maximumFractionDigits: 1,
-                      }).format(costBasedPrice.expectedPaidCreators),
+                      }).format(costCoverageEstimate.expectedPaidCreators),
                       breakEven: formatCurrency(
-                        costBasedPrice.breakEvenPerPaidCreator
+                        costCoverageEstimate.breakEvenPerPaidCreator
                       ),
                     })
                   : t("enterMonthlyCost")}
@@ -2458,7 +2529,7 @@ export function PlanLimitSimulator({
                 value={costSource}
                 onChange={(event) => setCostSource(event.target.value)}
                 placeholder={t("costSourcePlaceholder")}
-                className="h-9 w-full rounded-md border bg-transparent px-2 text-sm"
+                className="h-11 w-full rounded-md border bg-transparent px-3 text-base sm:h-9 sm:px-2 sm:text-sm"
               />
             </label>
             <p className="text-muted-foreground text-xs leading-relaxed">
@@ -2479,7 +2550,7 @@ export function PlanLimitSimulator({
               <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
                 {t("behaviorAssumption")}
               </p>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 gap-2 min-[360px]:grid-cols-2">
                 {(["lower", "upper"] as const).map((key) => (
                   <label key={key} className="space-y-1 text-xs">
                     <span className="text-muted-foreground">{t(key)}</span>
@@ -2495,7 +2566,7 @@ export function PlanLimitSimulator({
                             [key]: event.target.value,
                           }))
                         }
-                        className="h-9 w-full rounded-md border bg-transparent pr-6 pl-2 text-sm tabular-nums"
+                        className="h-11 w-full rounded-md border bg-transparent pr-7 pl-3 text-base tabular-nums sm:h-9 sm:pr-6 sm:pl-2 sm:text-sm"
                       />
                       <span className="text-muted-foreground absolute top-1/2 right-2 -translate-y-1/2">
                         %

--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -2,7 +2,18 @@
 
 import { useMemo, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
-import { Activity, Circle, Compass, Download, RefreshCcw } from "lucide-react";
+import {
+  Activity,
+  Circle,
+  Compass,
+  Download,
+  LayoutDashboard,
+  PenTool,
+  RefreshCcw,
+  Share2,
+  type LucideIcon,
+  Users,
+} from "lucide-react";
 import {
   ContentGrowthChart,
   EditorUsageBreakdown,
@@ -82,6 +93,29 @@ const JOURNEY_STAGES = [
 ] as const;
 
 const EVIDENCE_METRICS = ["MTR-001", "MTR-004", "MTR-006", "MTR-005"] as const;
+
+const METRICS_VIEWS = [
+  { view: "overview", key: "overview", icon: LayoutDashboard },
+  { view: "user-growth", key: "userGrowth", icon: Users },
+  { view: "acquisition", key: "acquisition", icon: Compass },
+  { view: "editor", key: "editor", icon: PenTool },
+  { view: "content", key: "content", icon: Activity },
+  { view: "exports", key: "exports", icon: Download },
+  { view: "sharing", key: "sharing", icon: Share2 },
+  { view: "retention", key: "retention", icon: RefreshCcw },
+] as const satisfies ReadonlyArray<{
+  view: MetricsView;
+  key:
+    | "overview"
+    | "userGrowth"
+    | "acquisition"
+    | "editor"
+    | "content"
+    | "exports"
+    | "sharing"
+    | "retention";
+  icon: LucideIcon;
+}>;
 
 const DICTIONARY_METRICS = [
   "MTR-001",
@@ -449,7 +483,10 @@ export default function MetricsWorkspace({
         </header>
       ) : null}
 
-      <nav aria-label={t("journey.label")} className="overflow-x-auto pb-1">
+      <nav
+        aria-label={t("journey.label")}
+        className="snap-x snap-mandatory [scrollbar-width:none] overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
+      >
         <ol className="grid min-w-[54rem] grid-cols-5 px-2 pt-2">
           {JOURNEY_STAGES.map(({ key, id, view }, index) => {
             const snapshot = snapshots.get(id)!;
@@ -457,7 +494,7 @@ export default function MetricsWorkspace({
             return (
               <li
                 key={id}
-                className="after:bg-border relative after:absolute after:top-2.5 after:left-8 after:h-px after:w-[calc(100%-2rem)] last:after:hidden"
+                className="after:bg-border relative snap-start after:absolute after:top-2.5 after:left-8 after:h-px after:w-[calc(100%-2rem)] last:after:hidden"
               >
                 <button
                   type="button"
@@ -503,26 +540,19 @@ export default function MetricsWorkspace({
         className="min-w-0"
       >
         <div className="flex items-end justify-between gap-4 border-b">
-          <div className="overflow-x-auto">
+          <div className="snap-x snap-mandatory [scrollbar-width:none] overflow-x-auto [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden">
             <TabsList
               className="h-auto min-w-max justify-start rounded-none bg-transparent p-0"
               aria-label={t("views.label")}
             >
-              {(
-                [
-                  "overview",
-                  "user-growth",
-                  "editor",
-                  "exports",
-                  "sharing",
-                ] as const
-              ).map((view) => (
+              {METRICS_VIEWS.map(({ view, key, icon: Icon }) => (
                 <TabsTrigger
                   key={view}
                   value={view}
-                  className="data-[state=active]:border-primary rounded-none border-b-2 border-transparent px-4 py-3 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
+                  className="data-[state=active]:border-primary min-h-11 snap-start gap-2 rounded-none border-b-2 border-transparent px-4 py-3 data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                 >
-                  {t(`views.${view === "user-growth" ? "userGrowth" : view}`)}
+                  <Icon className="size-4" aria-hidden="true" />
+                  {t(`views.${key}`)}
                 </TabsTrigger>
               ))}
             </TabsList>
@@ -674,27 +704,25 @@ export default function MetricsWorkspace({
           </section>
         </TabsContent>
 
-        {activeView === "acquisition" ? (
-          <div className="mt-4">
-            <section className="bg-card rounded-xl border p-4 sm:p-5">
-              <div className="mb-5 flex flex-col gap-2 border-b pb-4 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <h2 className="text-base font-semibold">
-                    {t("acquisition.title")}
-                  </h2>
-                  <p className="text-muted-foreground mt-1 max-w-3xl text-sm">
-                    {t("acquisition.description")}
-                  </p>
-                </div>
-                <QualityLabel quality={explorer.acquisition.quality} />
+        <TabsContent value="acquisition" className="mt-4">
+          <section className="bg-card rounded-xl border p-4 sm:p-5">
+            <div className="mb-5 flex flex-col gap-2 border-b pb-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-base font-semibold">
+                  {t("acquisition.title")}
+                </h2>
+                <p className="text-muted-foreground mt-1 max-w-3xl text-sm">
+                  {t("acquisition.description")}
+                </p>
               </div>
-              <ExplorerBarRows
-                metric={explorer.acquisition}
-                namespace="sources"
-              />
-            </section>
-          </div>
-        ) : null}
+              <QualityLabel quality={explorer.acquisition.quality} />
+            </div>
+            <ExplorerBarRows
+              metric={explorer.acquisition}
+              namespace="sources"
+            />
+          </section>
+        </TabsContent>
 
         <TabsContent value="editor" className="mt-4 space-y-4">
           <div className="grid gap-4 lg:grid-cols-2">
@@ -727,19 +755,17 @@ export default function MetricsWorkspace({
           </div>
         </TabsContent>
 
-        {activeView === "content" ? (
-          <div className="mt-4">
-            <section className="bg-card rounded-xl border p-4 sm:p-5">
-              <h2 className="text-base font-semibold">{t("content.title")}</h2>
-              <p className="text-muted-foreground mt-1 text-sm">
-                {t("content.description")}
-              </p>
-              <div className="mt-4">
-                <ContentGrowthChart data={insights.contentGrowth} />
-              </div>
-            </section>
-          </div>
-        ) : null}
+        <TabsContent value="content" className="mt-4">
+          <section className="bg-card rounded-xl border p-4 sm:p-5">
+            <h2 className="text-base font-semibold">{t("content.title")}</h2>
+            <p className="text-muted-foreground mt-1 text-sm">
+              {t("content.description")}
+            </p>
+            <div className="mt-4">
+              <ContentGrowthChart data={insights.contentGrowth} />
+            </div>
+          </section>
+        </TabsContent>
 
         <TabsContent value="exports" className="mt-4">
           <section className="bg-card max-w-4xl rounded-xl border p-4 sm:p-5">
@@ -794,57 +820,23 @@ export default function MetricsWorkspace({
           </section>
         </TabsContent>
 
-        {activeView === "retention" ? (
-          <div className="mt-4">
-            <section className="bg-card rounded-xl border p-4 sm:p-5">
-              <div className="mb-5 flex flex-col gap-2 border-b pb-4 sm:flex-row sm:items-start sm:justify-between">
-                <div>
-                  <h2 className="text-base font-semibold">
-                    {t("retention.title")}
-                  </h2>
-                  <p className="text-muted-foreground mt-1 max-w-3xl text-sm">
-                    {t("retention.description")}
-                  </p>
-                </div>
-                <QualityLabel quality={explorer.retention.quality} />
+        <TabsContent value="retention" className="mt-4">
+          <section className="bg-card rounded-xl border p-4 sm:p-5">
+            <div className="mb-5 flex flex-col gap-2 border-b pb-4 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-base font-semibold">
+                  {t("retention.title")}
+                </h2>
+                <p className="text-muted-foreground mt-1 max-w-3xl text-sm">
+                  {t("retention.description")}
+                </p>
               </div>
-              <RetentionTable metric={explorer.retention} />
-            </section>
-          </div>
-        ) : null}
+              <QualityLabel quality={explorer.retention.quality} />
+            </div>
+            <RetentionTable metric={explorer.retention} />
+          </section>
+        </TabsContent>
       </Tabs>
-
-      <nav
-        aria-label={t("explore.label")}
-        className="bg-card flex min-w-0 flex-col gap-2 rounded-md border px-3 py-2 sm:flex-row sm:items-center"
-      >
-        <span className="text-muted-foreground shrink-0 text-xs">
-          {t("explore.label")}
-        </span>
-        <div className="flex min-w-0 flex-1 gap-1 overflow-x-auto">
-          {(
-            [
-              { view: "acquisition", key: "acquisition", icon: Compass },
-              { view: "content", key: "content", icon: Activity },
-              { view: "retention", key: "retention", icon: RefreshCcw },
-            ] as const
-          ).map(({ view, key, icon: Icon }) => (
-            <button
-              key={view}
-              type="button"
-              onClick={() => setActiveView(view)}
-              aria-pressed={activeView === view}
-              className={cn(
-                "hover:bg-muted focus-visible:ring-ring inline-flex shrink-0 items-center gap-2 rounded-sm px-3 py-2 text-xs font-medium focus-visible:ring-2 focus-visible:outline-none",
-                activeView === view && "bg-muted text-foreground"
-              )}
-            >
-              <Icon className="size-3.5" aria-hidden="true" />
-              {t(`explore.${key}`)}
-            </button>
-          ))}
-        </div>
-      </nav>
 
       <details
         id="data-dictionary"

--- a/src/lib/metrics-planning.ts
+++ b/src/lib/metrics-planning.ts
@@ -92,18 +92,18 @@ export function calculateCostPerActiveCreator(
   return monthlyCost / activeCreators;
 }
 
-export type CostBasedPrice = {
+export type CostCoverageEstimate = {
   expectedPaidCreators: number;
   breakEvenPerPaidCreator: number;
-  priceFloorPerPaidCreator: number;
+  costCoveringPricePerPaidCreator: number;
 };
 
-export function calculateCostBasedPrice(
+export function calculateCostCoverageEstimate(
   monthlyCost: number,
   activeCreators: number,
   paidAdoptionPct: number,
-  targetGrossMarginPct: number
-): CostBasedPrice | null {
+  costBufferPct: number
+): CostCoverageEstimate | null {
   if (
     !Number.isFinite(monthlyCost) ||
     monthlyCost <= 0 ||
@@ -112,9 +112,9 @@ export function calculateCostBasedPrice(
     !Number.isFinite(paidAdoptionPct) ||
     paidAdoptionPct <= 0 ||
     paidAdoptionPct > 100 ||
-    !Number.isFinite(targetGrossMarginPct) ||
-    targetGrossMarginPct < 0 ||
-    targetGrossMarginPct >= 100
+    !Number.isFinite(costBufferPct) ||
+    costBufferPct < 0 ||
+    costBufferPct > 100
   ) {
     return null;
   }
@@ -125,8 +125,8 @@ export function calculateCostBasedPrice(
   return {
     expectedPaidCreators,
     breakEvenPerPaidCreator,
-    priceFloorPerPaidCreator:
-      breakEvenPerPaidCreator / (1 - targetGrossMarginPct / 100),
+    costCoveringPricePerPaidCreator:
+      breakEvenPerPaidCreator * (1 + costBufferPct / 100),
   };
 }
 

--- a/tests/components/dashboard/AppSidebar.test.tsx
+++ b/tests/components/dashboard/AppSidebar.test.tsx
@@ -53,7 +53,7 @@ describe("DashboardAppSidebar", () => {
     vi.unstubAllGlobals();
   });
 
-  it("shows plan decisions as a distinct metrics destination", () => {
+  it("shows plans and limits as a distinct insights destination", () => {
     currentPath = "/dashboard/metrics/planning";
     render(
       <SidebarProvider>
@@ -70,7 +70,7 @@ describe("DashboardAppSidebar", () => {
 
     const metricsLink = screen.getByRole("link", { name: "Metrics" });
     const planningLink = screen.getByRole("link", {
-      name: "Plan decisions",
+      name: "Plans & limits",
     });
 
     expect(metricsLink.getAttribute("href")).toBe("/dashboard/metrics");
@@ -79,5 +79,6 @@ describe("DashboardAppSidebar", () => {
       "/dashboard/metrics/planning"
     );
     expect(planningLink.getAttribute("aria-current")).toBe("page");
+    expect(screen.getByText("Insights")).toBeTruthy();
   });
 });

--- a/tests/components/dashboard/MetricsCharts.test.tsx
+++ b/tests/components/dashboard/MetricsCharts.test.tsx
@@ -256,10 +256,15 @@ describe("metrics decision views", () => {
       name: "Projects free-plan limit value",
     });
     expect(projectLimit.getAttribute("max")).toBe("20");
+    expect(projectLimit.className).toContain("h-11");
+    expect(
+      screen.getByRole("slider", { name: "Projects free-plan limit slider" })
+        .className
+    ).toContain("h-11");
     fireEvent.change(projectLimit, { target: { value: "999" } });
     expect((projectLimit as HTMLInputElement).value).toBe("5");
     expect(screen.getAllByText("21+")).toHaveLength(3);
-    expect(screen.getByText("Scenario impact")).toBeTruthy();
+    expect(screen.getByText("Free-plan impact")).toBeTruthy();
     expect(screen.getByText("Commercial signals")).toBeTruthy();
   });
 
@@ -281,6 +286,9 @@ describe("metrics decision views", () => {
       screen.getByText("100% of accounts with content · 1 near · 1 above")
     ).toBeTruthy();
     expect(screen.getAllByText("n/a").length).toBeGreaterThan(0);
+    expect(
+      screen.getByLabelText("Monthly infrastructure cost").className
+    ).toContain("h-11");
 
     await user.type(
       screen.getByLabelText("Monthly infrastructure cost"),
@@ -291,12 +299,14 @@ describe("metrics decision views", () => {
       "July invoice"
     );
 
-    expect(screen.getByText("Paid plan calculator")).toBeTruthy();
+    expect(screen.getByText("Cost coverage estimate")).toBeTruthy();
     expect(screen.getByText("€10.00 per active creator")).toBeTruthy();
     expect(
-      screen.getByText("0.5 expected paid creators · €200.00 break-even")
+      screen.getByText(
+        "0.5 expected paid creators · €200.00 base cost per paid account"
+      )
     ).toBeTruthy();
-    expect(screen.getByText("€666.67")).toBeTruthy();
+    expect(screen.getByText("€200.00")).toBeTruthy();
     const advanced = screen
       .getByText("Advanced assumptions")
       .closest("details");
@@ -483,19 +493,18 @@ describe("metrics decision views", () => {
       screen.queryByRole("button", { name: "Sharing + Embed reach" })
     ).toBeNull();
 
-    await user.click(
-      within(journey).getByRole("button", { name: /^Acquisition Building/ })
-    );
+    await user.click(screen.getByRole("tab", { name: "Acquisition" }));
+    expect(
+      screen.getByRole("tab", { name: "Acquisition" }).className
+    ).toContain("min-h-11");
     const acquisitionHeading = screen.getByRole("heading", {
       name: "Acquisition source mix",
     });
     expect(acquisitionHeading).toBeTruthy();
-    expect(acquisitionHeading.closest('[role="tabpanel"]')).toBeNull();
+    expect(acquisitionHeading.closest('[role="tabpanel"]')).toBeTruthy();
     expect(
-      screen
-        .getByRole("button", { name: "Acquisition sources" })
-        .getAttribute("aria-pressed")
-    ).toBe("true");
+      screen.queryByRole("navigation", { name: "Explore more views:" })
+    ).toBeNull();
     expect(screen.getByText("No data for this period.")).toBeTruthy();
 
     await user.click(screen.getByRole("tab", { name: "Sharing" }));

--- a/tests/components/dashboard/MetricsGrowthTooltip.test.tsx
+++ b/tests/components/dashboard/MetricsGrowthTooltip.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { GrowthByRange } from "@/lib/server/metrics";
+import { UserGrowthCard } from "@/components/dashboard/MetricsCharts";
+
+vi.mock("recharts", async () => {
+  const React = await import("react");
+  const Passthrough = ({ children }: { children?: React.ReactNode }) =>
+    React.createElement("div", null, children);
+  const Empty = () => null;
+
+  return {
+    ResponsiveContainer: Passthrough,
+    ComposedChart: Passthrough,
+    Area: Empty,
+    Bar: Empty,
+    CartesianGrid: Empty,
+    XAxis: Empty,
+    YAxis: Empty,
+    Legend: Empty,
+    Tooltip: ({ content }: { content?: React.ReactNode }) => {
+      if (!React.isValidElement(content)) {
+        return React.createElement(
+          "div",
+          { "data-testid": "growth-tooltip" },
+          "totalUsers: 12 newUsers: 2"
+        );
+      }
+
+      return React.createElement(
+        "div",
+        { "data-testid": "growth-tooltip" },
+        React.cloneElement(
+          content as React.ReactElement<Record<string, unknown>>,
+          {
+            active: true,
+            label: "Jul 2026",
+            payload: [
+              {
+                color: "#0284c7",
+                dataKey: "totalUsers",
+                name: "totalUsers",
+                payload: { label: "Jul 2026" },
+                value: 12,
+              },
+              {
+                color: "#10b981",
+                dataKey: "newUsers",
+                name: "newUsers",
+                payload: { label: "Jul 2026" },
+                value: 2,
+              },
+            ],
+          }
+        )
+      );
+    },
+  };
+});
+
+const growthData = {
+  bucket: "month" as const,
+  from: "2026-04-01",
+  to: "2026-07-09",
+  userGrowth: [{ period: "2026-07-01", label: "Jul 2026", users: 2 }],
+  userGrowthCumulative: [
+    { period: "2026-07-01", label: "Jul 2026", users: 12 },
+  ],
+};
+
+const growthByRange: GrowthByRange = {
+  "3m": growthData,
+  "6m": growthData,
+  "12m": growthData,
+  ytd: growthData,
+  previousYear: growthData,
+};
+
+describe("user growth tooltip", () => {
+  afterEach(cleanup);
+
+  it("uses translated labels instead of raw series keys", () => {
+    render(
+      <UserGrowthCard
+        growthByRange={growthByRange}
+        growthTimeline={{
+          dailyGrowth: [{ date: "2026-07-01", users: 2 }],
+          totalUsers: 12,
+          today: "2026-07-09",
+        }}
+      />
+    );
+
+    const tooltip = within(screen.getByTestId("growth-tooltip"));
+    expect(tooltip.getByText("Jul 2026")).toBeTruthy();
+    expect(tooltip.getByText("New this month")).toBeTruthy();
+    expect(tooltip.getByText("Total users")).toBeTruthy();
+    expect(tooltip.getByText("+2")).toBeTruthy();
+    expect(tooltip.getByText("12")).toBeTruthy();
+    expect(tooltip.queryByText(/newUsers/)).toBeNull();
+    expect(tooltip.queryByText(/totalUsers/)).toBeNull();
+  });
+});

--- a/tests/lib/metrics-planning.test.ts
+++ b/tests/lib/metrics-planning.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  calculateCostBasedPrice,
+  calculateCostCoverageEstimate,
   calculateCostPerActiveCreator,
   calculateCreatorRange,
   calculatePlanLimitImpact,
@@ -50,18 +50,18 @@ describe("planning metric helpers", () => {
     expect(calculateCostPerActiveCreator(42.8, 0)).toBeNull();
   });
 
-  it("derives a paid-plan price floor from explicit cost assumptions", () => {
-    expect(calculateCostBasedPrice(100, 200, 5, 75)).toEqual({
+  it("derives a cost-covering estimate from explicit assumptions", () => {
+    expect(calculateCostCoverageEstimate(100, 200, 5, 25)).toEqual({
       expectedPaidCreators: 10,
       breakEvenPerPaidCreator: 10,
-      priceFloorPerPaidCreator: 40,
+      costCoveringPricePerPaidCreator: 12.5,
     });
   });
 
   it("rejects incomplete or impossible pricing assumptions", () => {
-    expect(calculateCostBasedPrice(0, 200, 5, 75)).toBeNull();
-    expect(calculateCostBasedPrice(100, 200, 0, 75)).toBeNull();
-    expect(calculateCostBasedPrice(100, 200, 5, 100)).toBeNull();
+    expect(calculateCostCoverageEstimate(0, 200, 5, 25)).toBeNull();
+    expect(calculateCostCoverageEstimate(100, 200, 0, 25)).toBeNull();
+    expect(calculateCostCoverageEstimate(100, 200, 5, 101)).toBeNull();
   });
 
   it("normalizes behavioral bounds into a projected creator range", () => {


### PR DESCRIPTION
## Summary

- bring every metrics view into one icon-labelled tab navigation and move Metrics plus Plans & limits into a dedicated Insights sidebar group
- reframe the planning calculator around cost coverage and fair free-plan limits instead of a recommended commercial price
- improve mobile controls and replace raw growth-series keys with a compact, translated hover tooltip

## Why

The secondary “Explore more views” navigation made parts of the metrics workspace hard to discover, the previous pricing terminology overstated what the calculator could determine, and the growth tooltip exposed internal data keys with cramped spacing.

This keeps the dashboard easier to scan on desktop and mobile while making the planning assumptions more honest and useful for covering TrackDraw’s future running costs.

## Validation

- `npm run i18n:check`
- `npm run i18n:scan-hardcoded`
- `npm run lint`
- `npm run type`
- `npm run test` — 180 files, 961 tests
- `npx next build --webpack`

The default local Turbopack build hit its environment-level internal port restriction; the equivalent Next.js production build completed successfully through Webpack.