### PR TITLE
Clarify aggregation lag on metric quality badges, add manual run trigger

### DIFF
--- a/lang/en-US/dashboard.json
+++ b/lang/en-US/dashboard.json
@@ -232,6 +232,12 @@
     }
   },
   "metrics": {
+    "maintenance": {
+      "run": "Run aggregation now",
+      "running": "Running…",
+      "success": "Metric aggregation ran successfully.",
+      "failed": "Failed to run metric aggregation."
+    },
     "explorer": {
       "header": {
         "title": "Product metrics",
@@ -244,7 +250,8 @@
         "degraded": "Degraded",
         "invalid": "Invalid",
         "not_started": "Awaiting first complete period",
-        "buildingProgress": "Building — {elapsed}/{total}d"
+        "buildingProgress": "Building — {elapsed}/{total}d",
+        "scheduleHint": "Metrics are aggregated nightly at 00:17 UTC. If this doesn't clear after the next run, check the pipeline."
       },
       "comparison": {
         "unavailable": "No reliable comparison",

--- a/src/app/api/dashboard/metrics/maintenance/route.ts
+++ b/src/app/api/dashboard/metrics/maintenance/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { getCurrentUserFromHeaders } from "@/lib/server/auth-session";
+import { hasCapability } from "@/lib/server/authorization";
+import { isTrustedRequest } from "@/lib/server/csrf";
+import { getDatabase } from "@/lib/server/db";
+import { runProductMetricMaintenance } from "@/lib/server/product-metric-aggregates";
+
+export async function POST(request: Request) {
+  if (!isTrustedRequest(request)) {
+    return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+  }
+
+  const actor = await getCurrentUserFromHeaders(request.headers);
+  if (!actor) {
+    return NextResponse.json(
+      { ok: false, error: "Authentication required" },
+      { status: 401 }
+    );
+  }
+
+  if (!hasCapability(actor.role, "admin.metrics.read")) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "You do not have permission to perform this action.",
+      },
+      { status: 403 }
+    );
+  }
+
+  try {
+    const db = await getDatabase();
+    await runProductMetricMaintenance(db);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error("[TrackDraw] Failed to run product metric maintenance", {
+      error,
+    });
+    return NextResponse.json(
+      { ok: false, error: "Failed to run the maintenance job" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/dashboard/metrics/maintenance/route.ts
+++ b/src/app/api/dashboard/metrics/maintenance/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: Request) {
     );
   }
 
-  if (!hasCapability(actor.role, "admin.metrics.read")) {
+  if (!hasCapability(actor.role, "admin.metrics.run")) {
     return NextResponse.json(
       {
         ok: false,

--- a/src/app/api/dashboard/metrics/maintenance/route.ts
+++ b/src/app/api/dashboard/metrics/maintenance/route.ts
@@ -7,7 +7,10 @@ import { runProductMetricMaintenance } from "@/lib/server/product-metric-aggrega
 
 export async function POST(request: Request) {
   if (!isTrustedRequest(request)) {
-    return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+    return NextResponse.json(
+      { ok: false, error: "Forbidden" },
+      { status: 403 }
+    );
   }
 
   const actor = await getCurrentUserFromHeaders(request.headers);

--- a/src/app/dashboard/metrics/page.tsx
+++ b/src/app/dashboard/metrics/page.tsx
@@ -83,6 +83,10 @@ export default async function DashboardMetricsPage() {
           cockpit={cockpit}
           explorer={explorer}
           localizationDemand={localizationDemand}
+          canRunMaintenance={hasCapability(
+            currentUser.role,
+            "admin.metrics.run"
+          )}
           header={{
             title: tMetrics("explorer.header.title"),
             subtitle: tMetrics("explorer.header.subtitle"),

--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
+import { toast } from "sonner";
 import {
   Circle,
   Download,
@@ -9,6 +11,7 @@ import {
   Languages,
   LayoutDashboard,
   PenTool,
+  RefreshCw,
   Share2,
   type LucideIcon,
   Users,
@@ -30,6 +33,7 @@ import {
   TooltipTrigger,
 } from "@/components/AppTooltip";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
 import type {
   MetricsExplorerData,
   MetricsExplorerMetric,
@@ -191,7 +195,7 @@ function QualityLabel({
     quality === "building" && measuredSince && generatedAt
       ? buildingProgressDays(measuredSince, generatedAt)
       : null;
-  return (
+  const label = (
     <span
       className={cn(
         "inline-flex items-center gap-1.5 text-xs font-medium",
@@ -206,6 +210,61 @@ function QualityLabel({
           })
         : t(quality)}
     </span>
+  );
+
+  if (quality !== "not_started" && quality !== "building") return label;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button type="button" className="cursor-default text-left">
+            {label}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6}>
+          {t("scheduleHint")}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function RunMetricMaintenanceButton() {
+  const t = useTranslations("dashboard.metrics.maintenance");
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+
+  const run = async () => {
+    setPending(true);
+    try {
+      const response = await fetch("/api/dashboard/metrics/maintenance", {
+        method: "POST",
+      });
+      const payload = (await response.json()) as {
+        ok: boolean;
+        error?: string;
+      };
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.error ?? t("failed"));
+      }
+      toast.success(t("success"));
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : t("failed"));
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <Button variant="outline" size="sm" onClick={run} disabled={pending}>
+      <RefreshCw
+        className={cn("size-4", pending && "animate-spin")}
+        aria-hidden="true"
+      />
+      {pending ? t("running") : t("run")}
+    </Button>
   );
 }
 
@@ -737,16 +796,19 @@ export default function MetricsWorkspace({
               <time dateTime={header.dateTime}>{header.lastUpdated}</time>
             </p>
           </div>
-          <UserGrowthRangePicker
-            activeRange={growthRange}
-            customRange={growthCustomRange}
-            today={growthTimeline.today}
-            onPresetSelect={setGrowthRange}
-            onCustomApply={(value) => {
-              setGrowthCustomRange(value);
-              setGrowthRange("custom");
-            }}
-          />
+          <div className="flex items-center gap-2">
+            <RunMetricMaintenanceButton />
+            <UserGrowthRangePicker
+              activeRange={growthRange}
+              customRange={growthCustomRange}
+              today={growthTimeline.today}
+              onPresetSelect={setGrowthRange}
+              onCustomApply={(value) => {
+                setGrowthCustomRange(value);
+                setGrowthRange("custom");
+              }}
+            />
+          </div>
         </header>
       ) : null}
 

--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -63,6 +63,7 @@ type MetricsWorkspaceProps = {
   cockpit: DailyCockpitData;
   explorer: MetricsExplorerData;
   localizationDemand: LocalizationDemandMetrics;
+  canRunMaintenance?: boolean;
   header?: {
     title: string;
     subtitle: string;
@@ -218,9 +219,7 @@ function QualityLabel({
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <button type="button" className="cursor-default text-left">
-            {label}
-          </button>
+          <span>{label}</span>
         </TooltipTrigger>
         <TooltipContent side="top" sideOffset={6}>
           {t("scheduleHint")}
@@ -686,6 +685,7 @@ export default function MetricsWorkspace({
   cockpit,
   explorer,
   localizationDemand,
+  canRunMaintenance = false,
   header,
 }: MetricsWorkspaceProps) {
   const t = useTranslations("dashboard.metrics.explorer");
@@ -797,7 +797,7 @@ export default function MetricsWorkspace({
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <RunMetricMaintenanceButton />
+            {canRunMaintenance ? <RunMetricMaintenanceButton /> : null}
             <UserGrowthRangePicker
               activeRange={growthRange}
               customRange={growthCustomRange}

--- a/src/lib/server/authorization.ts
+++ b/src/lib/server/authorization.ts
@@ -15,6 +15,7 @@ export type AuthorizationCapability =
   | "admin.users.read"
   | "admin.users.update"
   | "admin.metrics.read"
+  | "admin.metrics.run"
   | "admin.api-keys.read"
   | "audit.read"
   | "account.role.assign"
@@ -41,6 +42,7 @@ const capabilityRoles: Record<AuthorizationCapability, AccountRole[]> = {
   "admin.users.read": ["admin"],
   "admin.users.update": ["admin"],
   "admin.metrics.read": ["admin"],
+  "admin.metrics.run": ["admin"],
   "admin.api-keys.read": ["admin"],
   "audit.read": ["admin"],
   "account.role.assign": ["admin"],

--- a/tests/components/dashboard/MetricsCharts.test.tsx
+++ b/tests/components/dashboard/MetricsCharts.test.tsx
@@ -8,7 +8,7 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ActivationFunnel,
   EditorUsageBreakdown,
@@ -26,6 +26,10 @@ import type {
   ProductInsights,
 } from "@/lib/server/metrics";
 import type { DailyCockpitData } from "@/lib/server/dashboard-cockpit";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: () => {} }),
+}));
 
 const growthData = {
   bucket: "month" as const,


### PR DESCRIPTION
## Summary
- After a deploy, several metrics on the dashboard metrics page flipped to "Awaiting first complete period" even though a full week of data existed — the nightly aggregation cron (00:17 UTC) had missed its tick around the deploy window, and there was no way to recover before the next scheduled run.
- The `not_started`/`building` quality badges now show a tooltip explaining the nightly schedule, so a temporary lag doesn't read as "this metric never started".
- Admins get a "Run aggregation now" button on the metrics page header that manually re-triggers `runProductMetricMaintenance` via a new authenticated API route, instead of having to wait for the next cron tick.

## Test plan
- [x] `npm run lint`
- [x] `npm run type`
- [ ] Manually trigger the new button in preview and confirm the metrics refresh and the tooltip renders correctly