### PR TITLE
fix: keep 3D preview touch camera controls stable across device rotation

### DIFF
--- a/src/components/canvas/editor/TrackPreview3D.tsx
+++ b/src/components/canvas/editor/TrackPreview3D.tsx
@@ -15,7 +15,7 @@ import {
 } from "react";
 import * as THREE from "three";
 import { SCENE_3D_THEME } from "@/components/canvas/preview3d/theme";
-import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsTouchDevice } from "@/hooks/use-mobile";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { useTheme } from "@/hooks/useTheme";
 import type {
@@ -293,7 +293,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
     const editableSelectedPolyline =
       selectedPolyline && !selectedPolyline.locked ? selectedPolyline : null;
     const theme = useTheme();
-    const isMobile = useIsMobile();
+    const isMobile = useIsTouchDevice();
     const { enabled: devMode } = useDeveloperMode();
     const t = SCENE_3D_THEME[theme];
     const cx = field.width / 2;

--- a/src/components/canvas/viewer/TrackPreview3D.tsx
+++ b/src/components/canvas/viewer/TrackPreview3D.tsx
@@ -15,7 +15,7 @@ import {
   useState,
 } from "react";
 import * as THREE from "three";
-import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsTouchDevice } from "@/hooks/use-mobile";
 import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { useTheme } from "@/hooks/useTheme";
 import { SCENE_3D_THEME } from "@/components/canvas/preview3d/theme";
@@ -71,7 +71,7 @@ const TrackPreview3D = forwardRef<TrackPreview3DHandle, TrackPreview3DProps>(
     useCatalogTextureWarmup(shapes);
     const hasPath = useEditor(selectHasPath);
     const theme = useTheme();
-    const isMobile = useIsMobile();
+    const isMobile = useIsTouchDevice();
     const t = SCENE_3D_THEME[theme];
     const cx = field.width / 2;
     const cz = field.height / 2;

--- a/tests/components/canvas/TrackPreview3D.editor.test.tsx
+++ b/tests/components/canvas/TrackPreview3D.editor.test.tsx
@@ -68,7 +68,7 @@ vi.mock("@react-three/drei", () => ({
 }));
 
 vi.mock("@/hooks/use-mobile", () => ({
-  useIsMobile: () => previewTestState.isMobile,
+  useIsTouchDevice: () => previewTestState.isMobile,
 }));
 
 vi.mock("@/hooks/useTheme", () => ({

--- a/tests/components/canvas/TrackPreview3D.large.test.tsx
+++ b/tests/components/canvas/TrackPreview3D.large.test.tsx
@@ -81,7 +81,7 @@ vi.mock("@react-three/drei", () => ({
 }));
 
 vi.mock("@/hooks/use-mobile", () => ({
-  useIsMobile: () => previewTestState.isMobile,
+  useIsTouchDevice: () => previewTestState.isMobile,
 }));
 
 vi.mock("@/hooks/useTheme", () => ({


### PR DESCRIPTION
## Summary
- Follow-up to #755: the same width-based `useIsMobile()` bug recurred in the 3D preview, this time gating camera controls instead of 2D touch-gesture logic.
- Both `TrackPreview3D.tsx` components (editor and read-only viewer) branch their `<OrbitControls>` configuration, `WheelBridge` enablement, and 3D drag-handle tap-target sizing on `isMobile`. Since `useIsMobile()` derives that purely from `window.innerWidth < 768`, a touch device wider than 768px in landscape gets treated as "desktop."
- That desktop `<OrbitControls>` branch has `enableZoom={false}` and no `touches` mapping, so rotating a phone into landscape silently killed pinch-zoom and two-finger pan on the 3D camera — while portrait kept working.
- Switched both files to the rotation-stable `useIsTouchDevice()` hook (added in #755, based on `matchMedia("(pointer: coarse)")`). Updated the corresponding test mocks (`TrackPreview3D.editor.test.tsx`, `TrackPreview3D.large.test.tsx`) to mock `useIsTouchDevice` instead of `useIsMobile`.

## Test plan
- [x] `npm run type`
- [x] `npm run lint`
- [x] Full test suite (`npx vitest run`) — 983/983 passing
- [ ] Manually verify on a mobile device: pinch-zoom and two-finger pan the 3D preview in both portrait and landscape, confirming identical behavior after rotating

🤖 Generated with [Claude Code](https://claude.com/claude-code)