### PR TITLE
feat: Show days-to-ready progress on building metric badges

### DIFF
--- a/lang/en-US/dashboard.json
+++ b/lang/en-US/dashboard.json
@@ -243,7 +243,8 @@
         "low_volume": "Low volume",
         "degraded": "Degraded",
         "invalid": "Invalid",
-        "not_started": "Awaiting first complete period"
+        "not_started": "Awaiting first complete period",
+        "buildingProgress": "Building — {elapsed}/{total}d"
       },
       "comparison": {
         "unavailable": "No reliable comparison",
@@ -535,6 +536,7 @@
     },
     "comparison": {
       "building": "30-day comparison is building",
+      "buildingProgress": "30-day comparison is building — {elapsed}/{total}d",
       "lowVolume": "Comparison hidden for low volume",
       "flat": "No change vs previous 30d",
       "changeUp": "Up {pct}% vs previous 30d",

--- a/src/components/dashboard/MetricsCharts.tsx
+++ b/src/components/dashboard/MetricsCharts.tsx
@@ -1419,7 +1419,12 @@ function UsageComparison({
   const t = useTranslations("dashboard.metrics.comparison");
   if (!hasComparisonBaseline(usage)) {
     return (
-      <span className="text-muted-foreground text-xs">{t("building")}</span>
+      <span className="text-muted-foreground text-xs">
+        {t("buildingProgress", {
+          elapsed: Math.min(usage.trackingDays, 60),
+          total: 60,
+        })}
+      </span>
     );
   }
   const previous = previousEventCount(usage, eventType);

--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -79,6 +79,7 @@ type MetricSnapshot = {
   quality: MetricsExplorerQuality;
   windowDays: number;
   measuredSince: string | null;
+  generatedAt: string;
 };
 
 type MetricsView =
@@ -673,6 +674,7 @@ export default function MetricsWorkspace({
           quality: metric.quality,
           windowDays: metric.windowDays,
           measuredSince: metric.measuredSince,
+          generatedAt: cockpit.generatedAt,
         } satisfies MetricSnapshot,
       ] as const;
     });
@@ -693,6 +695,7 @@ export default function MetricsWorkspace({
           quality: explorer.acquisition.quality,
           windowDays: explorer.acquisition.windowDays,
           measuredSince: explorer.acquisition.measuredSince,
+          generatedAt: explorer.generatedAt,
         },
       ],
       [
@@ -711,6 +714,7 @@ export default function MetricsWorkspace({
           quality: explorer.adoption.quality,
           windowDays: explorer.adoption.windowDays,
           measuredSince: explorer.adoption.measuredSince,
+          generatedAt: explorer.generatedAt,
         },
       ],
     ];
@@ -790,7 +794,7 @@ export default function MetricsWorkspace({
                         <QualityLabel
                           quality={snapshot.quality}
                           measuredSince={snapshot.measuredSince}
-                          generatedAt={explorer.generatedAt}
+                          generatedAt={snapshot.generatedAt}
                         />
                         <span className="mt-0.5 text-base font-semibold tabular-nums">
                           {snapshot.valueKind === "mix" ||
@@ -952,7 +956,7 @@ export default function MetricsWorkspace({
                           <QualityLabel
                             quality={snapshot.quality}
                             measuredSince={snapshot.measuredSince}
-                            generatedAt={explorer.generatedAt}
+                            generatedAt={snapshot.generatedAt}
                           />
                         </td>
                         <td className="px-4 py-2 text-right tabular-nums sm:pr-5">

--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -164,8 +164,32 @@ function formatRowValue(row: MetricsExplorerRow, percent: Intl.NumberFormat) {
   return row.value === null ? "—" : percent.format(row.value);
 }
 
-function QualityLabel({ quality }: { quality: MetricsExplorerQuality }) {
+const BUILDING_WINDOW_DAYS = 28;
+
+function buildingProgressDays(measuredSince: string, generatedAt: string) {
+  const elapsedMs =
+    Date.parse(generatedAt) - Date.parse(`${measuredSince}T00:00:00.000Z`);
+  const elapsed = Math.floor(elapsedMs / 86_400_000);
+  return {
+    elapsed: Math.min(Math.max(elapsed, 0), BUILDING_WINDOW_DAYS),
+    total: BUILDING_WINDOW_DAYS,
+  };
+}
+
+function QualityLabel({
+  quality,
+  measuredSince,
+  generatedAt,
+}: {
+  quality: MetricsExplorerQuality;
+  measuredSince?: string | null;
+  generatedAt?: string;
+}) {
   const t = useTranslations("dashboard.metrics.explorer.quality");
+  const progress =
+    quality === "building" && measuredSince && generatedAt
+      ? buildingProgressDays(measuredSince, generatedAt)
+      : null;
   return (
     <span
       className={cn(
@@ -174,7 +198,12 @@ function QualityLabel({ quality }: { quality: MetricsExplorerQuality }) {
       )}
     >
       <Circle className="size-2 fill-current" aria-hidden="true" />
-      {t(quality)}
+      {progress
+        ? t("buildingProgress", {
+            elapsed: progress.elapsed,
+            total: progress.total,
+          })
+        : t(quality)}
     </span>
   );
 }
@@ -758,7 +787,11 @@ export default function MetricsWorkspace({
                         <span className="text-xs font-medium">
                           {t(`journey.${key}.label`)}
                         </span>
-                        <QualityLabel quality={snapshot.quality} />
+                        <QualityLabel
+                          quality={snapshot.quality}
+                          measuredSince={snapshot.measuredSince}
+                          generatedAt={explorer.generatedAt}
+                        />
                         <span className="mt-0.5 text-base font-semibold tabular-nums">
                           {snapshot.valueKind === "mix" ||
                           snapshot.value === null
@@ -916,7 +949,11 @@ export default function MetricsWorkspace({
                           <MetricDelta snapshot={snapshot} percent={percent} />
                         </td>
                         <td className="px-3 py-2 text-right">
-                          <QualityLabel quality={snapshot.quality} />
+                          <QualityLabel
+                            quality={snapshot.quality}
+                            measuredSince={snapshot.measuredSince}
+                            generatedAt={explorer.generatedAt}
+                          />
                         </td>
                         <td className="px-4 py-2 text-right tabular-nums sm:pr-5">
                           {t("windowDays", { days: snapshot.windowDays })}
@@ -959,7 +996,11 @@ export default function MetricsWorkspace({
                   {t("retention.description")}
                 </p>
               </div>
-              <QualityLabel quality={explorer.retention.quality} />
+              <QualityLabel
+                quality={explorer.retention.quality}
+                measuredSince={explorer.retention.measuredSince}
+                generatedAt={explorer.generatedAt}
+              />
             </div>
             <RetentionTable metric={explorer.retention} />
           </section>
@@ -976,7 +1017,11 @@ export default function MetricsWorkspace({
                   {t("acquisition.description")}
                 </p>
               </div>
-              <QualityLabel quality={explorer.acquisition.quality} />
+              <QualityLabel
+                quality={explorer.acquisition.quality}
+                measuredSince={explorer.acquisition.measuredSince}
+                generatedAt={explorer.generatedAt}
+              />
             </div>
             <ExplorerBarRows
               metric={explorer.acquisition}
@@ -1020,7 +1065,11 @@ export default function MetricsWorkspace({
                     {t("adoption.description")}
                   </p>
                 </div>
-                <QualityLabel quality={explorer.adoption.quality} />
+                <QualityLabel
+                  quality={explorer.adoption.quality}
+                  measuredSince={explorer.adoption.measuredSince}
+                  generatedAt={explorer.generatedAt}
+                />
               </div>
               <ExplorerBarRows
                 metric={explorer.adoption}

--- a/tests/components/dashboard/MetricsCharts.test.tsx
+++ b/tests/components/dashboard/MetricsCharts.test.tsx
@@ -504,7 +504,7 @@ describe("metrics decision views", () => {
       screen.getByRole("button", { name: /^Acquisition Building/ })
     ).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: /^Activation Building 0%/ })
+      screen.getByRole("button", { name: /^Activation Building — \d+\/28d 0%/ })
     ).toBeTruthy();
     expect(screen.queryAllByRole("combobox")).toHaveLength(0);
     expect(screen.getAllByRole("tab")).toHaveLength(5);


### PR DESCRIPTION
## Summary
- Product metrics on the dashboard show a "Building" badge while a metric accumulates history, but gave no indication of how close it is to being ready, even though the measured-since timestamp and tracking-window data already existed server-side.
- `QualityLabel` (journey stages, evidence table, retention/acquisition/adoption sections) now renders "Building — N/28d" using the existing `measuredSince` and the fixed 28-day maturity window used by the aggregation job.
- The 30-day usage comparison badge now renders "30-day comparison is building — N/60d" using the existing `trackingDays` value instead of a bare "building" label.
- No backend or data-model changes: this only surfaces data that was already being computed and stored.

## Test plan
- [ ] Confirm badges on `/dashboard/metrics` show "Building — N/28d" for metrics still accumulating history, and fall back to the plain quality label once healthy.
- [ ] Confirm the editor usage comparison shows "30-day comparison is building — N/60d" before day 60 of tracking, and the normal delta after.
- [ ] `npm run lint` && `npm run type`

🤖 Generated with [Claude Code](https://claude.com/claude-code)