### PR TITLE
fix: re-fit canvas viewport on mobile device rotation

### DIFF
--- a/src/components/canvas/useTrackCanvasViewport.ts
+++ b/src/components/canvas/useTrackCanvasViewport.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, type RefObject } from "react";
+import { useEffect, useRef, type RefObject } from "react";
 import type { Stage as KonvaStage } from "konva/lib/Stage";
 
 interface TrackCanvasViewportParams {
@@ -48,6 +48,8 @@ export function useTrackCanvasViewport({
     };
   }, [stageInstance, syncTransform]);
 
+  const isPortraitRef = useRef<boolean | null>(null);
+
   useEffect(() => {
     const element = containerRef.current;
     if (!element) return;
@@ -55,15 +57,24 @@ export function useTrackCanvasViewport({
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (!entry) return;
-      setViewportSize({
-        width: Math.max(1, Math.floor(entry.contentRect.width)),
-        height: Math.max(1, Math.floor(entry.contentRect.height)),
-      });
+      const width = Math.max(1, Math.floor(entry.contentRect.width));
+      const height = Math.max(1, Math.floor(entry.contentRect.height));
+
+      const isPortrait = height >= width;
+      if (
+        isPortraitRef.current !== null &&
+        isPortraitRef.current !== isPortrait
+      ) {
+        setManualView(false);
+      }
+      isPortraitRef.current = isPortrait;
+
+      setViewportSize({ width, height });
     });
 
     observer.observe(element);
     return () => observer.disconnect();
-  }, [containerRef, setViewportSize]);
+  }, [containerRef, setManualView, setViewportSize]);
 
   useEffect(() => {
     if (hasManualViewRef.current) return;

--- a/src/components/canvas/useTrackCanvasViewport.ts
+++ b/src/components/canvas/useTrackCanvasViewport.ts
@@ -61,7 +61,11 @@ export function useTrackCanvasViewport({
       const height = Math.max(1, Math.floor(entry.contentRect.height));
 
       const isPortrait = height >= width;
+      const isTouchDevice =
+        typeof window !== "undefined" &&
+        window.matchMedia("(pointer: coarse)").matches;
       if (
+        isTouchDevice &&
         isPortraitRef.current !== null &&
         isPortraitRef.current !== isPortrait
       ) {

--- a/tests/components/canvas/useTrackCanvasViewport.test.tsx
+++ b/tests/components/canvas/useTrackCanvasViewport.test.tsx
@@ -55,6 +55,30 @@ function asKonvaStage(stage: StageMock): KonvaStage {
   return stage as unknown as KonvaStage;
 }
 
+function stubPointerType(pointer: "coarse" | "fine") {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => ({
+      matches: query === "(pointer: coarse)" && pointer === "coarse",
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+  );
+}
+
+function resize(
+  observer: ResizeObserverMock,
+  size: { width: number; height: number }
+) {
+  act(() => {
+    observer.callback(
+      [{ contentRect: size } as ResizeObserverEntry],
+      observer as unknown as ResizeObserver
+    );
+  });
+}
+
 function Harness({
   contentDragActive = false,
   hasManualView = false,
@@ -151,6 +175,35 @@ describe("useTrackCanvasViewport", () => {
     });
 
     expect(setViewportSize).toHaveBeenCalledWith({ width: 249, height: 1 });
+  });
+
+  it("resets manual view on a touch device when the orientation flips", () => {
+    stubPointerType("coarse");
+    const setManualView = vi.fn();
+    render(<Harness setManualView={setManualView} />);
+    const observer = ResizeObserverMock.instances.at(-1)!;
+
+    resize(observer, { width: 400, height: 800 }); // portrait
+    expect(setManualView).not.toHaveBeenCalled();
+
+    resize(observer, { width: 800, height: 400 }); // flips to landscape
+    expect(setManualView).toHaveBeenCalledWith(false);
+
+    setManualView.mockClear();
+    resize(observer, { width: 820, height: 410 }); // still landscape
+    expect(setManualView).not.toHaveBeenCalled();
+  });
+
+  it("does not reset manual view on non-touch devices when dimensions flip", () => {
+    stubPointerType("fine");
+    const setManualView = vi.fn();
+    render(<Harness setManualView={setManualView} />);
+    const observer = ResizeObserverMock.instances.at(-1)!;
+
+    resize(observer, { width: 400, height: 800 });
+    resize(observer, { width: 800, height: 400 });
+
+    expect(setManualView).not.toHaveBeenCalled();
   });
 
   it("pans the stage with the middle mouse button when content is not being dragged", () => {


### PR DESCRIPTION
## Summary
- Panning or pinch-zooming permanently set `hasManualViewRef` to `true`, which blocked the canvas viewport re-fit effect on every later resize, including a device rotation.
- The stage element resized correctly on rotation, but the pan/zoom transform kept the scale/position computed for the previous (swapped) width/height, so the track ended up off-screen or mis-scaled in landscape, and worse with each subsequent rotation.
- `useTrackCanvasViewport`'s `ResizeObserver` now detects a portrait/landscape flip and resets manual view state, so the existing fit-to-viewport logic re-applies after rotating, without affecting normal desktop window resizes.

## Test plan
- [x] `npm run type`
- [x] `npm run lint`
- [ ] Manually verify on a mobile device/simulator: pan/zoom the track, rotate portrait → landscape → portrait, confirm the track stays visible and correctly scaled after each rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)