### PR TITLE
Add tooltips to metrics journey stages

### DIFF
--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -25,6 +25,7 @@ import {
 import {
   Tooltip,
   TooltipContent,
+  TooltipProvider,
   TooltipTrigger,
 } from "@/components/AppTooltip";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -623,48 +624,51 @@ export default function MetricsWorkspace({
                 key={id}
                 className="after:bg-border relative snap-start after:absolute after:top-2.5 after:left-8 after:h-px after:w-[calc(100%-2rem)] last:after:hidden"
               >
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={() => setActiveView(view)}
-                      className={cn(
-                        "focus-visible:ring-ring group relative z-10 flex min-h-24 w-full flex-col items-start gap-1 px-2 pb-3 text-left focus-visible:ring-2 focus-visible:outline-none",
-                        active
-                          ? "text-foreground"
-                          : "text-muted-foreground hover:text-foreground"
-                      )}
-                      aria-current={active ? "step" : undefined}
-                    >
-                      <span
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => setActiveView(view)}
                         className={cn(
-                          "bg-background mb-1 flex size-5 items-center justify-center rounded-full border text-[10px] font-semibold tabular-nums",
+                          "focus-visible:ring-ring group relative z-10 flex min-h-24 w-full flex-col items-start gap-1 px-2 pb-3 text-left focus-visible:ring-2 focus-visible:outline-none",
                           active
-                            ? "border-sky-500 text-sky-500"
-                            : "border-muted-foreground/60"
+                            ? "text-foreground"
+                            : "text-muted-foreground hover:text-foreground"
                         )}
-                        aria-hidden="true"
+                        aria-current={active ? "step" : undefined}
                       >
-                        {index + 1}
-                      </span>
-                      <span className="text-xs font-medium">
-                        {t(`journey.${key}.label`)}
-                      </span>
-                      <QualityLabel quality={snapshot.quality} />
-                      <span className="mt-0.5 text-base font-semibold tabular-nums">
-                        {snapshot.valueKind === "mix" || snapshot.value === null
-                          ? t(`journey.${key}.value`)
-                          : formatValue(snapshot, number, percent)}
-                      </span>
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-64 text-left">
-                    <p className="font-medium">{t(`metrics.${id}.name`)}</p>
-                    <p className="text-xs opacity-80">
-                      {t(`metrics.${id}.definition`)}
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
+                        <span
+                          className={cn(
+                            "bg-background mb-1 flex size-5 items-center justify-center rounded-full border text-[10px] font-semibold tabular-nums",
+                            active
+                              ? "border-sky-500 text-sky-500"
+                              : "border-muted-foreground/60"
+                          )}
+                          aria-hidden="true"
+                        >
+                          {index + 1}
+                        </span>
+                        <span className="text-xs font-medium">
+                          {t(`journey.${key}.label`)}
+                        </span>
+                        <QualityLabel quality={snapshot.quality} />
+                        <span className="mt-0.5 text-base font-semibold tabular-nums">
+                          {snapshot.valueKind === "mix" ||
+                          snapshot.value === null
+                            ? t(`journey.${key}.value`)
+                            : formatValue(snapshot, number, percent)}
+                        </span>
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-64 text-left">
+                      <p className="font-medium">{t(`metrics.${id}.name`)}</p>
+                      <p className="text-xs opacity-80">
+                        {t(`metrics.${id}.definition`)}
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               </li>
             );
           })}

--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -22,6 +22,11 @@ import {
   UserGrowthCard,
   UserGrowthRangePicker,
 } from "@/components/dashboard/MetricsCharts";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/AppTooltip";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type {
   MetricsExplorerData,
@@ -618,38 +623,48 @@ export default function MetricsWorkspace({
                 key={id}
                 className="after:bg-border relative snap-start after:absolute after:top-2.5 after:left-8 after:h-px after:w-[calc(100%-2rem)] last:after:hidden"
               >
-                <button
-                  type="button"
-                  onClick={() => setActiveView(view)}
-                  className={cn(
-                    "focus-visible:ring-ring group relative z-10 flex min-h-24 w-full flex-col items-start gap-1 px-2 pb-3 text-left focus-visible:ring-2 focus-visible:outline-none",
-                    active
-                      ? "text-foreground"
-                      : "text-muted-foreground hover:text-foreground"
-                  )}
-                  aria-current={active ? "step" : undefined}
-                >
-                  <span
-                    className={cn(
-                      "bg-background mb-1 flex size-5 items-center justify-center rounded-full border text-[10px] font-semibold tabular-nums",
-                      active
-                        ? "border-sky-500 text-sky-500"
-                        : "border-muted-foreground/60"
-                    )}
-                    aria-hidden="true"
-                  >
-                    {index + 1}
-                  </span>
-                  <span className="text-xs font-medium">
-                    {t(`journey.${key}.label`)}
-                  </span>
-                  <QualityLabel quality={snapshot.quality} />
-                  <span className="mt-0.5 text-base font-semibold tabular-nums">
-                    {snapshot.valueKind === "mix" || snapshot.value === null
-                      ? t(`journey.${key}.value`)
-                      : formatValue(snapshot, number, percent)}
-                  </span>
-                </button>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={() => setActiveView(view)}
+                      className={cn(
+                        "focus-visible:ring-ring group relative z-10 flex min-h-24 w-full flex-col items-start gap-1 px-2 pb-3 text-left focus-visible:ring-2 focus-visible:outline-none",
+                        active
+                          ? "text-foreground"
+                          : "text-muted-foreground hover:text-foreground"
+                      )}
+                      aria-current={active ? "step" : undefined}
+                    >
+                      <span
+                        className={cn(
+                          "bg-background mb-1 flex size-5 items-center justify-center rounded-full border text-[10px] font-semibold tabular-nums",
+                          active
+                            ? "border-sky-500 text-sky-500"
+                            : "border-muted-foreground/60"
+                        )}
+                        aria-hidden="true"
+                      >
+                        {index + 1}
+                      </span>
+                      <span className="text-xs font-medium">
+                        {t(`journey.${key}.label`)}
+                      </span>
+                      <QualityLabel quality={snapshot.quality} />
+                      <span className="mt-0.5 text-base font-semibold tabular-nums">
+                        {snapshot.valueKind === "mix" || snapshot.value === null
+                          ? t(`journey.${key}.value`)
+                          : formatValue(snapshot, number, percent)}
+                      </span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-64 text-left">
+                    <p className="font-medium">{t(`metrics.${id}.name`)}</p>
+                    <p className="text-xs opacity-80">
+                      {t(`metrics.${id}.definition`)}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
               </li>
             );
           })}


### PR DESCRIPTION
## Summary
- The journey nav on the metrics dashboard (Acquisition, Activation, Engagement, Sharing, Retention) showed a bare number with no explanation of what it counts.
- Wraps each journey step in a `Tooltip` showing the metric's name and full definition, sourced from the existing `dashboard.metrics.explorer.metrics.{id}.{name,definition}` translation strings (already present in `lang/en-US/dashboard.json` but unused in the UI until now).
- Uses the existing `AppTooltip` component (`@/components/AppTooltip`), no new dependencies.

## Test plan
- [x] `npm run type`
- [x] `npm run lint`
- [ ] Manually hover each of the 5 journey steps on `/dashboard/metrics` to confirm tooltip content and positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)