### PR TITLE
fix: keep touch interaction behavior stable across device rotation

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -162,14 +162,16 @@ Why:
 - Alignment snapping helps while dragging, but it does not replace deliberate multi-selection alignment and equal-spacing operations
 - Users need a low-risk way to try an alternative layout without overwriting a working design or manually exporting and reimporting a project
 
-First slices:
+Remaining slices:
 
 - Add a keyboard-first `Cmd/Ctrl+K` command palette that searches existing actions such as Project Manager, Export, Share, Feedback, 3D Preview, and settings
 - Keep palette results context-aware, explain disabled actions, and call the existing handlers rather than duplicating editor or dialog state
 - Add horizontal and vertical align actions plus equal horizontal and vertical distribution for compatible selected items
 - Preserve lock behavior, exclude route waypoints from the first arrange slice, and record each alignment or distribution operation as one undoable change
-- Let users duplicate a device or account project from Project Manager into a clearly named independent project for exploring a variant
-- Copy editable project content only; do not inherit published-share ownership, gallery state, or restore history
+
+Current shipped foundation:
+
+- Project duplication: users can duplicate a device or account project from Project Manager into a clearly named independent project for exploring a variant, copying editable project content only and not inheriting published-share ownership, gallery state, or restore history
 
 Important boundary:
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -35,8 +35,8 @@ The next TrackDraw priority is generated flightpath validation first, completion
         Add a keyboard-first `Cmd/Ctrl+K` palette for existing actions such as Project Manager, Export, Share, Feedback, 3D Preview, and settings. Make unavailable actions explain their state, keep the results context-aware, and use the palette to avoid continued header growth rather than hiding essential primary actions.
   - [ ] Multi-selection align and distribute
         Add explicit horizontal and vertical alignment plus equal-spacing actions for compatible selected items. Preserve lock behavior, treat each operation as one undoable change, keep route waypoints outside the first slice, and expose the actions without crowding the canvas or inspector.
-  - [ ] Duplicate project as an independent variant
-        Let users duplicate a device or account project from Project Manager so they can explore an alternative layout without overwriting the original. Copy the editable design into a clearly named independent project, but do not copy share ownership, publication state, or restore history.
+  - [x] Duplicate project as an independent variant
+        Added project duplication from Project Manager for both device and account projects, opening a clearly named independent copy of the editable design. Share ownership, publication state, and restore history are not copied.
 
 - [ ] Production observability and scheduled-maintenance hardening
       Establish a privacy-safe production baseline across route families and background work without adding duplicate release validation. Use deliberate Workers log/trace sampling, actionable thresholds, and a practical notification path for 5xx responses, exceptions, `exceededCpu`, D1/R2 failures, authentication email failures, and repeated scheduled-task failures.

--- a/src/components/canvas/editor/TrackCanvas.tsx
+++ b/src/components/canvas/editor/TrackCanvas.tsx
@@ -71,7 +71,7 @@ import {
 } from "@/lib/track/shape-groups";
 import { CanvasRuler, RULER_SIZE } from "@/components/canvas/CanvasRuler";
 import { useTheme } from "@/hooks/useTheme";
-import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsMobile, useIsTouchDevice } from "@/hooks/use-mobile";
 import { useTranslations } from "next-intl";
 import {
   getShapeDisplayLabel,
@@ -321,8 +321,9 @@ const TrackCanvas = memo(
       () => (showObstacleNumbers ? getObstacleNumberMap(design) : null),
       [design, showObstacleNumbers]
     );
-    const isMobile = useIsMobile();
-    const showRulers = !isMobile || mobileRulersEnabled;
+    const isNarrowViewport = useIsMobile();
+    const isMobile = useIsTouchDevice();
+    const showRulers = !isNarrowViewport || mobileRulersEnabled;
     const showDesktopCanvasChrome = viewportSize.width >= 1024;
     const selectionRef = useRef(selection);
     const selectionIdSet = useMemo(() => new Set(selection), [selection]);

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -20,3 +20,23 @@ export function useIsMobile() {
 
   return !!isMobile;
 }
+
+// Unlike useIsMobile, this stays stable across a device rotation: a phone's
+// width can cross the mobile breakpoint in landscape even though it's still
+// a touch device, which flips touch-only interaction behavior mid-session.
+export function useIsTouchDevice() {
+  const [isTouchDevice, setIsTouchDevice] = React.useState<boolean>(
+    typeof window !== "undefined"
+      ? window.matchMedia("(pointer: coarse)").matches
+      : false
+  );
+
+  React.useEffect(() => {
+    const mql = window.matchMedia("(pointer: coarse)");
+    const onChange = () => setIsTouchDevice(mql.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return isTouchDevice;
+}

--- a/tests/hooks/use-mobile.test.tsx
+++ b/tests/hooks/use-mobile.test.tsx
@@ -49,7 +49,9 @@ function stubMatchMedia(initialMatches: boolean) {
   return mql;
 }
 
-function stubMatchMediaByQuery(mqlsByQuery: Record<string, MediaQueryListMock>) {
+function stubMatchMediaByQuery(
+  mqlsByQuery: Record<string, MediaQueryListMock>
+) {
   vi.stubGlobal(
     "matchMedia",
     vi.fn((query: string) => mqlsByQuery[query])

--- a/tests/hooks/use-mobile.test.tsx
+++ b/tests/hooks/use-mobile.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useIsTouchDevice } from "@/hooks/use-mobile";
+
+type MediaQueryListMock = {
+  matches: boolean;
+  media: string;
+  addEventListener: (
+    type: "change",
+    listener: (event: { matches: boolean }) => void
+  ) => void;
+  removeEventListener: (
+    type: "change",
+    listener: (event: { matches: boolean }) => void
+  ) => void;
+  fireChange: (matches: boolean) => void;
+};
+
+function stubMatchMedia(initialMatches: boolean) {
+  let matches = initialMatches;
+  let listener: ((event: { matches: boolean }) => void) | null = null;
+
+  const mql: MediaQueryListMock = {
+    get matches() {
+      return matches;
+    },
+    media: "(pointer: coarse)",
+    addEventListener: (_type, cb) => {
+      listener = cb;
+    },
+    removeEventListener: () => {
+      listener = null;
+    },
+    fireChange: (nextMatches: boolean) => {
+      matches = nextMatches;
+      listener?.({ matches: nextMatches });
+    },
+  };
+
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn(() => mql)
+  );
+
+  return mql;
+}
+
+describe("useIsTouchDevice", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("reflects the initial pointer:coarse match", () => {
+    stubMatchMedia(true);
+    const { result } = renderHook(() => useIsTouchDevice());
+    expect(result.current).toBe(true);
+  });
+
+  it("stays true across a width change that would flip useIsMobile (e.g. rotation)", () => {
+    const mql = stubMatchMedia(true);
+    const { result } = renderHook(() => useIsTouchDevice());
+
+    act(() => {
+      mql.fireChange(true);
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("updates when the pointer capability actually changes", () => {
+    const mql = stubMatchMedia(false);
+    const { result } = renderHook(() => useIsTouchDevice());
+    expect(result.current).toBe(false);
+
+    act(() => {
+      mql.fireChange(true);
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/tests/hooks/use-mobile.test.tsx
+++ b/tests/hooks/use-mobile.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useIsTouchDevice } from "@/hooks/use-mobile";
+import { useIsMobile, useIsTouchDevice } from "@/hooks/use-mobile";
 
 type MediaQueryListMock = {
   matches: boolean;
@@ -18,15 +18,15 @@ type MediaQueryListMock = {
   fireChange: (matches: boolean) => void;
 };
 
-function stubMatchMedia(initialMatches: boolean) {
+function createMql(media: string, initialMatches: boolean): MediaQueryListMock {
   let matches = initialMatches;
   let listener: ((event: { matches: boolean }) => void) | null = null;
 
-  const mql: MediaQueryListMock = {
+  return {
     get matches() {
       return matches;
     },
-    media: "(pointer: coarse)",
+    media,
     addEventListener: (_type, cb) => {
       listener = cb;
     },
@@ -38,13 +38,22 @@ function stubMatchMedia(initialMatches: boolean) {
       listener?.({ matches: nextMatches });
     },
   };
+}
 
+function stubMatchMedia(initialMatches: boolean) {
+  const mql = createMql("(pointer: coarse)", initialMatches);
   vi.stubGlobal(
     "matchMedia",
     vi.fn(() => mql)
   );
-
   return mql;
+}
+
+function stubMatchMediaByQuery(mqlsByQuery: Record<string, MediaQueryListMock>) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => mqlsByQuery[query])
+  );
 }
 
 describe("useIsTouchDevice", () => {
@@ -59,15 +68,37 @@ describe("useIsTouchDevice", () => {
     expect(result.current).toBe(true);
   });
 
-  it("stays true across a width change that would flip useIsMobile (e.g. rotation)", () => {
-    const mql = stubMatchMedia(true);
-    const { result } = renderHook(() => useIsTouchDevice());
-
-    act(() => {
-      mql.fireChange(true);
+  it("stays true across a rotation that flips useIsMobile's width-based result", () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 400,
+    });
+    const widthMql = createMql("(max-width: 767px)", true);
+    const pointerMql = createMql("(pointer: coarse)", true);
+    stubMatchMediaByQuery({
+      "(max-width: 767px)": widthMql,
+      "(pointer: coarse)": pointerMql,
     });
 
-    expect(result.current).toBe(true);
+    const { result } = renderHook(() => ({
+      isMobile: useIsMobile(),
+      isTouchDevice: useIsTouchDevice(),
+    }));
+    expect(result.current.isMobile).toBe(true);
+    expect(result.current.isTouchDevice).toBe(true);
+
+    // Simulate rotating a phone into landscape: it's now wider than the
+    // breakpoint (useIsMobile flips), but it's still a touch device.
+    act(() => {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: 800,
+      });
+      widthMql.fireChange(false);
+    });
+
+    expect(result.current.isMobile).toBe(false);
+    expect(result.current.isTouchDevice).toBe(true);
   });
 
   it("updates when the pointer capability actually changes", () => {


### PR DESCRIPTION
## Summary
- Follow-up to #749: the viewport transform fix solved the canvas going off-screen after rotation, but touch interaction behavior (panning, tap-to-select, mobile hit targets) still changed between portrait and landscape.
- Root cause: `useIsMobile` derives `isMobile` purely from `window.innerWidth < 768`. Many phones exceed 768px in landscape (e.g. iPhone 14 Pro Max at 926px) while still being touch devices, so `isMobile` silently flipped to `false` on rotation.
- That flag gated real touch-gesture logic in `useTrackCanvasInteractions`/`interaction-helpers` and `TrackShapeNode` — single-finger panning, tap coordinate resolution, mobile-sized hit targets, auto-switching to the select tool after placing a shape, and waypoint snap radius all silently changed or stopped working in landscape.
- Added `useIsTouchDevice` (`matchMedia("(pointer: coarse)")`), which stays stable across rotation, and switched the editor's `TrackCanvas` to use it for `isMobile` in all touch-interaction logic. `showRulers` keeps the original width-based check since that's a layout concern, not a touch-capability one. `useIsMobile` itself is untouched, so its other (layout) callers — dialogs, sidebar, etc. — keep working exactly as before, including narrow-desktop-window testing.

## Test plan
- [x] `npm run type`
- [x] `npm run lint`
- [x] New unit tests for `useIsTouchDevice` (`tests/hooks/use-mobile.test.tsx`)
- [x] Full canvas/dialog test suite still passes
- [ ] Manually verify on a mobile device: pan with one finger, tap-select a shape, and place a shape in both portrait and landscape, confirming identical behavior after rotating

🤖 Generated with [Claude Code](https://claude.com/claude-code)