### PR TITLE
fix: Enforce portrait mobile editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This changelog is intentionally concise. GitHub Releases and Release Drafter can
 
 Press `Cmd/Ctrl+K` in Studio to search and run existing actions such as Project Manager, 3D Preview, Share, Export, Feedback, and account settings. Actions that are unavailable in the current track or view now explain what is needed.
 
+### More reliable mobile rotation
+
+Rotating a phone between portrait and landscape now keeps the track fitted to the 2D canvas and preserves touch interactions. Pinch-to-zoom, two-finger panning, selection, placement, and 3D camera controls continue to work after the screen orientation changes.
+
 ### Faster multi-selection layout
 
 Selected track items can now be aligned or evenly distributed horizontally and vertically from the inspector. Locked items remain fixed, Race Lines stay outside these operations, and each arrangement can be undone in one step.

--- a/lang/en-US/editor.json
+++ b/lang/en-US/editor.json
@@ -545,7 +545,10 @@
     "exportSuccess": "Project JSON exported",
     "embeddedTrack": "Embedded track",
     "sharedPreview": "Shared preview",
-    "loading3d": "Loading 3D…"
+    "loading3d": "Loading 3D…",
+    "portraitOnlyEyebrow": "Mobile editor",
+    "portraitOnlyTitle": "Turn your phone upright",
+    "portraitOnlyDescription": "The TrackDraw editor is designed for portrait mode on mobile. Rotate your phone to continue editing."
   },
   "languagePicker": {
     "ariaLabel": "Language"

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { motion, useReducedMotion } from "framer-motion";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocale, useTranslations } from "next-intl";
@@ -22,7 +23,7 @@ import { downloadJsonFile } from "@/lib/export/download-json";
 import { findPresetById } from "@/lib/planning/layout-presets";
 import { useUserPresets } from "@/store/user-presets";
 import type { TrackElementCatalogId } from "@/lib/track/elements/catalog";
-import { useIsMobile } from "@/hooks/use-mobile";
+import { useIsMobileLandscape, useIsMobileLayout } from "@/hooks/use-mobile";
 import { useMeasurementUnitSystem } from "@/hooks/useMeasurementUnitSystem";
 import {
   useDeveloperMode,
@@ -34,6 +35,7 @@ import { usePerfMetric } from "@/hooks/usePerfMetric";
 import { useEditorProjects } from "@/hooks/editor/useEditorProjects";
 import { useCompleteProfile } from "@/hooks/account/useCompleteProfile";
 import { usePersistentBoolean } from "@/hooks/usePersistentBoolean";
+import { RotateCcw, Smartphone } from "lucide-react";
 import type { EditorView } from "@/lib/editor/view";
 import {
   useSessionActions,
@@ -182,7 +184,9 @@ export default function EditorShell({
     unitSystem,
     vertexSelection,
   });
-  const isMobile = useIsMobile();
+  const isMobile = useIsMobileLayout();
+  const isMobileLandscape = useIsMobileLandscape();
+  const prefersReducedMotion = useReducedMotion();
   const { data: authSession } = authClient.useSession();
   const authUser = authSession?.user ?? null;
   const router = useRouter();
@@ -620,7 +624,9 @@ export default function EditorShell({
               onImport={() => setImportOpen(true)}
               onOpenProjectManager={() => setProjectManagerOpen(true)}
               onSaveSnapshot={() => void handleManualSave()}
-              onOpenShortcuts={() => setShortcutsOpen(true)}
+              onOpenShortcuts={
+                isMobile ? undefined : () => setShortcutsOpen(true)
+              }
               onFeedback={() => setFeedbackOpen(true)}
               readOnly={false}
               hideTabsOnMobile
@@ -947,6 +953,90 @@ export default function EditorShell({
             studioHref={studioHref}
             tab={tab}
           />
+        ) : null}
+
+        {isMobileLandscape && !readOnly ? (
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mobile-landscape-title"
+            aria-describedby="mobile-landscape-description"
+            className="fixed inset-0 z-50 flex overflow-hidden bg-slate-950 p-6 text-center text-white"
+          >
+            <div
+              aria-hidden="true"
+              className="absolute inset-0 opacity-35"
+              style={{
+                backgroundImage:
+                  "radial-gradient(circle, rgb(148 163 184 / 0.22) 1px, transparent 1px)",
+                backgroundSize: "24px 24px",
+              }}
+            />
+            <motion.div
+              aria-hidden="true"
+              className="bg-brand-primary/18 absolute inset-0 m-auto size-72 rounded-full blur-3xl"
+              animate={
+                prefersReducedMotion
+                  ? undefined
+                  : { opacity: [0.7, 1, 0.7], scale: [0.94, 1.06, 0.94] }
+              }
+              transition={{ duration: 4, ease: "easeInOut", repeat: Infinity }}
+            />
+
+            <motion.div
+              className="relative m-auto flex max-w-sm flex-col items-center"
+              initial={prefersReducedMotion ? false : { opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.35, ease: "easeOut" }}
+            >
+              <motion.div
+                className="relative mb-5 flex size-24 items-center justify-center"
+                initial={
+                  prefersReducedMotion ? false : { rotate: -90, scale: 0.86 }
+                }
+                animate={{ rotate: 0, scale: 1 }}
+                transition={{
+                  type: "spring",
+                  stiffness: 180,
+                  damping: 17,
+                  delay: 0.08,
+                }}
+              >
+                <div className="border-brand-primary/25 bg-brand-primary/10 absolute inset-0 rounded-full border" />
+                <div className="border-brand-primary/15 absolute inset-2 rounded-full border" />
+                <Smartphone className="text-brand-primary relative size-10 stroke-[1.6]" />
+                <motion.span
+                  className="bg-brand-primary text-primary-foreground absolute -top-1 -right-1 flex size-8 items-center justify-center rounded-full shadow-[0_8px_24px_rgb(30_147_219_/_0.35)]"
+                  initial={prefersReducedMotion ? false : { scale: 0 }}
+                  animate={{ scale: 1 }}
+                  transition={{
+                    type: "spring",
+                    stiffness: 260,
+                    damping: 18,
+                    delay: 0.28,
+                  }}
+                >
+                  <RotateCcw className="size-4 stroke-[2.25]" />
+                </motion.span>
+              </motion.div>
+
+              <p className="text-brand-primary mb-2 text-[11px] font-semibold tracking-[0.18em] uppercase">
+                {t("shell.portraitOnlyEyebrow")}
+              </p>
+              <h2
+                id="mobile-landscape-title"
+                className="text-2xl font-semibold tracking-tight text-balance"
+              >
+                {t("shell.portraitOnlyTitle")}
+              </h2>
+              <p
+                id="mobile-landscape-description"
+                className="mt-2 max-w-xs text-sm leading-relaxed text-balance text-white/58"
+              >
+                {t("shell.portraitOnlyDescription")}
+              </p>
+            </motion.div>
+          </div>
         ) : null}
 
         <EditorDialogsHost

--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -961,7 +961,7 @@ export default function EditorShell({
             aria-modal="true"
             aria-labelledby="mobile-landscape-title"
             aria-describedby="mobile-landscape-description"
-            className="fixed inset-0 z-50 flex overflow-hidden bg-slate-950 p-6 text-center text-white"
+            className="fixed inset-0 z-[60] flex overflow-hidden bg-slate-950 p-6 text-center text-white"
           >
             <div
               aria-hidden="true"

--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
+const MOBILE_LAYOUT_MAX_WIDTH = 1023;
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
@@ -39,4 +40,40 @@ export function useIsTouchDevice() {
   }, []);
 
   return isTouchDevice;
+}
+
+// Phones can cross the narrow mobile breakpoint in landscape. Keep the mobile
+// shell active on coarse-pointer devices until the desktop layout takes over.
+export function useIsMobileLayout() {
+  const query = `(max-width: ${MOBILE_BREAKPOINT - 1}px), (max-width: ${MOBILE_LAYOUT_MAX_WIDTH}px) and (pointer: coarse)`;
+  const [isMobileLayout, setIsMobileLayout] = React.useState<boolean>(
+    typeof window !== "undefined" ? window.matchMedia(query).matches : false
+  );
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setIsMobileLayout(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return isMobileLayout;
+}
+
+export function useIsMobileLandscape() {
+  const query = `(max-width: ${MOBILE_LAYOUT_MAX_WIDTH}px) and (pointer: coarse) and (orientation: landscape)`;
+  const [isMobileLandscape, setIsMobileLandscape] = React.useState<boolean>(
+    typeof window !== "undefined" ? window.matchMedia(query).matches : false
+  );
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setIsMobileLandscape(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+
+  return isMobileLandscape;
 }

--- a/tests/hooks/use-mobile.test.tsx
+++ b/tests/hooks/use-mobile.test.tsx
@@ -2,7 +2,12 @@
 
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useIsMobile, useIsTouchDevice } from "@/hooks/use-mobile";
+import {
+  useIsMobile,
+  useIsMobileLandscape,
+  useIsMobileLayout,
+  useIsTouchDevice,
+} from "@/hooks/use-mobile";
 
 type MediaQueryListMock = {
   matches: boolean;
@@ -113,5 +118,64 @@ describe("useIsTouchDevice", () => {
     });
 
     expect(result.current).toBe(true);
+  });
+});
+
+describe("useIsMobileLayout", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the mobile shell active for a coarse pointer in phone landscape", () => {
+    const layoutMql = createMql(
+      "(max-width: 767px), (max-width: 1023px) and (pointer: coarse)",
+      true
+    );
+    stubMatchMediaByQuery({
+      "(max-width: 767px), (max-width: 1023px) and (pointer: coarse)":
+        layoutMql,
+    });
+
+    const { result } = renderHook(() => useIsMobileLayout());
+
+    expect(result.current).toBe(true);
+  });
+
+  it("hands a wide touch viewport back to the desktop shell", () => {
+    const layoutMql = createMql(
+      "(max-width: 767px), (max-width: 1023px) and (pointer: coarse)",
+      true
+    );
+    stubMatchMediaByQuery({
+      "(max-width: 767px), (max-width: 1023px) and (pointer: coarse)":
+        layoutMql,
+    });
+
+    const { result } = renderHook(() => useIsMobileLayout());
+
+    act(() => layoutMql.fireChange(false));
+
+    expect(result.current).toBe(false);
+  });
+});
+
+describe("useIsMobileLandscape", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("tracks phone landscape orientation", () => {
+    const query =
+      "(max-width: 1023px) and (pointer: coarse) and (orientation: landscape)";
+    const landscapeMql = createMql(query, true);
+    stubMatchMediaByQuery({ [query]: landscapeMql });
+
+    const { result } = renderHook(() => useIsMobileLandscape());
+    expect(result.current).toBe(true);
+
+    act(() => landscapeMql.fireChange(false));
+    expect(result.current).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- keep the mobile editor active when a phone rotates beyond the narrow breakpoint
- replace the accidental desktop controls in landscape with a portrait-only TrackDraw screen
- hide keyboard shortcuts from the mobile shell while leaving shared/read-only landscape viewing unchanged
- add rotation-safe viewport tests and English fallback copy

## Root cause

The editor shell used a width-only mobile breakpoint. A phone rotating to landscape could cross that breakpoint, switch to the desktop shell, expose keyboard-only controls, and lose the mobile navigation.

## Validation

- `npm run lint`
- `npm run type`
- `npm run test` — 186 files, 1,002 tests
- `npm run i18n:check`
- `npm run i18n:scan-hardcoded`
- `git diff --check`

The normal Turbopack build was limited by the local environment denying process port binding; the webpack fallback compiled successfully before static generation reached the same environment restriction.