### PR TITLE
feat: Add searchable command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog is intentionally concise. GitHub Releases and Release Drafter can
 
 ## [Unreleased]
 
+### Faster access to editor actions
+
+Press `Cmd/Ctrl+K` in Studio to search and run existing actions such as Project Manager, 3D Preview, Share, Export, Feedback, and account settings. Actions that are unavailable in the current track or view now explain what is needed.
+
 ### Faster multi-selection layout
 
 Selected track items can now be aligned or evenly distributed horizontally and vertically from the inspector. Locked items remain fixed, Race Lines stay outside these operations, and each arrangement can be undone in one step.

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -162,13 +162,9 @@ Why:
 - Alignment snapping helps while dragging, but it does not replace deliberate multi-selection alignment and equal-spacing operations
 - Users need a low-risk way to try an alternative layout without overwriting a working design or manually exporting and reimporting a project
 
-Remaining slices:
-
-- Add a keyboard-first `Cmd/Ctrl+K` command palette that searches existing actions such as Project Manager, Export, Share, Feedback, 3D Preview, and settings
-- Keep palette results context-aware, explain disabled actions, and call the existing handlers rather than duplicating editor or dialog state
-
 Current shipped foundation:
 
+- Searchable command palette: `Cmd/Ctrl+K` searches existing project, view, share, transfer, support, and account actions, explains contextually unavailable actions, and delegates to the existing editor handlers
 - Project duplication: users can duplicate a device or account project from Project Manager into a clearly named independent project for exploring a variant, copying editable project content only and not inheriting published-share ownership, gallery state, or restore history
 - Multi-selection arrange: compatible selected items can be aligned or evenly distributed horizontally and vertically from the inspector; locked items remain fixed, route waypoints stay outside the operation, and each action is one undoable change
 

--- a/docs/roadmap/github-roadmap.md
+++ b/docs/roadmap/github-roadmap.md
@@ -29,10 +29,10 @@ The next TrackDraw priority is generated flightpath validation first, completion
 - [ ] Generated flightpath validation follow-up (`Research`, `No account required`)
       Validate real layouts and tune warnings, route anchor heights, unclear sequence feedback, and lightweight density, spacing, and rhythm cues before treating generated routes as more than a first-pass drafting aid. Research document: `docs/research/generated-flightpath-assistance.md`.
 
-- [ ] Faster editor actions and safe project variants (`No account required`, `Account-backed`)
+- [x] Faster editor actions and safe project variants (`No account required`, `Account-backed`)
       Reduce repeated navigation and precision work without adding more permanent header controls. Keep each improvement independently shippable and reuse existing editor and project actions rather than introducing parallel state or workflows.
-  - [ ] Searchable command palette
-        Add a keyboard-first `Cmd/Ctrl+K` palette for existing actions such as Project Manager, Export, Share, Feedback, 3D Preview, and settings. Make unavailable actions explain their state, keep the results context-aware, and use the palette to avoid continued header growth rather than hiding essential primary actions.
+  - [x] Searchable command palette
+        Added a keyboard-first `Cmd/Ctrl+K` palette for existing project, view, share, transfer, support, and account actions. Search includes action keywords, unavailable actions explain their current context, and selecting an action delegates to the existing editor handler.
   - [x] Multi-selection align and distribute
         Add explicit horizontal and vertical alignment plus equal-spacing actions for compatible selected items. Preserve lock behavior, treat each operation as one undoable change, keep route waypoints outside the first slice, and expose the actions without crowding the canvas or inspector.
   - [x] Duplicate project as an independent variant

--- a/lang/en-US/dialogs.json
+++ b/lang/en-US/dialogs.json
@@ -862,17 +862,43 @@
   },
   "keyboardShortcuts": {
     "dialogTitle": "Keyboard Shortcuts",
-    "dialogSubtitle": "Available keyboard and canvas shortcuts in the studio.",
+    "dialogSubtitle": "Find the shortcut you need and fly faster.",
     "sectionTools": "Tools",
     "sectionSelection": "Selection",
     "sectionPathEditing": "Path Editing",
     "sectionCanvas": "Canvas",
+    "systemLayoutHint": "Shortcuts follow your system layout (Cmd on Mac, Ctrl on Windows and Linux).",
+    "categories": {
+      "label": "Shortcut categories",
+      "essentials": "Essentials",
+      "tools": "Tools",
+      "edit": "Edit",
+      "canvas": "Canvas"
+    },
+    "search": {
+      "label": "Search keyboard shortcuts",
+      "placeholder": "Search shortcuts…",
+      "results": "{count, plural, =0 {No results} =1 {1 result} other {# results}}",
+      "emptyTitle": "No shortcuts found",
+      "emptyBody": "Try an action, tool, or key combination."
+    },
+    "table": {
+      "description": "What it does",
+      "shortcut": "Shortcut"
+    },
+    "keys": {
+      "or": "or"
+    },
     "shortcuts": {
+      "undo": "Undo",
+      "redo": "Redo",
       "duplicateItems": "Duplicate selected items",
       "copyItems": "Copy selected items",
       "pasteItems": "Paste copied items",
       "rotateLeft": "Rotate selected items left",
       "rotateRight": "Rotate selected items right",
+      "rotateLeftSmall": "Rotate left precisely",
+      "rotateRightSmall": "Rotate right precisely",
       "mouseRotateSnap": "Mouse rotate snap",
       "mouseRotateFine": "Fine mouse rotate",
       "keyRotateFine": "Fine key rotate",
@@ -888,7 +914,39 @@
       "panView": "Pan view",
       "bypassSnap": "Temporarily bypass snap",
       "zoom": "Zoom",
+      "toggleSidebar": "Toggle sidebar",
+      "openCommandPalette": "Open command palette",
       "saveSnapshot": "Save snapshot"
+    },
+    "descriptions": {
+      "activateTool": "Activate the {tool} tool",
+      "undo": "Undo the last action",
+      "redo": "Redo the last undone action",
+      "duplicateItems": "Duplicate selected items",
+      "copyItems": "Copy selected items",
+      "pasteItems": "Paste copied items",
+      "rotateLeft": "Rotate the selection counter-clockwise",
+      "rotateRight": "Rotate the selection clockwise",
+      "rotateLeftSmall": "Rotate counter-clockwise in smaller steps",
+      "rotateRightSmall": "Rotate clockwise in smaller steps",
+      "mouseRotateSnap": "Rotate by dragging with snap enabled",
+      "mouseRotateFine": "Rotate freely while dragging",
+      "keyRotateFine": "Rotate in one degree steps",
+      "deleteItems": "Delete the selected items",
+      "nudgeItems": "Move the selection by one grid step",
+      "fineNudge": "Move the selection in small steps",
+      "finishPath": "Finish the path being drawn",
+      "removeLastPoint": "Remove the last point from the draft path",
+      "deletePathPoint": "Delete the selected path point",
+      "cancelDraft": "Cancel the current path draft",
+      "fitView": "Fit the whole field in view",
+      "clearSelection": "Clear selection and return to the Select tool",
+      "panView": "Pan the canvas with the mouse",
+      "bypassSnap": "Temporarily disable snapping",
+      "zoom": "Zoom the canvas in or out",
+      "toggleSidebar": "Show or hide the editor sidebar",
+      "openCommandPalette": "Search commands and actions",
+      "saveSnapshot": "Save a project snapshot"
     }
   },
   "versionConflict": {

--- a/lang/en-US/editor.json
+++ b/lang/en-US/editor.json
@@ -87,6 +87,68 @@
     "canvas2d": "2D canvas",
     "preview3d": "3D preview"
   },
+  "commandPalette": {
+    "title": "Command palette",
+    "description": "Search and run TrackDraw actions",
+    "placeholder": "Search actions…",
+    "searchLabel": "Search commands",
+    "resultsLabel": "Available commands",
+    "empty": "No matching actions",
+    "escapeKey": "Esc",
+    "hintNavigate": "↑↓ Navigate",
+    "hintRun": "Enter Run",
+    "groups": {
+      "navigate": "Navigate",
+      "view": "View",
+      "transfer": "Share and transfer",
+      "support": "Support"
+    },
+    "actions": {
+      "projects": {
+        "label": "Project Manager",
+        "description": "Open and manage saved projects"
+      },
+      "accountSettings": {
+        "label": "Account settings",
+        "description": "Manage profile, security and API keys"
+      },
+      "shortcuts": {
+        "label": "Keyboard shortcuts",
+        "description": "Review editor keys and shortcuts"
+      },
+      "view2d": {
+        "label": "Open 2D canvas",
+        "description": "Switch to the editable top-down view",
+        "alreadyActive": "Already viewing the 2D canvas"
+      },
+      "view3d": {
+        "label": "Open 3D preview",
+        "description": "Review the track in three dimensions",
+        "alreadyActive": "Already viewing the 3D preview"
+      },
+      "flyThrough": {
+        "label": "Start fly-through",
+        "description": "Preview the race line from the pilot view",
+        "noPathReason": "Draw a path first to enable fly-through"
+      },
+      "share": {
+        "label": "Share",
+        "description": "Publish a read-only link for this track"
+      },
+      "export": {
+        "label": "Export",
+        "description": "Download PNG, PDF, SVG or JSON"
+      },
+      "import": {
+        "label": "Import",
+        "description": "Bring in a JSON project file"
+      },
+      "feedback": {
+        "label": "Feedback",
+        "description": "Report a problem, share an idea or ask a question"
+      }
+    }
+  },
   "elementPlacementControl": {
     "official": "Official",
     "typeLabel": "{tool} type"

--- a/src/components/canvas/editor/useTrackCanvasShortcuts.ts
+++ b/src/components/canvas/editor/useTrackCanvasShortcuts.ts
@@ -4,7 +4,10 @@ import { type RefObject, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { useHistorySession } from "@/hooks/account/useHistorySession";
 import { isPolylineShape } from "@/lib/track/shape-utils";
-import type { EditorTool } from "@/lib/editor/tool-registry";
+import {
+  getToolForShortcut,
+  type EditorTool,
+} from "@/lib/editor/tool-registry";
 import type { Shape, ShapeDraft } from "@/lib/types";
 import {
   clipboard,
@@ -314,37 +317,9 @@ export function useTrackCanvasShortcuts({
         removeShapes(selectionRef.current);
       }
 
-      switch (key.toLowerCase()) {
-        case "v":
-          setActiveTool("select");
-          break;
-        case "h":
-          setActiveTool("grab");
-          break;
-        case "g":
-          setActiveTool("gate");
-          break;
-        case "f":
-          setActiveTool("flag");
-          break;
-        case "c":
-          if (!meta) setActiveTool("cone");
-          break;
-        case "l":
-          setActiveTool("label");
-          break;
-        case "p":
-          setActiveTool("polyline");
-          break;
-        case "s":
-          if (!meta) setActiveTool("startfinish");
-          break;
-        case "r":
-          setActiveTool("ladder");
-          break;
-        case "d":
-          if (!meta) setActiveTool("divegate");
-          break;
+      if (!meta) {
+        const shortcutTool = getToolForShortcut(key);
+        if (shortcutTool) setActiveTool(shortcutTool);
       }
     };
 

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -1,13 +1,22 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
-import { AnimatePresence, motion } from "framer-motion";
-import { ChevronDown } from "lucide-react";
-import { Kbd, KbdGroup } from "@/components/ui/kbd";
+import {
+  Folder,
+  Frame,
+  Pencil,
+  Search,
+  Sparkles,
+  Wrench,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import { Kbd } from "@/components/ui/kbd";
 import { MobileDrawer } from "@/components/MobileDrawer";
-import { DesktopModal } from "@/components/DesktopModal";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
 import {
   getToolLabel,
   toolShortcuts,
@@ -21,201 +30,508 @@ interface KeyboardShortcutsDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+type ShortcutCategoryId =
+  "essentials" | "tools" | "edit" | "canvas" | "project";
+type ShortcutChord = string[];
+
+interface ShortcutItem {
+  id: string;
+  category: Exclude<ShortcutCategoryId, "essentials">;
+  label: string;
+  description: string;
+  shortcuts: ShortcutChord[];
+  note?: string;
+}
+
+interface ShortcutCategory {
+  id: ShortcutCategoryId;
+  label: string;
+  icon: LucideIcon;
+  items: ShortcutItem[];
+}
+
 const toolShortcutOrder: EditorTool[] = [
   "select",
   "grab",
   ...getTrackItemToolConfigs().map((tool) => tool.id),
 ];
 
-function getToolShortcutItems(t: Translate) {
-  return toolShortcutOrder
-    .map((tool) => {
-      const shortcut = toolShortcuts[tool];
-      if (!shortcut) return null;
-      return { label: getToolLabel(tool, t), keys: [shortcut] };
-    })
-    .filter((item): item is { label: string; keys: string[] } => item !== null);
+function getToolShortcutItems(
+  t: Translate,
+  describe: (tool: string) => string
+): ShortcutItem[] {
+  return toolShortcutOrder.flatMap((tool): ShortcutItem[] => {
+    const shortcut = toolShortcuts[tool];
+    if (!shortcut) return [];
+    const label = getToolLabel(tool, t);
+    return [
+      {
+        id: `tool-${tool}`,
+        category: "tools",
+        label,
+        description: describe(label),
+        shortcuts: [[shortcut]],
+      },
+    ];
+  });
 }
 
-type ShortcutSectionId =
-  "tools" | "selection" | "pathEditing" | "canvas" | "project";
-
-function ShortcutSections() {
-  const t = useTranslations("dialogs");
-  const tCommon = useTranslations("common");
-  const tShapes = useTranslations("shapes") as unknown as Translate;
-  const [openSection, setOpenSection] = useState<ShortcutSectionId | null>(
-    "tools"
-  );
-
-  const shortcutSections: Array<{
-    id: ShortcutSectionId;
-    title: string;
-    items: Array<{ label: string; keys: string[] }>;
-  }> = [
-    {
-      id: "tools",
-      title: t("keyboardShortcuts.sectionTools"),
-      items: getToolShortcutItems(tShapes),
-    },
-    {
-      id: "selection",
-      title: t("keyboardShortcuts.sectionSelection"),
-      items: [
-        {
-          label: t("keyboardShortcuts.shortcuts.duplicateItems"),
-          keys: ["Ctrl/Cmd", "D"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.copyItems"),
-          keys: ["Ctrl/Cmd", "C"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.pasteItems"),
-          keys: ["Ctrl/Cmd", "V"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.rotateLeft"),
-          keys: ["Q / [", "15°"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.rotateRight"),
-          keys: ["E / ]", "15°"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.mouseRotateSnap"),
-          keys: ["Drag", "5°"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.mouseRotateFine"),
-          keys: ["Alt", "1°"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.keyRotateFine"),
-          keys: ["Alt", "1°"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.deleteItems"),
-          keys: ["Backspace/Delete"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.nudgeItems"),
-          keys: ["Arrow Keys"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.fineNudge"),
-          keys: ["Alt", "Arrow Keys"],
-        },
-      ],
-    },
-    {
-      id: "pathEditing",
-      title: t("keyboardShortcuts.sectionPathEditing"),
-      items: [
-        { label: t("keyboardShortcuts.shortcuts.finishPath"), keys: ["Enter"] },
-        {
-          label: t("keyboardShortcuts.shortcuts.removeLastPoint"),
-          keys: ["Backspace/Delete"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.deletePathPoint"),
-          keys: ["Backspace/Delete"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.cancelDraft"),
-          keys: ["Escape"],
-        },
-      ],
-    },
-    {
-      id: "canvas",
-      title: t("keyboardShortcuts.sectionCanvas"),
-      items: [
-        { label: t("keyboardShortcuts.shortcuts.fitView"), keys: ["0"] },
-        {
-          label: t("keyboardShortcuts.shortcuts.clearSelection"),
-          keys: ["Escape"],
-        },
-        {
-          label: t("keyboardShortcuts.shortcuts.panView"),
-          keys: ["Middle Click"],
-        },
-        { label: t("keyboardShortcuts.shortcuts.bypassSnap"), keys: ["Alt"] },
-        { label: t("keyboardShortcuts.shortcuts.zoom"), keys: ["Mouse Wheel"] },
-      ],
-    },
-    {
-      id: "project",
-      title: tCommon("labels.project"),
-      items: [
-        {
-          label: t("keyboardShortcuts.shortcuts.saveSnapshot"),
-          keys: ["Ctrl/Cmd", "S"],
-        },
-      ],
-    },
-  ];
+function ShortcutKeys({
+  item,
+  alternativeLabel,
+}: {
+  item: ShortcutItem;
+  alternativeLabel: string;
+}) {
+  const shortcutLabel = item.shortcuts
+    .map((chord) => chord.join(" plus "))
+    .join(" or ");
 
   return (
-    <div className="space-y-1.5">
-      {shortcutSections.map((section) => (
-        <div
-          key={section.id}
-          className="group border-border/70 bg-muted/15 overflow-hidden rounded-lg border"
-        >
-          <h3 className="m-0">
-            <button
-              type="button"
-              onClick={() =>
-                setOpenSection((current) =>
-                  current === section.id ? null : section.id
-                )
-              }
-              className="bg-muted/40 hover:bg-muted/60 flex w-full items-center justify-between gap-3 px-3 py-2 text-left transition-colors"
-              aria-expanded={openSection === section.id}
-            >
-              <span className="text-muted-foreground/80 text-[11px] font-semibold tracking-[0.16em] uppercase">
-                {section.title}
+    <div
+      className="flex shrink-0 flex-wrap items-center justify-end gap-1"
+      aria-label={shortcutLabel}
+    >
+      {item.shortcuts.map((chord, chordIndex) => (
+        <div key={`${item.id}-${chord.join("-")}`} className="contents">
+          {chordIndex > 0 ? (
+            <span className="text-muted-foreground/65 px-0.5 text-[11px]">
+              {alternativeLabel}
+            </span>
+          ) : null}
+          <span className="inline-flex items-center gap-1">
+            {chord.map((key, keyIndex) => (
+              <span
+                key={`${item.id}-${chordIndex}-${key}`}
+                className="inline-flex items-center gap-1"
+              >
+                {keyIndex > 0 ? (
+                  <span className="text-muted-foreground/55 text-[11px]">
+                    +
+                  </span>
+                ) : null}
+                <Kbd className="border-border/70 bg-muted/65 text-foreground/80 h-6 min-w-6 border px-1.5 text-[11px] shadow-[0_1px_0_rgba(0,0,0,0.06)]">
+                  {key}
+                </Kbd>
               </span>
-              <motion.div
-                animate={{ rotate: openSection === section.id ? 180 : 0 }}
-                transition={{ duration: 0.18, ease: "easeOut" }}
-              >
-                <ChevronDown className="text-muted-foreground size-3.5" />
-              </motion.div>
-            </button>
-          </h3>
-          <AnimatePresence initial={false}>
-            {openSection === section.id && (
-              <motion.div
-                initial={{ height: 0, opacity: 0 }}
-                animate={{ height: "auto", opacity: 1 }}
-                exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: 0.18, ease: "easeOut" }}
-                className="overflow-hidden"
-              >
-                <div className="divide-border/60 divide-y">
-                  {section.items.map((item) => (
-                    <div
-                      key={`${section.id}-${item.label}-${item.keys.join("-")}`}
-                      className="flex min-h-9 items-center justify-between gap-3 px-3 py-1.5"
-                    >
-                      <span className="text-foreground/80 pr-3 text-[13px] leading-5">
-                        {item.label}
-                      </span>
-                      <KbdGroup className="shrink-0 flex-wrap justify-end">
-                        {item.keys.map((key) => (
-                          <Kbd key={`${item.label}-${key}`}>{key}</Kbd>
-                        ))}
-                      </KbdGroup>
-                    </div>
-                  ))}
-                </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
+            ))}
+          </span>
         </div>
       ))}
+      {item.note ? (
+        <span className="text-muted-foreground/70 ml-1 text-[11px]">
+          {item.note}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function KeyboardShortcutBrowser({ mobile = false }: { mobile?: boolean }) {
+  const t = useTranslations("dialogs.keyboardShortcuts");
+  const tCommon = useTranslations("common");
+  const tShapes = useTranslations("shapes") as unknown as Translate;
+  const [query, setQuery] = useState("");
+  const [activeCategory, setActiveCategory] =
+    useState<ShortcutCategoryId>("essentials");
+
+  const categories = useMemo(() => {
+    const tools = getToolShortcutItems(tShapes, (tool) =>
+      t("descriptions.activateTool", { tool })
+    );
+    const edit: ShortcutItem[] = [
+      {
+        id: "undo",
+        category: "edit",
+        label: t("shortcuts.undo"),
+        description: t("descriptions.undo"),
+        shortcuts: [["Ctrl/Cmd", "Z"]],
+      },
+      {
+        id: "redo",
+        category: "edit",
+        label: t("shortcuts.redo"),
+        description: t("descriptions.redo"),
+        shortcuts: [
+          ["Ctrl/Cmd", "Shift", "Z"],
+          ["Ctrl", "Y"],
+        ],
+      },
+      {
+        id: "duplicate",
+        category: "edit",
+        label: t("shortcuts.duplicateItems"),
+        description: t("descriptions.duplicateItems"),
+        shortcuts: [["Ctrl/Cmd", "D"]],
+      },
+      {
+        id: "copy",
+        category: "edit",
+        label: t("shortcuts.copyItems"),
+        description: t("descriptions.copyItems"),
+        shortcuts: [["Ctrl/Cmd", "C"]],
+      },
+      {
+        id: "paste",
+        category: "edit",
+        label: t("shortcuts.pasteItems"),
+        description: t("descriptions.pasteItems"),
+        shortcuts: [["Ctrl/Cmd", "V"]],
+      },
+      {
+        id: "rotate-left",
+        category: "edit",
+        label: t("shortcuts.rotateLeft"),
+        description: t("descriptions.rotateLeft"),
+        shortcuts: [["Q"], ["["]],
+        note: "15°",
+      },
+      {
+        id: "rotate-right",
+        category: "edit",
+        label: t("shortcuts.rotateRight"),
+        description: t("descriptions.rotateRight"),
+        shortcuts: [["E"], ["]"]],
+        note: "15°",
+      },
+      {
+        id: "rotate-left-small",
+        category: "edit",
+        label: t("shortcuts.rotateLeftSmall"),
+        description: t("descriptions.rotateLeftSmall"),
+        shortcuts: [
+          ["Shift", "Q"],
+          ["Shift", "["],
+        ],
+        note: "5°",
+      },
+      {
+        id: "rotate-right-small",
+        category: "edit",
+        label: t("shortcuts.rotateRightSmall"),
+        description: t("descriptions.rotateRightSmall"),
+        shortcuts: [
+          ["Shift", "E"],
+          ["Shift", "]"],
+        ],
+        note: "5°",
+      },
+      {
+        id: "key-rotate-fine",
+        category: "edit",
+        label: t("shortcuts.keyRotateFine"),
+        description: t("descriptions.keyRotateFine"),
+        shortcuts: [["Alt", "Q / E / [ / ]"]],
+        note: "1°",
+      },
+      {
+        id: "mouse-rotate-snap",
+        category: "edit",
+        label: t("shortcuts.mouseRotateSnap"),
+        description: t("descriptions.mouseRotateSnap"),
+        shortcuts: [["Drag"]],
+        note: "5°",
+      },
+      {
+        id: "mouse-rotate-fine",
+        category: "edit",
+        label: t("shortcuts.mouseRotateFine"),
+        description: t("descriptions.mouseRotateFine"),
+        shortcuts: [["Alt", "Drag"]],
+        note: "1°",
+      },
+      {
+        id: "delete",
+        category: "edit",
+        label: t("shortcuts.deleteItems"),
+        description: t("descriptions.deleteItems"),
+        shortcuts: [["Backspace"], ["Delete"]],
+      },
+      {
+        id: "nudge",
+        category: "edit",
+        label: t("shortcuts.nudgeItems"),
+        description: t("descriptions.nudgeItems"),
+        shortcuts: [["Arrow keys"]],
+      },
+      {
+        id: "fine-nudge",
+        category: "edit",
+        label: t("shortcuts.fineNudge"),
+        description: t("descriptions.fineNudge"),
+        shortcuts: [["Alt", "Arrow keys"]],
+      },
+      {
+        id: "finish-path",
+        category: "edit",
+        label: t("shortcuts.finishPath"),
+        description: t("descriptions.finishPath"),
+        shortcuts: [["Enter"]],
+      },
+      {
+        id: "remove-last-point",
+        category: "edit",
+        label: t("shortcuts.removeLastPoint"),
+        description: t("descriptions.removeLastPoint"),
+        shortcuts: [["Backspace"], ["Delete"]],
+      },
+      {
+        id: "delete-path-point",
+        category: "edit",
+        label: t("shortcuts.deletePathPoint"),
+        description: t("descriptions.deletePathPoint"),
+        shortcuts: [["Backspace"], ["Delete"]],
+      },
+      {
+        id: "cancel-draft",
+        category: "edit",
+        label: t("shortcuts.cancelDraft"),
+        description: t("descriptions.cancelDraft"),
+        shortcuts: [["Escape"]],
+      },
+    ];
+    const canvas: ShortcutItem[] = [
+      {
+        id: "fit-view",
+        category: "canvas",
+        label: t("shortcuts.fitView"),
+        description: t("descriptions.fitView"),
+        shortcuts: [["0"]],
+      },
+      {
+        id: "clear-selection",
+        category: "canvas",
+        label: t("shortcuts.clearSelection"),
+        description: t("descriptions.clearSelection"),
+        shortcuts: [["Escape"]],
+      },
+      {
+        id: "pan-view",
+        category: "canvas",
+        label: t("shortcuts.panView"),
+        description: t("descriptions.panView"),
+        shortcuts: [["Middle click"]],
+      },
+      {
+        id: "bypass-snap",
+        category: "canvas",
+        label: t("shortcuts.bypassSnap"),
+        description: t("descriptions.bypassSnap"),
+        shortcuts: [["Alt"]],
+      },
+      {
+        id: "zoom",
+        category: "canvas",
+        label: t("shortcuts.zoom"),
+        description: t("descriptions.zoom"),
+        shortcuts: [["Mouse wheel"]],
+      },
+      {
+        id: "toggle-sidebar",
+        category: "canvas",
+        label: t("shortcuts.toggleSidebar"),
+        description: t("descriptions.toggleSidebar"),
+        shortcuts: [["Ctrl/Cmd", "B"]],
+      },
+    ];
+    const project: ShortcutItem[] = [
+      {
+        id: "command-palette",
+        category: "project",
+        label: t("shortcuts.openCommandPalette"),
+        description: t("descriptions.openCommandPalette"),
+        shortcuts: [["Ctrl/Cmd", "K"]],
+      },
+      {
+        id: "save-snapshot",
+        category: "project",
+        label: t("shortcuts.saveSnapshot"),
+        description: t("descriptions.saveSnapshot"),
+        shortcuts: [["Ctrl/Cmd", "S"]],
+      },
+    ];
+    const byId = new Map(
+      [...tools, ...edit, ...canvas, ...project].map((item) => [item.id, item])
+    );
+    const essentials = [
+      "tool-select",
+      "tool-grab",
+      "fit-view",
+      "command-palette",
+      "undo",
+      "redo",
+      "delete",
+      "duplicate",
+      "copy",
+      "paste",
+      "clear-selection",
+    ]
+      .map((id) => byId.get(id))
+      .filter((item): item is ShortcutItem => Boolean(item));
+    const categoryList: ShortcutCategory[] = [
+      {
+        id: "essentials",
+        label: t("categories.essentials"),
+        icon: Sparkles,
+        items: essentials,
+      },
+      {
+        id: "tools",
+        label: t("categories.tools"),
+        icon: Wrench,
+        items: tools,
+      },
+      {
+        id: "edit",
+        label: t("categories.edit"),
+        icon: Pencil,
+        items: edit,
+      },
+      {
+        id: "canvas",
+        label: t("categories.canvas"),
+        icon: Frame,
+        items: canvas,
+      },
+      {
+        id: "project",
+        label: tCommon("labels.project"),
+        icon: Folder,
+        items: project,
+      },
+    ];
+    return categoryList;
+  }, [t, tCommon, tShapes]);
+
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const activeItems = normalizedQuery
+    ? Array.from(
+        new Map(
+          categories
+            .flatMap((category) => category.items)
+            .map((item) => [item.id, item])
+        ).values()
+      ).filter((item) =>
+        [item.label, item.description, item.shortcuts.flat().join(" ")]
+          .join(" ")
+          .toLocaleLowerCase()
+          .includes(normalizedQuery)
+      )
+    : (categories.find((category) => category.id === activeCategory)?.items ??
+      []);
+  const activeCategoryLabel = normalizedQuery
+    ? t("search.results", { count: activeItems.length })
+    : categories.find((category) => category.id === activeCategory)?.label;
+
+  return (
+    <div className={cn("flex min-h-0 flex-col", mobile ? "gap-3" : "gap-4")}>
+      <label className="relative block">
+        <span className="sr-only">{t("search.label")}</span>
+        <Search
+          className="text-muted-foreground pointer-events-none absolute top-1/2 left-3.5 size-4 -translate-y-1/2"
+          aria-hidden="true"
+        />
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder={t("search.placeholder")}
+          className="border-border bg-background/75 text-foreground placeholder:text-muted-foreground focus:border-primary/65 focus:ring-primary/15 h-11 w-full rounded-xl border pr-10 pl-10 text-sm transition outline-none focus:ring-4"
+          autoFocus={!mobile}
+        />
+      </label>
+
+      <div
+        className={cn(
+          "border-border/70 min-h-0 overflow-hidden rounded-xl border",
+          mobile ? "flex flex-col" : "grid grid-cols-[13rem_minmax(0,1fr)]"
+        )}
+      >
+        <nav
+          aria-label={t("categories.label")}
+          className={cn(
+            "bg-muted/15",
+            mobile
+              ? "border-border/60 [scrollbar-width:none] overflow-x-auto border-b [-webkit-overflow-scrolling:touch] [&::-webkit-scrollbar]:hidden"
+              : "border-border/60 border-r p-1.5"
+          )}
+        >
+          <div className={cn(mobile ? "flex min-w-max p-1.5" : "space-y-0.5")}>
+            {categories.map((category) => {
+              const Icon = category.icon;
+              const active = !normalizedQuery && activeCategory === category.id;
+              return (
+                <button
+                  key={category.id}
+                  type="button"
+                  onClick={() => {
+                    setQuery("");
+                    setActiveCategory(category.id);
+                  }}
+                  aria-current={active ? "page" : undefined}
+                  className={cn(
+                    "focus-visible:ring-primary/30 flex items-center gap-2 rounded-lg text-left text-sm transition focus-visible:ring-2 focus-visible:outline-none",
+                    mobile ? "px-3 py-2" : "w-full px-3 py-2.5",
+                    active
+                      ? "bg-primary/10 text-primary"
+                      : "text-muted-foreground hover:bg-muted/55 hover:text-foreground"
+                  )}
+                >
+                  <Icon className="size-4 shrink-0" aria-hidden="true" />
+                  <span className="font-medium">{category.label}</span>
+                  <span className="text-muted-foreground/70 ml-auto text-xs tabular-nums">
+                    {category.items.length}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </nav>
+
+        <section className="bg-background/35 min-h-0" aria-live="polite">
+          <div className="border-border/60 text-muted-foreground/75 grid grid-cols-[minmax(0,1fr)_auto] gap-3 border-b px-4 py-2 text-[10px] font-semibold tracking-[0.14em] uppercase sm:grid-cols-[13.5rem_minmax(10rem,1fr)_16rem]">
+            <span>{activeCategoryLabel}</span>
+            <span className="hidden sm:block">{t("table.description")}</span>
+            <span className="text-right">{t("table.shortcut")}</span>
+          </div>
+          <div
+            className={cn(
+              "divide-border/55 divide-y overflow-y-auto",
+              mobile ? "max-h-[44dvh]" : "max-h-[min(25rem,calc(90vh-19rem))]"
+            )}
+          >
+            {activeItems.length ? (
+              activeItems.map((item) => (
+                <div
+                  key={item.id}
+                  className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-4 py-2.5 sm:grid-cols-[13.5rem_minmax(10rem,1fr)_16rem]"
+                >
+                  <span className="text-foreground/90 text-[13px] leading-5 font-medium">
+                    {item.label}
+                  </span>
+                  <span className="text-muted-foreground hidden text-xs leading-5 sm:block">
+                    {item.description}
+                  </span>
+                  <ShortcutKeys item={item} alternativeLabel={t("keys.or")} />
+                </div>
+              ))
+            ) : (
+              <div className="px-4 py-10 text-center">
+                <p className="text-foreground/85 text-sm font-medium">
+                  {t("search.emptyTitle")}
+                </p>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  {t("search.emptyBody")}
+                </p>
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <p className="text-muted-foreground/75 text-[11px] leading-relaxed">
+        {t("systemLayoutHint")}
+      </p>
     </div>
   );
 }
@@ -224,7 +540,8 @@ export default function KeyboardShortcutsDialog({
   open,
   onOpenChange,
 }: KeyboardShortcutsDialogProps) {
-  const t = useTranslations("dialogs");
+  const t = useTranslations("dialogs.keyboardShortcuts");
+  const tCommon = useTranslations("common");
   const isMobile = useIsMobile();
 
   if (isMobile) {
@@ -232,23 +549,43 @@ export default function KeyboardShortcutsDialog({
       <MobileDrawer
         open={open}
         onOpenChange={onOpenChange}
-        title={t("keyboardShortcuts.dialogTitle")}
-        subtitle={t("keyboardShortcuts.dialogSubtitle")}
+        title={t("dialogTitle")}
+        subtitle={t("dialogSubtitle")}
+        contentClassName="max-h-[92dvh]"
+        bodyClassName="px-3 pt-3"
       >
-        <ShortcutSections />
+        <KeyboardShortcutBrowser mobile />
       </MobileDrawer>
     );
   }
 
   return (
-    <DesktopModal
-      open={open}
-      onOpenChange={onOpenChange}
-      title={t("keyboardShortcuts.dialogTitle")}
-      subtitle={t("keyboardShortcuts.dialogSubtitle")}
-      maxWidth="max-w-2xl"
-    >
-      <ShortcutSections />
-    </DesktopModal>
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-slate-950/20 backdrop-blur-sm" />
+        <Dialog.Content className="border-border/60 bg-card fixed top-1/2 left-1/2 z-50 flex max-h-[min(90vh,52rem)] w-[min(64rem,calc(100vw-2.5rem))] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-3xl border p-7 shadow-[0_28px_90px_rgba(15,23,42,0.18)] focus:outline-none">
+          <div className="mb-4 flex shrink-0 items-start justify-between gap-4">
+            <div>
+              <Dialog.Title className="text-foreground text-xl font-semibold tracking-[-0.02em]">
+                {t("dialogTitle")}
+              </Dialog.Title>
+              <Dialog.Description className="text-muted-foreground mt-1 text-sm leading-relaxed">
+                {t("dialogSubtitle")}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                className="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-primary/30 rounded-full p-2 transition focus-visible:ring-2 focus-visible:outline-none"
+                aria-label={tCommon("actions.close")}
+              >
+                <X className="size-4" />
+              </button>
+            </Dialog.Close>
+          </div>
+          <KeyboardShortcutBrowser />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }

--- a/src/components/dialogs/KeyboardShortcutsDialog.tsx
+++ b/src/components/dialogs/KeyboardShortcutsDialog.tsx
@@ -84,8 +84,8 @@ function ShortcutKeys({
   alternativeLabel: string;
 }) {
   const shortcutLabel = item.shortcuts
-    .map((chord) => chord.join(" plus "))
-    .join(" or ");
+    .map((chord) => chord.join(" + "))
+    .join(` ${alternativeLabel} `);
 
   return (
     <div

--- a/src/components/editor/CommandPalette.tsx
+++ b/src/components/editor/CommandPalette.tsx
@@ -1,0 +1,391 @@
+"use client";
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentType,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
+import {
+  Box,
+  Download,
+  FolderOpen,
+  Import,
+  Keyboard,
+  MessageCircle,
+  Search,
+  Settings,
+  Share2,
+  View,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import type { EditorView } from "@/lib/editor/view";
+
+type CommandPaletteProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  activeView: EditorView;
+  hasPath: boolean;
+  onOpenProjects: () => void;
+  onOpenAccountSettings: () => void;
+  onOpenShortcuts: () => void;
+  onSwitchView: (view: EditorView) => void;
+  onStartFlyThrough: () => void;
+  onShare: () => void;
+  onExport: () => void;
+  onImport: () => void;
+  onFeedback: () => void;
+};
+
+type PaletteAction = {
+  id: string;
+  group: "navigate" | "view" | "transfer" | "support";
+  label: string;
+  description: string;
+  keywords: string[];
+  icon: ComponentType<{ className?: string }>;
+  onSelect: () => void;
+  disabledReason?: string;
+};
+
+function normalizeSearchValue(value: string) {
+  return value.trim().toLocaleLowerCase();
+}
+
+export default function CommandPalette({
+  open,
+  onOpenChange,
+  activeView,
+  hasPath,
+  onOpenProjects,
+  onOpenAccountSettings,
+  onOpenShortcuts,
+  onSwitchView,
+  onStartFlyThrough,
+  onShare,
+  onExport,
+  onImport,
+  onFeedback,
+}: CommandPaletteProps) {
+  const t = useTranslations("editor.commandPalette");
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const actions = useMemo<PaletteAction[]>(
+    () => [
+      {
+        id: "projects",
+        group: "navigate",
+        label: t("actions.projects.label"),
+        description: t("actions.projects.description"),
+        keywords: ["project", "files", "manage", "open"],
+        icon: FolderOpen,
+        onSelect: onOpenProjects,
+      },
+      {
+        id: "account-settings",
+        group: "navigate",
+        label: t("actions.accountSettings.label"),
+        description: t("actions.accountSettings.description"),
+        keywords: ["account", "profile", "security", "settings"],
+        icon: Settings,
+        onSelect: onOpenAccountSettings,
+      },
+      {
+        id: "keyboard-shortcuts",
+        group: "navigate",
+        label: t("actions.shortcuts.label"),
+        description: t("actions.shortcuts.description"),
+        keywords: ["keyboard", "help", "keys", "shortcuts"],
+        icon: Keyboard,
+        onSelect: onOpenShortcuts,
+      },
+      {
+        id: "view-2d",
+        group: "view",
+        label: t("actions.view2d.label"),
+        description: t("actions.view2d.description"),
+        keywords: ["2d", "canvas", "editor", "view"],
+        icon: View,
+        onSelect: () => onSwitchView("2d"),
+        disabledReason:
+          activeView === "2d" ? t("actions.view2d.alreadyActive") : undefined,
+      },
+      {
+        id: "view-3d",
+        group: "view",
+        label: t("actions.view3d.label"),
+        description: t("actions.view3d.description"),
+        keywords: ["3d", "preview", "view", "orbit"],
+        icon: Box,
+        onSelect: () => onSwitchView("3d"),
+        disabledReason:
+          activeView === "3d" ? t("actions.view3d.alreadyActive") : undefined,
+      },
+      {
+        id: "fly-through",
+        group: "view",
+        label: t("actions.flyThrough.label"),
+        description: t("actions.flyThrough.description"),
+        keywords: ["3d", "fpv", "flight", "fly", "preview", "route"],
+        icon: Box,
+        onSelect: onStartFlyThrough,
+        disabledReason: hasPath
+          ? undefined
+          : t("actions.flyThrough.noPathReason"),
+      },
+      {
+        id: "share",
+        group: "transfer",
+        label: t("actions.share.label"),
+        description: t("actions.share.description"),
+        keywords: ["publish", "link", "share"],
+        icon: Share2,
+        onSelect: onShare,
+      },
+      {
+        id: "export",
+        group: "transfer",
+        label: t("actions.export.label"),
+        description: t("actions.export.description"),
+        keywords: ["download", "png", "pdf", "svg", "json", "export"],
+        icon: Download,
+        onSelect: onExport,
+      },
+      {
+        id: "import",
+        group: "transfer",
+        label: t("actions.import.label"),
+        description: t("actions.import.description"),
+        keywords: ["upload", "json", "import"],
+        icon: Import,
+        onSelect: onImport,
+      },
+      {
+        id: "feedback",
+        group: "support",
+        label: t("actions.feedback.label"),
+        description: t("actions.feedback.description"),
+        keywords: ["support", "idea", "problem", "bug", "feedback"],
+        icon: MessageCircle,
+        onSelect: onFeedback,
+      },
+    ],
+    [
+      activeView,
+      hasPath,
+      onExport,
+      onFeedback,
+      onImport,
+      onOpenAccountSettings,
+      onOpenProjects,
+      onOpenShortcuts,
+      onShare,
+      onStartFlyThrough,
+      onSwitchView,
+      t,
+    ]
+  );
+
+  const filteredActions = useMemo(() => {
+    const normalizedQuery = normalizeSearchValue(query);
+    if (!normalizedQuery) return actions;
+
+    return actions.filter((action) =>
+      normalizeSearchValue(
+        [action.label, action.description, ...action.keywords].join(" ")
+      ).includes(normalizedQuery)
+    );
+  }, [actions, query]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        setQuery("");
+        setActiveIndex(0);
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange]
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
+      if (event.key.toLocaleLowerCase() !== "k") return;
+
+      if (!open && document.querySelector('[role="dialog"]')) return;
+
+      event.preventDefault();
+      handleOpenChange(!open);
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleOpenChange, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    window.setTimeout(() => inputRef.current?.focus(), 0);
+  }, [open]);
+
+  const runAction = (action: PaletteAction) => {
+    if (action.disabledReason) return;
+    handleOpenChange(false);
+    window.setTimeout(action.onSelect, 0);
+  };
+
+  const handleInputKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((current) =>
+        filteredActions.length ? (current + 1) % filteredActions.length : 0
+      );
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((current) =>
+        filteredActions.length
+          ? (current - 1 + filteredActions.length) % filteredActions.length
+          : 0
+      );
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+      const action = filteredActions[activeIndex];
+      if (action) runAction(action);
+    }
+  };
+
+  const groups = ["navigate", "view", "transfer", "support"] as const;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="top-[18vh] max-w-xl translate-y-0 gap-0 overflow-hidden p-0 sm:rounded-xl">
+        <DialogTitle className="sr-only">{t("title")}</DialogTitle>
+        <DialogDescription className="sr-only">
+          {t("description")}
+        </DialogDescription>
+
+        <div className="border-border flex items-center gap-3 border-b py-0 pr-14 pl-4">
+          <Search className="text-muted-foreground size-4 shrink-0" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setActiveIndex(0);
+            }}
+            onKeyDown={handleInputKeyDown}
+            placeholder={t("placeholder")}
+            role="combobox"
+            aria-label={t("searchLabel")}
+            aria-controls="command-palette-results"
+            aria-expanded={open}
+            aria-autocomplete="list"
+            aria-activedescendant={
+              filteredActions[activeIndex]
+                ? `command-palette-${filteredActions[activeIndex].id}`
+                : undefined
+            }
+            className="placeholder:text-muted-foreground h-13 min-w-0 flex-1 bg-transparent text-sm outline-none"
+          />
+          <kbd className="border-border bg-muted text-muted-foreground hidden rounded border px-1.5 py-0.5 font-mono text-[10px] sm:inline-flex">
+            {t("escapeKey")}
+          </kbd>
+        </div>
+
+        <div
+          id="command-palette-results"
+          role="listbox"
+          aria-label={t("resultsLabel")}
+          className="max-h-[min(60vh,28rem)] overflow-y-auto p-2"
+        >
+          {filteredActions.length ? (
+            groups.map((group) => {
+              const groupActions = filteredActions.filter(
+                (action) => action.group === group
+              );
+              if (!groupActions.length) return null;
+
+              return (
+                <div key={group} role="group" aria-label={t(`groups.${group}`)}>
+                  <h2 className="text-muted-foreground px-2 pt-2 pb-1 text-[10px] font-semibold tracking-[0.14em] uppercase">
+                    {t(`groups.${group}`)}
+                  </h2>
+                  <div>
+                    {groupActions.map((action) => {
+                      const index = filteredActions.indexOf(action);
+                      const Icon = action.icon;
+                      const disabled = Boolean(action.disabledReason);
+
+                      return (
+                        <button
+                          key={action.id}
+                          id={`command-palette-${action.id}`}
+                          type="button"
+                          role="option"
+                          aria-selected={index === activeIndex}
+                          aria-disabled={disabled}
+                          onMouseMove={() => setActiveIndex(index)}
+                          onClick={() => runAction(action)}
+                          className={cn(
+                            "flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left outline-none",
+                            index === activeIndex && "bg-muted",
+                            disabled && "text-muted-foreground"
+                          )}
+                        >
+                          <span className="border-border bg-background flex size-8 shrink-0 items-center justify-center rounded-md border">
+                            <Icon className="size-3.5" />
+                          </span>
+                          <span className="min-w-0 flex-1">
+                            <span className="block text-sm font-medium">
+                              {action.label}
+                            </span>
+                            <span
+                              className={cn(
+                                "text-muted-foreground block truncate text-xs",
+                                action.disabledReason &&
+                                  "text-amber-600 dark:text-amber-400"
+                              )}
+                            >
+                              {action.disabledReason ?? action.description}
+                            </span>
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })
+          ) : (
+            <div className="text-muted-foreground px-4 py-10 text-center text-sm">
+              {t("empty")}
+            </div>
+          )}
+        </div>
+
+        <div className="border-border text-muted-foreground flex items-center gap-4 border-t px-4 py-2 text-[10px]">
+          <span>{t("hintNavigate")}</span>
+          <span>{t("hintRun")}</span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -67,6 +67,9 @@ const Toolbar = dynamic(() => import("./Toolbar"), { ssr: false });
 const PerformanceHud = dynamic(() => import("./PerformanceHud"), {
   ssr: false,
 });
+const CommandPalette = dynamic(() => import("./CommandPalette"), {
+  ssr: false,
+});
 
 const EditorMobilePanels = dynamic(
   () =>
@@ -250,6 +253,8 @@ export default function EditorShell({
     setProjectManagerOpen,
     presetPickerOpen,
     setPresetPickerOpen,
+    commandPaletteOpen,
+    setCommandPaletteOpen,
     openNewProjectDialog,
   } = useEditorDialogs({
     isMobile,
@@ -262,6 +267,12 @@ export default function EditorShell({
     const nextQuery = params.toString();
     const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname;
     router.replace(nextUrl, { scroll: false });
+  }, [pathname, router, searchParams]);
+
+  const openAccountSettings = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("account", "profile");
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
   }, [pathname, router, searchParams]);
 
   const {
@@ -1033,6 +1044,27 @@ export default function EditorShell({
           onOpenCloudConflictVersion={handleOpenCloudConflictVersion}
           onKeepLocalConflictCopy={handleKeepLocalConflictCopy}
         />
+
+        {!readOnly ? (
+          <CommandPalette
+            open={commandPaletteOpen}
+            onOpenChange={setCommandPaletteOpen}
+            activeView={tab}
+            hasPath={hasPath}
+            onOpenProjects={() => setProjectManagerOpen(true)}
+            onOpenAccountSettings={openAccountSettings}
+            onOpenShortcuts={() => setShortcutsOpen(true)}
+            onSwitchView={handleTabChange}
+            onStartFlyThrough={() => {
+              handleTabChange("3d");
+              setPendingFlyThroughStart(true);
+            }}
+            onShare={() => setShareOpen(true)}
+            onExport={() => setExportOpen(true)}
+            onImport={() => setImportOpen(true)}
+            onFeedback={() => setFeedbackOpen(true)}
+          />
+        ) : null}
 
         <FeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
 

--- a/src/components/editor/useEditorDialogs.ts
+++ b/src/components/editor/useEditorDialogs.ts
@@ -18,6 +18,7 @@ export function useEditorDialogs({
   const [newProjectOpen, setNewProjectOpen] = useState(false);
   const [projectManagerOpen, setProjectManagerOpen] = useState(false);
   const [presetPickerOpen, setPresetPickerOpen] = useState(false);
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
   const mobileNewProjectTimerRef = useRef<number | null>(null);
 
   const openNewProjectDialog = useCallback(() => {
@@ -61,6 +62,8 @@ export function useEditorDialogs({
     setProjectManagerOpen,
     presetPickerOpen,
     setPresetPickerOpen,
+    commandPaletteOpen,
+    setCommandPaletteOpen,
     openNewProjectDialog,
   };
 }

--- a/src/lib/editor/tool-registry.ts
+++ b/src/lib/editor/tool-registry.ts
@@ -57,6 +57,14 @@ export const toolShortcuts = {
   ),
 } as Partial<Record<EditorTool, string>>;
 
+export function getToolForShortcut(key: string): EditorTool | null {
+  const normalizedKey = key.toLocaleUpperCase();
+  const entry = Object.entries(toolShortcuts).find(
+    ([, shortcut]) => shortcut?.toLocaleUpperCase() === normalizedKey
+  );
+  return (entry?.[0] as EditorTool | undefined) ?? null;
+}
+
 export const toolCatalogEntryIds = Object.fromEntries(
   getTrackItemToolConfigs()
     .filter((tool) => Boolean(tool.defaultCatalogEntryId))

--- a/src/lib/editor/tool-registry.ts
+++ b/src/lib/editor/tool-registry.ts
@@ -58,9 +58,9 @@ export const toolShortcuts = {
 } as Partial<Record<EditorTool, string>>;
 
 export function getToolForShortcut(key: string): EditorTool | null {
-  const normalizedKey = key.toLocaleUpperCase();
+  const normalizedKey = key.toUpperCase();
   const entry = Object.entries(toolShortcuts).find(
-    ([, shortcut]) => shortcut?.toLocaleUpperCase() === normalizedKey
+    ([, shortcut]) => shortcut?.toUpperCase() === normalizedKey
   );
   return (entry?.[0] as EditorTool | undefined) ?? null;
 }

--- a/tests/components/dialogs/KeyboardShortcutsDialog.test.tsx
+++ b/tests/components/dialogs/KeyboardShortcutsDialog.test.tsx
@@ -13,18 +13,6 @@ vi.mock("@/hooks/use-mobile", () => ({
   useIsMobile: () => mobileState.isMobile,
 }));
 
-vi.mock("framer-motion", () => ({
-  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
-  motion: {
-    div: ({
-      children,
-      ...props
-    }: React.HTMLAttributes<HTMLDivElement> & {
-      children?: React.ReactNode;
-    }) => <div {...props}>{children}</div>,
-  },
-}));
-
 vi.mock("@/components/MobileDrawer", () => ({
   MobileDrawer: ({
     children,
@@ -48,35 +36,44 @@ describe("KeyboardShortcutsDialog", () => {
     mobileState.isMobile = false;
   });
 
-  it("opens with tools shortcuts and expands another section on desktop", async () => {
-    const user = userEvent.setup();
-
+  it("opens as a searchable desktop dialog with essential shortcuts", () => {
     render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
 
-    expect(screen.getByText("Keyboard Shortcuts")).toBeTruthy();
-    expect(screen.getByText("Gate")).toBeTruthy();
-    expect(screen.getByText("G")).toBeTruthy();
-    expect(screen.getByText("Tower")).toBeTruthy();
-    expect(screen.getByText("T")).toBeTruthy();
-    expect(screen.queryByText("Save snapshot")).toBeNull();
-
-    await user.click(screen.getByRole("button", { name: "Project" }));
-
-    expect(screen.getByText("Save snapshot")).toBeTruthy();
-    expect(screen.getByText("Ctrl/Cmd")).toBeTruthy();
-    expect(screen.getByText("S")).toBeTruthy();
+    expect(
+      screen.getByRole("dialog", { name: "Keyboard Shortcuts" })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("searchbox", { name: "Search keyboard shortcuts" })
+    ).toBeTruthy();
+    expect(screen.getAllByText("Essentials").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Undo").length).toBeGreaterThan(0);
   });
 
-  it("collapses the open shortcuts section when clicked again", async () => {
+  it("filters shortcuts by action, description, or key", async () => {
     const user = userEvent.setup();
 
     render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
 
-    expect(screen.getByText("Select")).toBeTruthy();
+    await user.type(
+      screen.getByRole("searchbox", { name: "Search keyboard shortcuts" }),
+      "barrier"
+    );
 
-    await user.click(screen.getByRole("button", { name: "Tools" }));
+    expect(screen.getByText("Barrier")).toBeTruthy();
+    expect(screen.getByText("Activate the Barrier tool")).toBeTruthy();
+  });
 
-    expect(screen.queryByText("Select")).toBeNull();
+  it("switches between shortcut categories", async () => {
+    const user = userEvent.setup();
+
+    render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /Project/ }));
+
+    expect(screen.getByText("Save snapshot")).toBeTruthy();
+    expect(screen.getAllByText("Open command palette").length).toBeGreaterThan(
+      0
+    );
   });
 
   it("uses the mobile drawer shell on small screens", () => {

--- a/tests/components/dialogs/KeyboardShortcutsDialog.test.tsx
+++ b/tests/components/dialogs/KeyboardShortcutsDialog.test.tsx
@@ -76,6 +76,18 @@ describe("KeyboardShortcutsDialog", () => {
     );
   });
 
+  it("uses symbols and the localized alternative label for shortcut chords", async () => {
+    const user = userEvent.setup();
+
+    render(<KeyboardShortcutsDialog open onOpenChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /Edit/ }));
+
+    expect(
+      screen.getByLabelText("Ctrl/Cmd + Shift + Z or Ctrl + Y")
+    ).toBeTruthy();
+  });
+
   it("uses the mobile drawer shell on small screens", () => {
     mobileState.isMobile = true;
 

--- a/tests/components/editor/CommandPalette.test.tsx
+++ b/tests/components/editor/CommandPalette.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ComponentProps } from "react";
+import CommandPalette from "@/components/editor/CommandPalette";
+
+function renderPalette(
+  overrides: Partial<ComponentProps<typeof CommandPalette>> = {}
+) {
+  const props: ComponentProps<typeof CommandPalette> = {
+    open: true,
+    onOpenChange: vi.fn(),
+    activeView: "2d",
+    hasPath: false,
+    onOpenProjects: vi.fn(),
+    onOpenAccountSettings: vi.fn(),
+    onOpenShortcuts: vi.fn(),
+    onSwitchView: vi.fn(),
+    onStartFlyThrough: vi.fn(),
+    onShare: vi.fn(),
+    onExport: vi.fn(),
+    onImport: vi.fn(),
+    onFeedback: vi.fn(),
+    ...overrides,
+  };
+
+  render(<CommandPalette {...props} />);
+  return props;
+}
+
+describe("CommandPalette", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("filters actions by labels, descriptions and keywords", async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    await user.type(
+      screen.getByRole("combobox", { name: "Search commands" }),
+      "pdf"
+    );
+
+    expect(screen.getByRole("option", { name: /Export/ })).toBeTruthy();
+    expect(
+      screen.queryByRole("option", { name: /Project Manager/ })
+    ).toBeNull();
+  });
+
+  it("explains unavailable contextual actions and does not run them", async () => {
+    const user = userEvent.setup();
+    const onStartFlyThrough = vi.fn();
+    renderPalette({ onStartFlyThrough });
+
+    const flyThrough = screen.getByRole("option", {
+      name: /Start fly-through Draw a path first to enable fly-through/,
+    });
+    expect(flyThrough.getAttribute("aria-disabled")).toBe("true");
+
+    await user.click(flyThrough);
+    expect(onStartFlyThrough).not.toHaveBeenCalled();
+  });
+
+  it("closes before running the selected existing action", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const onExport = vi.fn();
+    renderPalette({ onOpenChange, onExport });
+
+    await user.click(screen.getByRole("option", { name: /Export/ }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    await vi.waitFor(() => expect(onExport).toHaveBeenCalledTimes(1));
+  });
+
+  it("runs a searched action with the keyboard", async () => {
+    const user = userEvent.setup();
+    const onExport = vi.fn();
+    renderPalette({ onExport });
+
+    const search = screen.getByRole("combobox", { name: "Search commands" });
+    await user.type(search, "pdf{Enter}");
+
+    await vi.waitFor(() => expect(onExport).toHaveBeenCalledTimes(1));
+  });
+
+  it("opens with Cmd or Ctrl K and keeps the browser shortcut suppressed", () => {
+    const onOpenChange = vi.fn();
+    renderPalette({ open: false, onOpenChange });
+
+    const event = new KeyboardEvent("keydown", {
+      key: "k",
+      ctrlKey: true,
+      cancelable: true,
+    });
+    fireEvent(window, event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/tests/lib/editor/tool-registry-and-catalog-type-patch.test.ts
+++ b/tests/lib/editor/tool-registry-and-catalog-type-patch.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   createShapeForTool,
   getShapeDisplayLabel,
+  getToolForShortcut,
   getToolLabel,
   toolShortcuts,
 } from "@/lib/editor/tool-registry";
@@ -47,6 +48,9 @@ describe("editor tool helpers", () => {
     expect(toolShortcuts.tower).toBe("T");
     expect(toolShortcuts.divegate).toBe("D");
     expect(toolShortcuts.preset).toBeUndefined();
+    expect(getToolForShortcut("t")).toBe("tower");
+    expect(getToolForShortcut("B")).toBe("barrier");
+    expect(getToolForShortcut("?")).toBeNull();
   });
 
   it("creates default shape drafts for supported placement tools", () => {

--- a/tests/lib/editor/tool-registry-and-catalog-type-patch.test.ts
+++ b/tests/lib/editor/tool-registry-and-catalog-type-patch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   buildCatalogTypePatch,
   buildBarrierCatalogTypePatch,
@@ -51,6 +51,19 @@ describe("editor tool helpers", () => {
     expect(getToolForShortcut("t")).toBe("tower");
     expect(getToolForShortcut("B")).toBe("barrier");
     expect(getToolForShortcut("?")).toBeNull();
+  });
+
+  it("matches shortcut keys without locale-sensitive case conversion", () => {
+    const localeUpperCase = vi
+      .spyOn(String.prototype, "toLocaleUpperCase")
+      .mockReturnValue("NOT-A-SHORTCUT");
+
+    try {
+      expect(getToolForShortcut("t")).toBe("tower");
+      expect(localeUpperCase).not.toHaveBeenCalled();
+    } finally {
+      localeUpperCase.mockRestore();
+    }
   });
 
   it("creates default shape drafts for supported placement tools", () => {


### PR DESCRIPTION
## Summary

- add a keyboard-first `Cmd/Ctrl+K` palette for existing Studio actions, with search and contextual disabled states
- redesign the keyboard shortcuts dialog as an aligned, searchable reference across desktop and mobile
- derive tool activation from the shared shortcut registry so displayed Tower and Barrier shortcuts are executable

## Validation

- `npm run lint`
- `npm run test` (186 files, 997 tests)
- `npm run type`
- `npm run build`
- `npm run i18n:check`
- `npm run i18n:scan-hardcoded`
- Prettier check for all changed files