### PR TITLE
Landing page login + dashboard mobile UX fixes

### DIFF
--- a/lang/en-US/dashboard.json
+++ b/lang/en-US/dashboard.json
@@ -356,6 +356,7 @@
         "sessionCount": "{count} sessions",
         "leadingCountries": "Leading countries",
         "groupedForPrivacy": "Grouped for privacy",
+        "groupedForPrivacyDetail": "{count} languages below the 5-session disclosure threshold, combined so no individual creator is identifiable.",
         "previousPeriod": "Previous 28d: {count}",
         "privacyNote": "Individual languages appear after 5 creator sessions.",
         "privacyAndComparisonNote": "Individual languages appear after 5 creator sessions. Previous-period comparison will appear when the measurement period is complete.",

--- a/lang/en-US/landing.json
+++ b/lang/en-US/landing.json
@@ -27,6 +27,8 @@
     "themeTooltip": "Switch the public site theme.",
     "languageAriaLabel": "Language",
     "languageTooltip": "Switch the site language.",
+    "login": "Log in",
+    "account": "Account",
     "openStudio": "Open Studio"
   },
   "hero": {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -137,10 +137,10 @@ function PlatformStat({
 }) {
   return (
     <div
-      className={`flex h-full min-w-0 items-center gap-3 border-t-2 p-4 sm:px-5 ${accent}`}
+      className={`flex h-full min-w-0 items-center gap-3 rounded-xl border border-t-2 p-3.5 sm:p-4 sm:px-5 ${accent}`}
     >
       <span
-        className={`inline-flex size-10 shrink-0 items-center justify-center rounded-lg ${iconTone}`}
+        className={`inline-flex size-9 shrink-0 items-center justify-center rounded-lg sm:size-10 ${iconTone}`}
       >
         <Icon className="size-4" />
       </span>
@@ -373,7 +373,7 @@ export default async function DashboardPage() {
   return (
     <>
       <DashboardSiteHeader title={tPages("overview")} />
-      <main className="mx-auto flex w-full max-w-[1600px] min-w-0 flex-1 flex-col gap-6 p-3 pt-0 sm:p-4 sm:pt-0">
+      <main className="mx-auto flex w-full max-w-[1600px] min-w-0 flex-1 flex-col gap-6 p-4 pt-0">
         <header className="flex items-end justify-between gap-4">
           <h1 className="text-2xl font-semibold tracking-tight">
             {tPages("overview")}
@@ -396,13 +396,13 @@ export default async function DashboardPage() {
               {t("sections.platformSnapshotDescription")}
             </p>
           </div>
-          <div className="grid grid-cols-1 overflow-hidden rounded-xl border sm:grid-cols-2 xl:grid-cols-4 xl:[&>*]:border-b-0 [&>*:not(:last-child)]:border-b xl:[&>*:not(:last-child)]:border-r sm:[&>*:nth-child(odd)]:border-r">
+          <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
             <Reveal className="h-full">
               <PlatformStat
                 label={t("kpi.totalUsers.label")}
                 value={overviewStats.totalUsers}
                 icon={Users}
-                accent="border-emerald-500/70"
+                accent="border-t-emerald-500/70"
                 iconTone="bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
               />
             </Reveal>
@@ -411,7 +411,7 @@ export default async function DashboardPage() {
                 label={t("kpi.activeProjects.label")}
                 value={overviewStats.activeProjects}
                 icon={FolderOpen}
-                accent="border-violet-500/70"
+                accent="border-t-violet-500/70"
                 iconTone="bg-violet-500/10 text-violet-700 dark:text-violet-300"
               />
             </Reveal>
@@ -420,7 +420,7 @@ export default async function DashboardPage() {
                 label={t("kpi.activeShares.label")}
                 value={overviewStats.activeShares}
                 icon={Link2}
-                accent="border-orange-500/70"
+                accent="border-t-orange-500/70"
                 iconTone="bg-orange-500/10 text-orange-700 dark:text-orange-300"
               />
             </Reveal>
@@ -429,7 +429,7 @@ export default async function DashboardPage() {
                 label={t("kpi.gallery.label")}
                 value={galleryStats.public}
                 icon={ImageIcon}
-                accent="border-sky-500/70"
+                accent="border-t-sky-500/70"
                 iconTone="bg-sky-500/10 text-sky-700 dark:text-sky-300"
               />
             </Reveal>

--- a/src/app/dashboard/users/columns.tsx
+++ b/src/app/dashboard/users/columns.tsx
@@ -90,7 +90,7 @@ export function getUsersColumns({
     },
     {
       accessorKey: "projectCount",
-      meta: { className: "hidden w-28 sm:table-cell" },
+      meta: { className: "w-28" },
       header: ({ column }) => (
         <Button
           variant="ghost"
@@ -156,7 +156,7 @@ export function getUsersColumns({
     },
     {
       accessorKey: "lastLoginAt",
-      meta: { className: "hidden w-36 sm:table-cell" },
+      meta: { className: "w-36" },
       header: ({ column }) => (
         <Button
           variant="ghost"

--- a/src/components/dashboard/AppSidebar.tsx
+++ b/src/components/dashboard/AppSidebar.tsx
@@ -33,6 +33,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarSeparator,
+  useSidebar,
 } from "@/components/ui/sidebar";
 import type { DashboardModule } from "@/lib/server/authorization";
 import { cn } from "@/lib/utils";
@@ -183,11 +184,13 @@ function NavMenuItem({
   currentPath,
   badge,
   label,
+  onNavigate,
 }: {
   item: NavItem;
   currentPath: string;
   badge?: number;
   label: string;
+  onNavigate: () => void;
 }) {
   const isActive = isItemActive(currentPath, item);
   const Icon = item.icon;
@@ -210,6 +213,7 @@ function NavMenuItem({
           href={item.href}
           prefetch={false}
           aria-current={isActive ? "page" : undefined}
+          onClick={onNavigate}
         >
           <Icon />
           <span>{label}</span>
@@ -251,6 +255,10 @@ export default function DashboardAppSidebar({
   const currentPath = usePathname();
   const theme = useTheme();
   const t = useTranslations("dashboard.sidebar");
+  const { isMobile, setOpenMobile } = useSidebar();
+  const closeMobileSidebar = () => {
+    if (isMobile) setOpenMobile(false);
+  };
 
   const filteredTopItems = topNavItems.filter((item) => {
     if (item.key === "overview") return visibleModules.includes("overview");
@@ -318,6 +326,7 @@ export default function DashboardAppSidebar({
                     currentPath={currentPath}
                     badge={itemBadges[item.key]}
                     label={t(`nav.${item.titleKey}`)}
+                    onNavigate={closeMobileSidebar}
                   />
                 ))}
               </SidebarMenu>
@@ -336,6 +345,7 @@ export default function DashboardAppSidebar({
                     currentPath={currentPath}
                     badge={itemBadges[item.key]}
                     label={t(`nav.${item.titleKey}`)}
+                    onNavigate={closeMobileSidebar}
                   />
                 ))}
               </SidebarMenu>
@@ -354,6 +364,7 @@ export default function DashboardAppSidebar({
                     currentPath={currentPath}
                     badge={itemBadges[item.key]}
                     label={t(`nav.${item.titleKey}`)}
+                    onNavigate={closeMobileSidebar}
                   />
                 ))}
               </SidebarMenu>
@@ -377,7 +388,11 @@ export default function DashboardAppSidebar({
                   className="hover:bg-muted/80 hover:text-foreground"
                   asChild
                 >
-                  <Link href={item.href} prefetch={false}>
+                  <Link
+                    href={item.href}
+                    prefetch={false}
+                    onClick={closeMobileSidebar}
+                  >
                     <Icon className="group-data-[collapsible=icon]:size-4.5" />
                     <span>{label}</span>
                   </Link>

--- a/src/components/dashboard/DailyCockpit.tsx
+++ b/src/components/dashboard/DailyCockpit.tsx
@@ -86,6 +86,8 @@ function MetricCell({
   index: number;
 }) {
   const Icon = METRIC_ICONS[id];
+  const isLastItem = index === METRIC_IDS.length - 1;
+  const isDesktopBottomRow = index >= Math.ceil(METRIC_IDS.length / 2);
   const currentDisplay = metric
     ? formatValue(
         metric.valueKind,
@@ -125,7 +127,7 @@ function MetricCell({
     <Link
       href={metric?.drilldown ?? METRIC_DRILLDOWNS[id]}
       prefetch={false}
-      className={`hover:bg-muted/35 focus-visible:ring-ring group flex min-h-28 min-w-0 gap-3 p-4 transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:outline-none ${index < 2 ? "border-b" : ""} ${index % 2 === 0 ? "sm:border-r" : ""}`}
+      className={`hover:bg-muted/35 focus-visible:ring-ring group flex min-h-28 min-w-0 gap-3 p-4 transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:outline-none ${!isLastItem ? "border-b" : ""} ${isDesktopBottomRow ? "sm:border-b-0" : ""} ${index % 2 === 0 ? "sm:border-r" : ""}`}
       aria-label={t("kpis.openDrilldown", { metric: t(`kpis.${id}.label`) })}
     >
       <span className="bg-muted text-muted-foreground inline-flex size-10 shrink-0 items-center justify-center rounded-lg">

--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -560,7 +560,8 @@ function LocalizationDemandTable({
                       className="outline-none"
                       style={{
                         width: `${Math.min(row.share * 100, 100)}%`,
-                        backgroundColor: chartColors[index % chartColors.length],
+                        backgroundColor:
+                          chartColors[index % chartColors.length],
                       }}
                     />
                   </TooltipTrigger>
@@ -568,7 +569,8 @@ function LocalizationDemandTable({
                     <span
                       className="size-2 shrink-0 rounded-full"
                       style={{
-                        backgroundColor: chartColors[index % chartColors.length],
+                        backgroundColor:
+                          chartColors[index % chartColors.length],
                       }}
                       aria-hidden="true"
                     />

--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -514,6 +514,13 @@ function LocalizationDemandTable({
                       .join(" · ")}
                   </p>
                 ) : null}
+                {row.groupedLanguageCount != null ? (
+                  <p className="mt-1 pl-3.5">
+                    {t("groupedForPrivacyDetail", {
+                      count: number.format(row.groupedLanguageCount),
+                    })}
+                  </p>
+                ) : null}
               </div>
             </li>
           ))}
@@ -544,34 +551,36 @@ function LocalizationDemandTable({
             })}
           >
             {metrics.servedLocales.map((row, index) => (
-              <div
-                key={row.locale}
-                style={{
-                  width: `${Math.min(row.share * 100, 100)}%`,
-                  backgroundColor: chartColors[index % chartColors.length],
-                }}
-              />
+              <TooltipProvider key={row.locale} delayDuration={100}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={`${formatLanguage(row.locale)} ${percent.format(row.share)}`}
+                      className="outline-none"
+                      style={{
+                        width: `${Math.min(row.share * 100, 100)}%`,
+                        backgroundColor: chartColors[index % chartColors.length],
+                      }}
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent className="flex items-center gap-2">
+                    <span
+                      className="size-2 shrink-0 rounded-full"
+                      style={{
+                        backgroundColor: chartColors[index % chartColors.length],
+                      }}
+                      aria-hidden="true"
+                    />
+                    <span>{formatLanguage(row.locale)}</span>
+                    <span className="font-semibold tabular-nums">
+                      {percent.format(row.share)}
+                    </span>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             ))}
           </div>
-          <ul className="mt-3 flex flex-wrap gap-x-6 gap-y-2">
-            {metrics.servedLocales.map((row, index) => (
-              <li key={row.locale} className="flex items-center gap-2 text-xs">
-                <span
-                  className="size-2 rounded-full"
-                  style={{
-                    backgroundColor: chartColors[index % chartColors.length],
-                  }}
-                  aria-hidden="true"
-                />
-                <span className="text-muted-foreground">
-                  {formatLanguage(row.locale)}
-                </span>
-                <span className="font-medium tabular-nums">
-                  {percent.format(row.share)}
-                </span>
-              </li>
-            ))}
-          </ul>
         </section>
       ) : null}
     </div>

--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -557,7 +557,7 @@ function LocalizationDemandTable({
                     <button
                       type="button"
                       aria-label={`${formatLanguage(row.locale)} ${percent.format(row.share)}`}
-                      className="outline-none"
+                      className="focus-visible:ring-ring p-0 outline-none focus-visible:ring-2 focus-visible:ring-inset"
                       style={{
                         width: `${Math.min(row.share * 100, 100)}%`,
                         backgroundColor:

--- a/src/components/data-table/DataTableLayout.ts
+++ b/src/components/data-table/DataTableLayout.ts
@@ -7,7 +7,7 @@ export type DataTableColumnMeta = {
 };
 
 export const dataTableWrapperClassName =
-  "overflow-hidden rounded-lg border bg-background";
+  "overflow-x-auto rounded-lg border bg-background";
 
 export const dataTableClassName = "min-w-[760px] table-fixed";
 

--- a/src/components/landing/PublicSiteHeader.tsx
+++ b/src/components/landing/PublicSiteHeader.tsx
@@ -369,7 +369,7 @@ export function PublicSiteHeader({
                         </p>
                         <LanguagePicker
                           variant="full"
-                          className="h-8 w-36 shrink-0 border-0 bg-muted"
+                          className="bg-muted h-8 w-36 shrink-0 border-0"
                         />
                       </div>
                       <div className="flex items-center justify-between gap-3 py-2.5">

--- a/src/components/landing/PublicSiteHeader.tsx
+++ b/src/components/landing/PublicSiteHeader.tsx
@@ -10,12 +10,15 @@ import {
   Home,
   Images,
   ListChecks,
+  LogIn,
   Menu,
 } from "lucide-react";
 import { LanguagePicker } from "@/components/LanguagePicker";
 import { MobileDrawerHeader } from "@/components/MobileDrawer";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import UserAvatar from "@/components/UserAvatar";
 import { Drawer, DrawerContent } from "@/components/ui/drawer";
+import { authClient } from "@/lib/auth-client";
 import { cn } from "@/lib/utils";
 
 type PublicSiteHeaderProps = {
@@ -134,6 +137,12 @@ export function PublicSiteHeader({
 }: PublicSiteHeaderProps) {
   const t = useTranslations("landing");
   const [openMobileMenu, setOpenMobileMenu] = useState(false);
+  const { data: session } = authClient.useSession();
+  const user = session?.user ?? null;
+  const accountHref =
+    user?.role === "moderator" || user?.role === "admin"
+      ? "/dashboard"
+      : "/studio";
 
   const navItems: NavItem[] = [
     {
@@ -241,16 +250,67 @@ export function PublicSiteHeader({
                 <ThemeToggle />
               </div>
             </div>
-            <Link
-              href="/studio"
-              prefetch={false}
-              className="inline-flex h-9 items-center gap-1.5 rounded-full bg-[#1E93DB] px-4 text-sm font-medium text-white shadow-md shadow-[#1E93DB]/30 transition hover:brightness-110"
-            >
-              {t("header.openStudio")} <ArrowRight className="size-3.5" />
-            </Link>
+
+            <div className="bg-border/60 h-5 w-px" aria-hidden="true" />
+
+            <div className="flex items-center gap-3">
+              {user ? (
+                <Link
+                  href={accountHref}
+                  prefetch={false}
+                  aria-label={t("header.account")}
+                  className="text-muted-foreground hover:text-foreground inline-flex h-9 items-center gap-2 rounded-full px-1 transition-colors"
+                >
+                  <UserAvatar
+                    name={user.name}
+                    email={user.email}
+                    className="size-7 text-[11px]"
+                  />
+                </Link>
+              ) : (
+                <Link
+                  href="/login"
+                  prefetch={false}
+                  className="text-muted-foreground hover:text-foreground inline-flex h-9 items-center px-1 text-sm font-medium transition-colors"
+                >
+                  {t("header.login")}
+                </Link>
+              )}
+              <Link
+                href="/studio"
+                prefetch={false}
+                className="inline-flex h-9 items-center gap-1.5 rounded-full bg-[#1E93DB] px-4 text-sm font-medium text-white shadow-md shadow-[#1E93DB]/30 transition hover:brightness-110"
+              >
+                {t("header.openStudio")} <ArrowRight className="size-3.5" />
+              </Link>
+            </div>
           </div>
 
-          <div className="sm:hidden">
+          <div className="flex items-center gap-2 sm:hidden">
+            {user ? (
+              <Link
+                href={accountHref}
+                prefetch={false}
+                aria-label={t("header.account")}
+                className="inline-flex size-8 items-center justify-center"
+              >
+                <UserAvatar
+                  name={user.name}
+                  email={user.email}
+                  className="size-7 text-[11px]"
+                />
+              </Link>
+            ) : (
+              <Link
+                href="/login"
+                prefetch={false}
+                aria-label={t("header.login")}
+                className="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex size-8 items-center justify-center rounded-md transition-colors"
+              >
+                <LogIn className="size-4" />
+              </Link>
+            )}
+
             <button
               type="button"
               onClick={(event) => {
@@ -302,14 +362,14 @@ export function PublicSiteHeader({
                   </div>
 
                   <div className="border-border/60 bg-background shrink-0 border-t px-3 py-3">
-                    <div className="border-border/60 bg-card divide-border/60 divide-y rounded-2xl border px-3 py-1">
+                    <div className="bg-card divide-border/60 divide-y rounded-2xl px-3 py-1">
                       <div className="flex items-center justify-between gap-3 py-2.5">
                         <p className="text-[13px] font-medium">
                           {t("header.languageAriaLabel")}
                         </p>
                         <LanguagePicker
                           variant="full"
-                          className="h-8 w-36 shrink-0"
+                          className="h-8 w-36 shrink-0 border-0 bg-muted"
                         />
                       </div>
                       <div className="flex items-center justify-between gap-3 py-2.5">

--- a/src/lib/server/localization-demand.ts
+++ b/src/lib/server/localization-demand.ts
@@ -29,6 +29,7 @@ export type LocalizationDemandMetrics = {
     share: number;
     supported: boolean | null;
     countries: Array<{ country: string; creatorSessions: number }>;
+    groupedLanguageCount?: number;
   }>;
   servedLocales: Array<{
     locale: SupportedLocale;
@@ -49,6 +50,18 @@ function addUtcDays(day: string, days: number) {
   const date = new Date(`${day}T00:00:00.000Z`);
   date.setUTCDate(date.getUTCDate() + days);
   return utcDay(date);
+}
+
+function sumCurrentSessions(rows: LocalizationDemandRow[]) {
+  return rows.reduce((sum, row) => sum + row.current_sessions, 0);
+}
+
+function sumPreviousSessions(rows: LocalizationDemandRow[]) {
+  return rows.reduce((sum, row) => sum + row.previous_sessions, 0);
+}
+
+function shareOf(sessions: number, total: number) {
+  return total === 0 ? 0 : sessions / total;
 }
 
 function mergeCountries(
@@ -170,7 +183,10 @@ export async function getLocalizationDemandMetrics(
           ? "low_volume"
           : "healthy";
 
-  const languageRows = new Map<string, LocalizationDemandRow[]>();
+  const languageRows = new Map<
+    LocalizationDemandLanguage | "unknown",
+    LocalizationDemandRow[]
+  >();
   for (const row of rows) {
     const current = languageRows.get(row.preferred_language) ?? [];
     current.push(row);
@@ -180,45 +196,34 @@ export async function getLocalizationDemandMetrics(
   const visibleLanguages: LocalizationDemandMetrics["languages"] = [];
   const hiddenRows: LocalizationDemandRow[] = [];
   for (const [language, groupedRows] of languageRows) {
-    const creatorSessions = groupedRows.reduce(
-      (sum, row) => sum + row.current_sessions,
-      0
-    );
+    const creatorSessions = sumCurrentSessions(groupedRows);
     if (creatorSessions < DISCLOSURE_THRESHOLD) {
       hiddenRows.push(...groupedRows);
       continue;
     }
-    const previousCreatorSessions = groupedRows.reduce(
-      (sum, row) => sum + row.previous_sessions,
-      0
-    );
     visibleLanguages.push({
-      language: language as LocalizationDemandLanguage | "unknown",
+      language,
       creatorSessions,
-      previousCreatorSessions,
-      share:
-        totalCreatorSessions === 0 ? 0 : creatorSessions / totalCreatorSessions,
+      previousCreatorSessions: sumPreviousSessions(groupedRows),
+      share: shareOf(creatorSessions, totalCreatorSessions),
       supported:
         language === "unknown" ? null : supportedLanguageSet.has(language),
       countries: mergeCountries(groupedRows),
     });
   }
   if (hiddenRows.length > 0) {
-    const creatorSessions = hiddenRows.reduce(
-      (sum, row) => sum + row.current_sessions,
-      0
-    );
+    const creatorSessions = sumCurrentSessions(hiddenRows);
+    const groupedLanguageCount = new Set(
+      hiddenRows.map((row) => row.preferred_language)
+    ).size;
     visibleLanguages.push({
       language: "other",
       creatorSessions,
-      previousCreatorSessions: hiddenRows.reduce(
-        (sum, row) => sum + row.previous_sessions,
-        0
-      ),
-      share:
-        totalCreatorSessions === 0 ? 0 : creatorSessions / totalCreatorSessions,
+      previousCreatorSessions: sumPreviousSessions(hiddenRows),
+      share: shareOf(creatorSessions, totalCreatorSessions),
       supported: null,
       countries: [],
+      groupedLanguageCount,
     });
   }
   visibleLanguages.sort(
@@ -263,10 +268,7 @@ export async function getLocalizationDemandMetrics(
         return {
           locale,
           creatorSessions,
-          share:
-            totalCreatorSessions === 0
-              ? 0
-              : creatorSessions / totalCreatorSessions,
+          share: shareOf(creatorSessions, totalCreatorSessions),
         };
       })
       .filter((row) => row.creatorSessions > 0)

--- a/tests/lib/server/localization-demand.test.ts
+++ b/tests/lib/server/localization-demand.test.ts
@@ -118,6 +118,57 @@ describe("localization demand aggregation", () => {
       { country: "FR", creatorSessions: 6 },
       { country: "other", creatorSessions: 2 },
     ]);
+    expect(metrics.languages[2]).toMatchObject({
+      language: "other",
+      groupedLanguageCount: 1,
+    });
+  });
+
+  it("counts distinct grouped languages, not grouped rows, in the other bucket", async () => {
+    const rows = createD1AllStatement([
+      {
+        preferred_language: "de",
+        served_locale: "en",
+        country_code: "DE",
+        current_sessions: 2,
+        previous_sessions: 0,
+      },
+      {
+        preferred_language: "de",
+        served_locale: "en",
+        country_code: "AT",
+        current_sessions: 1,
+        previous_sessions: 0,
+      },
+      {
+        preferred_language: "it",
+        served_locale: "en",
+        country_code: "IT",
+        current_sessions: 3,
+        previous_sessions: 0,
+      },
+      {
+        preferred_language: "en",
+        served_locale: "en",
+        country_code: "US",
+        current_sessions: 20,
+        previous_sessions: 15,
+      },
+    ]);
+    const state = createD1Statement({
+      first: { measured_since: "2026-05-01" },
+    });
+    installD1Statements(mocks.prepare, [rows, state]);
+
+    const metrics = await getLocalizationDemandMetrics(
+      new Date("2026-08-16T12:00:00.000Z")
+    );
+
+    const other = metrics.languages.find((row) => row.language === "other");
+    expect(other).toMatchObject({
+      creatorSessions: 6,
+      groupedLanguageCount: 2,
+    });
   });
 
   it("derives supported language primaries from the locale configuration", async () => {


### PR DESCRIPTION
## Summary
- Landing page header shows a session-aware login/account link (avatar for signed-in users, routed by role) with a mobile-friendly icon next to the hamburger.
- Dashboard mobile fixes: sidebar drawer now closes on navigation, overview page padding matches the rest of the dashboard, platform snapshot renders as a 2x2 card grid, and the product-pulse divider bug (missing border between the 3rd/4th row once the grid collapses to 1 column) is fixed.
- Admin data tables (users/gallery/shares/api-keys/audit) scroll horizontally on mobile instead of clipping content; the users table no longer hides project-count/last-login below `sm`.
- Metrics: "Interface language used" shows a hover tooltip per language instead of a separate dot-legend, and the "Other low-volume languages" row now discloses how many languages are grouped (not which ones, to preserve the privacy threshold).

## Test plan
- [ ] Visit the landing page logged out and logged in (as a regular user and as a moderator/admin) on desktop and mobile widths, confirm the login/account control behaves as described.
- [ ] Open the dashboard on a mobile viewport, tap a sidebar nav item, confirm the drawer closes.
- [ ] Check `/dashboard`, `/dashboard/users`, `/dashboard/gallery` on a narrow viewport for layout/scrolling.
- [ ] Hover a segment in the "Interface language used" chart on `/dashboard/metrics` and confirm the tooltip and "Other low-volume languages" detail line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)