### PR TITLE
docs: Add Crowdin translation badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,8 @@ npm run migrate:up:production
 
 ## Translation Workflow
 
+[![Crowdin](https://badges.crowdin.net/trackdraw/localized.svg)](https://crowdin.com/project/trackdraw)
+
 During the Crowdin pilot, English source copy remains in `lang/en-US/` and normal feature pull requests. Dutch (`lang/nl-NL/`), German (`lang/de-DE/`), and Simplified Chinese (`lang/zh-CN/`) are maintained in Crowdin and return through localization pull requests; do not edit those target catalogs directly outside a production emergency. Generated locale assets use the same regional directory names. Product locale identifiers stored by the frontend remain the shorter `en`, `nl`, `de`, and `zh-CN` values.
 
 This applies to AI-assisted feature work too: coding agents should add or change only the English source messages. TrackDraw does not use paid Crowdin AI or machine translation to fill new target strings. Crowdin may reuse previously approved perfect Translation Memory matches; contributors translate the remaining copy in Crowdin, and missing messages safely fall back to English until then. A maintainer may also request a separate no-cost assisted seeding batch after the English source has reached Crowdin. Such a batch must contain only missing keys, be uploaded to Crowdin as unapproved translations, and return through the normal localization pull request instead of being committed directly. Keeping target editing and approval inside Crowdin preserves its glossary, translation memory, QA history, and human corrections.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,9 +140,9 @@ npm run migrate:up:production
 ## Translation Workflow
 
 <a href="https://crowdin.com/project/trackdraw"><picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://badges.crowdin.net/badge/light/crowdin-on-dark.png 1x, https://badges.crowdin.net/badge/light/crowdin-on-dark@2x.png 2x">
-  <source media="(prefers-color-scheme: light)" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x">
-  <img style="width:140px;height:40px" src="https://badges.crowdin.net/badge/dark/crowdin-on-light.png" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x" alt="Crowdin | Agile localization for tech companies" />
+<source media="(prefers-color-scheme: dark)" srcset="https://badges.crowdin.net/badge/light/crowdin-on-dark.png 1x, https://badges.crowdin.net/badge/light/crowdin-on-dark@2x.png 2x">
+<source media="(prefers-color-scheme: light)" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x">
+<img style="width:140px;height:40px" src="https://badges.crowdin.net/badge/dark/crowdin-on-light.png" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x" alt="Crowdin | Agile localization for tech companies" />
 </picture></a>
 
 During the Crowdin pilot, English source copy remains in `lang/en-US/` and normal feature pull requests. Dutch (`lang/nl-NL/`), German (`lang/de-DE/`), and Simplified Chinese (`lang/zh-CN/`) are maintained in Crowdin and return through localization pull requests; do not edit those target catalogs directly outside a production emergency. Generated locale assets use the same regional directory names. Product locale identifiers stored by the frontend remain the shorter `en`, `nl`, `de`, and `zh-CN` values.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,11 @@ npm run migrate:up:production
 
 ## Translation Workflow
 
-[![Crowdin](https://badges.crowdin.net/trackdraw/localized.svg)](https://crowdin.com/project/trackdraw)
+<a href="https://crowdin.com/?utm_term=click-badge-add-on"><picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://badges.crowdin.net/badge/light/crowdin-on-dark.png 1x, https://badges.crowdin.net/badge/light/crowdin-on-dark@2x.png 2x">
+  <source media="(prefers-color-scheme: light)" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x">
+  <img style="width:140px;height:40px" src="https://badges.crowdin.net/badge/dark/crowdin-on-light.png" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x" alt="Crowdin | Agile localization for tech companies" />
+</picture></a>
 
 During the Crowdin pilot, English source copy remains in `lang/en-US/` and normal feature pull requests. Dutch (`lang/nl-NL/`), German (`lang/de-DE/`), and Simplified Chinese (`lang/zh-CN/`) are maintained in Crowdin and return through localization pull requests; do not edit those target catalogs directly outside a production emergency. Generated locale assets use the same regional directory names. Product locale identifiers stored by the frontend remain the shorter `en`, `nl`, `de`, and `zh-CN` values.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ npm run migrate:up:production
 
 ## Translation Workflow
 
-<a href="https://crowdin.com/?utm_term=click-badge-add-on"><picture>
+<a href="https://crowdin.com/project/trackdraw"><picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://badges.crowdin.net/badge/light/crowdin-on-dark.png 1x, https://badges.crowdin.net/badge/light/crowdin-on-dark@2x.png 2x">
   <source media="(prefers-color-scheme: light)" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x">
   <img style="width:140px;height:40px" src="https://badges.crowdin.net/badge/dark/crowdin-on-light.png" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x" alt="Crowdin | Agile localization for tech companies" />

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
     src="https://img.shields.io/badge/license-AGPL--3.0--only-blue"
     alt="License"
   /></a>
+  <a href="https://crowdin.com/project/trackdraw"><img
+    src="https://badges.crowdin.net/trackdraw/localized.svg"
+    alt="Crowdin"
+  /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@
     src="https://img.shields.io/badge/license-AGPL--3.0--only-blue"
     alt="License"
   /></a>
-  <a href="https://crowdin.com/?utm_term=click-badge-add-on"><picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://badges.crowdin.net/badge/light/crowdin-on-dark.png 1x, https://badges.crowdin.net/badge/light/crowdin-on-dark@2x.png 2x">
-    <source media="(prefers-color-scheme: light)" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x">
-    <img style="width:140px;height:40px" src="https://badges.crowdin.net/badge/dark/crowdin-on-light.png" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x" alt="Crowdin | Agile localization for tech companies" />
-  </picture></a>
 </p>
 
 <p align="center">
@@ -85,6 +80,14 @@ You are welcome to contribute to TrackDraw. You can find a guide on how to contr
 <a href="https://github.com/dutchdronesquad/trackdraw/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=dutchdronesquad/trackdraw" alt="Contributors" />
 </a>
+
+Want to help translate TrackDraw? See the [Translation Workflow](CONTRIBUTING.md#translation-workflow) in CONTRIBUTING.md.
+
+<a href="https://crowdin.com/?utm_term=click-badge-add-on"><picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://badges.crowdin.net/badge/light/crowdin-on-dark.png 1x, https://badges.crowdin.net/badge/light/crowdin-on-dark@2x.png 2x">
+  <source media="(prefers-color-scheme: light)" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x">
+  <img style="width:140px;height:40px" src="https://badges.crowdin.net/badge/dark/crowdin-on-light.png" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x" alt="Crowdin | Agile localization for tech companies" />
+</picture></a>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@
     src="https://img.shields.io/badge/license-AGPL--3.0--only-blue"
     alt="License"
   /></a>
-  <a href="https://crowdin.com/project/trackdraw"><img
-    src="https://badges.crowdin.net/trackdraw/localized.svg"
-    alt="Crowdin"
-  /></a>
+  <a href="https://crowdin.com/?utm_term=click-badge-add-on"><picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://badges.crowdin.net/badge/light/crowdin-on-dark.png 1x, https://badges.crowdin.net/badge/light/crowdin-on-dark@2x.png 2x">
+    <source media="(prefers-color-scheme: light)" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x">
+    <img style="width:140px;height:40px" src="https://badges.crowdin.net/badge/dark/crowdin-on-light.png" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x" alt="Crowdin | Agile localization for tech companies" />
+  </picture></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You are welcome to contribute to TrackDraw. You can find a guide on how to contr
 
 Want to help translate TrackDraw? See the [Translation Workflow](CONTRIBUTING.md#translation-workflow) in CONTRIBUTING.md.
 
-<a href="https://crowdin.com/?utm_term=click-badge-add-on"><picture>
+<a href="https://crowdin.com/project/trackdraw"><picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://badges.crowdin.net/badge/light/crowdin-on-dark.png 1x, https://badges.crowdin.net/badge/light/crowdin-on-dark@2x.png 2x">
   <source media="(prefers-color-scheme: light)" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x">
   <img style="width:140px;height:40px" src="https://badges.crowdin.net/badge/dark/crowdin-on-light.png" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x" alt="Crowdin | Agile localization for tech companies" />

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ You are welcome to contribute to TrackDraw. You can find a guide on how to contr
 Want to help translate TrackDraw? See the [Translation Workflow](CONTRIBUTING.md#translation-workflow) in CONTRIBUTING.md.
 
 <a href="https://crowdin.com/project/trackdraw"><picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://badges.crowdin.net/badge/light/crowdin-on-dark.png 1x, https://badges.crowdin.net/badge/light/crowdin-on-dark@2x.png 2x">
-  <source media="(prefers-color-scheme: light)" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x">
-  <img style="width:140px;height:40px" src="https://badges.crowdin.net/badge/dark/crowdin-on-light.png" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x" alt="Crowdin | Agile localization for tech companies" />
+<source media="(prefers-color-scheme: dark)" srcset="https://badges.crowdin.net/badge/light/crowdin-on-dark.png 1x, https://badges.crowdin.net/badge/light/crowdin-on-dark@2x.png 2x">
+<source media="(prefers-color-scheme: light)" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x">
+<img style="width:140px;height:40px" src="https://badges.crowdin.net/badge/dark/crowdin-on-light.png" srcset="https://badges.crowdin.net/badge/dark/crowdin-on-light.png 1x, https://badges.crowdin.net/badge/dark/crowdin-on-light@2x.png 2x" alt="Crowdin | Agile localization for tech companies" />
 </picture></a>
 
 ## License


### PR DESCRIPTION
## Summary
- Add the official Crowdin badge to the Contributing section of README.md, linking to the TrackDraw Crowdin project, as a call-to-action for translation contributors
- Add the same badge above the Translation Workflow section in CONTRIBUTING.md
- Badges switch between Crowdin's light/dark variants based on color scheme, matching the existing logo pattern in README.md

## Test plan
- [ ] Confirm both badges render and link to https://crowdin.com/project/trackdraw
- [ ] Confirm the badge switches variant between light and dark GitHub themes