### PR TITLE
Revoke shares on project archive, auto-promote shares to a project

### DIFF
--- a/docs/research/project-share-lifecycle-integrity.md
+++ b/docs/research/project-share-lifecycle-integrity.md
@@ -23,11 +23,19 @@ Both are proposed as independent slices — fix 1 can ship on its own regardless
 
 When a project is archived, revoke every share still pointing at it.
 
-- Add a step to `archiveProjectForUser` that runs, in the same transaction as the `archived_at` update:
-  `update shares set revoked_at = now() where project_id = ? and revoked_at is null`
+- Add a step to `archiveProjectForUser` that revokes shares tied to that project after the `archived_at` update.
 - Reuse the existing `revoked_at` column and revocation semantics already used elsewhere in `src/lib/server/shares.ts` — no new share state is introduced.
 - Do the same for any hard-delete project path, if one exists, for consistency.
 - Unarchiving (if that exists) should not un-revoke shares automatically — treat revocation as final, matching how manual share revocation already behaves.
+
+### Implemented as
+
+D1 (Cloudflare's SQLite-based product) does not expose a general multi-statement transaction API to this codebase's `getDatabase()` helper, and no other code path here wraps multiple writes in one transaction either — so this ships as two sequential statements, not one atomic transaction, matching the existing style of every other multi-step write in `src/lib/server/projects.ts`/`shares.ts`:
+
+1. `update projects set archived_at = ?, updated_at = ? where id = ? and owner_user_id = ? and archived_at is null`, checked via the D1 result's `meta.changes`.
+2. Only if step 1 actually changed a row (i.e. the caller really did own and archive that project — a 0-row match from a wrong owner or an already-archived project must not cascade), call `revokeSharesForProject(projectId, ownerUserId)`. That function selects active share tokens scoped to both `project_id` and `owner_user_id`, then calls the existing `revokeShare(token)` per token — so gallery entries and preview images are cleaned up the same way manual revocation already does, instead of a raw `UPDATE shares` that would skip that cleanup.
+
+Because this isn't atomic, a crash between step 1 and step 2 would leave the project archived with its shares still active. That's an acceptable, narrow gap: the archive write is the rarer, deliberate action here, and the existing codebase accepts the same non-atomicity elsewhere (e.g. `deleteSharesOwnedByUser`'s per-row loop).
 
 ### Risk and scope
 
@@ -66,10 +74,12 @@ When a signed-in user shares a design that has no `projectId` yet, silently crea
 
 - Matches `accounts-project-sync.md`'s existing decision: "Published shares should attach to a project, and that project can in turn belong to an account."
 - Does not require resolving the harder, still-open ROADMAP question of auto-creating a project on _every_ first edit for signed-in users — it only fires at share time, which is a narrower, lower-risk surface.
-- Implementation sketch:
-  - In `src/app/api/shares/route.ts`, before calling `createShare`, if `user` is present and `body.projectId` is absent, call a new `ensureAccountProject(user.id, design)` helper (in `src/lib/server/projects.ts`, alongside `createProjectDuplicate`) that creates the project row using the same path `handleSyncProject` uses client-side (`useAccountProjectSync.ts:647-702`), then use the resulting id as `projectId`.
-  - Client-side `ShareDialog.tsx` doesn't need to change — it can keep omitting `projectId` when none exists yet; the server fills the gap.
-  - After this ships, a share with `owner_user_id` set and `project_id = null` should no longer be created going forward. Existing rows in that state are left alone (see Migration below).
+
+Implemented as: in `src/app/api/shares/route.ts`, before calling `createShare`, if `user` is present and `body.projectId` is absent, call the existing `saveProjectForUser(user.id, design, { projectId: design.id })` — the same server-side function `POST /api/projects` already uses for "Sync to account" — and use the resulting id as `projectId`. No separate `ensureAccountProject` helper was needed; `saveProjectForUser` already creates-or-updates in one call when given a `projectId`.
+
+`design.id` is passed explicitly as the project id rather than letting `saveProjectForUser` generate a random one, matching the convention `useAccountProjectSync`'s "Sync to account" flow already uses (the account project id equals the design id). Without this, every repeated publish of the same still-unsynced design would create a brand-new project instead of reusing/updating the one from the previous publish.
+
+Client-side `ShareDialog.tsx` doesn't need to change — it can keep omitting `projectId` when none exists yet; the server fills the gap. After this ships, a share with `owner_user_id` set and `project_id = null` should no longer be created going forward. Existing rows in that state are left alone (see Migration below).
 
 **Option C — Full auto-create-project-on-first-edit (out of scope here)**
 
@@ -87,7 +97,7 @@ Do not backfill `projects` rows for existing shares that have `project_id = null
 
 ### Resolved: project visibility after auto-promote
 
-`ensureAccountProject` creates a real, fully visible account project — identical to what "Sync to account" produces — not a hidden row that only exists to satisfy the share's `project_id`. This keeps the account model consistent with `accounts-project-sync.md`, which argues against hiding account-backed state from users.
+The share route's auto-promote call to `saveProjectForUser` creates a real, fully visible account project — identical to what "Sync to account" produces — not a hidden row that only exists to satisfy the share's `project_id`. This keeps the account model consistent with `accounts-project-sync.md`, which argues against hiding account-backed state from users.
 
 ## Suggested sequencing
 

--- a/docs/research/project-share-lifecycle-integrity.md
+++ b/docs/research/project-share-lifecycle-integrity.md
@@ -1,0 +1,97 @@
+# Project/Share Lifecycle Integrity
+
+Date: August 24, 2026
+
+Status: decided — Fix 1 and Fix 2 Option B approved for implementation. Option C stays a separate, still-open roadmap item (see ROADMAP.md item 1) and is intentionally not bundled here.
+
+## Purpose
+
+This document proposes fixes for two related gaps between projects and shares, found while investigating why a new account showed `0 projects` / `1 share`:
+
+1. Archiving a project does not revoke its shares, so a share can keep working after its project is gone.
+2. A signed-in user can publish a share for a design that was never saved as an account project, so `shares.project_id` and `shares.owner_user_id` can diverge from `projects` entirely. This second gap is not a bug against current code, but it does contradict the account model already agreed in [accounts-project-sync.md](accounts-project-sync.md) ("Published shares should attach to a project") and reflects the still-open question in [ROADMAP.md](../roadmap/ROADMAP.md) item 1.
+
+Both are proposed as independent slices — fix 1 can ship on its own regardless of what happens with fix 2.
+
+## Fix 1: Revoke shares when a project is archived
+
+### Problem
+
+`archiveProjectForUser` (`src/lib/server/projects.ts:341-357`) only sets `archived_at` on the project. It never touches `shares`. A share created with a `project_id` pointing at that project stays `active` in `getUserContextStats` (`src/lib/server/users.ts:308-368`) and keeps resolving publicly — a "ghost link" for a project the owner considers gone.
+
+### Recommendation
+
+When a project is archived, revoke every share still pointing at it.
+
+- Add a step to `archiveProjectForUser` that runs, in the same transaction as the `archived_at` update:
+  `update shares set revoked_at = now() where project_id = ? and revoked_at is null`
+- Reuse the existing `revoked_at` column and revocation semantics already used elsewhere in `src/lib/server/shares.ts` — no new share state is introduced.
+- Do the same for any hard-delete project path, if one exists, for consistency.
+- Unarchiving (if that exists) should not un-revoke shares automatically — treat revocation as final, matching how manual share revocation already behaves.
+
+### Risk and scope
+
+Low risk. It's an additive write inside an existing mutation, using an existing column and existing query semantics. No schema migration needed. No client changes needed — a revoked share already renders as "no longer available" wherever that's handled today.
+
+### Existing data
+
+The code change only affects archive actions going forward. Projects already archived before this ships keep any still-active shares as-is unless a one-time backfill runs:
+
+`update shares set revoked_at = <now> where revoked_at is null and project_id in (select id from projects where archived_at is not null)`
+
+This backfill is included as part of this fix — it's a direct application of the same invariant, not a separate decision.
+
+### Test plan
+
+- Archive a project with an active published share → share becomes unreachable and `activeShareCount` drops.
+- Archive a project with no shares → no-op, unchanged behavior.
+- Archive a project with an already-revoked share → no-op on that row.
+
+## Fix 2: Decide what "share" means relative to "project"
+
+### The actual disagreement to resolve
+
+Two coherent models exist. Today's code implements neither one consistently — it lets a share exist with `project_id = null` while `owner_user_id` is set, which is the "share is independent of project" model, but the rest of the product (project management, "my projects" counts, `accounts-project-sync.md`) assumes the other model.
+
+**Option A — Share stays independent of project (current behavior, keep and document it)**
+
+Sharing a design is a lightweight, always-available action, whether or not the design has ever been saved as an account project. This is intentionally decoupled so a user can share fast without a save step in the way.
+
+- No code change required beyond Fix 1.
+- Requires only a UX/labeling fix: `getUserContextStats` and any dashboard should stop implying a share always corresponds to a saved project. If there's an admin or profile view that lists shares next to projects, it should show "design not saved as a project" rather than nothing, so it doesn't read as broken.
+
+**Option B — Auto-promote to a project the moment a signed-in user shares (recommended)**
+
+When a signed-in user shares a design that has no `projectId` yet, silently create the account project first (same as pressing "Sync to account"), then attach the share to it. This is the smaller, more contained version of "auto-create," scoped to the one moment where the product already promises project-backed shares.
+
+- Matches `accounts-project-sync.md`'s existing decision: "Published shares should attach to a project, and that project can in turn belong to an account."
+- Does not require resolving the harder, still-open ROADMAP question of auto-creating a project on _every_ first edit for signed-in users — it only fires at share time, which is a narrower, lower-risk surface.
+- Implementation sketch:
+  - In `src/app/api/shares/route.ts`, before calling `createShare`, if `user` is present and `body.projectId` is absent, call a new `ensureAccountProject(user.id, design)` helper (in `src/lib/server/projects.ts`, alongside `createProjectDuplicate`) that creates the project row using the same path `handleSyncProject` uses client-side (`useAccountProjectSync.ts:647-702`), then use the resulting id as `projectId`.
+  - Client-side `ShareDialog.tsx` doesn't need to change — it can keep omitting `projectId` when none exists yet; the server fills the gap.
+  - After this ships, a share with `owner_user_id` set and `project_id = null` should no longer be created going forward. Existing rows in that state are left alone (see Migration below).
+
+**Option C — Full auto-create-project-on-first-edit (out of scope here)**
+
+This is ROADMAP item 1 in full: every signed-in user's design becomes an account project as soon as they start working, not just at share time. It's the most product-visible change (affects Project Manager's device/account split, autosync triggers, first-run experience) and should stay a separate roadmap decision, not bundled into this lifecycle fix. Option B is compatible with Option C landing later — nothing in B needs to be undone if C ships afterward.
+
+Tracked separately: [#773](https://github.com/dutchdronesquad/trackdraw/issues/773).
+
+### Decision
+
+Option B, approved. It resolves the specific inconsistency (`0 projects`, `1 share`) without waiting on the bigger, still-open auto-sync-on-edit decision, and it's a direct implementation of a decision already made in `accounts-project-sync.md`. Option C remains a separate roadmap decision, to be made alongside broader accounts/project UX work (Project Manager redesign, onboarding), not as a side effect of this fix.
+
+### Migration for existing data
+
+Do not backfill `projects` rows for existing shares that have `project_id = null`. Retroactively creating projects for old shares would fabricate ownership history and project timestamps that never existed. Leave existing orphaned-by-design shares as they are; Option B only changes behavior for shares created after the change ships.
+
+### Resolved: project visibility after auto-promote
+
+`ensureAccountProject` creates a real, fully visible account project — identical to what "Sync to account" produces — not a hidden row that only exists to satisfy the share's `project_id`. This keeps the account model consistent with `accounts-project-sync.md`, which argues against hiding account-backed state from users.
+
+## Suggested sequencing
+
+1. Ship Fix 1 (archive cascade) — independent, low-risk, no product decision needed.
+2. Get a decision on Fix 2 (Option A vs B) — B is recommended.
+3. If B is accepted, implement `ensureAccountProject` and wire it into the share route.
+4. Leave Option C (full auto-create-on-edit) on the roadmap as its own item, informed by whatever is learned from B.

--- a/migrations/0018_revoke_shares_for_archived_projects.sql
+++ b/migrations/0018_revoke_shares_for_archived_projects.sql
@@ -1,0 +1,19 @@
+-- Archiving a project used to leave its shares active ("ghost links").
+-- Revoke any share still active for a project that is already archived,
+-- matching the invariant now enforced going forward by archiveProjectForUser.
+UPDATE shares
+SET revoked_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+    updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE revoked_at IS NULL
+  AND project_id IN (SELECT id FROM projects WHERE archived_at IS NOT NULL);
+
+-- Drop the now-stale gallery rows for those shares. Any stored preview image
+-- blob for these rows is not reclaimed here; volume is expected to be small
+-- since it only covers shares tied to already-archived projects.
+DELETE FROM gallery_entries
+WHERE share_token IN (
+  SELECT s.token
+  FROM shares s
+  JOIN projects p ON p.id = s.project_id
+  WHERE p.archived_at IS NOT NULL
+);

--- a/src/app/api/shares/route.ts
+++ b/src/app/api/shares/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { parseDesign } from "@/lib/track/design";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
 import { isTrustedRequest } from "@/lib/server/csrf";
-import { getProjectForUser } from "@/lib/server/projects";
+import { getProjectForUser, saveProjectForUser } from "@/lib/server/projects";
 import {
   createShare,
   getShareByProjectIdForUser,
@@ -90,10 +90,16 @@ export async function POST(request: Request) {
       }
     }
 
+    let projectId = body.projectId ?? null;
+    if (user && !projectId) {
+      const project = await saveProjectForUser(user.id, design);
+      projectId = project.id;
+    }
+
     const share = await createShare(design, {
       expiresInDays: user ? undefined : (body.expiresInDays ?? 90),
       ownerUserId: user?.id ?? null,
-      projectId: body.projectId ?? null,
+      projectId,
     });
     const path = buildStoredSharePath(
       share.token,

--- a/src/app/api/shares/route.ts
+++ b/src/app/api/shares/route.ts
@@ -92,7 +92,13 @@ export async function POST(request: Request) {
 
     let projectId = body.projectId ?? null;
     if (user && !projectId) {
-      const project = await saveProjectForUser(user.id, design);
+      // Reuse the design id as the project id, matching the convention
+      // useAccountProjectSync's "Sync to account" flow already uses, so a
+      // repeated publish of the same design promotes/updates the same
+      // project instead of creating a new one every time.
+      const project = await saveProjectForUser(user.id, design, {
+        projectId: design.id,
+      });
       projectId = project.id;
     }
 

--- a/src/lib/server/projects.ts
+++ b/src/lib/server/projects.ts
@@ -346,7 +346,7 @@ export async function archiveProjectForUser(
   const db = await getDatabase();
   const now = new Date().toISOString();
 
-  await db
+  const result = await db
     .prepare(
       `
         update projects
@@ -355,7 +355,11 @@ export async function archiveProjectForUser(
       `
     )
     .bind(now, now, projectId, ownerUserId)
-    .run();
+    .run<{ meta?: { changes?: number } }>();
 
-  await revokeSharesForProject(projectId);
+  // Only cascade if this call actually archived the project — a 0-row match
+  // (wrong owner, already archived, or unknown id) must not revoke shares.
+  if ((result.meta?.changes ?? 0) > 0) {
+    await revokeSharesForProject(projectId, ownerUserId);
+  }
 }

--- a/src/lib/server/projects.ts
+++ b/src/lib/server/projects.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/track/design";
 import type { SerializedTrackDesign, TrackDesign } from "@/lib/types";
 import { getDatabase } from "@/lib/server/db";
+import { revokeSharesForProject } from "@/lib/server/shares";
 
 type ProjectRow = {
   id: string;
@@ -355,4 +356,6 @@ export async function archiveProjectForUser(
     )
     .bind(now, now, projectId, ownerUserId)
     .run();
+
+  await revokeSharesForProject(projectId);
 }

--- a/src/lib/server/shares.ts
+++ b/src/lib/server/shares.ts
@@ -352,7 +352,10 @@ export async function purgeRevokedShare(token: string) {
     .run();
 }
 
-export async function revokeSharesForProject(projectId: string) {
+export async function revokeSharesForProject(
+  projectId: string,
+  ownerUserId: string
+) {
   const db = await getDatabase();
 
   const rows = await db
@@ -360,10 +363,10 @@ export async function revokeSharesForProject(projectId: string) {
       `
         select token
         from shares
-        where project_id = ? and revoked_at is null
+        where project_id = ? and owner_user_id = ? and revoked_at is null
       `
     )
-    .bind(projectId)
+    .bind(projectId, ownerUserId)
     .all<{ token: string }>();
 
   for (const row of rows.results ?? []) {

--- a/src/lib/server/shares.ts
+++ b/src/lib/server/shares.ts
@@ -352,6 +352,25 @@ export async function purgeRevokedShare(token: string) {
     .run();
 }
 
+export async function revokeSharesForProject(projectId: string) {
+  const db = await getDatabase();
+
+  const rows = await db
+    .prepare(
+      `
+        select token
+        from shares
+        where project_id = ? and revoked_at is null
+      `
+    )
+    .bind(projectId)
+    .all<{ token: string }>();
+
+  for (const row of rows.results ?? []) {
+    await revokeShare(row.token);
+  }
+}
+
 export async function deleteSharesOwnedByUser(userId: string) {
   const db = await getDatabase();
 

--- a/tests/app/api/shares.route.test.ts
+++ b/tests/app/api/shares.route.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/lib/server/auth-session", () => ({
 
 vi.mock("@/lib/server/projects", () => ({
   getProjectForUser: vi.fn(),
+  saveProjectForUser: vi.fn(),
 }));
 
 vi.mock("@/lib/server/shares", () => ({
@@ -27,7 +28,7 @@ vi.mock("@/lib/server/shares", () => ({
 
 import { GET, POST } from "@/app/api/shares/route";
 import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
-import { getProjectForUser } from "@/lib/server/projects";
+import { getProjectForUser, saveProjectForUser } from "@/lib/server/projects";
 import {
   createShare,
   getShareByProjectIdForUser,
@@ -127,6 +128,55 @@ describe("shares API route", () => {
         projectId: "project-1",
       }
     );
+  });
+
+  it("auto-promotes an unsaved design to a project when a signed-in user publishes without a projectId", async () => {
+    const design = createDefaultDesign();
+    const project = createStoredProjectFixture({ id: design.id, design });
+    const share = createStoredShareFixture({
+      expiresAt: null,
+      ownerUserId: testUser.id,
+      projectId: project.id,
+      shareType: "published",
+    });
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(testUser);
+    vi.mocked(saveProjectForUser).mockResolvedValue(project);
+    vi.mocked(createShare).mockResolvedValue(share);
+
+    const response = await POST(postRequest({ design, view: "2d" }));
+
+    expect(response.status).toBe(200);
+    expect(getProjectForUser).not.toHaveBeenCalled();
+    expect(saveProjectForUser).toHaveBeenCalledWith(
+      testUser.id,
+      expect.objectContaining({ id: design.id }),
+      { projectId: design.id }
+    );
+    expect(createShare).toHaveBeenCalledWith(
+      expect.objectContaining({ id: design.id }),
+      {
+        expiresInDays: undefined,
+        ownerUserId: testUser.id,
+        projectId: project.id,
+      }
+    );
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      share: { projectId: project.id },
+    });
+  });
+
+  it("does not auto-create a project for anonymous share publishes", async () => {
+    const design = createDefaultDesign();
+    const share = createStoredShareFixture({
+      expiresAt: "2026-05-02T12:00:00.000Z",
+    });
+    vi.mocked(getCurrentUserFromHeaders).mockResolvedValue(null);
+    vi.mocked(createShare).mockResolvedValue(share);
+
+    await POST(postRequest({ design, view: "2d" }));
+
+    expect(saveProjectForUser).not.toHaveBeenCalled();
   });
 
   it("rejects project-linked publish for anonymous users", async () => {

--- a/tests/lib/server/projects.test.ts
+++ b/tests/lib/server/projects.test.ts
@@ -10,12 +10,17 @@ vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
   prepare: vi.fn(),
+  revokeSharesForProject: vi.fn(),
 }));
 
 vi.mock("@/lib/server/db", () => ({
   getDatabase: vi.fn(async () => ({
     prepare: mocks.prepare,
   })),
+}));
+
+vi.mock("@/lib/server/shares", () => ({
+  revokeSharesForProject: mocks.revokeSharesForProject,
 }));
 
 import {
@@ -47,6 +52,7 @@ function projectRow(design: TrackDesign) {
 describe("project server helpers", () => {
   beforeEach(() => {
     mocks.prepare.mockReset();
+    mocks.revokeSharesForProject.mockReset();
   });
 
   it("rejects stale account project saves before overwriting cloud state", async () => {
@@ -203,7 +209,7 @@ describe("project server helpers", () => {
   });
 
   it("archiveProjectForUser runs an UPDATE query with the correct bindings", async () => {
-    const runStmt = createD1Statement();
+    const runStmt = createD1Statement({ run: { meta: { changes: 1 } } });
     mocks.prepare.mockReturnValue(runStmt);
 
     await archiveProjectForUser("project-1", "user-1");
@@ -218,5 +224,26 @@ describe("project server helpers", () => {
     expect(mocks.prepare).toHaveBeenCalledWith(
       expect.stringContaining("archived_at")
     );
+  });
+
+  it("archiveProjectForUser revokes the project's shares once the archive actually changes a row", async () => {
+    const runStmt = createD1Statement({ run: { meta: { changes: 1 } } });
+    mocks.prepare.mockReturnValue(runStmt);
+
+    await archiveProjectForUser("project-1", "user-1");
+
+    expect(mocks.revokeSharesForProject).toHaveBeenCalledWith(
+      "project-1",
+      "user-1"
+    );
+  });
+
+  it("archiveProjectForUser does not revoke shares when no row matched (wrong owner or already archived)", async () => {
+    const runStmt = createD1Statement({ run: { meta: { changes: 0 } } });
+    mocks.prepare.mockReturnValue(runStmt);
+
+    await archiveProjectForUser("project-1", "someone-elses-user-id");
+
+    expect(mocks.revokeSharesForProject).not.toHaveBeenCalled();
   });
 });

--- a/tests/lib/server/shares.test.ts
+++ b/tests/lib/server/shares.test.ts
@@ -51,6 +51,7 @@ import {
   getSharesByUserId,
   resolveStoredShare,
   revokeShare,
+  revokeSharesForProject,
 } from "@/lib/server/shares";
 
 afterEach(() => {
@@ -237,6 +238,51 @@ describe("deleteSharesOwnedByUser", () => {
     expect(mocks.deleteGalleryEntry).toHaveBeenNthCalledWith(2, "tok-b");
     expect(deleteB.bind).toHaveBeenCalledWith("tok-b");
     expect(deleteB.run).toHaveBeenCalledOnce();
+  });
+});
+
+describe("revokeSharesForProject", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-25T12:00:00.000Z"));
+    mocks.prepare.mockReset();
+    mocks.deleteGalleryEntry.mockReset();
+  });
+
+  it("does nothing when the project has no active shares", async () => {
+    const selectStmt = createD1AllStatement([]);
+    installStatements([selectStmt]);
+
+    await revokeSharesForProject("project-1", "user-1");
+
+    expect(selectStmt.bind).toHaveBeenCalledWith("project-1", "user-1");
+    expect(mocks.deleteGalleryEntry).not.toHaveBeenCalled();
+  });
+
+  it("revokes every active share for the project, scoped to the owner", async () => {
+    const selectStmt = createD1AllStatement([
+      { token: "tok-a" },
+      { token: "tok-b" },
+    ]);
+    const revokeA = createStatement();
+    const revokeB = createStatement();
+    installStatements([selectStmt, revokeA, revokeB]);
+
+    await revokeSharesForProject("project-1", "user-1");
+
+    expect(selectStmt.bind).toHaveBeenCalledWith("project-1", "user-1");
+    expect(revokeA.bind).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      "tok-a"
+    );
+    expect(mocks.deleteGalleryEntry).toHaveBeenNthCalledWith(1, "tok-a");
+    expect(revokeB.bind).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      "tok-b"
+    );
+    expect(mocks.deleteGalleryEntry).toHaveBeenNthCalledWith(2, "tok-b");
   });
 });
 


### PR DESCRIPTION
## Summary

- Investigated why a new account could show `0 projects` but `1 share`: shares were never guaranteed to be backed by a `projects` row, and archiving a project never revoked shares still pointing at it.
- `archiveProjectForUser` now revokes every share tied to the archived project via a new `revokeSharesForProject` (reuses `revokeShare` so gallery entries/preview images are cleaned up too, not just the `shares` row).
- Added a one-time backfill migration (`0018_revoke_shares_for_archived_projects.sql`) so projects already archived before this ships also get their still-active shares revoked.
- The shares API (`POST /api/shares`) now creates the account project on the fly (`saveProjectForUser`) when a signed-in user publishes a share without an existing `projectId`, so `owner_user_id` and `project_id` no longer diverge going forward. Existing orphaned shares are intentionally left alone — see the migration note in the doc for why backfilling those would be wrong.
- Full analysis, the options considered, and the decision record are in `docs/research/project-share-lifecycle-integrity.md`.
- The broader, still-open question — auto-creating a project on first edit for signed-in users, not just at share time — is intentionally out of scope here and tracked as #773.

## Test plan

- [ ] Archive a project with an active published share → share becomes unreachable, `activeShareCount` drops for the user
- [ ] Archive a project with no shares → no-op, unchanged behavior
- [ ] Archive a project with an already-revoked share → no-op on that row
- [ ] Run migration `0018` against a DB with pre-existing archived projects that still have active shares → those shares get revoked and their gallery rows removed
- [ ] Signed-in user publishes a share for a design with no `projectId` → a new account project is created and the share is attached to it, visible in Project Manager
- [ ] Signed-in user publishes a share with an existing valid `projectId` → unchanged behavior (no duplicate project created)
- [ ] Signed-in user publishes a share with a `projectId` they don't own → still 404s as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)