### PR TITLE
Trim inline comment verbosity in project/share lifecycle fix

### DIFF
--- a/src/app/api/shares/route.ts
+++ b/src/app/api/shares/route.ts
@@ -92,10 +92,7 @@ export async function POST(request: Request) {
 
     let projectId = body.projectId ?? null;
     if (user && !projectId) {
-      // Reuse the design id as the project id, matching the convention
-      // useAccountProjectSync's "Sync to account" flow already uses, so a
-      // repeated publish of the same design promotes/updates the same
-      // project instead of creating a new one every time.
+      // Reuse design.id so repeated publishes update the same project instead of creating a new one each time.
       const project = await saveProjectForUser(user.id, design, {
         projectId: design.id,
       });

--- a/src/lib/server/projects.ts
+++ b/src/lib/server/projects.ts
@@ -357,8 +357,7 @@ export async function archiveProjectForUser(
     .bind(now, now, projectId, ownerUserId)
     .run<{ meta?: { changes?: number } }>();
 
-  // Only cascade if this call actually archived the project — a 0-row match
-  // (wrong owner, already archived, or unknown id) must not revoke shares.
+  // Only cascade if the archive actually matched a row (right owner, not already archived).
   if ((result.meta?.changes ?? 0) > 0) {
     await revokeSharesForProject(projectId, ownerUserId);
   }


### PR DESCRIPTION
## Summary

- Small follow-up to #774 (already merged): condenses two multi-line comments in `src/lib/server/projects.ts` and `src/app/api/shares/route.ts` down to single lines, per feedback that this codebase should keep inline comments minimal — only the non-obvious WHY, no restating what the code already says.
- No behavior change.

## Test plan

- [x] `npm run type` clean.
- [x] `npm run lint` clean (one pre-existing, unrelated warning in `MetricsWorkspace.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)