### PR TITLE
fix: Sort metrics usage from highest to lowest

### DIFF
--- a/src/components/dashboard/MetricsCharts.tsx
+++ b/src/components/dashboard/MetricsCharts.tsx
@@ -1538,6 +1538,10 @@ export function ExportUsageBreakdown({
   const extras = usage.exportFormats30d
     .filter((row) => !knownFormatSet.has(row.format))
     .map((row) => ({ key: row.format, label: row.format, count: row.count }));
+  const sortedRows = [...rows, ...extras].sort(
+    (left, right) =>
+      right.count - left.count || left.key.localeCompare(right.key)
+  );
 
   return (
     <div className={compact ? "space-y-2" : "space-y-3"}>
@@ -1572,7 +1576,7 @@ export function ExportUsageBreakdown({
         </div>
       </div>
       <UsageBreakdownRows
-        rows={[...rows, ...extras]}
+        rows={sortedRows}
         total={usage.exports30d}
         emptyLabel={t("noData")}
         compact={compact}

--- a/src/components/dashboard/MetricsWorkspace.tsx
+++ b/src/components/dashboard/MetricsWorkspace.tsx
@@ -313,7 +313,9 @@ function ExplorerBarRows({
     [locale]
   );
   const rows = [...metric.rows].sort(
-    (left, right) => (right.value ?? 0) - (left.value ?? 0)
+    (left, right) =>
+      (right.value ?? 0) - (left.value ?? 0) ||
+      left.dimension.localeCompare(right.dimension)
   );
 
   if (rows.length === 0) {

--- a/tests/components/dashboard/MetricsCharts.test.tsx
+++ b/tests/components/dashboard/MetricsCharts.test.tsx
@@ -13,6 +13,7 @@ import {
   ActivationFunnel,
   EditorUsageBreakdown,
   EmbedReachTable,
+  ExportUsageBreakdown,
   GrowthTabs,
   PlanLimitSimulator,
   UsageTabs,
@@ -171,6 +172,28 @@ describe("metrics decision views", () => {
     expect(
       screen.getByRole("region", { name: "Detected embed websites" })
     ).toBeTruthy();
+  });
+
+  it("sorts export usage from highest to lowest", () => {
+    const { container } = render(
+      <ExportUsageBreakdown
+        usage={{
+          ...usage,
+          exports30d: 10,
+          exportFormats30d: [
+            { format: "png", count: 2 },
+            { format: "json", count: 7 },
+            { format: "custom", count: 1 },
+          ],
+        }}
+      />
+    );
+
+    expect(
+      Array.from(container.querySelectorAll(".text-foreground")).map(
+        (row) => row.textContent
+      )
+    ).toEqual(["Project file (JSON)", "2D image (PNG)", "custom"]);
   });
 
   it("left-aligns creator-funnel journey steps", () => {
@@ -431,7 +454,34 @@ describe("metrics decision views", () => {
     const explorer = {
       generatedAt: "2026-08-15T12:00:00.000Z",
       acquisition: emptyMetric,
-      adoption: { ...emptyMetric, id: "MTR-009" },
+      adoption: {
+        ...emptyMetric,
+        id: "MTR-009",
+        rows: [
+          {
+            dimension: "import",
+            day: "2026-08-14",
+            numerator: 2,
+            denominator: 10,
+            sampleSize: 10,
+            value: 0.2,
+            quality: "building",
+            previousValue: null,
+            comparisonReady: false,
+          },
+          {
+            dimension: "preview_3d",
+            day: "2026-08-14",
+            numerator: 7,
+            denominator: 10,
+            sampleSize: 10,
+            value: 0.7,
+            quality: "building",
+            previousValue: null,
+            comparisonReady: false,
+          },
+        ],
+      },
       retention: { ...emptyMetric, id: "MTR-005", windowDays: 30 },
     } satisfies MetricsExplorerData;
 
@@ -574,6 +624,15 @@ describe("metrics decision views", () => {
 
     await user.click(screen.getByRole("tab", { name: "Creation" }));
     expect(screen.getByText("Content growth")).toBeTruthy();
+    const adoption = screen
+      .getByRole("heading", { name: "Feature adoption" })
+      .closest("section");
+    expect(adoption).toBeTruthy();
+    expect(
+      within(adoption!)
+        .getAllByRole("img")
+        .map((row) => row.getAttribute("aria-label"))
+    ).toEqual(["3D preview: 70%", "Import: 20%"]);
 
     await user.click(screen.getByRole("tab", { name: "Distribution" }));
     expect(screen.getByText("Export usage")).toBeTruthy();

--- a/tests/components/dashboard/MetricsCharts.test.tsx
+++ b/tests/components/dashboard/MetricsCharts.test.tsx
@@ -175,7 +175,7 @@ describe("metrics decision views", () => {
   });
 
   it("sorts export usage from highest to lowest", () => {
-    const { container } = render(
+    render(
       <ExportUsageBreakdown
         usage={{
           ...usage,
@@ -190,9 +190,9 @@ describe("metrics decision views", () => {
     );
 
     expect(
-      Array.from(container.querySelectorAll(".text-foreground")).map(
-        (row) => row.textContent
-      )
+      screen
+        .getAllByText(/^(Project file \(JSON\)|2D image \(PNG\)|custom)$/)
+        .map((row) => row.textContent)
     ).toEqual(["Project file (JSON)", "2D image (PNG)", "custom"]);
   });
 


### PR DESCRIPTION
## Summary

- sort export formats by completed export count
- keep feature adoption ordered by adoption rate with deterministic ties
- add regression coverage for both dashboard sections

## Validation

- `npm run test -- --run tests/components/dashboard/MetricsCharts.test.tsx`
- `npm run type`
- `npm run lint` (passes with one pre-existing exhaustive-deps warning)