### PR TITLE
Auto-promote brand-new designs to account projects on first meaningful edit

### DIFF
--- a/src/components/editor/EditorShell.tsx
+++ b/src/components/editor/EditorShell.tsx
@@ -337,6 +337,8 @@ export default function EditorShell({
     projectManagerOpen,
     historyPaused,
     interactionSessionDepth,
+    projects,
+    initialized,
     snapshotCurrentDesign,
     replaceDesign,
     setProjects,

--- a/src/components/editor/useAccountProjectSync.ts
+++ b/src/components/editor/useAccountProjectSync.ts
@@ -7,6 +7,7 @@ import { getDesignShapes } from "@/lib/track/design";
 import {
   createProjectDuplicate,
   deleteProject,
+  hasMeaningfulProjectContent,
   listProjects,
   listRestorePointsForProject,
   loadProject,
@@ -89,6 +90,8 @@ type UseAccountProjectSyncOptions = {
   projectManagerOpen: boolean;
   historyPaused: boolean;
   interactionSessionDepth: number;
+  projects: ProjectMeta[];
+  initialized: boolean;
   snapshotCurrentDesign: () => void;
   replaceDesign: (design: TrackDesign) => void;
   setProjects: (projects: ProjectMeta[]) => void;
@@ -104,6 +107,8 @@ export function useAccountProjectSync({
   projectManagerOpen,
   historyPaused,
   interactionSessionDepth,
+  projects,
+  initialized,
   snapshotCurrentDesign,
   replaceDesign,
   setProjects,
@@ -139,6 +144,18 @@ export function useAccountProjectSync({
   const previousAuthUserIdRef = useRef<string | null>(authUserId);
   const pendingReentryConflictCheckRef = useRef(false);
 
+  // Snapshot of local project ids that existed the moment the local project
+  // list finished loading, captured once. A design id present here was
+  // already a device-local project before auto-promote logic engaged this
+  // session, and must never be auto-promoted (manual "Sync to account" only).
+  const localProjectIdsAtLoadRef = useRef<Set<string> | null>(null);
+  // One-shot guard: once an auto-promote attempt (success or failure) has
+  // been made for a design id, never attempt it again automatically. A
+  // failed attempt already falls back to a normal local-project save (via
+  // syncDesignToAccount's own catch/saveLocalSyncFallback), after which the
+  // design is handled by the ordinary manual Sync-to-account flow.
+  const autoPromoteAttemptedIdsRef = useRef<Set<string>>(new Set());
+
   const [accountShares, setAccountShares] = useState<AccountShareItem[]>([]);
   const [accountSharesLoading, setAccountSharesLoading] = useState(false);
   const accountSharesFetchedForUserRef = useRef<string | null>(null);
@@ -146,6 +163,13 @@ export function useAccountProjectSync({
   useEffect(() => {
     designRef.current = design;
   }, [design]);
+
+  useEffect(() => {
+    if (!initialized || localProjectIdsAtLoadRef.current) return;
+    localProjectIdsAtLoadRef.current = new Set(
+      projects.map((project) => project.id)
+    );
+  }, [initialized, projects]);
 
   useEffect(() => {
     accountProjectsRef.current = accountProjects;
@@ -810,6 +834,68 @@ export function useAccountProjectSync({
     historyPaused,
     interactionSessionDepth,
     handleSyncProject,
+    markProjectSyncFailed,
+    readOnly,
+    setSaveStatusLabel,
+    syncDesignToAccount,
+  ]);
+
+  useEffect(() => {
+    if (
+      readOnly ||
+      !authUserId ||
+      !cloudProjectsAvailable ||
+      isAccountProject ||
+      historyPaused ||
+      interactionSessionDepth > 0
+    ) {
+      return;
+    }
+
+    const knownLocalIds = localProjectIdsAtLoadRef.current;
+    if (!knownLocalIds || knownLocalIds.has(currentDesignId)) return;
+    if (autoPromoteAttemptedIdsRef.current.has(currentDesignId)) return;
+    if (!hasMeaningfulProjectContent(designRef.current)) return;
+
+    const timeoutId = window.setTimeout(() => {
+      autoPromoteAttemptedIdsRef.current.add(currentDesignId);
+      void syncDesignToAccount(designRef.current, {
+        updateStatusLabel: true,
+      }).catch((error) => {
+        if (isAccountProjectSyncConflictError(error)) {
+          setSaveStatusLabel("Review project version");
+          return;
+        }
+
+        markProjectSyncFailed(
+          currentDesignId,
+          error instanceof Error ? error.message : "Account sync failed"
+        );
+        setSaveStatusLabel("Account sync failed; saved locally");
+        toast.error("Account sync failed", {
+          description:
+            "TrackDraw saved this new project on this device, but could not create the account copy yet. Retry sync when the connection is back.",
+          action: {
+            label: "Retry",
+            onClick: () => {
+              void handleSyncProject(currentDesignId);
+            },
+          },
+        });
+        console.error("[TrackDraw auto-promote]", error);
+      });
+    }, 4000);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [
+    authUserId,
+    cloudProjectsAvailable,
+    currentDesignId,
+    currentProjectSyncSignature,
+    handleSyncProject,
+    historyPaused,
+    interactionSessionDepth,
+    isAccountProject,
     markProjectSyncFailed,
     readOnly,
     setSaveStatusLabel,

--- a/src/components/editor/useAccountProjectSync.ts
+++ b/src/components/editor/useAccountProjectSync.ts
@@ -847,6 +847,8 @@ export function useAccountProjectSync({
     const knownLocalIds = localProjectIdsAtLoadRef.current;
     if (!knownLocalIds || knownLocalIds.has(currentDesignId)) return;
     if (autoPromoteAttemptedIdsRef.current.has(currentDesignId)) return;
+    // A default title alone counts as "meaningful"; require an actual edit too.
+    if (designRef.current.updatedAt === designRef.current.createdAt) return;
     if (!hasMeaningfulProjectContent(designRef.current)) return;
 
     const timeoutId = window.setTimeout(() => {
@@ -886,6 +888,7 @@ export function useAccountProjectSync({
     currentProjectSyncSignature,
     handleSyncProject,
     historyPaused,
+    initialized,
     interactionSessionDepth,
     isAccountProject,
     markProjectSyncFailed,

--- a/src/components/editor/useAccountProjectSync.ts
+++ b/src/components/editor/useAccountProjectSync.ts
@@ -144,16 +144,8 @@ export function useAccountProjectSync({
   const previousAuthUserIdRef = useRef<string | null>(authUserId);
   const pendingReentryConflictCheckRef = useRef(false);
 
-  // Snapshot of local project ids that existed the moment the local project
-  // list finished loading, captured once. A design id present here was
-  // already a device-local project before auto-promote logic engaged this
-  // session, and must never be auto-promoted (manual "Sync to account" only).
+  // Ids present here predate this session and are never auto-promoted.
   const localProjectIdsAtLoadRef = useRef<Set<string> | null>(null);
-  // One-shot guard: once an auto-promote attempt (success or failure) has
-  // been made for a design id, never attempt it again automatically. A
-  // failed attempt already falls back to a normal local-project save (via
-  // syncDesignToAccount's own catch/saveLocalSyncFallback), after which the
-  // design is handled by the ordinary manual Sync-to-account flow.
   const autoPromoteAttemptedIdsRef = useRef<Set<string>>(new Set());
 
   const [accountShares, setAccountShares] = useState<AccountShareItem[]>([]);

--- a/tests/components/editor/useAccountProjectSync.test.tsx
+++ b/tests/components/editor/useAccountProjectSync.test.tsx
@@ -321,6 +321,7 @@ describe("useAccountProjectSync", () => {
     it("auto-promotes a brand-new signed-in draft with meaningful content", async () => {
       const design = createDefaultDesign();
       design.id = "draft-1";
+      design.updatedAt = "2026-04-20T10:05:00.000Z";
       const fetchMock = vi.fn(
         async (_input: RequestInfo | URL, init?: RequestInit) => {
           if (init?.method === "POST") {
@@ -426,6 +427,7 @@ describe("useAccountProjectSync", () => {
     it("degrades gracefully and only attempts once when auto-promote fails", async () => {
       const design = createDefaultDesign();
       design.id = "draft-3";
+      design.updatedAt = "2026-04-20T10:05:00.000Z";
       const fetchMock = vi.fn(
         async (_input: RequestInfo | URL, init?: RequestInit) => {
           if (init?.method === "POST") {
@@ -498,6 +500,98 @@ describe("useAccountProjectSync", () => {
       expect(
         fetchMock.mock.calls.filter(([, init]) => init?.method === "POST")
       ).toHaveLength(1);
+    });
+
+    it("does not auto-promote an untouched default design", async () => {
+      const design = createDefaultDesign();
+      design.id = "draft-4";
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          Response.json({ ok: true, projects: [] })
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      renderAccountProjectSync({
+        authUserId: "user-1",
+        design,
+        projects: [],
+        initialized: true,
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      const postCall = fetchMock.mock.calls.find(
+        ([, init]) => init?.method === "POST"
+      );
+      expect(postCall).toBeUndefined();
+    });
+
+    it("auto-promotes once local projects finish loading, not before", async () => {
+      const design = createDefaultDesign();
+      design.id = "draft-5";
+      design.updatedAt = "2026-04-20T10:05:00.000Z";
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          if (init?.method === "POST") {
+            return Response.json({
+              ok: true,
+              project: {
+                id: design.id,
+                title: design.title,
+                updatedAt: "2026-04-20T10:30:00.000Z",
+                designUpdatedAt: design.updatedAt,
+                shapeCount: 0,
+              },
+            });
+          }
+
+          return Response.json({ ok: true, projects: [] });
+        }
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const baseOptions: HookOptions = {
+        authUserId: "user-1",
+        readOnly: false,
+        design,
+        projectManagerOpen: false,
+        historyPaused: false,
+        interactionSessionDepth: 0,
+        projects: [],
+        initialized: false,
+        snapshotCurrentDesign: vi.fn(),
+        replaceDesign: vi.fn(),
+        setProjects: vi.fn(),
+        setRestorePoints: vi.fn(),
+        setActiveRestorePointId: vi.fn(),
+        setSaveStatusLabel: vi.fn(),
+      };
+
+      const { rerender } = renderHook(
+        (initialized: boolean) =>
+          useAccountProjectSync({ ...baseOptions, initialized }),
+        { initialProps: false }
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      expect(
+        fetchMock.mock.calls.find(([, init]) => init?.method === "POST")
+      ).toBeUndefined();
+
+      rerender(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      expect(
+        fetchMock.mock.calls.find(([, init]) => init?.method === "POST")
+      ).toBeDefined();
     });
   });
 });

--- a/tests/components/editor/useAccountProjectSync.test.tsx
+++ b/tests/components/editor/useAccountProjectSync.test.tsx
@@ -2,12 +2,13 @@
 
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "sonner";
 import { createDefaultDesign } from "@/lib/track/design";
 import {
   AccountProjectSyncConflictError,
   useAccountProjectSync,
 } from "@/components/editor/useAccountProjectSync";
-import { saveProject } from "@/lib/projects";
+import { saveProject, type ProjectMeta } from "@/lib/projects";
 import type { TrackDesign } from "@/lib/types";
 import { createMemoryStorage } from "../../helpers/storage";
 
@@ -38,6 +39,8 @@ function renderAccountProjectSync(overrides: Partial<HookOptions> = {}) {
     projectManagerOpen: false,
     historyPaused: false,
     interactionSessionDepth: 0,
+    projects: [],
+    initialized: true,
     snapshotCurrentDesign: vi.fn(),
     replaceDesign: vi.fn(),
     setProjects: vi.fn(),
@@ -306,6 +309,195 @@ describe("useAccountProjectSync", () => {
     expect(result.current.projectSyncMetaById["local-copy-id"]).toMatchObject({
       status: "local-only",
       lastSyncedAt: null,
+    });
+  });
+
+  describe("auto-promote", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.mocked(toast.error).mockClear();
+    });
+
+    it("auto-promotes a brand-new signed-in draft with meaningful content", async () => {
+      const design = createDefaultDesign();
+      design.id = "draft-1";
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          if (init?.method === "POST") {
+            return Response.json({
+              ok: true,
+              project: {
+                id: design.id,
+                title: design.title,
+                updatedAt: "2026-04-20T10:30:00.000Z",
+                designUpdatedAt: design.updatedAt,
+                shapeCount: 0,
+              },
+            });
+          }
+
+          return Response.json({ ok: true, projects: [] });
+        }
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const { result } = renderAccountProjectSync({
+        authUserId: "user-1",
+        design,
+        projects: [],
+        initialized: true,
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      const postCall = fetchMock.mock.calls.find(
+        ([input, init]) =>
+          String(input) === "/api/projects" && init?.method === "POST"
+      );
+      expect(postCall).toBeDefined();
+      expect(JSON.parse(String(postCall?.[1]?.body))).toMatchObject({
+        projectId: "draft-1",
+      });
+      expect(result.current.isAccountProject).toBe(true);
+    });
+
+    it("does not auto-promote a design that was already a local project before this session", async () => {
+      const design = createDefaultDesign();
+      design.id = "existing-local-1";
+      const existingProject: ProjectMeta = {
+        id: design.id,
+        title: design.title,
+        updatedAt: design.updatedAt,
+        createdAt: design.createdAt,
+        shapeCount: 0,
+      };
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          Response.json({ ok: true, projects: [] })
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      renderAccountProjectSync({
+        authUserId: "user-1",
+        design,
+        projects: [existingProject],
+        initialized: true,
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      const postCall = fetchMock.mock.calls.find(
+        ([, init]) => init?.method === "POST"
+      );
+      expect(postCall).toBeUndefined();
+    });
+
+    it("does not auto-promote while an interaction is in progress", async () => {
+      const design = createDefaultDesign();
+      design.id = "draft-2";
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          Response.json({ ok: true, projects: [] })
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      renderAccountProjectSync({
+        authUserId: "user-1",
+        design,
+        projects: [],
+        initialized: true,
+        interactionSessionDepth: 1,
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      const postCall = fetchMock.mock.calls.find(
+        ([, init]) => init?.method === "POST"
+      );
+      expect(postCall).toBeUndefined();
+    });
+
+    it("degrades gracefully and only attempts once when auto-promote fails", async () => {
+      const design = createDefaultDesign();
+      design.id = "draft-3";
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          if (init?.method === "POST") {
+            return Response.json(
+              { ok: false, error: "Network unavailable" },
+              { status: 500 }
+            );
+          }
+
+          return Response.json({ ok: true, projects: [] });
+        }
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const baseOptions: HookOptions = {
+        authUserId: "user-1",
+        readOnly: false,
+        design,
+        projectManagerOpen: false,
+        historyPaused: false,
+        interactionSessionDepth: 0,
+        projects: [],
+        initialized: true,
+        snapshotCurrentDesign: vi.fn(),
+        replaceDesign: vi.fn(),
+        setProjects: vi.fn(),
+        setRestorePoints: vi.fn(),
+        setActiveRestorePointId: vi.fn(),
+        setSaveStatusLabel: vi.fn(),
+      };
+
+      const { result, rerender } = renderHook(
+        (currentDesign: TrackDesign) =>
+          useAccountProjectSync({ ...baseOptions, design: currentDesign }),
+        { initialProps: design }
+      );
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      expect(
+        fetchMock.mock.calls.filter(([, init]) => init?.method === "POST")
+      ).toHaveLength(1);
+      expect(
+        JSON.parse(
+          localStorage.getItem(`trackdraw-project-${design.id}`) ?? "null"
+        )
+      ).toMatchObject({ id: design.id });
+      expect(toast.error).toHaveBeenCalledWith(
+        "Account sync failed",
+        expect.objectContaining({
+          action: expect.objectContaining({ label: "Retry" }),
+        })
+      );
+      expect(result.current.projectSyncMetaById[design.id]).toMatchObject({
+        status: "failed",
+      });
+
+      const editedDesign: TrackDesign = {
+        ...design,
+        updatedAt: "2026-04-20T11:00:00.000Z",
+      };
+      rerender(editedDesign);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(4000);
+      });
+
+      expect(
+        fetchMock.mock.calls.filter(([, init]) => init?.method === "POST")
+      ).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
Closes #773

## Summary

- For a signed-in user, a design that was never a device-local project before this session now auto-syncs to the account the moment it gets meaningful content, instead of requiring an explicit "Sync to account" click.
- Directly closes the "share a design with no backing project" gap from `docs/research/project-share-lifecycle-integrity.md` (#774), without touching Project Manager UI, the sign-in flow, or migrating any pre-existing local project.
- Correctness hinges on a **one-time snapshot** of local project ids taken when `useEditorProjects` finishes loading (`localProjectIdsAtLoadRef`), not a live check — the existing 350ms local-autosave effect would otherwise always beat any reasonable auto-promote debounce, making every design look "already local" by the time it's checked. A design id present in that snapshot is permanently excluded from auto-promote for the session, which is what keeps pre-existing local projects on the existing manual sync path.
- Reuses `syncDesignToAccount` (same function the manual "Sync to account" button and `useStarterExperience`'s starter-pick auto-sync already call) and mirrors the existing autosync effect's debounce/interaction-gating/failure handling exactly, so conflict/failure/retry behavior is identical to what already exists for already-synced projects.
- `useAccountProjectSync.ts`'s toast/status copy stays hardcoded English, matching this file's existing (pre-#773) convention — translating it is tracked separately as #776 rather than done as a partial migration here.

## Test plan

- [x] Added unit tests in `tests/components/editor/useAccountProjectSync.test.tsx`: auto-promotes a brand-new signed-in draft, does not auto-promote a design already present in the local project list at render, does not fire while `interactionSessionDepth > 0`, degrades gracefully on a failed POST (local fallback save + toast with Retry) and only attempts once per design id, does not auto-promote an untouched default design, and correctly triggers once `initialized` flips from false to true.
- [x] `npm run type` clean.
- [x] `npm run lint` clean (one pre-existing, unrelated warning in `MetricsWorkspace.tsx`).
- [ ] Manual verification in `npm run preview` (dev's auth shim disables cloud projects): sign in fresh, draw a shape on a blank canvas, confirm it becomes an account project with no click; reopen an existing local project and confirm it is *not* auto-promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
