### PR TITLE
Fix untranslated render_3d/race_pack labels in export usage metrics

### DIFF
--- a/src/components/dashboard/MetricsCharts.tsx
+++ b/src/components/dashboard/MetricsCharts.tsx
@@ -1507,22 +1507,25 @@ export function ExportUsageBreakdown({
   compact?: boolean;
 }) {
   const t = useTranslations("dashboard.metrics.exportUsage");
-  const knownFormats = [
-    "png",
-    "svg",
-    "render3d",
-    "racePack",
-    "json",
-    "webm",
-    "velocidrone",
-  ] as const;
+  const formatTranslationKeys = {
+    png: "png",
+    svg: "svg",
+    render_3d: "render3d",
+    race_pack: "racePack",
+    json: "json",
+    webm: "webm",
+    velocidrone: "velocidrone",
+  } as const;
+  const knownFormats = Object.keys(
+    formatTranslationKeys
+  ) as (keyof typeof formatTranslationKeys)[];
   const counts = new Map(
     usage.exportFormats30d.map((row) => [row.format, row.count])
   );
   const rows = knownFormats
     .map((format) => ({
       key: format,
-      label: t(`formats.${format}`),
+      label: t(`formats.${formatTranslationKeys[format]}`),
       count: counts.get(format) ?? 0,
     }))
     .filter((row) => row.count > 0);


### PR DESCRIPTION
## Summary
- The export usage breakdown on the metrics dashboard matched export event formats against a camelCase list (`render3d`, `racePack`), while logged product events use snake_case keys (`render_3d`, `race_pack`).
- The mismatch made these two formats fall through to the untranslated "extras" path, showing the raw event key instead of a translated label.
- Added an explicit mapping from event format keys to the existing i18n `formats.*` subkeys so both formats resolve to their translated labels again.

## Test plan
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] Visually confirm the export usage breakdown on `/dashboard` shows translated labels for 3D render and race pack exports