### PR TITLE
feat: Add multi-selection arrange actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog is intentionally concise. GitHub Releases and Release Drafter can
 
 ## [Unreleased]
 
+### Faster multi-selection layout
+
+Selected track items can now be aligned or evenly distributed horizontally and vertically from the inspector. Locked items remain fixed, Race Lines stay outside these operations, and each arrangement can be undone in one step.
+
 ### Duplicate a project
 
 Project Manager now has a Duplicate action for both device and account projects. Duplicating creates an independent, clearly named copy of the design, without carrying over the source project's share links, publication state, or restore history.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -166,12 +166,11 @@ Remaining slices:
 
 - Add a keyboard-first `Cmd/Ctrl+K` command palette that searches existing actions such as Project Manager, Export, Share, Feedback, 3D Preview, and settings
 - Keep palette results context-aware, explain disabled actions, and call the existing handlers rather than duplicating editor or dialog state
-- Add horizontal and vertical align actions plus equal horizontal and vertical distribution for compatible selected items
-- Preserve lock behavior, exclude route waypoints from the first arrange slice, and record each alignment or distribution operation as one undoable change
 
 Current shipped foundation:
 
 - Project duplication: users can duplicate a device or account project from Project Manager into a clearly named independent project for exploring a variant, copying editable project content only and not inheriting published-share ownership, gallery state, or restore history
+- Multi-selection arrange: compatible selected items can be aligned or evenly distributed horizontally and vertically from the inspector; locked items remain fixed, route waypoints stay outside the operation, and each action is one undoable change
 
 Important boundary:
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -33,7 +33,7 @@ The next TrackDraw priority is generated flightpath validation first, completion
       Reduce repeated navigation and precision work without adding more permanent header controls. Keep each improvement independently shippable and reuse existing editor and project actions rather than introducing parallel state or workflows.
   - [ ] Searchable command palette
         Add a keyboard-first `Cmd/Ctrl+K` palette for existing actions such as Project Manager, Export, Share, Feedback, 3D Preview, and settings. Make unavailable actions explain their state, keep the results context-aware, and use the palette to avoid continued header growth rather than hiding essential primary actions.
-  - [ ] Multi-selection align and distribute
+  - [x] Multi-selection align and distribute
         Add explicit horizontal and vertical alignment plus equal-spacing actions for compatible selected items. Preserve lock behavior, treat each operation as one undoable change, keep route waypoints outside the first slice, and expose the actions without crowding the canvas or inspector.
   - [x] Duplicate project as an independent variant
         Added project duplication from Project Manager for both device and account projects, opening a clearly named independent copy of the editable design. Share ownership, publication state, and restore history are not copied.

--- a/lang/en-US/inspector.json
+++ b/lang/en-US/inspector.json
@@ -134,7 +134,14 @@
     "groupCountMeta": "{count, plural, one {1 group} other {{count} groups}}",
     "joinAvailableMeta": "join available",
     "saveSectionLabel": "Save section",
-    "lockedItemsNote": "Locked items stay unchanged."
+    "lockedItemsNote": "Locked items stay unchanged.",
+    "arrange": {
+      "sectionTitle": "Arrange",
+      "alignHorizontal": "Align horizontal centers",
+      "alignVertical": "Align vertical centers",
+      "distributeHorizontal": "Space evenly horizontally",
+      "distributeVertical": "Space evenly vertically"
+    }
   },
   "polyline": {
     "sectionTitle": "Race Line",

--- a/src/components/inspector/Inspector.tsx
+++ b/src/components/inspector/Inspector.tsx
@@ -71,6 +71,7 @@ function Inspector({
     setMapReferenceOpacity,
     setMapReferenceRotation,
     addShape,
+    arrangeShapes,
     reorderShapes,
   } = useTrackActions();
   const { setSelection } = useSessionActions();
@@ -209,6 +210,7 @@ function Inspector({
         setSelection={selectAndOpenSelectionPanel}
         ungroupSelection={ungroupSelection}
         updateShapesCatalogType={updateShapesCatalogType}
+        arrangeShapes={arrangeShapes}
         onSaveAsPreset={
           canSavePresets ? () => setSaveAsPresetManuallyOpen(true) : undefined
         }

--- a/src/components/inspector/views/multi-selection.tsx
+++ b/src/components/inspector/views/multi-selection.tsx
@@ -17,7 +17,19 @@ import {
   selectionHasGroupedShapes,
 } from "@/lib/track/shape-groups";
 import type { Shape } from "@/lib/types";
-import { Bookmark, Copy, GitMerge, Group, Trash2, Ungroup } from "lucide-react";
+import {
+  AlignHorizontalDistributeCenter,
+  AlignHorizontalSpaceBetween,
+  AlignVerticalDistributeCenter,
+  AlignVerticalSpaceBetween,
+  Bookmark,
+  Copy,
+  GitMerge,
+  Group,
+  Trash2,
+  Ungroup,
+} from "lucide-react";
+import type { ArrangeShapesMode } from "@/lib/editor/shape-mutations";
 import {
   inspectorActionBtnClass,
   inspectorActionBtnDangerClass,
@@ -34,6 +46,11 @@ import {
   Section,
   useInspectorInputBatch,
 } from "@/components/inspector/shared";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/AppTooltip";
 import { InspectorLead, InspectorScrollBody } from "./layout";
 import { useTranslations } from "next-intl";
 
@@ -51,6 +68,7 @@ export interface MultiInspectorViewProps {
     ids: string[],
     entryId: TrackElementCatalogId
   ) => void;
+  arrangeShapes: (ids: string[], mode: ArrangeShapesMode) => void;
   onSaveAsPreset?: () => void;
   mobileInline?: boolean;
 }
@@ -102,6 +120,7 @@ export function MultiInspectorView({
   setSelection,
   ungroupSelection,
   updateShapesCatalogType,
+  arrangeShapes,
   onSaveAsPreset,
   mobileInline = false,
 }: MultiInspectorViewProps) {
@@ -143,6 +162,40 @@ export function MultiInspectorView({
   const placeableCount = selectedShapes.filter(
     (s) => s.kind !== "polyline"
   ).length;
+  const editablePlaceableCount = selectedShapes.filter(
+    (shape) => shape.kind !== "polyline" && !shape.locked
+  ).length;
+  const arrangeActions: Array<{
+    mode: ArrangeShapesMode;
+    label: string;
+    icon: typeof AlignHorizontalDistributeCenter;
+    minimum: number;
+  }> = [
+    {
+      mode: "align-horizontal",
+      label: t("multiSelection.arrange.alignHorizontal"),
+      icon: AlignHorizontalDistributeCenter,
+      minimum: 2,
+    },
+    {
+      mode: "align-vertical",
+      label: t("multiSelection.arrange.alignVertical"),
+      icon: AlignVerticalDistributeCenter,
+      minimum: 2,
+    },
+    {
+      mode: "distribute-horizontal",
+      label: t("multiSelection.arrange.distributeHorizontal"),
+      icon: AlignHorizontalSpaceBetween,
+      minimum: 3,
+    },
+    {
+      mode: "distribute-vertical",
+      label: t("multiSelection.arrange.distributeVertical"),
+      icon: AlignVerticalSpaceBetween,
+      minimum: 3,
+    },
+  ];
   const batchCatalogKind = getBatchCatalogKind(selectedShapes);
   const batchCatalogEntries = batchCatalogKind
     ? getCatalogEntriesByKind(batchCatalogKind)
@@ -280,6 +333,44 @@ export function MultiInspectorView({
                 ))}
             </div>
           </Section>
+          {placeableCount >= 2 ? (
+            <Section
+              title={t("multiSelection.arrange.sectionTitle")}
+              collapsible={false}
+            >
+              <div
+                role="group"
+                aria-label={t("multiSelection.arrange.sectionTitle")}
+                className="border-border/40 bg-muted/35 grid grid-cols-4 gap-1 rounded-lg border p-1"
+              >
+                {arrangeActions.map(({ mode, label, icon: Icon, minimum }) => (
+                  <Tooltip key={mode}>
+                    <TooltipTrigger asChild>
+                      <span className="min-w-0">
+                        <button
+                          type="button"
+                          onClick={() => arrangeShapes(selection, mode)}
+                          aria-label={label}
+                          disabled={editablePlaceableCount < minimum}
+                          className="text-muted-foreground hover:bg-background/90 hover:text-foreground focus-visible:ring-ring/40 flex h-8 w-full items-center justify-center rounded-md transition-[color,background-color,box-shadow] hover:shadow-xs focus-visible:ring-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-35 disabled:hover:bg-transparent disabled:hover:shadow-none lg:h-7"
+                        >
+                          <Icon className="size-4 shrink-0" />
+                        </button>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" sideOffset={6}>
+                      {label}
+                    </TooltipContent>
+                  </Tooltip>
+                ))}
+              </div>
+              {hasLockedSelection ? (
+                <p className="text-muted-foreground px-0.5 text-[10px] leading-relaxed">
+                  {t("multiSelection.lockedItemsNote")}
+                </p>
+              ) : null}
+            </Section>
+          ) : null}
           {batchCatalogEntries ? (
             <Section title={t("catalog.sectionTitle")} defaultOpen>
               <Row label={tCommon("labels.type")}>

--- a/src/lib/editor/shape-mutations.ts
+++ b/src/lib/editor/shape-mutations.ts
@@ -8,6 +8,12 @@ import type {
   TrackDesign,
 } from "@/lib/types";
 
+export type ArrangeShapesMode =
+  | "align-horizontal"
+  | "align-vertical"
+  | "distribute-horizontal"
+  | "distribute-vertical";
+
 function reversePolyline(path: PolylineShape): PolylineShape {
   return {
     ...path,
@@ -205,6 +211,51 @@ export function nudgeShapes(
       shape.x += dx;
       shape.y += dy;
     }
+    changed = true;
+  }
+
+  return changed;
+}
+
+export function arrangeShapes(
+  shapeById: TrackDesign["shapeById"],
+  ids: string[],
+  mode: ArrangeShapesMode
+) {
+  const shapes = ids
+    .map((id) => shapeById[id])
+    .filter((shape): shape is Exclude<Shape, PolylineShape> =>
+      Boolean(shape && shape.kind !== "polyline" && !shape.locked)
+    );
+  const isDistribution = mode.startsWith("distribute");
+  if (shapes.length < (isDistribution ? 3 : 2)) return false;
+
+  const axis = mode.endsWith("horizontal") ? "x" : "y";
+  const targetPositions = new Map<string, number>();
+
+  if (isDistribution) {
+    const ordered = shapes
+      .map((shape, index) => ({ shape, index }))
+      .sort((a, b) => a.shape[axis] - b.shape[axis] || a.index - b.index);
+    const first = ordered[0].shape[axis];
+    const last = ordered.at(-1)!.shape[axis];
+    const step = (last - first) / (ordered.length - 1);
+    ordered.forEach(({ shape }, index) => {
+      targetPositions.set(shape.id, first + step * index);
+    });
+  } else {
+    const target =
+      shapes.reduce((total, shape) => total + shape[axis], 0) / shapes.length;
+    shapes.forEach((shape) => targetPositions.set(shape.id, target));
+  }
+
+  let changed = false;
+  for (const shape of shapes) {
+    const target = targetPositions.get(shape.id);
+    if (target === undefined || Object.is(shape[axis], target)) {
+      continue;
+    }
+    shape[axis] = target;
     changed = true;
   }
 

--- a/src/lib/editor/store-types.ts
+++ b/src/lib/editor/store-types.ts
@@ -10,6 +10,7 @@ import type {
 import type { EditorTool } from "@/lib/editor/tool-registry";
 import type { DraftPoint, RectLike } from "@/lib/canvas/shared";
 import type { TrackElementCatalogId } from "@/lib/track/elements/catalog";
+import type { ArrangeShapesMode } from "@/lib/editor/shape-mutations";
 
 export interface EditorTrackState {
   design: TrackDesign;
@@ -91,6 +92,7 @@ export interface EditorTrackActions {
   joinPolylines: (ids: string[]) => string | null;
   closePolyline: (id: string) => boolean;
   nudgeShapes: (ids: string[], dx: number, dy: number) => void;
+  arrangeShapes: (ids: string[], mode: ArrangeShapesMode) => void;
   updateField: (patch: Partial<FieldSpec>) => void;
   updateDesignMeta: (
     patch: Partial<

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -26,6 +26,7 @@ export function useTrackActions() {
   const joinPolylines = useEditor((state) => state.joinPolylines);
   const closePolyline = useEditor((state) => state.closePolyline);
   const nudgeShapes = useEditor((state) => state.nudgeShapes);
+  const arrangeShapes = useEditor((state) => state.arrangeShapes);
   const updateField = useEditor((state) => state.updateField);
   const updateDesignMeta = useEditor((state) => state.updateDesignMeta);
   const setMapReference = useEditor((state) => state.setMapReference);
@@ -67,6 +68,7 @@ export function useTrackActions() {
     joinPolylines,
     closePolyline,
     nudgeShapes,
+    arrangeShapes,
     updateField,
     updateDesignMeta,
     setMapReference,

--- a/src/store/editor.ts
+++ b/src/store/editor.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/track/design";
 import {
   appendPolylinePoint,
+  arrangeShapes,
   applyShapePatch,
   closePolyline,
   duplicateShapes,
@@ -81,6 +82,7 @@ interface EditorState {
   joinPolylines: EditorTrackActions["joinPolylines"];
   closePolyline: EditorTrackActions["closePolyline"];
   nudgeShapes: EditorTrackActions["nudgeShapes"];
+  arrangeShapes: EditorTrackActions["arrangeShapes"];
   updateField: EditorTrackActions["updateField"];
   updateDesignMeta: EditorTrackActions["updateDesignMeta"];
   setMapReference: EditorTrackActions["setMapReference"];
@@ -402,6 +404,16 @@ export const useEditor = create<EditorState>()(
           if (!nudgeShapes(draft.track.design.shapeById, ids, dx, dy)) return;
           touchTrackDesign(draft);
         }),
+
+      arrangeShapes: (ids, mode) => {
+        let changed = false;
+        set((draft) => {
+          if (!arrangeShapes(draft.track.design.shapeById, ids, mode)) return;
+          touchTrackDesign(draft);
+          changed = true;
+        });
+        if (changed) trackMeaningfulEdit("transform");
+      },
 
       duplicateShapes: (ids) =>
         set((draft) => {

--- a/tests/components/inspector/Inspector.test.tsx
+++ b/tests/components/inspector/Inspector.test.tsx
@@ -9,8 +9,14 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import Inspector from "@/components/inspector/Inspector";
+import { TooltipProvider } from "@/components/AppTooltip";
 import { useEditor } from "@/store/editor";
-import { gateDraft, resetEditorStore } from "../../helpers/editor-store";
+import {
+  flagDraft,
+  gateDraft,
+  polylineDraft,
+  resetEditorStore,
+} from "../../helpers/editor-store";
 
 vi.mock("@/components/inspector/ElevationChart", () => ({
   default: () => <div data-testid="elevation-chart" />,
@@ -21,6 +27,13 @@ vi.mock("@/components/editor/SaveAsPresetDialog", () => ({
 }));
 
 describe("Inspector tab switching", () => {
+  const renderInspector = () =>
+    render(
+      <TooltipProvider delayDuration={0}>
+        <Inspector mobileInline />
+      </TooltipProvider>
+    );
+
   beforeEach(() => {
     resetEditorStore();
     vi.stubGlobal(
@@ -45,7 +58,7 @@ describe("Inspector tab switching", () => {
       useEditor.getState().setSelection([gateId]);
     });
 
-    render(<Inspector mobileInline />);
+    renderInspector();
 
     fireEvent.click(screen.getByRole("tab", { name: "Layout" }));
     expect(
@@ -68,7 +81,7 @@ describe("Inspector tab switching", () => {
     act(() => {
       useEditor.getState().setSelection([gateId]);
     });
-    render(<Inspector mobileInline />);
+    renderInspector();
 
     const layoutTab = screen.getByRole("tab", { name: "Layout" });
     const selectionTab = screen.getByRole("tab", { name: "Selection" });
@@ -80,5 +93,41 @@ describe("Inspector tab switching", () => {
     expect(document.activeElement).toBe(layoutTab);
     expect(layoutTab.tabIndex).toBe(0);
     expect(selectionTab.tabIndex).toBe(-1);
+  });
+
+  it("exposes arrange actions for compatible multi-selections", () => {
+    const firstId = useEditor.getState().addShape(gateDraft({ x: 1 }));
+    const secondId = useEditor.getState().addShape(flagDraft({ x: 5 }));
+    act(() => useEditor.getState().setSelection([firstId, secondId]));
+
+    renderInspector();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Align horizontal centers" })
+    );
+    expect(useEditor.getState().track.design.shapeById[firstId]?.x).toBe(3);
+    expect(useEditor.getState().track.design.shapeById[secondId]?.x).toBe(3);
+    expect(
+      screen.getByRole("button", { name: "Space evenly horizontally" })
+    ).toHaveProperty("disabled", true);
+  });
+
+  it("does not expose arrange actions for path-only selections", () => {
+    const firstId = useEditor.getState().addShape(polylineDraft());
+    const secondId = useEditor.getState().addShape(
+      polylineDraft({
+        points: [
+          { x: 2, y: 0 },
+          { x: 6, y: 0 },
+        ],
+      })
+    );
+    act(() => useEditor.getState().setSelection([firstId, secondId]));
+
+    renderInspector();
+
+    expect(
+      screen.queryByRole("button", { name: "Align horizontal centers" })
+    ).toBeNull();
   });
 });

--- a/tests/store/editor.test.ts
+++ b/tests/store/editor.test.ts
@@ -1301,6 +1301,85 @@ describe("editor store history", () => {
     expect(nextDesign.shapeById[secondId]).toMatchObject({ x: 9, y: 7 });
   });
 
+  it("aligns compatible shapes around their shared center as one undoable change", () => {
+    const state = useEditor.getState();
+    const firstId = state.addShape(gateDraft({ x: 1, y: 2 }));
+    const secondId = state.addShape(flagDraft({ x: 5, y: 8 }));
+
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:12:15.000Z");
+    state.arrangeShapes([firstId, secondId], "align-horizontal");
+
+    let design = useEditor.getState().track.design;
+    expect(design.shapeById[firstId]).toMatchObject({ x: 3, y: 2 });
+    expect(design.shapeById[secondId]).toMatchObject({ x: 3, y: 8 });
+    expectDesignUpdatedAt("2026-04-13T10:12:15.000Z");
+    expectPastStatesCount(1);
+
+    runHistoryStep(useEditor.temporal.getState().undo);
+    design = useEditor.getState().track.design;
+    expect(design.shapeById[firstId]).toMatchObject({ x: 1, y: 2 });
+    expect(design.shapeById[secondId]).toMatchObject({ x: 5, y: 8 });
+  });
+
+  it("distributes compatible shapes evenly while excluding paths and preserving locks", () => {
+    const state = useEditor.getState();
+    const firstId = state.addShape(gateDraft({ x: 0, y: 0, locked: true }));
+    const secondId = state.addShape(flagDraft({ x: 2, y: 3 }));
+    const thirdId = state.addShape(coneDraft({ x: 9, y: 6 }));
+    const fourthId = state.addShape(ladderDraft({ x: 12, y: 9 }));
+    const pathId = state.addShape(polylineDraft({ x: 40, y: 40 }));
+
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:12:16.000Z");
+    state.arrangeShapes(
+      [firstId, secondId, pathId, thirdId, fourthId],
+      "distribute-horizontal"
+    );
+
+    const design = useEditor.getState().track.design;
+    expect(design.shapeById[firstId]).toMatchObject({ x: 0, y: 0 });
+    expect(design.shapeById[secondId]).toMatchObject({ x: 2, y: 3 });
+    expect(design.shapeById[thirdId]).toMatchObject({ x: 7, y: 6 });
+    expect(design.shapeById[fourthId]).toMatchObject({ x: 12, y: 9 });
+    expect(design.shapeById[pathId]).toMatchObject({ x: 40, y: 40 });
+    expectPastStatesCount(1);
+  });
+
+  it("excludes locked items from alignment and skips arrange no-ops", () => {
+    const state = useEditor.getState();
+    const lockedId = state.addShape(gateDraft({ x: 2, y: 4, locked: true }));
+    const editableId = state.addShape(flagDraft({ x: 8, y: 9 }));
+    const otherEditableId = state.addShape(coneDraft({ x: 12, y: 5 }));
+    const pathId = state.addShape(polylineDraft());
+
+    state.clearHistory();
+    setEditorTestTime("2026-04-13T10:12:17.000Z");
+    state.arrangeShapes(
+      [editableId, lockedId, otherEditableId, pathId],
+      "align-vertical"
+    );
+
+    expect(useEditor.getState().track.design.shapeById[lockedId]).toMatchObject(
+      {
+        x: 2,
+        y: 4,
+      }
+    );
+    expect(
+      useEditor.getState().track.design.shapeById[editableId]
+    ).toMatchObject({ x: 8, y: 7 });
+    expect(
+      useEditor.getState().track.design.shapeById[otherEditableId]
+    ).toMatchObject({ x: 12, y: 7 });
+    expectPastStatesCount(1);
+
+    state.clearHistory();
+    const beforeUpdatedAt = useEditor.getState().track.design.updatedAt;
+    state.arrangeShapes([lockedId, pathId], "align-horizontal");
+    expectNoDesignHistoryChange(beforeUpdatedAt);
+  });
+
   it("reorderShapes moves a shape before another", () => {
     const state = useEditor.getState();
     const a = state.addShape(coneDraft());


### PR DESCRIPTION
## Summary

- add center-alignment and even-spacing actions to the multi-selection inspector
- keep locked items and Race Lines unchanged while recording each arrangement as one undoable edit
- present the actions as a compact icon control with accessible tooltips and update the roadmap and changelog

## Validation

- npm run lint
- npm run test (991 tests)
- npm run type
- npm run i18n:check
- npm run i18n:scan-hardcoded
- npm run build